### PR TITLE
NR-179188 report invalid remote yaml for Super Agent

### DIFF
--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -14,7 +14,7 @@ pub enum SuperAgentConfigError {
     #[error("sub agents configuration not found in the remote config map")]
     SubAgentsNotFound,
 
-    #[error("`{0}`")]
+    #[error("configuration is not valid YAML: `{0}`")]
     InvalidYamlConfiguration(#[from] serde_yaml::Error),
 
     #[error("remote config error: `{0}`")]

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -144,7 +144,7 @@ pub(crate) mod tests {
         },
     };
 
-    use mockall::mock;
+    use mockall::{mock, predicate};
 
     mock! {
         pub SubAgentsConfigStore {}
@@ -163,6 +163,14 @@ pub(crate) mod tests {
             self.expect_load()
                 .once()
                 .returning(move || Ok(sub_agents_config.clone()));
+        }
+
+        pub fn should_store(&mut self, sub_agents_config: &SubAgentsConfig) {
+            let sub_agents_config = sub_agents_config.clone();
+            self.expect_store()
+                .once()
+                .with(predicate::eq(sub_agents_config))
+                .returning(move |_| Ok(()));
         }
     }
 

--- a/src/opamp/client_builder.rs
+++ b/src/opamp/client_builder.rs
@@ -122,9 +122,20 @@ pub(crate) mod test {
             });
         }
 
-        pub fn should_set_remote_config_status(&mut self, times: usize) {
+        // assertion just for the call of the method but not the remote
+        // status itself (so any remote config status)
+        pub fn should_set_any_remote_config_status(&mut self, times: usize) {
             self.expect_set_remote_config_status()
                 .times(times)
+                .returning(|_| Ok(()));
+        }
+
+        // assertion just for the call of the method but not the remote
+        // status itself (so any remote config status)
+        pub fn should_set_remote_config_status(&mut self, status: RemoteConfigStatus) {
+            self.expect_set_remote_config_status()
+                .once()
+                .with(predicate::eq(status))
                 .returning(|_| Ok(()));
         }
     }

--- a/src/sub_agent/collection.rs
+++ b/src/sub_agent/collection.rs
@@ -122,4 +122,16 @@ pub mod test {
             StartedSubAgents(value)
         }
     }
+
+    // allow creating an empty StartedSubAgents for testing
+    impl<S> Default for StartedSubAgents<S>
+    where
+        S: StartedSubAgent,
+    {
+        fn default() -> Self {
+            StartedSubAgents {
+                0: HashMap::default(),
+            }
+        }
+    }
 }

--- a/src/sub_agent/on_host/builder.rs
+++ b/src/sub_agent/on_host/builder.rs
@@ -209,7 +209,7 @@ mod test {
             |_, _, _| {
                 let mut started_client = MockOpAMPClientMock::new();
                 started_client.should_set_health(1);
-                started_client.should_set_remote_config_status(1);
+                started_client.should_set_any_remote_config_status(1);
                 started_client.should_stop(1);
                 Ok(started_client)
             },

--- a/src/sub_agent/opamp/mod.rs
+++ b/src/sub_agent/opamp/mod.rs
@@ -35,7 +35,7 @@ where
     report_remote_config_status(
         opamp_client,
         hash,
-        RemoteConfigStatuses::Applied as i32,
+        RemoteConfigStatuses::Failed as i32,
         error_msg,
     )
 }


### PR DESCRIPTION
The goal of this PR is to ensure that an invalid remote configuration for the Super Agent doesn't get applied nor breaks the execution.