### PR TITLE
chore: path instead of str in file reader

### DIFF
--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -12,19 +12,21 @@ pub enum FileReaderError {
 }
 
 pub trait FileReader {
-    fn read(&self, path: &str) -> Result<String, FileReaderError>;
+    fn read(&self, path: &Path) -> Result<String, FileReaderError>;
 }
 
 #[derive(Default)]
 pub struct FSFileReader;
 
 impl FileReader for FSFileReader {
-    fn read(&self, path: &str) -> Result<String, FileReaderError> {
-        let file_path = Path::new(&path);
+    fn read(&self, file_path: &Path) -> Result<String, FileReaderError> {
         if !file_path.is_file() {
-            return Err(FileReaderError::FileNotFound(path.to_string()));
+            return Err(FileReaderError::FileNotFound(format!(
+                "{}",
+                file_path.display()
+            )));
         }
-        match read_to_string(path) {
+        match read_to_string(file_path) {
             Err(e) => Err(FileReaderError::Read(e)),
             Ok(content) => Ok(content),
         }
@@ -36,33 +38,34 @@ pub mod test {
     use super::*;
     use mockall::{mock, predicate};
     use std::io::{Error, ErrorKind};
+    use std::path::PathBuf;
 
     mock! {
         pub FileReaderMock {}
 
         impl FileReader for FileReaderMock {
-            fn read(&self, path:&str) -> Result<String, FileReaderError>;
+            fn read(&self, path:&Path) -> Result<String, FileReaderError>;
         }
     }
 
     impl MockFileReaderMock {
-        pub fn should_read(&mut self, path: String, content: String) {
+        pub fn should_read(&mut self, path: &Path, content: String) {
             self.expect_read()
-                .with(predicate::eq(path.clone()))
+                .with(predicate::eq(PathBuf::from(path.clone())))
                 .times(1)
                 .returning(move |_| Ok(content.clone()));
         }
 
-        pub fn should_not_read_file_not_found(&mut self, path: String, error_message: String) {
+        pub fn should_not_read_file_not_found(&mut self, path: &Path, error_message: String) {
             self.expect_read()
-                .with(predicate::eq(path.clone()))
+                .with(predicate::eq(PathBuf::from(path.clone())))
                 .once()
                 .returning(move |_| Err(FileReaderError::FileNotFound(error_message.clone())));
         }
 
-        pub fn should_not_read_io_error(&mut self, path: String) {
+        pub fn should_not_read_io_error(&mut self, path: &Path) {
             self.expect_read()
-                .with(predicate::eq(path.clone()))
+                .with(predicate::eq(PathBuf::from(path.clone())))
                 .once()
                 .returning(move |_| {
                     Err(FileReaderError::Read(Error::from(
@@ -72,9 +75,9 @@ pub mod test {
         }
 
         // the test is not idempotent as it iterates hashmap. For now let's use this
-        pub fn could_read(&mut self, path: String, content: String) {
+        pub fn could_read(&mut self, path: &Path, content: String) {
             self.expect_read()
-                .with(predicate::eq(path.clone()))
+                .with(predicate::eq(PathBuf::from(path.clone())))
                 .returning(move |_| Ok(content.clone()));
         }
     }

--- a/src/opamp/remote_config_hash.rs
+++ b/src/opamp/remote_config_hash.rs
@@ -153,13 +153,10 @@ where
 
     fn get(&self, agent_id: &AgentID) -> Result<Hash, HashRepositoryError> {
         let mut conf_path = self.conf_path.clone();
-        let hash_path = self.hash_file_path(agent_id, &mut conf_path).to_str();
-        if let Some(path) = hash_path {
-            let contents = self.file_reader.read(path)?;
-            let result = serde_yaml::from_str(&contents);
-            return Ok(result?);
-        }
-        Err(HashRepositoryError::WrongPath)
+        let hash_path = self.hash_file_path(agent_id, &mut conf_path);
+        let contents = self.file_reader.read(hash_path)?;
+        let result = serde_yaml::from_str(&contents);
+        Ok(result?)
     }
 }
 
@@ -296,10 +293,7 @@ state: applied
         let mut expected_path = some_path.clone();
         expected_path.push(format!("{}.{}", agent_id.get(), HASH_FILE_EXTENSION));
 
-        file_reader_mock.should_read(
-            expected_path.to_str().unwrap().to_string(),
-            content.to_string(),
-        );
+        file_reader_mock.should_read(expected_path.as_path(), content.to_string());
         file_writer_mock.should_write(
             expected_path.as_path(),
             content.to_string(),


### PR DESCRIPTION
This PR changes the signature of the FileReader 
from
```rust
fn read(&self, path: &str) -> Result<String, FileReaderError>;
```
To
```rust
fn read(&self, file_path: &Path) -> Result<String, FileReaderError>;
```
