### PR TITLE
Bundle the New Relic eBPF agent for install.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ builds:
   -
     main: ./build/dummy.go
     goarch:
-      - arm64
       - amd64
     goos:
       - linux
@@ -65,6 +64,11 @@ nfpms:
         dst: /usr/bin/newrelic-infra
       - src: build/embedded/artifacts/{{- .Arch }}/newrelic-infra/LICENSE.txt
         dst: /var/db/newrelic-infra/LICENSE.txt
+      # eBPF agent
+      - src: build/embedded/artifacts/{{- .Arch }}/nr-ebpf-agent/nr-ebpf-agent
+        dst: /usr/bin/nr-ebpf-agent
+      - src: build/embedded/artifacts/{{- .Arch }}/nr-ebpf-agent-client/nr-ebpf-agent-client
+        dst: /usr/bin/nr-ebpf-agent-client
       # nri-docker
       - src: build/embedded/artifacts/{{- .Arch }}/nri-docker
         dst: /var/db/newrelic-infra/newrelic-integrations/bin/nri-docker

--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -55,6 +55,17 @@ artifacts:
         src: etc/newrelic-infra/logging.d/tcp.yml.example
         dest: artifacts/{{.Arch}}/fluent-bit
 
+  - name: nr-ebpf-agent
+    version: 0.0.1
+    url: http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/nr-ebpf-agent/nr-ebpf-agent_{{.Version | trimv}}_{{.Arch}}.deb
+    files:
+      - name: nr-ebpf-agent binary
+        src: usr/bin/nr-ebpf-agent
+        dest: artifacts/{{.Arch}}/nr-ebpf-agent
+      - name: nt-ebpf-agent-client binary
+        src: usr/bin/nr-ebpf-agent-client
+        dest: artifacts/{{.Arch}}/nr-ebpf-agent-client
+
   - name: nr-otel-collector
     version: 0.5.0
     url: https://github.com/newrelic/opentelemetry-collector-releases/releases/download/nr-otel-collector-{{.Version | trimv}}/nr-otel-collector_{{.Version | trimv}}_linux_{{.Arch}}.deb


### PR DESCRIPTION
Summary: We add `nr-ebpf-agent` and `nr-ebpf-agent-client` as part of the default install bundle.

Test plan: WIP and nb `arm64` is not supported yet.