### PR TITLE
NR-169031 refactor (1) : OpAMP client builders for Super Agent and Sub Agents

### DIFF
--- a/src/opamp/client_builder.rs
+++ b/src/opamp/client_builder.rs
@@ -1,11 +1,7 @@
-use futures::executor::block_on;
 use opamp_client::error::{NotStartedClientError, StartedClientError};
-use opamp_client::http::{
-    HttpClientError, HttpClientReqwest, HttpConfig, NotStartedHttpClient, StartedHttpClient,
-};
-use opamp_client::opamp::proto::AgentHealth;
+use opamp_client::http::{HttpClientError, HttpClientReqwest, HttpConfig};
 use opamp_client::operation::settings::StartSettings;
-use opamp_client::{Client, NotStartedClient, StartedClient};
+use opamp_client::StartedClient;
 use std::time::SystemTimeError;
 use thiserror::Error;
 use tracing::error;
@@ -13,9 +9,7 @@ use tracing::error;
 use crate::config::super_agent_configs::{AgentID, OpAMPClientConfig};
 
 use crate::context::Context;
-use crate::super_agent::callbacks::AgentCallbacks;
 use crate::super_agent::super_agent::SuperAgentEvent;
-use crate::utils::time::get_sys_time_nano;
 
 #[derive(Error, Debug)]
 pub enum OpAMPClientBuilderError {
@@ -42,50 +36,19 @@ pub trait OpAMPClientBuilder {
     ) -> Result<Self::Client, OpAMPClientBuilderError>;
 }
 
