### PR TITLE
NR-182254: support casting in variables expansion for yaml

### DIFF
--- a/src/config/agent_type/runtime_config_templates.rs
+++ b/src/config/agent_type/runtime_config_templates.rs
@@ -66,8 +66,8 @@ fn replace(
 ) -> Result<String, AgentTypeError> {
     let value = normalized_var
         .final_value
-        .clone()
-        .or(normalized_var.default.clone())
+        .as_ref()
+        .or(normalized_var.default.as_ref())
         .ok_or(AgentTypeError::MissingTemplateKey(var_name.to_string()))?
         .to_string();
     Ok(re.replace(s, value).to_string())


### PR DESCRIPTION
## Context

This PR adds support to variable types when expanding variables in unstructured yaml fields. 

### Example:

**Variables**
```yaml
# (simplified example, not proper syntax)
var1: true # bool type
var2: 8 # number type
var3: thing # string type
```

**Template**
```yaml
key1: ${var1} # This should be true, not "true"
key2: ${var2} # This should be 8 not "8"
key3: thing
key4: ${var1}-${var2} # This needs to be a string "true-8"
```

## Notes for reviewers

* The implementation involves a small refactor (I've included it in the same PR because the scope is really narrow, it's in the [first commit](def74a5e9431225581318f9188e4478a08bdc8a1)): I needed to split the `template_string` function into smaller functions in order to avoid repeating its code.