### PR TITLE
chore: run k8s tests with k8s feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ mockall = "0.11.4"
 [[test]]
 name = "k8s"
 path = "test/k8s/mod.rs"
+required-features = ["k8s"]
 
 [[test]]
 name = "integration"


### PR DESCRIPTION
Skip K8S tests for features other than K8s. This way we don't need to pull and compile k8s dependencies.