### PR TITLE
POC: k8s runtime CRs examples (NR-172013)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -42,6 +43,12 @@ checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -226,6 +233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +426,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +473,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -453,6 +517,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "either"
@@ -726,6 +796,10 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -879,6 +953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1073,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff1e1486799e3f64129f8ccad108b38290df9cd7015cd31bed17239f0789d6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "treediff",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1118,8 @@ dependencies = [
  "k8s-openapi",
  "kube-client",
  "kube-core",
+ "kube-derive",
+ "kube-runtime",
 ]
 
 [[package]]
@@ -1063,11 +1166,52 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
+ "json-patch",
  "k8s-openapi",
  "once_cell",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "kube-derive"
+version = "0.86.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8dd623cf49cd632da4727a70e05d9cb948d5ea1098a1af49b1fd3bc9ec60b3c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.86.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde2bd0b2d248be72f30c658b728f87e84c68495bec2c689dff7a3479eb29afd"
+dependencies = [
+ "ahash",
+ "async-trait",
+ "backoff",
+ "derivative",
+ "futures",
+ "hashbrown 0.14.1",
+ "json-patch",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1839,6 +1983,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +2073,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2194,14 +2373,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]
@@ -2354,6 +2534,15 @@ dependencies = [
  "lazy_static",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "treediff"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ cfg-if = "1.0.0"
 
 # K8S subagent dependencies
 # IMPORTANT: All k8s only deps needs to be `optional = true` so they won't be compiled by default
-kube = { version="0.86.0", default-features = false, features = ["client",
-"openssl-tls"], optional = true }
+kube = { version="0.86.0", default-features = false, features = ["client", "openssl-tls", "runtime", "derive"], optional = true }
 k8s-openapi = { version= "0.20.0", features = ["latest"], optional = true }
 tower = { version = "0.4.13", features = [], optional = true }
 hyper = { version = "0.14.27", optional = true }
@@ -65,3 +64,13 @@ path = "src/bin/main.rs"
 default = ["onhost"]
 onhost = []
 k8s = ["dep:kube", "dep:k8s-openapi", "dep:tower", "dep:hyper", "dep:mockall"]
+
+
+# TODO: examples for development purposes
+[[example]]
+name = "k8s-dynamic-crs-api"
+path = "src/k8s/examples/dynamic-cr.rs"
+
+[[example]]
+name = "k8s-dynamic-reflectors"
+path = "src/k8s/examples/dynamic-reflectors.rs"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -53,6 +53,14 @@ Distributed under the following license(s):
 
 
 
+## allocator-api2 (https://crates.io/crates/allocator-api2)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+
 ## android-tzdata (https://crates.io/crates/android-tzdata)
 
 Distributed under the following license(s):
@@ -161,6 +169,14 @@ Distributed under the following license(s):
 Distributed under the following license(s):
 * Apache-2.0
 * MIT
+
+
+
+## backoff (https://crates.io/crates/backoff)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
 
 
 
@@ -323,6 +339,27 @@ Distributed under the following license(s):
 
 
 
+## darling (https://crates.io/crates/darling)
+
+Distributed under the following license(s):
+* MIT
+
+
+
+## darling_core (https://crates.io/crates/darling_core)
+
+Distributed under the following license(s):
+* MIT
+
+
+
+## darling_macro (https://crates.io/crates/darling_macro)
+
+Distributed under the following license(s):
+* MIT
+
+
+
 ## dary_heap (https://crates.io/crates/dary_heap)
 
 Distributed under the following license(s):
@@ -332,6 +369,14 @@ Distributed under the following license(s):
 
 
 ## deranged (https://crates.io/crates/deranged)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+
+## derivative (https://crates.io/crates/derivative)
 
 Distributed under the following license(s):
 * MIT
@@ -356,6 +401,14 @@ Distributed under the following license(s):
 ## duration-str (https://crates.io/crates/duration-str)
 
 Distributed under the following license(s):
+* Apache-2.0
+
+
+
+## dyn-clone (https://crates.io/crates/dyn-clone)
+
+Distributed under the following license(s):
+* MIT
 * Apache-2.0
 
 
@@ -675,6 +728,14 @@ Distributed under the following license(s):
 
 
 
+## ident_case (https://crates.io/crates/ident_case)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+
 ## idna (https://crates.io/crates/idna)
 
 Distributed under the following license(s):
@@ -713,6 +774,13 @@ Distributed under the following license(s):
 
 
 
+## instant (https://crates.io/crates/instant)
+
+Distributed under the following license(s):
+* BSD-3-Clause
+
+
+
 ## ipnet (https://crates.io/crates/ipnet)
 
 Distributed under the following license(s):
@@ -738,6 +806,14 @@ Distributed under the following license(s):
 
 
 ## js-sys (https://crates.io/crates/js-sys)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+
+## json-patch (https://crates.io/crates/json-patch)
 
 Distributed under the following license(s):
 * MIT
@@ -774,6 +850,20 @@ Distributed under the following license(s):
 
 
 ## kube-core (https://crates.io/crates/kube-core)
+
+Distributed under the following license(s):
+* Apache-2.0
+
+
+
+## kube-derive (https://crates.io/crates/kube-derive)
+
+Distributed under the following license(s):
+* Apache-2.0
+
+
+
+## kube-runtime (https://crates.io/crates/kube-runtime)
 
 Distributed under the following license(s):
 * Apache-2.0
@@ -1331,6 +1421,20 @@ Distributed under the following license(s):
 
 
 
+## schemars (https://crates.io/crates/schemars)
+
+Distributed under the following license(s):
+* MIT
+
+
+
+## schemars_derive (https://crates.io/crates/schemars_derive)
+
+Distributed under the following license(s):
+* MIT
+
+
+
 ## scopeguard (https://crates.io/crates/scopeguard)
 
 Distributed under the following license(s):
@@ -1379,6 +1483,14 @@ Distributed under the following license(s):
 
 
 ## serde_derive (https://crates.io/crates/serde_derive)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+
+## serde_derive_internals (https://crates.io/crates/serde_derive_internals)
 
 Distributed under the following license(s):
 * MIT
@@ -1670,6 +1782,14 @@ Distributed under the following license(s):
 
 Distributed under the following license(s):
 * MIT
+
+
+
+## treediff (https://crates.io/crates/treediff)
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
 
 
 

--- a/src/k8s/examples/README.md
+++ b/src/k8s/examples/README.md
@@ -1,0 +1,14 @@
+# k8s examples
+
+Temporal examples for development purposes.
+
+The examples require a k8s cluster. They use `.kubeconfig` and the default context, so beware of
+your context before executing. They were tested using minikube.
+
+```bash
+# start minikube
+$ minikube start
+# execute examples (check their code for details)
+$ RUST_LOG=info cargo run --example k8s-dynamic-reflectors --features k8s
+$ RUST_LOG=info cargo run --example k8s-dynamic-crs-api --features k8s
+```

--- a/src/k8s/examples/dynamic-cr.rs
+++ b/src/k8s/examples/dynamic-cr.rs
@@ -1,0 +1,109 @@
+use std::error::Error;
+
+use kube::{
+    core::{DynamicObject, GroupVersionKind},
+    Api, Client, ResourceExt,
+};
+use tracing::info;
+
+// This example assumes the Foo CRD already exists. It can be created using:
+// $ kubectl apply -f manifests/foo-crd.yaml
+// It handles CRS whose group, version and kind are known at runtime.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt::init();
+    let client = Client::try_default().await?;
+
+    let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
+
+    // Use API discovery to identify more information about the type (like its plural)
+    let (api_resource, _caps) = kube::discovery::pinned_kind(&client, &gvk).await?;
+
+    let api: Api<DynamicObject> = Api::default_namespaced_with(client, &api_resource);
+
+    let foo_id = ulid::Ulid::new().to_string().to_lowercase();
+
+    let cr_definition = format!(
+        r#"
+apiVersion: clux.dev/v1
+kind: Foo
+metadata:
+  name: {foo_id}
+  labels:
+    l1: v1
+spec:
+  name: {foo_id}
+  info: this is {foo_id}
+"#
+    );
+
+    let cr_from_yaml: DynamicObject = serde_yaml::from_str(&cr_definition)?;
+
+    // Created (first time)
+    update_or_create_cr(&api, &foo_id, cr_from_yaml.clone(), "k2", "v2").await?;
+
+    show_foo_crs(&api).await?;
+
+    // Updated (as it already exists)
+    update_or_create_cr(&api, &foo_id, cr_from_yaml, "k3", "v3").await?;
+
+    show_foo_crs(&api).await?;
+
+    info!("Delete {foo_id} Foo");
+    api.delete(&foo_id, &Default::default())
+        .await?
+        .map_left(|cr| {
+            info!("Deleting {foo_id}: {:?}", cr.metadata.deletion_timestamp);
+        })
+        .map_right(|s| {
+            info!("Deleted {foo_id}: {:?}", s);
+        });
+
+    show_foo_crs(&api).await?;
+
+    Ok(())
+}
+
+// This could be generic for any Api<K> where K implements Resource.
+// It doesn't use reflectors/informers, so the API is triggered every time.
+async fn show_foo_crs(api: &Api<DynamicObject>) -> Result<(), Box<dyn Error>> {
+    info!("List all Foo CRs");
+    api.list(&Default::default())
+        .await?
+        .into_iter()
+        .for_each(|cr| {
+            info!(
+                "-  Found CR with name '{}' and labels: {:?}",
+                cr.name_any(),
+                cr.labels()
+            );
+        });
+    Ok(())
+}
+
+async fn update_or_create_cr(
+    api: &Api<DynamicObject>,
+    name: &str,
+    cr_definition: DynamicObject,
+    key_label: &str,
+    value_label: &str,
+) -> Result<(), Box<dyn Error>> {
+    info!("Update or create {name} Foo, and include the label {key_label}:{value_label}");
+    api.entry(name)
+        .await?
+        // apply the change if it already exists
+        .and_modify(|cr| {
+            cr.labels_mut()
+                .insert(key_label.to_string(), value_label.to_string());
+        })
+        .or_insert(|| cr_definition)
+        // apply the change even if we have just created it the CR
+        .and_modify(|cr| {
+            cr.labels_mut()
+                .insert(key_label.to_string(), value_label.to_string());
+        })
+        // persists the changes
+        .commit(&Default::default())
+        .await?;
+    Ok(())
+}

