### PR TITLE
`super_agent.rs`: suppress an expected warning.

### DIFF
--- a/src/super_agent/super_agent.rs
+++ b/src/super_agent/super_agent.rs
@@ -128,8 +128,7 @@ where
                 Err(HashRepositoryError::WrongPath) => {
                     // The wrong path error occurs if there is no remote config hash yaml
                     // file available. This can occur, e.g., if no remote config has been
-                    // created. We suppress this error message here because it is an expected
-                    // condition.
+                    // created. Suppress this error message because it is an expected condition.
                     None
                 }
                 maybe_remote_config_hash => {


### PR DESCRIPTION
We suppress the warning log message for the case where the remote config hash file is not yet initialized.