### PR TITLE
fix(SA): fix client and improve UX of make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ build-super-agent:
 	ARCH=$(ARCH) BUILD_MODE=$(BUILD_MODE) ./build/scripts/build_super_agent.sh
 
 .PHONY: build-dev-image
-build-dev-image: build-super-agent
+build-dev-image:
+	make build-super-agent BUILD_FEATURE=k8s
 	docker build . -t newrelic-super-agent:dev
 
 .PHONY: tilt-up

--- a/src/k8s/executor.rs
+++ b/src/k8s/executor.rs
@@ -36,11 +36,18 @@ impl K8sExecutor {
     ///
     pub async fn try_default(namespace: String) -> Result<K8sExecutor, K8sError> {
         debug!("trying inClusterConfig for k8s client");
-        let mut config = Config::incluster().unwrap_or({
-            debug!("inClusterConfig failed, trying kubeconfig for k8s client");
-            let c = KubeConfigOptions::default();
-            Config::from_kubeconfig(&c).await?
-        });
+
+        let mut config = match Config::incluster() {
+            Ok(c) => c,
+            Err(e) => {
+                debug!(
+                    "inClusterConfig failed {}, trying kubeconfig for k8s client",
+                    e
+                );
+                let c = KubeConfigOptions::default();
+                Config::from_kubeconfig(&c).await?
+            }
+        };
 
         config.default_namespace = namespace;
 


### PR DESCRIPTION
Two small fixes:
 - the make target is intended to build the image for K8s
 - unwrap_or does not compute the value in a lazy way. Therefore the default is always computed before the "actual" value. If it produces an error it makes the whole call to fail without testing the main path 