### PR TITLE
fix: allow for empty agents config

### DIFF
--- a/src/config/super_agent_configs.rs
+++ b/src/config/super_agent_configs.rs
@@ -80,6 +80,7 @@ impl Display for AgentID {
 /// SubAgentsConfig represents the configuration for the sub agents.
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
 pub struct SubAgentsConfig {
+    #[serde(default)]
     pub(crate) agents: HashMap<AgentID, SubAgentConfig>,
 }
 
@@ -113,7 +114,7 @@ impl TryFrom<&RemoteConfig> for SubAgentsConfig {
 #[serde(deny_unknown_fields)]
 pub struct SuperAgentConfig {
     /// agents is a map of agent types to their specific configuration (if any).
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub agents: SubAgentsConfig,
 
     /// opamp contains the OpAMP client configuration
@@ -207,6 +208,13 @@ agents:
     agent_type: namespace/agent_type:0.0.1
 "#;
 
+    const EXAMPLE_SUPERAGENT_CONFIG_NO_AGENTS: &str = r#"
+opamp:
+  endpoint: http://localhost:8080/some/path
+  headers:
+    some-key: some-value
+"#;
+
     const EXAMPLE_SUBAGENTS_CONFIG: &str = r#"
 agents:
   agent_1:
@@ -263,6 +271,9 @@ agents:
     #[test]
     fn basic_parse() {
         assert!(serde_yaml::from_str::<SuperAgentConfig>(EXAMPLE_SUPERAGENT_CONFIG).is_ok());
+        assert!(
+            serde_yaml::from_str::<SuperAgentConfig>(EXAMPLE_SUPERAGENT_CONFIG_NO_AGENTS).is_ok()
+        );
         assert!(serde_yaml::from_str::<SubAgentsConfig>(EXAMPLE_SUBAGENTS_CONFIG).is_ok())
     }
 


### PR DESCRIPTION
This addresses the detected situation in which a super agent config without the `agents` key causes the program to crash when it should be allowed.

I have my doubts wrt how the `SubAgentsConfig` type is defined, but just changing from

```rust
struct SubAgentsConfig {
    agents: HashMap<AgentID, SubAgentConfig>,
}
```

to

```rust
struct SubAgentsConfig (HashMap<AgentID, SubAgentConfig>)
```

makes the current `SubAgentsConfigStore` implementation to stop working, so I'd like to clarify its usage before proposing a refactor.
