### PR TITLE
fix(executor): avoid multiple client creation

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -147,12 +147,6 @@ fn run_super_agent(
     let sub_agent_hash_repository = HashRepositoryFile::new_sub_agent_repository();
     let k8s_config = config_storer.load()?.k8s.ok_or(AgentError::K8sConfig())?;
 
-    let instance_id_getter =
-        futures::executor::block_on(ULIDInstanceIDGetter::try_with_identifiers(
-            k8s_config.namespace.clone(),
-            instance_id::get_identifiers(k8s_config.cluster_name),
-        ))?;
-
     // Initialize K8sExecutor
     // TODO: once we know how we're going to use the K8sExecutor, we might need to refactor and move this.
     let executor = Arc::new(
@@ -164,6 +158,13 @@ fn run_super_agent(
         )
         .map_err(|e| AgentError::ExternalError(e.to_string()))?,
     );
+
+    let instance_id_getter =
+        futures::executor::block_on(ULIDInstanceIDGetter::try_with_identifiers(
+            executor.clone(),
+            instance_id::get_identifiers(k8s_config.cluster_name),
+        ))?;
+
     /////////////////////////
 
     let sub_agent_builder = newrelic_super_agent::sub_agent::k8s::builder::K8sSubAgentBuilder::new(

--- a/src/k8s/error.rs
+++ b/src/k8s/error.rs
@@ -4,8 +4,8 @@ use kube::{api, config::KubeconfigError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum K8sError {
-    #[error("it is not possible to create a k8s client")]
-    UnableToSetupClient,
+    #[error("it is not possible to create a k8s client: {0}")]
+    UnableToSetupClient(String),
 
     #[error("the kube client returned an error: `{0}`")]
     Generic(#[from] kube::Error),

--- a/src/opamp/instance_id/k8s/getter.rs
+++ b/src/opamp/instance_id/k8s/getter.rs
@@ -2,6 +2,7 @@ use crate::k8s;
 use crate::opamp::instance_id::getter::ULIDInstanceIDGetter;
 use crate::opamp::instance_id::k8s::storer::{Storer, StorerError};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::executor::K8sExecutor;
@@ -26,12 +27,9 @@ pub enum GetterError {
 
 impl ULIDInstanceIDGetter<Storer> {
     pub async fn try_with_identifiers(
-        namespace: String,
+        executor: Arc<K8sExecutor>,
         identifiers: Identifiers,
     ) -> Result<Self, GetterError> {
-        Ok(Self::new(
-            Storer::new(K8sExecutor::try_new(namespace).await?),
-            identifiers,
-        ))
+        Ok(Self::new(Storer::new(executor), identifiers))
     }
 }

--- a/test/k8s/executor.rs
+++ b/test/k8s/executor.rs
@@ -8,6 +8,14 @@ use std::time::Duration;
 // tokio test runs with 1 thread by default causing deadlock when executing `block_on` code during test helper drop.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs k8s cluster"]
+async fn k8s_client_creation_fail() {
+    let test_ns = "test-not-existing-namespace";
+    assert!(K8sExecutor::try_new(test_ns.to_string()).await.is_err());
+}
+
+// tokio test runs with 1 thread by default causing deadlock when executing `block_on` code during test helper drop.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs k8s cluster"]
 async fn k8s_create_dynamic_resource() {
     let mut test = K8sEnv::new().await;
     let test_ns = test.test_namespace().await;


### PR DESCRIPTION
This PR:
 - removes the creation of a second executor client
 - test default_namespace existence