--- a/src/k8s/examples/dynamic-reflectors.rs
+++ b/src/k8s/examples/dynamic-reflectors.rs
@@ -1,0 +1,96 @@
+use futures::{future, StreamExt};
+use std::error::Error;
+use tracing::{info, trace, warn};
+
+use kube::{
+    api::{Api, ResourceExt},
+    core::{DynamicObject, GroupVersionKind},
+    runtime::{
+        reflector::{self, Store},
+        watcher, WatchStreamExt,
+    },
+    Client,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt::init();
+
+    let client = Client::try_default().await?;
+
+    // The example requires the Foo CRD to be installed
+    // $ kubectl apply -f manifests/foo-crd.yaml
+
+    // Usually, reader/writer can be created using `reflector::store` but it requires knowing the resource
+    // kind, version and group at compile-time.
+    // Check out the example at <https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/crd_reflector.rs#L36>
+
+    // Define (at runtime) group, version and kind, so we can get the `api` and `api_resource`.
+    let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
+    // Use API discovery to identify more information about the type (like its plural)
+    let (api_resource, _caps) = kube::discovery::pinned_kind(&client, &gvk).await?;
+    let api: Api<DynamicObject> = Api::default_namespaced_with(client, &api_resource);
+
+    // Create reader and writer
+    let writer = reflector::store::Writer::<DynamicObject>::new(api_resource.clone());
+    let reader = writer.as_reader();
+
+    // The watcher config can define filtering (labels, fields, ...), we list all Foo CRs in this example
+    let watcher_config = watcher::Config::default().any_semantic();
+
+    // polling the events is needed to keep the reader updated
+    let writer_task = tokio::spawn(poll_events(writer, api, watcher_config));
+    let reader_task = tokio::spawn(read_crs_periodically(reader));
+
+    // This is an example of how to clean up the tokio tasks.
+    // Details: <https://github.com/tokio-rs/tokio/discussions/5534>
+    // We could use channels or signals if `abort()` is not enough.
+    tokio::signal::ctrl_c().await?;
+    info!("Cleaning up tasks...");
+    reader_task.abort();
+    writer_task.abort();
+    info!("Bye!");
+    Ok(())
+}
+
+// Defines a watcher to poll all CR events and reflects changes in the writer.
+async fn poll_events(
+    writer: reflector::store::Writer<DynamicObject>,
+    api: Api<DynamicObject>,
+    watcher_config: watcher::Config,
+) {
+    // TODO. check watcher's memory usage <https://docs.rs/kube/latest/kube/runtime/fn.reflector.html#memory-usage>
+    // `metadata_watcher` could be another option. Would it be feasible?
+    watcher(api, watcher_config)
+        .default_backoff()
+        .reflect(writer)
+        .touched_objects()
+        .for_each(|o| {
+            if let Some(e) = o.err() {
+                // Errors ar supposed to be recoverable: <https://docs.rs/kube/latest/kube/runtime/fn.watcher.html#recovery>
+                warn!("Error polling events: {e}")
+            }
+            future::ready(())
+        })
+        .await
+}
+
+// Reads the state periodically
+// We can create/edit/delete CRs to check how it works. For example:
+// $ kubectl apply -f manifest/crd-bax.yaml
+async fn read_crs_periodically(reader: Store<DynamicObject>) {
+    reader.wait_until_ready().await.unwrap();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        info!("CRs state:");
+        reader.state().iter().for_each(|r| {
+            info!(
+                " - Foo with name: {} and labels {:?}",
+                r.name_any(),
+                r.labels(),
+            );
+            let yaml = serde_yaml::to_string(r.as_ref()).unwrap();
+            trace!("yaml: {}", yaml);
+        });
+    }
+}

--- a/src/k8s/examples/manifests/cr-baz.yaml
+++ b/src/k8s/examples/manifests/cr-baz.yaml
@@ -1,0 +1,7 @@
+apiVersion: clux.dev/v1
+kind: Foo
+metadata:
+  name: baz
+spec:
+  name: baz
+  info: this is baz

--- a/src/k8s/examples/manifests/cr-qux.yaml
+++ b/src/k8s/examples/manifests/cr-qux.yaml
@@ -1,0 +1,7 @@
+apiVersion: clux.dev/v1
+kind: Foo
+metadata:
+  name: qux
+spec:
+  name: qux
+  info: this is qux

--- a/src/k8s/examples/manifests/foo-crd.yaml
+++ b/src/k8s/examples/manifests/foo-crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.clux.dev
+spec:
+  group: clux.dev
+  names:
+    categories: []
+    kind: Foo
+    plural: foos
+    shortNames: []
+    singular: foo
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns: []
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for FooSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              info:
+                type: string
+              name:
+                type: string
+            required:
+            - info
+            - name
+            type: object
+        required:
+        - spec
+        title: Foo
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
This draft PR include a couple of examples showing how we can use `kube-rs` to handle k8s Custom Resources whose kind, group and version is only known at runtime.