### PR TITLE
chore: remove cfg_if crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,6 @@ dependencies = [
  "assert_fs",
  "async-trait",
  "bollard",
- "cfg-if",
  "clap",
  "ctrlc",
  "duration-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ulid = "1.0.1"
 openssl = { version = "0.10.57", features = ["vendored"] }
 aquamarine = "0.3.2"
 duration-str = "0.7.0"
-cfg-if = "1.0.0"
 
 # OnHost subagent dependencies
 # IMPORTANT: All onhost only deps needs to be `optional = true` so they won't be compiled by default


### PR DESCRIPTION
Using `#[cfg()]` macro logic instead of `if_cfg` create