### PR TITLE
chore: explicitly add `user` feature in `nix` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4.4.1", features = ["derive"] }
 config = "0.13.1"
 serde = { version = "1.0.188", features = ["derive"] }
 thiserror = "1.0.47"
-nix = { version = "0.26.2", features = ["signal"] }
+nix = { version = "0.26.2", features = ["signal", "user"] }
 log = { version = "0.4.20", features = ["kv_unstable"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing = "0.1.37"


### PR DESCRIPTION
nix crate v0.27+ disables default features, so we need to do it manually
