### PR TITLE
feat(running_mode): change behaviour depending on the environment

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,11 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    // Program must run as root, but should accept simple behaviors such as --version, --help, etc
+    // Program must run as root if running_mode=OnHost, but should accept simple behaviors such as --version, --help, etc
     #[cfg(unix)]
-    if !nix::unistd::Uid::effective().is_root()
-        && cli.get_running_mode() == AgentRunningMode::OnHost
-    {
+    if !nix::unistd::Uid::effective().is_root() && cli.running_mode() == AgentRunningMode::OnHost {
         return Err("Program must run as root".into());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,7 +27,7 @@ impl Cli {
         PathBuf::from(&self.config)
     }
 
-    pub fn get_running_mode(&self) -> running_mode::AgentRunningMode {
+    pub fn running_mode(&self) -> running_mode::AgentRunningMode {
         self.running_mode
     }
 

--- a/src/cli/running_mode.rs
+++ b/src/cli/running_mode.rs
@@ -1,7 +1,6 @@
 use clap::builder::PossibleValue;
 use clap::ValueEnum;
 use std::fmt;
-use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AgentRunningMode {
@@ -9,21 +8,6 @@ pub enum AgentRunningMode {
     OnHost,
 }
 
-impl FromStr for AgentRunningMode {
-    type Err = String;
-    fn from_str(input: &str) -> Result<AgentRunningMode, Self::Err> {
-        for variant in Self::value_variants() {
-            if variant
-                .to_possible_value()
-                .expect("to_possible_value should cover all running modes")
-                .matches(input, false)
-            {
-                return Ok(*variant);
-            }
-        }
-        Err(format!("invalid variant: {input}"))
-    }
-}
 impl fmt::Display for AgentRunningMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_possible_value()


### PR DESCRIPTION
### Context
In different parts of the code, we will need to change behavior depending on the environment in which the SuperAgent is running. 


I think that an Argument is better than a config option to push ourselves to check that parameter in the main only. The idea would be to initialize all objects leveraging `running_mode` and not use it somewhere else.
However, I am curious to hear your opinions 😄 

### Options Discarded
 - In some cases, we could leverage the agent config, but in others, it would be cumbersome to do so (i.e. where to store agentTypes, how to store ULIDs, etc). For this reason, we thought of adding an explicit parameter for that.
 - We could define everything with a "set of features" instead. For example enable/disable:  storing in cm, creating CRD, ..
    It would be more flexible, but it would lead to weird configurations that would not make sense.
 - Two mains to avoid complexity in the CI and the risk of diverging