-/// OpAMPBuilderCfg
-pub struct OpAMPHttpBuilder {
-    config: OpAMPClientConfig,
-}
+pub fn build_http_client(
+    config: &OpAMPClientConfig,
+) -> Result<HttpClientReqwest, OpAMPClientBuilderError> {
+    let headers = config.headers.clone().unwrap_or_default();
+    let headers: Vec<(&str, &str)> = headers
+        .iter()
+        .map(|(h, v)| (h.as_str(), v.as_str()))
+        .collect();
 
-impl OpAMPHttpBuilder {
-    pub fn new(config: OpAMPClientConfig) -> Self {
-        Self { config }
-    }
-}
+    let http_client =
+        HttpClientReqwest::new(HttpConfig::new(config.endpoint.as_str())?.with_headers(headers)?)?;
 
-impl OpAMPClientBuilder for OpAMPHttpBuilder {
-    type Client = StartedHttpClient<AgentCallbacks, HttpClientReqwest>;
-    fn build_and_start(
-        &self,
-        ctx: Context<Option<SuperAgentEvent>>,
-        agent_id: AgentID,
-        start_settings: StartSettings,
-    ) -> Result<Self::Client, OpAMPClientBuilderError> {
-        // TODO: cleanup
-        let headers = self.config.headers.clone().unwrap_or_default();
-        let headers: Vec<(&str, &str)> = headers
-            .iter()
-            .map(|header| (header.0.as_str(), header.1.as_str()))
-            .collect();
-
-        let http_client = HttpClientReqwest::new(
-            HttpConfig::new(self.config.endpoint.as_str())?.with_headers(headers)?,
-        )?;
-
-        let callbacks = AgentCallbacks::new(ctx, agent_id);
-
-        let not_started_client = NotStartedHttpClient::new(callbacks, start_settings, http_client)?;
-
-        let started_client = block_on(not_started_client.start())?;
-        // set OpAMP health
-        block_on(started_client.set_health(AgentHealth {
-            healthy: true,
-            start_time_unix_nano: get_sys_time_nano()?,
-            last_error: "".to_string(),
-        }))?;
-
-        Ok(started_client)
-    }
+    Ok(http_client)
 }
 
 #[cfg(test)]

--- a/src/sub_agent/callbacks.rs
+++ b/src/sub_agent/callbacks.rs
@@ -1,0 +1,192 @@
+use crate::config::remote_config::{ConfigMap, RemoteConfig, RemoteConfigError};
+use crate::config::remote_config_hash::Hash;
+use crate::config::super_agent_configs::AgentID;
+use crate::context::Context;
+use crate::super_agent::super_agent::SuperAgentEvent;
+use opamp_client::opamp::proto::AgentRemoteConfig;
+use opamp_client::{
+    error::ConnectionError,
+    http::HttpClientError,
+    opamp::proto::{
+        EffectiveConfig, OpAmpConnectionSettings, ServerErrorResponse, ServerToAgentCommand,
+    },
+    operation::callbacks::{Callbacks, MessageData},
+};
+use std::str;
+use std::str::Utf8Error;
+use thiserror::Error;
+use tracing::error;
+
+pub struct AgentCallbacks {
+    agent_id: AgentID,
+    ctx: Context<Option<SuperAgentEvent>>,
+}
+
+#[derive(Debug, Error)]
+pub enum AgentCallbacksError {
+    #[error("deserialization error: `{0}`")]
+    DeserializationError(#[from] RemoteConfigError),
+
+    #[error("Invalid UTF-8 sequence: `{0}`")]
+    UTF8(#[from] Utf8Error),
+
+    #[error("agent remote config with empty config body")]
+    EmptyRemoteConfig,
+
+    #[error("unable to send event through context")]
+    ContextError,
+}
+
+impl AgentCallbacks {
+    pub fn new(ctx: Context<Option<SuperAgentEvent>>, agent_id: AgentID) -> Self {
+        Self { ctx, agent_id }
+    }
+
+    fn update_remote_config(
+        &self,
+        agent_id: AgentID,
+        msg_remote_config: &AgentRemoteConfig,
+    ) -> Result<(), AgentCallbacksError> {
+        if let Some(msg_config_map) = &msg_remote_config.config {
+            //Check if hash is empty
+            let config: Result<ConfigMap, RemoteConfigError> = msg_config_map.try_into();
+
+            let current_hash = str::from_utf8(&msg_remote_config.config_hash)?.to_string();
+
+            let event = match config {
+                Err(e) => SuperAgentEvent::RemoteConfig(Err(RemoteConfigError::InvalidConfig(
+                    current_hash,
+                    e.to_string(),
+                ))),
+                Ok(config) => {
+                    let remote_config = RemoteConfig {
+                        agent_id,
+                        hash: Hash::new(current_hash),
+                        config_map: config,
+                    };
+                    SuperAgentEvent::RemoteConfig(Ok(remote_config))
+                }
+            };
+            return self
+                .ctx
+                .cancel_all(Some(event))
+                .map_err(|_| AgentCallbacksError::ContextError);
+        }
+        Err(AgentCallbacksError::EmptyRemoteConfig)
+    }
+}
+
+impl Callbacks for AgentCallbacks {
+    type Error = AgentCallbacksError;
+
+    fn on_error(&self, _err: ServerErrorResponse) {}
+
+    fn on_connect(&self) {}
+
+    fn on_message(&self, msg: MessageData) {
+        let agent_id = self.agent_id.clone();
+        if let Some(msg_remote_config) = msg.remote_config {
+            let _ = self
+                .update_remote_config(agent_id, &msg_remote_config)
+                .map_err(|error| error!("{}", error));
+        }
+    }
+
+    fn on_command(&self, _command: &ServerToAgentCommand) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn on_connect_failed(&self, err: ConnectionError) {
+        log_on_http_status_code(&err);
+    }
+
+    fn get_effective_config(&self) -> Result<EffectiveConfig, Self::Error> {
+        Ok(EffectiveConfig::default())
+    }
+
+    fn on_opamp_connection_settings(
+        &self,
+        _settings: &OpAmpConnectionSettings,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn on_opamp_connection_settings_accepted(&self, _settings: &OpAmpConnectionSettings) {}
+}
+
+fn log_on_http_status_code(err: &ConnectionError) {
+    // Check if the error comes from receiving an undesired HTTP status code
+    if let ConnectionError::HTTPClientError(HttpClientError::UnsuccessfulResponse(code, reason)) =
+        &err
+    {
+        const STATUS_CODE_MSG: &str = "Received HTTP status code";
+        match code {
+            400 => error!("{STATUS_CODE_MSG} {code} ({reason}). The request was malformed. Possible reason: invalid ULID."),
+            401 => error!("{STATUS_CODE_MSG} {code} ({reason}). Check for missing or invalid license key."
+            ),
+            403 => error!("{STATUS_CODE_MSG} {code} ({reason}). The account provided is not allowed to use this resource."),
+            404 => error!("{STATUS_CODE_MSG} {code} ({reason}). The requested resource was not found."),
+            415 => error!("{STATUS_CODE_MSG} {code} ({reason}). Content-Type or Content-Encoding for the HTTP request was wrong."),
+            500 => error!("{STATUS_CODE_MSG} {code} ({reason}). Server-side problem."),
+            _ => error!("{STATUS_CODE_MSG} {code} ({reason}). Reasons unknown"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opamp_client::opamp::proto::{AgentConfigFile, AgentConfigMap, AgentRemoteConfig};
+    use std::collections::HashMap;
+    use std::thread::spawn;
+
+    #[test]
+    fn on_message_send_correct_config() {
+        let ctx: Context<Option<SuperAgentEvent>> = Context::new();
+        let agent_id = AgentID::new("an-agent-id").unwrap();
+
+        spawn({
+            let ctx = ctx.clone();
+            move || {
+                let callbacks = AgentCallbacks::new(ctx, agent_id);
+                let msg = MessageData {
+                    remote_config: Option::from(AgentRemoteConfig {
+                        config: Option::from(AgentConfigMap {
+                            config_map: HashMap::from([(
+                                "my-config".to_string(),
+                                AgentConfigFile {
+                                    body: "enable_proces_metrics: true".as_bytes().to_vec(),
+                                    content_type: "".to_string(),
+                                },
+                            )]),
+                        }),
+                        config_hash: "cool-hash".as_bytes().to_vec(),
+                    }),
+                    own_metrics: None,
+                    own_traces: None,
+                    own_logs: None,
+                    other_connection_settings: None,
+                    agent_identification: None,
+                };
+
+                callbacks.on_message(msg);
+            }
+        });
+
+        let Some(event) = ctx.wait_condvar().unwrap() else {
+            unreachable!()
+        };
+
+        let SuperAgentEvent::RemoteConfig(remote_config) = event else {
+            unreachable!()
+        };
+        let result = remote_config.unwrap();
+
+        assert_eq!(AgentID::new("an-agent-id").unwrap(), result.agent_id);
+        assert_eq!("cool-hash".to_string(), result.hash.get());
+        assert_eq!(
+            &"enable_proces_metrics: true".to_string(),
+            result.config_map.get(&"my-config".to_string()).unwrap(),
+        );
+    }
+}

--- a/src/sub_agent/mod.rs
+++ b/src/sub_agent/mod.rs
@@ -7,6 +7,7 @@ pub mod restart_policy;
 #[cfg(feature = "onhost")]
 pub mod on_host;
 
+pub mod callbacks;
 #[cfg(feature = "k8s")]
 pub mod k8s;
 

--- a/src/sub_agent/on_host/mod.rs
+++ b/src/sub_agent/on_host/mod.rs
@@ -5,4 +5,4 @@ pub mod supervisor;
 // Module implementing the SubAgent traits.
 pub mod sub_agent;
 
-mod opamp;
+pub mod opamp;

--- a/src/sub_agent/on_host/opamp.rs
+++ b/src/sub_agent/on_host/opamp.rs
@@ -1,11 +1,98 @@
-use crate::config::super_agent_configs::{AgentID, AgentTypeFQN};
+use crate::config::super_agent_configs::{AgentID, AgentTypeFQN, OpAMPClientConfig};
 use crate::context::Context;
-use crate::opamp::client_builder::{OpAMPClientBuilder, OpAMPClientBuilderError};
+use crate::opamp::client_builder::{
+    build_http_client, OpAMPClientBuilder, OpAMPClientBuilderError,
+};
+use crate::sub_agent::callbacks::AgentCallbacks as SubAgentCallbacks;
+use crate::super_agent::callbacks::AgentCallbacks as SuperAgentCallbacks;
 use crate::super_agent::instance_id::InstanceIDGetter;
 use crate::super_agent::super_agent::SuperAgentEvent;
+use crate::utils::time::get_sys_time_nano;
+use futures::executor::block_on;
 use nix::unistd::gethostname;
+use opamp_client::http::{HttpClientReqwest, NotStartedHttpClient, StartedHttpClient};
+use opamp_client::opamp::proto::{AgentCapabilities, AgentHealth};
 use opamp_client::operation::settings::{AgentDescription, StartSettings};
+use opamp_client::{capabilities, Client, NotStartedClient};
 use std::collections::HashMap;
+
+/// OpAMPBuilderCfg
+pub struct SuperAgentOpAMPHttpBuilder {
+    config: OpAMPClientConfig,
+}
+
+impl SuperAgentOpAMPHttpBuilder {
+    pub fn new(config: OpAMPClientConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl OpAMPClientBuilder for SuperAgentOpAMPHttpBuilder {
+    type Client = StartedHttpClient<SuperAgentCallbacks, HttpClientReqwest>;
+    fn build_and_start(
+        &self,
+        ctx: Context<Option<SuperAgentEvent>>,
+        agent_id: AgentID,
+        start_settings: StartSettings,
+    ) -> Result<Self::Client, OpAMPClientBuilderError> {
+        let http_client = build_http_client(&self.config)?;
+        let callbacks = SuperAgentCallbacks::new(ctx, agent_id);
+        let not_started_client = NotStartedHttpClient::new(callbacks, start_settings, http_client)?;
+        let started_client = block_on(not_started_client.start())?;
+        // TODO remove opamp health from here, it should be done outside
+        // set OpAMP health
+        block_on(started_client.set_health(AgentHealth {
+            healthy: true,
+            start_time_unix_nano: get_sys_time_nano()?,
+            last_error: "".to_string(),
+        }))?;
+
+        Ok(started_client)
+    }
+}
+
+/// OpAMPBuilderCfg
+pub struct SubAgentOpAMPHttpBuilder {
+    config: OpAMPClientConfig,
+}
+
+impl SubAgentOpAMPHttpBuilder {
+    pub fn new(config: OpAMPClientConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl<'a> From<&'a SuperAgentOpAMPHttpBuilder> for SubAgentOpAMPHttpBuilder {
+    fn from(value: &'a SuperAgentOpAMPHttpBuilder) -> Self {
+        SubAgentOpAMPHttpBuilder {
+            config: value.config.clone(),
+        }
+    }
+}
+
+impl OpAMPClientBuilder for SubAgentOpAMPHttpBuilder {
+    type Client = StartedHttpClient<SubAgentCallbacks, HttpClientReqwest>;
+    fn build_and_start(
+        &self,
+        ctx: Context<Option<SuperAgentEvent>>,
+        agent_id: AgentID,
+        start_settings: StartSettings,
+    ) -> Result<Self::Client, OpAMPClientBuilderError> {
+        let http_client = build_http_client(&self.config)?;
+        let callbacks = SubAgentCallbacks::new(ctx, agent_id);
+        let not_started_client = NotStartedHttpClient::new(callbacks, start_settings, http_client)?;
+        let started_client = block_on(not_started_client.start())?;
+        // TODO remove opamp health from here, it should be done outside
+        // set OpAMP health
+        block_on(started_client.set_health(AgentHealth {
+            healthy: true,
+            start_time_unix_nano: get_sys_time_nano()?,
+            last_error: "".to_string(),
+        }))?;
+
+        Ok(started_client)
+    }
+}
 
 pub(super) fn build_opamp_and_start_client<OpAMPBuilder, InstanceIdGetter>(
     ctx: Context<Option<SuperAgentEvent>>,

--- a/src/super_agent/super_agent.rs
+++ b/src/super_agent/super_agent.rs
@@ -18,10 +18,11 @@ use crate::config::remote_config_hash::{Hash, HashRepository, HashRepositoryFile
 use crate::config::store::{SubAgentsConfigStore, SuperAgentConfigStoreFile};
 use crate::config::super_agent_configs::{AgentID, SubAgentConfig, SubAgentsConfig};
 use crate::context::Context;
-use crate::opamp::client_builder::{OpAMPClientBuilder, OpAMPHttpBuilder};
+use crate::opamp::client_builder::OpAMPClientBuilder;
 use crate::sub_agent::collection::{NotStartedSubAgents, StartedSubAgents};
 use crate::sub_agent::error::SubAgentBuilderError;
 use crate::sub_agent::logger::{Event, EventLogger, StdEventReceiver};
+use crate::sub_agent::on_host::opamp::SuperAgentOpAMPHttpBuilder;
 use crate::sub_agent::NotStartedSubAgent;
 use crate::sub_agent::SubAgentBuilder;
 use crate::super_agent::defaults::{SUPER_AGENT_NAMESPACE, SUPER_AGENT_TYPE, SUPER_AGENT_VERSION};
@@ -47,7 +48,7 @@ pub struct SuperAgent<
     'a,
     Assembler,
     S,
-    OpAMPBuilder = OpAMPHttpBuilder,
+    OpAMPBuilder = SuperAgentOpAMPHttpBuilder,
     ID = ULIDInstanceIDGetter,
     HR = HashRepositoryFile,
     SL = SuperAgentConfigStoreFile,
@@ -1050,7 +1051,7 @@ agents:
         send_event_after(
             ctx.clone(),
             SuperAgentEvent::Stop,
-            Duration::from_millis(100),
+            Duration::from_millis(300),
         );
         assert!(agent.run(ctx).is_ok())
     }


### PR DESCRIPTION
This PR adds custom OpAMP Builders for Super Agent and Sub Agents so Super Agent and Sub Agents can have different callbacks and publish different types of events if Super Agent or Sub Agents.

Currently, Sub Agent callbacks is a C&P to validate the approach. If this is validated, in a current PR we will add specific callbacks for Sub Agents.

This PR is a necessary refactor to be able to persist remote configs for Sub Agents.