### PR TITLE
chore: bump RUST_VERSION

### DIFF
--- a/build/scripts/replace_go_with_rust.sh
+++ b/build/scripts/replace_go_with_rust.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-RUST_VERSION="1.69.0"
+RUST_VERSION="1.70.0"
 
 # remove go generated files
 rm -rf ./target/**


### PR DESCRIPTION
We are using some features that stabilized on 1.70 (e.g. `is_some_and`)