### PR TITLE
[image] Add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ARG TARGETARCH
 
 COPY --chmod=755 bin/newrelic-super-agent-${TARGETARCH} /bin/newrelic-super-agent
 
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    apt-get clean
+
 USER nobody
 
 ENTRYPOINT ["/bin/newrelic-super-agent"]


### PR DESCRIPTION
The agent inside the image is not able to connect to the backend. The error looks like this:
```
2023-10-23T12:04:27.084091Z  INFO newrelic_super_agent::agent: Starting superagent's OpAMP Client.
Error: OpAMPNotStartedClientError(ClientError(SenderError(ReqwestError(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("opamp.staging-service.newrelic.com")), port: None, path: "/v1/opamp", query: None, fragment: None }, source: hyper::Error(Connect, Ssl(Error { code: ErrorCode(5), cause: Some(Ssl(ErrorStack([Error { code: 2147483650, library: "system library", function: "file_open", file: "providers/implementations/storemgmt/file_store.c", line: 267, data: "calling stat(/usr/local/ssl/certs)" }, Error { code: 2147483650, library: "system library", function: "file_open", file: "providers/implementations/storemgmt/file_store.c", line: 267, data: "calling stat(/usr/local/ssl/certs)" }, Error { code: 2147483650, library: "system library", function: "file_open", file: "providers/implementations/storemgmt/file_store.c", line: 267, data: "calling stat(/usr/local/ssl/certs)" }, Error { code: 167772294, library: "SSL routines", function: "tls_post_process_server_certificate", reason: "certificate verify failed", file: "ssl/statem/statem_clnt.c", line: 1890 }]))) }, X509VerifyResult { code: 20, error: "unable to get local issuer certificate" })) }))))
```
It is because there are no CAs inside the image, after doing a local patch with a Dockerfile like this:
```
FROM newrelic/newrelic-super-agent:nightly

USER root
RUN apt-get update && \
    apt-get install -y ca-certificates && \
    apt-get clean
USER nobody
```
The image was able to run and fail gracefully because I did not test with a valid licenseKey:
```
2023-10-23T12:08:30.900965Z  INFO newrelic_super_agent: Creating the global context
2023-10-23T12:08:30.900988Z  INFO newrelic_super_agent: Creating the signal handler
2023-10-23T12:08:30.901645Z  INFO newrelic_super_agent: Starting the super agent
2023-10-23T12:08:30.901661Z  INFO newrelic_super_agent::agent: Creating agent's communication channels
2023-10-23T12:08:30.901695Z  INFO newrelic_super_agent::agent: Starting superagent's OpAMP Client.
Error: OpAMPNotStartedClientError(ClientError(SenderError(UnsuccessfulResponse(403, "Forbidden"))))
```