### PR TITLE
`uncompressor_deb.go`: support different tar file extensions.

### DIFF
--- a/build/embedded/uncompressor_deb.go
+++ b/build/embedded/uncompressor_deb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"errors"
 	"os/exec"
 	"path/filepath"
 )
@@ -14,16 +15,47 @@ func NewUncompressorDeb(uncompressorTarGz UncompressorTarGz) *UncompressorDeb {
 	return &UncompressorDeb{uncompressorTarGz: uncompressorTarGz}
 }
 
-func (u UncompressorDeb) Uncompress(compressedFilePath string, fileType FileType, destination string) error {
-	cmd := exec.Command("ar", []string{"x", compressedFilePath}...)
+func filePathExists(filePath string) bool {
+	if _, err := os.Stat(filePath); err == nil {
+		return true
+	}
+	return false
+}
+
+func uncompressDeb(debFilePath string, destination string) error {
+	cmd := exec.Command("ar", []string{"x", debFilePath}...)
 	cmd.Dir = destination
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 
 	err := cmd.Run()
+	return err
+}
+
+func (u UncompressorDeb) Uncompress(compressedFilePath string, fileType FileType, destination string) error {
+	err := uncompressDeb(compressedFilePath, destination)
 	if err != nil {
 		return err
 	}
 
-	return u.uncompressorTarGz.Uncompress(filepath.Join(destination, "data.tar.gz"), fileType, destination)
+	// A list of expected filenames for the data tarball.
+	tarFileNames := []string{"data.tar.gz", "data.tar"}
+	var errs error
+
+	// Try each filename in the list tarFileNames.
+	for _, tarFileName := range tarFileNames {
+		tarFilePath := filepath.Join(destination, tarFileName)
+		if filePathExists(tarFilePath) {
+			err := u.uncompressorTarGz.Uncompress(tarFilePath, fileType, destination)
+			if err == nil {
+				// We only need one data tarball to uncompress.
+				// If we get here, any previous errors can be discarded.
+				return nil
+			}
+			errs = errors.Join(errs, err)
+		} else {
+			errs = errors.Join(errs, errors.New("Could not find file path: " + tarFilePath))
+		}
+	}
+	return errs
 }


### PR DESCRIPTION
Summary: Some `.deb` files have file `data.tar` but not `data.tar.gz`. In this patch, we update the tar file uncompressor to support both filenames.

Test plan: We discovered this issue when testing with `.deb` files produced by the Bazel [pkg_tar rule](https://docs.bazel.build/versions/1.0.0/be/pkg.html#pkg_tar) which defaults to not using any compression type. When re-testing using this patch, the uncompressor succeeds.