### PR TITLE
Templatable unstructured yaml (NR-185395)

### DIFF
--- a/src/config/agent_type/runtime_config_templates.rs
+++ b/src/config/agent_type/runtime_config_templates.rs
@@ -161,7 +161,7 @@ impl Templateable for serde_yaml::Value {
             serde_yaml::Value::Sequence(seq) => {
                 serde_yaml::Value::Sequence(seq.template_with(variables)?)
             }
-            serde_yaml::Value::String(st) => template_value_string(st, variables)?,
+            serde_yaml::Value::String(st) => template_yaml_value_string(st, variables)?,
             _ => self,
         };
 
@@ -185,7 +185,7 @@ impl Templateable for serde_yaml::Sequence {
     }
 }
 
-fn template_value_string(
+fn template_yaml_value_string(
     st: String,
     variables: &NormalizedVariables,
 ) -> Result<serde_yaml::Value, AgentTypeError> {


### PR DESCRIPTION
This PR adds the ability to template arbitrary YAML in the config section.

Implements the `Templateable` trait to `serde_yaml::Value` and recurses if the `Value` is a `Mapping` of a `Sequence`.

We still have no mechanism to change the Value type from String to another value type. I left a comment as a TODO we will cover in a future iteration.