### PR TITLE
fix(k8s): default helmRelease apiVersion

### DIFF
--- a/src/config/super_agent_configs.rs
+++ b/src/config/super_agent_configs.rs
@@ -218,7 +218,7 @@ fn default_group_version_kinds() -> Vec<TypeMeta> {
             kind: "HelmRepository".to_string(),
         },
         TypeMeta {
-            api_version: "helm.toolkit.fluxcd.io/v2beta1".to_string(),
+            api_version: "helm.toolkit.fluxcd.io/v2beta2".to_string(),
             kind: "HelmRelease".to_string(),
         },
     ]


### PR DESCRIPTION
fixing apiVersion name of [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/) CRD