### PR TITLE
`Makefile`: use `?=` assignment for `ARCH` and `BUILD_MODE`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ help:
 	@echo $(addsuffix -clean,$(TARGETS))
 
 
-ARCH:=arm64
-BUILD_MODE:=release
+ARCH ?= arm64
+BUILD_MODE ?= release
 
 .PHONY: build-super-agent 
 # Cross-compilation only works from amd64 host.


### PR DESCRIPTION
We update assignment operator for Makefile variables `ARCH` and `BUILD_MODE`  to use `?=` such that pre-existing assignments to those variables are not overridden.