### PR TITLE
Add `nr-ebpf-agent` and `nr-ebpf-agent-client`.

### DIFF
--- a/src/config/agent_type_registry.rs
+++ b/src/config/agent_type_registry.rs
@@ -6,7 +6,6 @@ use crate::super_agent::defaults::{
     NEWRELIC_INFRA_TYPE,
     NRDOT_TYPE,
     NR_EBPF_AGENT_TYPE,
-    NR_EBPF_AGENT_CLIENT_TYPE,
 };
 
 use super::agent_type::agent_types::FinalAgent;
@@ -37,7 +36,6 @@ impl Default for LocalRegistry {
             NEWRELIC_INFRA_TYPE,
             NRDOT_TYPE,
             NR_EBPF_AGENT_TYPE,
-            NR_EBPF_AGENT_CLIENT_TYPE,
         ];
 
         agent_types.map(|agent_type| {

--- a/src/super_agent/defaults.rs
+++ b/src/super_agent/defaults.rs
@@ -71,24 +71,13 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/nr-ebpf-agent
-    restart_policy:
-      backoff_strategy:
-        type: fixed
-        backoff_delay_seconds: 5
-"#;
-
-// NR_EBPF_AGENT_CLIENT_TYPE AgentType
-pub(crate) const NR_EBPF_AGENT_CLIENT_TYPE: &str = r#"
-namespace: newrelic
-name: com.newrelic.nr_ebpf_client
-version: 0.0.1
-variables:
-deployment:
-  on_host:
-    executables:
+        restart_policy:
+           backoff_strategy:
+           type: fixed
+           backoff_delay_seconds: 5
       - path: /usr/bin/nr-ebpf-agent-client
-    restart_policy:
-      backoff_strategy:
-        type: fixed
-        backoff_delay_seconds: 5
+        restart_policy:
+           backoff_strategy:
+           type: fixed
+           backoff_delay_seconds: 5
 "#;


### PR DESCRIPTION
We add `nr-ebpf-agent` and `nr-ebpf-agent-client` to the default set of known agent types.