### PR TITLE
NR-198795 Sub Agents Event loop - Implementation (2)

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,10 +4,9 @@ use newrelic_super_agent::event::SuperAgentEvent;
 #[cfg(feature = "k8s")]
 use newrelic_super_agent::opamp::instance_id;
 use newrelic_super_agent::opamp::instance_id::getter::ULIDInstanceIDGetter;
-#[cfg(feature = "onhost")]
-use newrelic_super_agent::opamp::instance_id::IdentifiersProvider;
+
 use newrelic_super_agent::opamp::remote_config_hash::HashRepositoryFile;
-use newrelic_super_agent::sub_agent::values::values_repository::ValuesRepositoryFile;
+
 use newrelic_super_agent::super_agent::error::AgentError;
 use newrelic_super_agent::super_agent::opamp::client_builder::SuperAgentOpAMPHttpBuilder;
 use newrelic_super_agent::super_agent::super_agent::{super_agent_fqn, SuperAgent};
@@ -81,12 +80,17 @@ fn run_super_agent(
     super_agent_consumer: EventConsumer<SuperAgentEvent>,
     opamp_client_builder: Option<SuperAgentOpAMPHttpBuilder>,
 ) -> Result<(), AgentError> {
+    use newrelic_super_agent::opamp::instance_id::IdentifiersProvider;
+    use newrelic_super_agent::sub_agent::values::values_repository::{
+        ValuesRepository, ValuesRepositoryFile,
+    };
     use newrelic_super_agent::{
         config::super_agent_configs::AgentID, opamp::operations::build_opamp_and_start_client,
-        sub_agent::on_host::event_processor_builder::SubAgentEventProcessorBuilder,
+        sub_agent::on_host::event_processor_builder::EventProcessorBuilder,
         sub_agent::opamp::client_builder::SubAgentOpAMPHttpBuilder,
         super_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler,
     };
+    use std::sync::Arc;
 
     #[cfg(unix)]
     if !nix::unistd::Uid::effective().is_root() {
@@ -97,9 +101,12 @@ fn run_super_agent(
         ULIDInstanceIDGetter::default().with_identifiers(IdentifiersProvider::default().provide());
 
     let hash_repository = HashRepositoryFile::default();
-    let sub_agent_hash_repository = HashRepositoryFile::new_sub_agent_repository();
     let agents_assembler = LocalEffectiveAgentsAssembler::default().with_remote();
-    let sub_agent_event_processor_builder = SubAgentEventProcessorBuilder;
+    // HashRepo and ValuesRepo needs to be shared between threads
+    let sub_agent_hash_repository = Arc::new(HashRepositoryFile::new_sub_agent_repository());
+    let values_repository = Arc::new(ValuesRepositoryFile::default());
+    let sub_agent_event_processor_builder =
+        EventProcessorBuilder::new(sub_agent_hash_repository.clone(), values_repository.clone());
 
     let sub_agent_opamp_builder = opamp_client_builder
         .as_ref()
@@ -108,13 +115,12 @@ fn run_super_agent(
         newrelic_super_agent::sub_agent::on_host::builder::OnHostSubAgentBuilder::new(
             sub_agent_opamp_builder.as_ref(),
             &instance_id_getter,
-            &sub_agent_hash_repository,
+            sub_agent_hash_repository,
             &agents_assembler,
             &sub_agent_event_processor_builder,
         );
 
     info!("Starting the super agent");
-    let values_repository = ValuesRepositoryFile::default();
 
     let (super_agent_opamp_publisher, super_agent_opamp_consumer) = pub_sub();
 
@@ -127,13 +133,16 @@ fn run_super_agent(
         super_agent_opamp_non_identifying_attributes(),
     )?;
 
+    if maybe_client.is_none() {
+        // Delete remote values
+        values_repository.delete_remote_all()?;
+    }
+
     SuperAgent::new(
         maybe_client,
         &hash_repository,
         sub_agent_builder,
         config_storer,
-        &sub_agent_hash_repository,
-        values_repository,
     )
     .run(
         super_agent_consumer,
@@ -152,7 +161,6 @@ fn run_super_agent(
     };
 
     let hash_repository = HashRepositoryFile::default();
-    let sub_agent_hash_repository = HashRepositoryFile::new_sub_agent_repository();
     let k8s_config = config_storer.load()?.k8s.ok_or(AgentError::K8sConfig())?;
 
     let instance_id_getter =
@@ -180,7 +188,6 @@ fn run_super_agent(
     );
 
     info!("Starting the super agent");
-    let values_repository = ValuesRepositoryFile::default();
     let (opamp_publisher, opamp_consumer) = pub_sub();
 
     let maybe_client = build_opamp_and_start_client(
@@ -197,8 +204,6 @@ fn run_super_agent(
         &hash_repository,
         sub_agent_builder,
         config_storer,
-        &sub_agent_hash_repository,
-        values_repository,
     )
     .run(super_agent_consumer, (opamp_publisher, opamp_consumer))
 }

--- a/src/sub_agent/error.rs
+++ b/src/sub_agent/error.rs
@@ -7,6 +7,7 @@ use crate::opamp::remote_config_hash::HashRepositoryError;
 use crate::super_agent::effective_agents_assembler::EffectiveAgentsAssemblerError;
 
 use crate::config::agent_values::AgentValuesError;
+use crate::event::channel::EventPublisherError;
 use crate::opamp::remote_config::RemoteConfigError;
 use crate::sub_agent::values::values_repository::ValuesRepositoryError;
 use thiserror::Error;
@@ -52,6 +53,9 @@ pub enum SubAgentError {
 
     #[error("Supervisor stop error: `{0}`")]
     SupervisorStopError(String),
+
+    #[error("Error publishing event: `{0}`")]
+    EventPublisherError(#[from] EventPublisherError),
 }
 
 #[derive(Error, Debug)]

--- a/src/sub_agent/mod.rs
+++ b/src/sub_agent/mod.rs
@@ -81,6 +81,14 @@ pub mod test {
         }
     }
 
+    impl MockNotStartedSubAgent {
+        pub fn should_run(&mut self, started_sub_agent: MockStartedSubAgent) {
+            self.expect_run()
+                .once()
+                .return_once(move || Ok(started_sub_agent));
+        }
+    }
+
     mock! {
         pub SubAgentBuilderMock {}
 
@@ -114,12 +122,12 @@ pub mod test {
                 Ok(not_started_sub_agent)
             });
         }
-        // should_build_running provides a helper method to create a Sub Agent which runs
-        // successfully and does not stop
-        pub(crate) fn should_build_running(
+
+        pub(crate) fn should_build_not_started(
             &mut self,
             agent_id: &AgentID,
             sub_agent_config: SubAgentConfig,
+            sub_agent: MockNotStartedSubAgent,
         ) {
             self.expect_build()
                 .once()
@@ -129,14 +137,7 @@ pub mod test {
                     predicate::always(),
                     predicate::always(),
                 )
-                .returning(|_, _, _, _| {
-                    let mut not_started_sub_agent = MockNotStartedSubAgent::new();
-                    not_started_sub_agent
-                        .expect_run()
-                        .once()
-                        .returning(|| Ok(MockStartedSubAgent::new()));
-                    Ok(not_started_sub_agent)
-                });
+                .return_once(move |_, _, _, _| Ok(sub_agent));
         }
 
         pub(crate) fn should_not_build(&mut self, times: usize) {

--- a/src/sub_agent/on_host/builder.rs
+++ b/src/sub_agent/on_host/builder.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[cfg(unix)]
 use nix::unistd::gethostname;
@@ -13,7 +14,6 @@ use crate::opamp::remote_config_report::{
     report_remote_config_status_applied, report_remote_config_status_error,
 };
 
-#[cfg_attr(test, mockall_double::double)]
 use crate::sub_agent::on_host::event_processor_builder::SubAgentEventProcessorBuilder;
 use crate::sub_agent::on_host::sub_agent::NotStarted;
 use crate::sub_agent::on_host::supervisor::command_supervisor;
@@ -42,33 +42,35 @@ use super::{
     },
 };
 
-pub struct OnHostSubAgentBuilder<'a, O, I, HR, A>
-where
-    O: OpAMPClientBuilder<SubAgentCallbacks>,
-    I: InstanceIDGetter,
-    // HR: HashRepository, // TODO??
-    A: EffectiveAgentsAssembler,
-{
-    opamp_builder: Option<&'a O>,
-    instance_id_getter: &'a I,
-    hash_repository: &'a HR,
-    effective_agent_assembler: &'a A,
-    event_processor_builder: &'a SubAgentEventProcessorBuilder,
-}
-
-impl<'a, O, I, HR, A> OnHostSubAgentBuilder<'a, O, I, HR, A>
+pub struct OnHostSubAgentBuilder<'a, O, I, HR, A, E>
 where
     O: OpAMPClientBuilder<SubAgentCallbacks>,
     I: InstanceIDGetter,
     HR: HashRepository,
     A: EffectiveAgentsAssembler,
+    E: SubAgentEventProcessorBuilder<O::Client>,
+{
+    opamp_builder: Option<&'a O>,
+    instance_id_getter: &'a I,
+    hash_repository: Arc<HR>,
+    effective_agent_assembler: &'a A,
+    event_processor_builder: &'a E,
+}
+
+impl<'a, O, I, HR, A, E> OnHostSubAgentBuilder<'a, O, I, HR, A, E>
+where
+    O: OpAMPClientBuilder<SubAgentCallbacks>,
+    I: InstanceIDGetter,
+    HR: HashRepository,
+    A: EffectiveAgentsAssembler,
+    E: SubAgentEventProcessorBuilder<O::Client>,
 {
     pub fn new(
         opamp_builder: Option<&'a O>,
         instance_id_getter: &'a I,
-        hash_repository: &'a HR,
+        hash_repository: Arc<HR>,
         effective_agent_assembler: &'a A,
-        event_processor_builder: &'a SubAgentEventProcessorBuilder,
+        event_processor_builder: &'a E,
     ) -> Self {
         Self {
             opamp_builder,
@@ -80,14 +82,18 @@ where
     }
 }
 
-impl<'a, O, I, HR, A> SubAgentBuilder for OnHostSubAgentBuilder<'a, O, I, HR, A>
+impl<'a, O, I, HR, A, E> SubAgentBuilder for OnHostSubAgentBuilder<'a, O, I, HR, A, E>
 where
     O: OpAMPClientBuilder<SubAgentCallbacks>,
     I: InstanceIDGetter,
     HR: HashRepository,
     A: EffectiveAgentsAssembler,
+    E: SubAgentEventProcessorBuilder<O::Client>,
 {
-    type NotStartedSubAgent = SubAgentOnHost<NotStarted<O::Client>, command_supervisor::NotStarted>;
+    type NotStartedSubAgent = SubAgentOnHost<
+        NotStarted<O::Client, E::SubAgentEventProcessor>,
+        command_supervisor::NotStarted,
+    >;
 
     fn build(
         &self,
@@ -211,8 +217,9 @@ mod test {
     use crate::opamp::instance_id::getter::test::MockInstanceIDGetterMock;
     use crate::opamp::remote_config_hash::test::MockHashRepositoryMock;
     use crate::opamp::remote_config_hash::Hash;
-    use crate::sub_agent::on_host::event_processor::MockEventProcessor;
-    use crate::sub_agent::on_host::event_processor_builder::MockSubAgentEventProcessorBuilder;
+    use crate::sub_agent::on_host::event_processor::test::MockEventProcessorMock;
+    use crate::sub_agent::on_host::event_processor_builder::test::MockSubAgentEventProcessorBuilderMock;
+    use crate::sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock;
     use crate::sub_agent::{NotStartedSubAgent, StartedSubAgent};
     use crate::{
         config::agent_type::runtime_config::OnHost,
@@ -267,22 +274,22 @@ mod test {
             final_agent,
         );
 
-        let mut sub_agent_event_processor: MockEventProcessor<
+        let mut sub_agent_event_processor: MockEventProcessorMock<
             MockStartedOpAMPClientMock<SubAgentCallbacks>,
-        > = MockEventProcessor::default();
+        > = MockEventProcessorMock::default();
 
         let mut started_client = MockStartedOpAMPClientMock::new();
         started_client.should_stop(1);
         started_client.should_set_health(1);
         sub_agent_event_processor.should_process(Some(started_client));
 
-        let mut sub_agent_event_processor_builder = MockSubAgentEventProcessorBuilder::new();
+        let mut sub_agent_event_processor_builder = MockSubAgentEventProcessorBuilderMock::new();
         sub_agent_event_processor_builder.should_build(sub_agent_event_processor);
 
         let on_host_builder = OnHostSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
-            &hash_repository_mock,
+            Arc::new(hash_repository_mock),
             &effective_agent_assembler,
             &sub_agent_event_processor_builder,
         );
@@ -346,18 +353,18 @@ mod test {
             Hash::failed("a-hash".to_string(), "this is an error message".to_string());
         hash_repository_mock.should_get_hash(&sub_agent_id, failed_hash);
 
-        let sub_agent_event_processor: MockEventProcessor<
+        let sub_agent_event_processor: MockEventProcessorMock<
             MockStartedOpAMPClientMock<SubAgentCallbacks>,
-        > = MockEventProcessor::default();
+        > = MockEventProcessorMock::default();
 
-        let mut sub_agent_event_processor_builder = MockSubAgentEventProcessorBuilder::new();
+        let mut sub_agent_event_processor_builder = MockSubAgentEventProcessorBuilderMock::new();
         sub_agent_event_processor_builder.should_build(sub_agent_event_processor);
 
         // Sub Agent Builder
         let on_host_builder = OnHostSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
-            &hash_repository_mock,
+            Arc::new(hash_repository_mock),
             &effective_agent_assembler,
             &sub_agent_event_processor_builder,
         );

--- a/src/sub_agent/on_host/event_handler/mod.rs
+++ b/src/sub_agent/on_host/event_handler/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opamp;

--- a/src/sub_agent/on_host/event_handler/opamp/invalid_remote_config.rs
+++ b/src/sub_agent/on_host/event_handler/opamp/invalid_remote_config.rs
@@ -1,0 +1,115 @@
+use futures::executor::block_on;
+use opamp_client::opamp::proto::{RemoteConfigStatus, RemoteConfigStatuses};
+use opamp_client::StartedClient;
+
+use crate::opamp::remote_config_hash::HashRepository;
+use crate::sub_agent::on_host::event_processor::EventProcessor;
+use crate::sub_agent::values::values_repository::ValuesRepository;
+use crate::sub_agent::SubAgentCallbacks;
+use crate::{opamp::remote_config::RemoteConfigError, super_agent::error::AgentError};
+
+impl<C, H, R> EventProcessor<C, H, R>
+where
+    C: StartedClient<SubAgentCallbacks> + 'static,
+    H: HashRepository,
+    R: ValuesRepository,
+{
+    pub(crate) fn invalid_remote_config(
+        &self,
+        remote_config_error: RemoteConfigError,
+    ) -> Result<(), AgentError> {
+        if self.maybe_opamp_client.is_some() {
+            if let RemoteConfigError::InvalidConfig(hash, error) = remote_config_error {
+                block_on(
+                    self.maybe_opamp_client
+                        .as_ref()
+                        .unwrap()
+                        .set_remote_config_status(RemoteConfigStatus {
+                            last_remote_config_hash: hash.into_bytes(),
+                            error_message: error,
+                            status: RemoteConfigStatuses::Failed as i32,
+                        }),
+                )?;
+                Ok(())
+            } else {
+                unreachable!()
+            }
+        } else {
+            unreachable!("got remote config without OpAMP being enabled")
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use crate::event::channel::pub_sub;
+    use crate::opamp::client_builder::test::MockStartedOpAMPClientMock;
+    use crate::opamp::remote_config::RemoteConfigError::InvalidConfig;
+    use crate::opamp::remote_config_hash::test::MockHashRepositoryMock;
+    use crate::opamp::remote_config_hash::Hash;
+    use crate::sub_agent::on_host::event_processor::EventProcessor;
+    use crate::sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock;
+    use crate::sub_agent::SubAgentCallbacks;
+    use opamp_client::opamp::proto::RemoteConfigStatus;
+    use opamp_client::opamp::proto::RemoteConfigStatuses::Failed;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_error_is_reported_to_opamp() {
+        let mut opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, _sub_agent_consumer) = pub_sub();
+        let (_sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let hash_repository = MockHashRepositoryMock::default();
+        let values_repository = MockRemoteValuesRepositoryMock::default();
+
+        let hash = Hash::new(String::from("some-hash"));
+
+        // report failed config
+        let status = RemoteConfigStatus {
+            status: Failed as i32,
+            last_remote_config_hash: hash.get().into_bytes(),
+            error_message: "some error".to_string(),
+        };
+        opamp_client.should_set_remote_config_status(status);
+
+        let remote_config_error =
+            InvalidConfig(String::from("some-hash"), String::from("some error"));
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+
+        event_processor
+            .invalid_remote_config(remote_config_error)
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_no_opamp_should_panic() {
+        let (sub_agent_publisher, _sub_agent_consumer) = pub_sub();
+        let (_sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let hash_repository = MockHashRepositoryMock::default();
+        let values_repository = MockRemoteValuesRepositoryMock::default();
+
+        let remote_config_error =
+            InvalidConfig(String::from("some-hash"), String::from("some error"));
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            None::<MockStartedOpAMPClientMock<SubAgentCallbacks>>,
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+
+        let _ = event_processor.invalid_remote_config(remote_config_error);
+    }
+}

--- a/src/sub_agent/on_host/event_handler/opamp/mod.rs
+++ b/src/sub_agent/on_host/event_handler/opamp/mod.rs
@@ -1,0 +1,2 @@
+pub(super) mod invalid_remote_config;
+pub(super) mod valid_remote_config;

--- a/src/sub_agent/on_host/event_handler/opamp/valid_remote_config.rs
+++ b/src/sub_agent/on_host/event_handler/opamp/valid_remote_config.rs
@@ -1,0 +1,229 @@
+use crate::event::SubAgentEvent;
+use crate::sub_agent::error::SubAgentError;
+use crate::sub_agent::on_host::event_processor::EventProcessor;
+use crate::sub_agent::SubAgentCallbacks;
+use crate::{
+    config::agent_values::AgentValues,
+    opamp::{
+        remote_config::RemoteConfig, remote_config_hash::HashRepository,
+        remote_config_report::report_remote_config_status_error,
+    },
+    sub_agent::values::values_repository::ValuesRepository,
+};
+use opamp_client::StartedClient;
+
+impl<C, S, R> EventProcessor<C, S, R>
+where
+    C: StartedClient<SubAgentCallbacks> + 'static,
+    S: HashRepository,
+    R: ValuesRepository,
+{
+    pub(crate) fn valid_remote_config(
+        &self,
+        remote_config: RemoteConfig,
+    ) -> Result<(), SubAgentError> {
+        if self.maybe_opamp_client.is_some() {
+            self.process_sub_agent_remote_config(remote_config)
+        } else {
+            unreachable!("got remote config without OpAMP being enabled")
+        }
+    }
+
+    fn process_sub_agent_remote_config(
+        &self,
+        mut remote_config: RemoteConfig,
+    ) -> Result<(), SubAgentError> {
+        self.sub_agent_remote_config_hash_repository
+            .save(&remote_config.agent_id, &remote_config.hash)?;
+        let remote_config_value = remote_config.get_unique()?;
+
+        // If remote config is empty, we delete the persisted remote config so later the store
+        // will load the local config
+        if remote_config_value.is_empty() {
+            self.remote_values_repo
+                .delete_remote(&remote_config.agent_id)?;
+        } else {
+            match AgentValues::try_from(remote_config_value.to_string()) {
+                // Invalid config will persist hash as invalid and report config status error to OpAMP
+                Err(err) => {
+                    remote_config.hash.fail(err.to_string());
+                    self.sub_agent_remote_config_hash_repository
+                        .save(&remote_config.agent_id, &remote_config.hash)?;
+
+                    report_remote_config_status_error(
+                        self.maybe_opamp_client.as_ref().unwrap(),
+                        &remote_config.hash,
+                        format!("Error applying Sub Agent remote config: {}", err),
+                    )?;
+                    return Err(err.into());
+                }
+                Ok(agent_values) => self
+                    .remote_values_repo
+                    .store_remote(&remote_config.agent_id, &agent_values)?,
+            }
+        }
+
+        Ok(self
+            .sub_agent_publisher
+            .publish(SubAgentEvent::ConfigUpdated(remote_config.agent_id.clone()))?)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::event::SubAgentEvent::ConfigUpdated;
+    use crate::sub_agent::on_host::event_processor::EventProcessor;
+    use crate::{
+        config::{
+            agent_type::trivial_value::TrivialValue, agent_values::AgentValues,
+            super_agent_configs::AgentID,
+        },
+        event::channel::pub_sub,
+        opamp::{
+            client_builder::test::MockStartedOpAMPClientMock,
+            remote_config::{ConfigMap, RemoteConfig},
+            remote_config_hash::{test::MockHashRepositoryMock, Hash},
+        },
+        sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock,
+    };
+    use opamp_client::opamp::proto::RemoteConfigStatus;
+    use opamp_client::opamp::proto::RemoteConfigStatuses::Failed;
+
+    #[test]
+    fn test_valid_config_not_empty() {
+        let opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, sub_agent_consumer) = pub_sub();
+        let (_sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let mut hash_repository = MockHashRepositoryMock::default();
+        let mut values_repository = MockRemoteValuesRepositoryMock::default();
+
+        // Event's config
+        let agent_id = AgentID::new("some-agent-id").unwrap();
+        let hash = Hash::new(String::from("some-hash"));
+        let config_map = ConfigMap::new(HashMap::from([(
+            "".to_string(),
+            "some_item: some_value".to_string(),
+        )]));
+
+        hash_repository.should_save_hash(&agent_id, &hash);
+        values_repository.should_store_remote(
+            &agent_id,
+            &AgentValues::new(HashMap::from([(
+                String::from("some_item"),
+                TrivialValue::String(String::from("some_value")),
+            )])),
+        );
+
+        let remote_config = RemoteConfig {
+            config_map,
+            hash,
+            agent_id: agent_id.clone(),
+        };
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+
+        event_processor.valid_remote_config(remote_config).unwrap();
+
+        let expected_event = ConfigUpdated(agent_id.clone());
+        assert_eq!(expected_event, sub_agent_consumer.as_ref().recv().unwrap());
+    }
+
+    #[test]
+    fn test_valid_config_empty() {
+        let opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, sub_agent_consumer) = pub_sub();
+        let (_sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let mut hash_repository = MockHashRepositoryMock::default();
+        let mut values_repository = MockRemoteValuesRepositoryMock::default();
+
+        // Event's config
+        let agent_id = AgentID::new("some-agent-id").unwrap();
+        let hash = Hash::new(String::from("some-hash"));
+        let config_map = ConfigMap::new(HashMap::from([("".to_string(), "".to_string())]));
+
+        hash_repository.should_save_hash(&agent_id, &hash);
+        values_repository.should_delete_remote(&agent_id);
+
+        let remote_config = RemoteConfig {
+            config_map,
+            hash,
+            agent_id: agent_id.clone(),
+        };
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+
+        event_processor.valid_remote_config(remote_config).unwrap();
+
+        let expected_event = ConfigUpdated(agent_id.clone());
+        assert_eq!(expected_event, sub_agent_consumer.as_ref().recv().unwrap());
+    }
+
+    #[test]
+    fn test_valid_config_invalid_values() {
+        let mut opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, _sub_agent_consumer) = pub_sub();
+        let (_sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let mut hash_repository = MockHashRepositoryMock::default();
+        let values_repository = MockRemoteValuesRepositoryMock::default();
+
+        // Event's config
+        let agent_id = AgentID::new("some-agent-id").unwrap();
+        let config_map = ConfigMap::new(HashMap::from([(
+            "".to_string(),
+            "this is not valid yaml".to_string(),
+        )]));
+
+        let mut hash = Hash::new(String::from("some-hash"));
+
+        let remote_config = RemoteConfig {
+            config_map,
+            hash: hash.clone(),
+            agent_id: agent_id.clone(),
+        };
+
+        hash_repository.should_save_hash(&agent_id, &hash);
+        // Fail the hash and report the error
+        hash.fail(String::from("invalid agent values format: `invalid type: string \"this is not valid yaml\", expected a map`"));
+        hash_repository.should_save_hash(&agent_id, &hash);
+
+        // report failed config
+        let status = RemoteConfigStatus {
+            status: Failed as i32,
+            last_remote_config_hash: hash.get().into_bytes(),
+            error_message: "Error applying Sub Agent remote config: invalid agent values format: `invalid type: string \"this is not valid yaml\", expected a map`".to_string(),
+        };
+        opamp_client.should_set_remote_config_status(status);
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+
+        let res = event_processor.valid_remote_config(remote_config);
+        assert_eq!(
+            "sub agent values error: `invalid agent values format: `invalid type: string \"this is not valid yaml\", expected a map``",
+            res.unwrap_err().to_string()
+        );
+    }
+}

--- a/src/sub_agent/on_host/event_processor.rs
+++ b/src/sub_agent/on_host/event_processor.rs
@@ -1,42 +1,70 @@
 use crate::event::channel::{EventConsumer, EventPublisher};
 use crate::event::{OpAMPEvent, SubAgentEvent};
+use crate::opamp::remote_config_hash::HashRepository;
+use crate::sub_agent::values::values_repository::ValuesRepository;
 use crate::sub_agent::SubAgentCallbacks;
 use crossbeam::select;
 use opamp_client::StartedClient;
+use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
-use tracing::debug;
+use tracing::{debug, error};
 
-pub struct EventProcessor<C>
+// This trait is meant for testing, there are no multiple implementations expected
+// It cannot be doubled as the implementation has a lifetime constraint
+pub trait SubAgentEventProcessor<C>
 where
     C: StartedClient<SubAgentCallbacks> + 'static,
 {
-    sub_agent_publisher: EventPublisher<SubAgentEvent>,
-    sub_agent_opamp_consumer: EventConsumer<OpAMPEvent>,
-    maybe_opamp_client: Option<C>,
+    fn process(self) -> JoinHandle<Option<C>>;
 }
 
-#[cfg_attr(test, mockall::automock)]
-impl<C> EventProcessor<C>
+pub struct EventProcessor<C, H, R>
 where
     C: StartedClient<SubAgentCallbacks> + 'static,
+    H: HashRepository,
+    R: ValuesRepository,
+{
+    pub(super) sub_agent_publisher: EventPublisher<SubAgentEvent>,
+    pub(super) sub_agent_opamp_consumer: EventConsumer<OpAMPEvent>,
+    pub(super) maybe_opamp_client: Option<C>,
+    pub(super) sub_agent_remote_config_hash_repository: Arc<H>,
+    pub(super) remote_values_repo: Arc<R>,
+}
+
+impl<C, H, R> EventProcessor<C, H, R>
+where
+    C: StartedClient<SubAgentCallbacks> + 'static,
+    H: HashRepository,
+    R: ValuesRepository,
 {
     pub fn new(
         sub_agent_publisher: EventPublisher<SubAgentEvent>,
         sub_agent_opamp_consumer: EventConsumer<OpAMPEvent>,
         maybe_opamp_client: Option<C>,
+        sub_agent_remote_config_hash_repository: Arc<H>,
+        remote_values_repo: Arc<R>,
     ) -> Self {
         EventProcessor {
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             maybe_opamp_client,
+            sub_agent_remote_config_hash_repository,
+            remote_values_repo,
         }
     }
+}
 
+impl<C, H, R> SubAgentEventProcessor<C> for EventProcessor<C, H, R>
+where
+    C: StartedClient<SubAgentCallbacks> + 'static,
+    H: HashRepository + Send + Sync + 'static,
+    R: ValuesRepository + Send + Sync + 'static,
+{
     // process will process the Sub Agent OpAMP events and will return the OpAMP client
     // when processing ends.
     // It will end when sub_agent_opamp_publisher is closed
-    pub fn process(self) -> JoinHandle<Option<C>> {
+    fn process(self) -> JoinHandle<Option<C>> {
         thread::spawn(move || {
             loop {
                 select! {
@@ -46,11 +74,17 @@ where
                                 debug!("channel closed");
                                 break;
                             }
-                            Ok(OpAMPEvent::InvalidRemoteConfigReceived(_remote_config_error)) => {
-                                debug!("InvalidRemoteConfigReceived");
+                            Ok(OpAMPEvent::InvalidRemoteConfigReceived(remote_config_error)) => {
+                                debug!("invalid remote config received");
+                                if let Err(e) = self.invalid_remote_config(remote_config_error){
+                                    error!("error processing invalid remote config: {}",e.to_string())
+                                }
                             }
-                            Ok(OpAMPEvent::ValidRemoteConfigReceived(_remote_config)) => {
-                                debug!("ValidRemoteConfigReceived");
+                            Ok(OpAMPEvent::ValidRemoteConfigReceived(remote_config)) => {
+                                debug!("valid remote config received");
+                                if let Err(e) = self.valid_remote_config(remote_config){
+                                     error!("error processing valid remote config: {}",e.to_string())
+                                }
                             }
                         }
                     }
@@ -67,18 +101,39 @@ pub mod test {
     use crate::event::channel::pub_sub;
     use crate::event::OpAMPEvent;
     use crate::opamp::client_builder::test::MockStartedOpAMPClientMock;
-    use crate::opamp::remote_config::RemoteConfigError::InvalidConfig;
-    use crate::opamp::remote_config::{ConfigMap, RemoteConfig};
+    use crate::opamp::remote_config::{ConfigMap, RemoteConfig, RemoteConfigError};
     use crate::opamp::remote_config_hash::Hash;
-    use crate::sub_agent::on_host::event_processor::{EventProcessor, MockEventProcessor};
+    use crate::sub_agent::on_host::event_processor::{EventProcessor, SubAgentEventProcessor};
+    use mockall::mock;
+    use opamp_client::opamp::proto::RemoteConfigStatus;
+    use opamp_client::opamp::proto::RemoteConfigStatuses::Failed;
     use opamp_client::StartedClient;
+    use std::collections::HashMap;
+    use std::sync::Arc;
     use std::thread;
+    use std::thread::JoinHandle;
 
+    use crate::config::agent_type::trivial_value::TrivialValue;
+    use crate::config::agent_values::AgentValues;
+    use crate::event::SubAgentEvent::ConfigUpdated;
+    use crate::opamp::remote_config_hash::test::MockHashRepositoryMock;
+    use crate::sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock;
     use crate::sub_agent::SubAgentCallbacks;
     use tracing_test::internal::logs_with_scope_contain;
     use tracing_test::traced_test;
 
-    impl<C> MockEventProcessor<C>
+    mock! {
+         pub EventProcessorMock<C> {}
+
+        impl<C> SubAgentEventProcessor<C> for EventProcessorMock<C>
+        where
+            C: StartedClient<SubAgentCallbacks> + 'static,
+        {
+            fn process(self) -> JoinHandle<Option<C>>;
+        }
+    }
+
+    impl<C> MockEventProcessorMock<C>
     where
         C: StartedClient<SubAgentCallbacks> + 'static,
     {
@@ -95,29 +150,73 @@ pub mod test {
         let opamp_client = MockStartedOpAMPClientMock::new();
         let (sub_agent_publisher, _sub_agent_consumer) = pub_sub();
         let (sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let hash_repository = MockHashRepositoryMock::default();
+        let values_repository = MockRemoteValuesRepositoryMock::default();
 
         let event_processor = EventProcessor::new(
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
         );
         let handle = event_processor.process();
 
-        // publish an event
-        sub_agent_opamp_publisher
-            .publish(OpAMPEvent::InvalidRemoteConfigReceived(InvalidConfig(
-                String::from("some"),
-                String::from("string"),
-            )))
-            .unwrap();
+        // close the OpAMP Publisher
+        drop(sub_agent_opamp_publisher);
 
-        // publish another event
+        handle.join().unwrap().unwrap();
+
+        assert!(logs_with_scope_contain(
+            "DEBUG newrelic_super_agent::sub_agent::on_host::event_processor",
+            "channel closed"
+        ));
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_valid_config() {
+        let opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, sub_agent_consumer) = pub_sub();
+        let (sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let mut hash_repository = MockHashRepositoryMock::default();
+        let mut values_repository = MockRemoteValuesRepositoryMock::default();
+
+        // Event's config
+        let agent_id = AgentID::new("some-agent-id").unwrap();
+        let hash = Hash::new(String::from("some-hash"));
+        let config_map = ConfigMap::new(HashMap::from([(
+            "".to_string(),
+            "some_item: some_value".to_string(),
+        )]));
+
+        hash_repository.should_save_hash(&agent_id, &hash);
+        values_repository.should_store_remote(
+            &agent_id,
+            &AgentValues::new(HashMap::from([(
+                String::from("some_item"),
+                TrivialValue::String(String::from("some_value")),
+            )])),
+        );
+
+        let remote_config = RemoteConfig {
+            config_map,
+            hash,
+            agent_id: agent_id.clone(),
+        };
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+        let handle = event_processor.process();
+
+        // publish event
         sub_agent_opamp_publisher
-            .publish(OpAMPEvent::ValidRemoteConfigReceived(RemoteConfig {
-                agent_id: AgentID::new("some-id").unwrap(),
-                hash: Hash::new(String::from("some-hash")),
-                config_map: ConfigMap::default(),
-            }))
+            .publish(OpAMPEvent::ValidRemoteConfigReceived(remote_config))
             .unwrap();
 
         // close the OpAMP Publisher
@@ -127,11 +226,55 @@ pub mod test {
 
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_super_agent::sub_agent::on_host::event_processor",
-            "InvalidRemoteConfigReceived"
+            "valid remote config received",
         ));
+
+        let expected_event = ConfigUpdated(agent_id.clone());
+        assert_eq!(expected_event, sub_agent_consumer.as_ref().recv().unwrap());
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_invalid_config() {
+        let mut opamp_client = MockStartedOpAMPClientMock::new();
+        let (sub_agent_publisher, _sub_agent_consumer) = pub_sub();
+        let (sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
+        let hash_repository = MockHashRepositoryMock::default();
+        let values_repository = MockRemoteValuesRepositoryMock::default();
+
+        opamp_client.should_set_remote_config_status(RemoteConfigStatus {
+            error_message: "this is an error message".to_string(),
+            status: Failed as i32,
+            last_remote_config_hash: "a-hash".as_bytes().to_vec(),
+        });
+
+        let remote_config_error = RemoteConfigError::InvalidConfig(
+            String::from("a-hash"),
+            String::from("this is an error message"),
+        );
+
+        let event_processor = EventProcessor::new(
+            sub_agent_publisher,
+            sub_agent_opamp_consumer,
+            Some(opamp_client),
+            Arc::new(hash_repository),
+            Arc::new(values_repository),
+        );
+        let handle = event_processor.process();
+
+        // publish event
+        sub_agent_opamp_publisher
+            .publish(OpAMPEvent::InvalidRemoteConfigReceived(remote_config_error))
+            .unwrap();
+
+        // close the OpAMP Publisher
+        drop(sub_agent_opamp_publisher);
+
+        handle.join().unwrap().unwrap();
+
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_super_agent::sub_agent::on_host::event_processor",
-            "ValidRemoteConfigReceived"
+            "invalid remote config received",
         ));
     }
 }

--- a/src/sub_agent/on_host/mod.rs
+++ b/src/sub_agent/on_host/mod.rs
@@ -3,6 +3,7 @@ pub mod command;
 pub mod supervisor;
 
 // Module implementing the SubAgent traits.
+pub mod event_handler;
 pub mod event_processor;
 pub mod event_processor_builder;
 pub mod sub_agent;

--- a/src/super_agent/event_handler/mod.rs
+++ b/src/super_agent/event_handler/mod.rs
@@ -1,1 +1,2 @@
 pub(super) mod opamp;
+pub(super) mod sub_agent;

--- a/src/super_agent/event_handler/opamp/invalid_remote_config.rs
+++ b/src/super_agent/event_handler/opamp/invalid_remote_config.rs
@@ -5,21 +5,19 @@ use opamp_client::StartedClient;
 use crate::{
     config::store::SubAgentsConfigStore,
     opamp::{remote_config::RemoteConfigError, remote_config_hash::HashRepository},
-    sub_agent::{values::values_repository::ValuesRepository, SubAgentBuilder},
+    sub_agent::SubAgentBuilder,
     super_agent::{
         error::AgentError,
         super_agent::{SuperAgent, SuperAgentCallbacks},
     },
 };
 
-impl<'a, S, O, HR, SL, HRS, VR> SuperAgent<'a, S, O, HR, SL, HRS, VR>
+impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,
     S: SubAgentBuilder,
     SL: SubAgentsConfigStore,
-    HRS: HashRepository,
-    VR: ValuesRepository,
 {
     pub(crate) fn invalid_remote_config(
         &self,

--- a/src/super_agent/event_handler/opamp/valid_remote_config.rs
+++ b/src/super_agent/event_handler/opamp/valid_remote_config.rs
@@ -5,7 +5,7 @@ use tracing::{error, info};
 
 use crate::event::SubAgentEvent;
 use crate::{
-    config::{agent_values::AgentValues, store::SubAgentsConfigStore},
+    config::store::SubAgentsConfigStore,
     event::channel::EventPublisher,
     opamp::{
         remote_config::RemoteConfig,
@@ -16,8 +16,7 @@ use crate::{
         },
     },
     sub_agent::{
-        collection::StartedSubAgents, logger::AgentLog,
-        values::values_repository::ValuesRepository, NotStartedSubAgent, SubAgentBuilder,
+        collection::StartedSubAgents, logger::AgentLog, NotStartedSubAgent, SubAgentBuilder,
     },
     super_agent::{
         error::AgentError,
@@ -25,14 +24,12 @@ use crate::{
     },
 };
 
-impl<'a, S, O, HR, SL, HRS, VR> SuperAgent<'a, S, O, HR, SL, HRS, VR>
+impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,
     S: SubAgentBuilder,
     SL: SubAgentsConfigStore,
-    HRS: HashRepository,
-    VR: ValuesRepository,
 {
     pub(crate) fn valid_remote_config(
         &self,
@@ -43,15 +40,6 @@ where
         >,
         tx: Sender<AgentLog>,
     ) -> Result<(), AgentError> {
-        if !remote_config.agent_id.is_super_agent_id() {
-            return self.process_sub_agent_remote_config(
-                remote_config,
-                sub_agents,
-                tx,
-                sub_agent_publisher,
-            );
-        }
-
         if let Some(opamp_client) = &self.opamp_client {
             self.process_super_agent_remote_config(
                 opamp_client,
@@ -65,58 +53,6 @@ where
         }
     }
 
-    // TODO This call should be moved to on subagent event loop when opamp event remote_config
-    // Sub Agent on remote config
-    fn process_sub_agent_remote_config(
-        &self,
-        mut remote_config: RemoteConfig,
-        sub_agents: &mut StartedSubAgents<
-            <S::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
-        >,
-        tx: Sender<AgentLog>,
-        sub_agent_publisher: EventPublisher<SubAgentEvent>,
-    ) -> Result<(), AgentError> {
-        let agent_id = remote_config.agent_id.clone();
-
-        self.sub_agent_remote_config_hash_repository
-            .save(&remote_config.agent_id, &remote_config.hash)?;
-        let remote_config_value = remote_config.get_unique()?;
-        // If remote config is empty, we delete the persisted remote config so later the store
-        // will load the local config
-        if remote_config_value.is_empty() {
-            self.remote_values_repo
-                .delete_remote(&remote_config.agent_id)?;
-        } else {
-            // If the config is not valid log we cannot report it to OpAMP as
-            // we don't have access to the Sub Agent OpAMP Client here (yet) so
-            // for now we mark the remote config as failed and we don't persist it.
-            // When the Sub Agent is "recreated" it will report the remote config
-            // as failed.
-            match AgentValues::try_from(remote_config_value.to_string()) {
-                Err(e) => {
-                    error!("Error applying Sub Agent remote config: {}", e);
-                    remote_config.hash.fail(e.to_string());
-                    self.sub_agent_remote_config_hash_repository
-                        .save(&remote_config.agent_id, &remote_config.hash)?;
-                }
-                Ok(agent_values) => self
-                    .remote_values_repo
-                    .store_remote(&remote_config.agent_id, &agent_values)?,
-            }
-        }
-
-        let config = self.sub_agents_config_store.load()?;
-        let config = config.get(&agent_id)?;
-        self.recreate_sub_agent(
-            agent_id,
-            config,
-            tx.clone(),
-            sub_agents,
-            sub_agent_publisher,
-        )?;
-
-        Ok(())
-    }
     // Super Agent on remote config
     // Configuration will be reported as applying to OpAMP
     // Valid configuration will be applied and reported as applied to OpAMP
@@ -168,10 +104,8 @@ mod tests {
 
     use crate::{
         config::{
-            agent_type::trivial_value::TrivialValue,
-            agent_values::AgentValues,
             store::tests::MockSubAgentsConfigStore,
-            super_agent_configs::{AgentID, AgentTypeFQN, SubAgentConfig, SubAgentsConfig},
+            super_agent_configs::{AgentID, SubAgentConfig, SubAgentsConfig},
         },
         event::channel::pub_sub,
         opamp::{
@@ -182,205 +116,11 @@ mod tests {
         sub_agent::{
             collection::StartedSubAgents,
             test::{MockStartedSubAgent, MockSubAgentBuilderMock},
-            values::values_repository::test::MockRemoteValuesRepositoryMock,
         },
         super_agent::super_agent::SuperAgent,
     };
     use opamp_client::opamp::proto::RemoteConfigStatus;
     use opamp_client::opamp::proto::RemoteConfigStatuses::{Applied, Applying, Failed};
-
-    // TODO Move to SubAgent when its event loop is created
-    #[test]
-    fn receive_sub_agent_opamp_remote_config_existing_sub_agent_should_be_recreated() {
-        let (tx, _) = std::sync::mpsc::channel();
-
-        let hash_repository_mock = MockHashRepositoryMock::new();
-        let mut sub_agent_builder = MockSubAgentBuilderMock::new();
-        let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
-        let mut sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let mut sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
-
-        // Given that we have 3 running Sub Agents
-        let mut sub_agents = StartedSubAgents::from(HashMap::from([
-            (
-                AgentID::new("fluent_bit").unwrap(),
-                MockStartedSubAgent::new(),
-            ),
-            (
-                AgentID::new("infra_agent").unwrap(),
-                MockStartedSubAgent::new(),
-            ),
-            (AgentID::new("nrdot").unwrap(), MockStartedSubAgent::new()),
-        ]));
-
-        // When we receive a remote config for a Sub Agent
-        let sub_agent_id = AgentID::new("infra_agent").unwrap();
-
-        let remote_config = RemoteConfig {
-            agent_id: sub_agent_id.clone(),
-            hash: Hash::new("sub-agent-hash".to_string()),
-            config_map: ConfigMap::new(HashMap::from([(
-                "".to_string(),
-                r#"
-config_file: /some/path/newrelic-infra.yml
-"#
-                .to_string(),
-            )])),
-        };
-
-        // Then hash repository should save the received hash
-        sub_agent_hash_repository_mock
-            .should_save_hash(&remote_config.agent_id, &remote_config.hash);
-        // And values repo should store the received config as values
-        let expected_agent_values = AgentValues::new(HashMap::from([(
-            "config_file".to_string(),
-            TrivialValue::String("/some/path/newrelic-infra.yml".to_string()),
-        )]));
-        sub_agent_values_repo.should_store_remote(&sub_agent_id, &expected_agent_values);
-        // And we reload the config from the Sub Agent Config Store
-        let sub_agents_config = SubAgentsConfig::from(HashMap::from([
-            (
-                AgentID::new("nrdot").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_rdot"),
-                },
-            ),
-            (
-                AgentID::new("infra_agent").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_infra_agent"),
-                },
-            ),
-            (
-                AgentID::new("fluent_bit").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_fluent_bit"),
-                },
-            ),
-        ]));
-        sub_agents_config_store.should_load(&sub_agents_config);
-        // And the Sub Agent should be stopped
-        sub_agents.get(&sub_agent_id).should_stop();
-        // And the Sub Agent should be re-created
-        sub_agent_builder.should_build_running(
-            &sub_agent_id,
-            SubAgentConfig {
-                agent_type: AgentTypeFQN::from("fqn_infra_agent"),
-            },
-        );
-
-        // Create the Super Agent and run Sub Agents
-        let super_agent = SuperAgent::new_custom(
-            Some(MockStartedOpAMPClientMock::new()),
-            &hash_repository_mock,
-            sub_agent_builder,
-            sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
-        );
-
-        let (sub_agent_publisher, _sub_agent_publisher) = pub_sub();
-
-        assert!(super_agent
-            .process_sub_agent_remote_config(
-                remote_config,
-                &mut sub_agents,
-                tx,
-                sub_agent_publisher
-            )
-            .is_ok());
-    }
-
-    // TODO Move to SubAgent when its event loop is created
-    #[test]
-    fn receive_sub_agent_remote_deleted_config_should_delete_and_use_local() {
-        let (tx, _) = std::sync::mpsc::channel();
-
-        let hash_repository_mock = MockHashRepositoryMock::new();
-        let mut sub_agent_builder = MockSubAgentBuilderMock::new();
-        let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
-        let mut sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let mut sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
-
-        // Given that we have 3 running Sub Agents
-        let mut sub_agents = StartedSubAgents::from(HashMap::from([
-            (
-                AgentID::new("fluent_bit").unwrap(),
-                MockStartedSubAgent::new(),
-            ),
-            (
-                AgentID::new("infra_agent").unwrap(),
-                MockStartedSubAgent::new(),
-            ),
-            (AgentID::new("nrdot").unwrap(), MockStartedSubAgent::new()),
-        ]));
-
-        let sub_agent_id = AgentID::new("infra_agent").unwrap();
-
-        // When we receive an empty remote config for a Sub Agent
-        let remote_config = RemoteConfig {
-            agent_id: sub_agent_id.clone(),
-            hash: Hash::new("sub-agent-hash".to_string()),
-            config_map: ConfigMap::new(HashMap::from([("".to_string(), "".to_string())])),
-        };
-
-        // Then hash repository should save the received hash
-        sub_agent_hash_repository_mock
-            .should_save_hash(&remote_config.agent_id, &remote_config.hash);
-        // And config should be deleted
-        sub_agent_values_repo.should_delete_remote(&sub_agent_id);
-        // And we reload the config from the Sub Agent Config Store
-        let sub_agents_config = SubAgentsConfig::from(HashMap::from([
-            (
-                AgentID::new("nrdot").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_rdot"),
-                },
-            ),
-            (
-                AgentID::new("infra_agent").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_infra_agent"),
-                },
-            ),
-            (
-                AgentID::new("fluent_bit").unwrap(),
-                SubAgentConfig {
-                    agent_type: AgentTypeFQN::from("fqn_fluent_bit"),
-                },
-            ),
-        ]));
-        sub_agents_config_store.should_load(&sub_agents_config);
-        // And the Sub Agent should be stopped
-        sub_agents.get(&sub_agent_id).should_stop();
-        // And the Sub Agent should be re-created
-        sub_agent_builder.should_build_running(
-            &sub_agent_id,
-            SubAgentConfig {
-                agent_type: AgentTypeFQN::from("fqn_infra_agent"),
-            },
-        );
-
-        // Create the Super Agent and rub Sub Agents
-        let super_agent = SuperAgent::new_custom(
-            Some(MockStartedOpAMPClientMock::new()),
-            &hash_repository_mock,
-            sub_agent_builder,
-            sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
-        );
-
-        let (sub_agent_publisher, _sub_agent_publisher) = pub_sub();
-        assert!(super_agent
-            .process_sub_agent_remote_config(
-                remote_config,
-                &mut sub_agents,
-                tx,
-                sub_agent_publisher
-            )
-            .is_ok());
-    }
 
     // Invalid configuration should be reported to OpAMP as Failed and the Super Agent should
     // not apply it nor crash execution.
@@ -388,8 +128,6 @@ config_file: /some/path/newrelic-infra.yml
     fn super_agent_invalid_remote_config_should_be_reported_as_failed() {
         let (tx, _) = std::sync::mpsc::channel();
         // Mocked services
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
         let sub_agent_builder = MockSubAgentBuilderMock::new();
         let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
         let hash_repository_mock = MockHashRepositoryMock::new();
@@ -435,8 +173,6 @@ config_file: /some/path/newrelic-infra.yml
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
         );
 
         let (opamp_publisher, _opamp_consumer) = pub_sub();
@@ -455,8 +191,6 @@ config_file: /some/path/newrelic-infra.yml
     fn super_agent_valid_remote_config_should_be_reported_as_applied() {
         let (tx, _) = std::sync::mpsc::channel();
         // Mocked services
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
         let sub_agent_builder = MockSubAgentBuilderMock::new();
         let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
         let mut hash_repository_mock = MockHashRepositoryMock::new();
@@ -522,8 +256,6 @@ config_file: /some/path/newrelic-infra.yml
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
         );
 
         let (opamp_publisher, _opamp_consumer) = pub_sub();

--- a/src/super_agent/event_handler/sub_agent/config_updated.rs
+++ b/src/super_agent/event_handler/sub_agent/config_updated.rs
@@ -1,0 +1,40 @@
+use crate::config::store::SubAgentsConfigStore;
+use crate::config::super_agent_configs::AgentID;
+use crate::event::channel::EventPublisher;
+use crate::event::SubAgentEvent;
+use crate::opamp::remote_config_hash::HashRepository;
+use crate::sub_agent::collection::StartedSubAgents;
+use crate::sub_agent::logger::AgentLog;
+use crate::sub_agent::{NotStartedSubAgent, SubAgentBuilder};
+use crate::super_agent::error::AgentError;
+use crate::super_agent::super_agent::{SuperAgent, SuperAgentCallbacks};
+use opamp_client::StartedClient;
+use std::sync::mpsc::Sender;
+
+impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
+where
+    O: StartedClient<SuperAgentCallbacks>,
+    HR: HashRepository,
+    S: SubAgentBuilder,
+    SL: SubAgentsConfigStore,
+{
+    pub(crate) fn sub_agent_config_updated(
+        &self,
+        agent_id: AgentID,
+        tx: Sender<AgentLog>,
+        sub_agent_publisher: EventPublisher<SubAgentEvent>,
+        sub_agents: &mut StartedSubAgents<
+            <S::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
+        >,
+    ) -> Result<(), AgentError> {
+        let agents_config = self.sub_agents_config_store.load()?;
+        let agent_config = agents_config.get(&agent_id)?;
+        self.recreate_sub_agent(
+            agent_id,
+            agent_config,
+            tx.clone(),
+            sub_agents,
+            sub_agent_publisher,
+        )
+    }
+}

--- a/src/super_agent/event_handler/sub_agent/mod.rs
+++ b/src/super_agent/event_handler/sub_agent/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod config_updated;

--- a/src/super_agent/super_agent.rs
+++ b/src/super_agent/super_agent.rs
@@ -1,6 +1,5 @@
 use crate::config::agent_type::agent_types::FinalAgent;
 use crate::config::error::SuperAgentConfigError;
-use crate::config::persister::directory_manager::DirectoryManagerFs;
 use crate::config::store::{SubAgentsConfigStore, SuperAgentConfigStoreFile};
 use crate::config::super_agent_configs::{AgentID, AgentTypeFQN, SubAgentConfig, SubAgentsConfig};
 use crate::event::channel::{pub_sub, EventConsumer, EventPublisher};
@@ -14,7 +13,6 @@ use crate::sub_agent::logger::{AgentLog, EventLogger, StdEventReceiver};
 use crate::sub_agent::SubAgentBuilder;
 
 use crate::event::{OpAMPEvent, SubAgentEvent, SuperAgentEvent};
-use crate::sub_agent::values::values_repository::{ValuesRepository, ValuesRepositoryFile};
 use crate::sub_agent::NotStartedSubAgent;
 use crate::super_agent::defaults::{SUPER_AGENT_NAMESPACE, SUPER_AGENT_TYPE, SUPER_AGENT_VERSION};
 use crate::super_agent::error::AgentError;
@@ -28,53 +26,38 @@ use std::collections::HashMap;
 use std::string::ToString;
 use std::sync::mpsc::{self, Sender};
 use thiserror::Error;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::opamp::remote_config_publisher::SuperAgentRemoteConfigPublisher;
 
 pub(super) type SuperAgentCallbacks = AgentCallbacks<SuperAgentRemoteConfigPublisher>;
 
-pub struct SuperAgent<
-    'a,
-    S,
-    O,
-    HR = HashRepositoryFile,
-    SL = SuperAgentConfigStoreFile,
-    HRS = HashRepositoryFile,
-    VR = ValuesRepositoryFile<DirectoryManagerFs>,
-> where
+pub struct SuperAgent<'a, S, O, HR = HashRepositoryFile, SL = SuperAgentConfigStoreFile>
+where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,
     SL: SubAgentsConfigStore,
-    HRS: HashRepository,
     S: SubAgentBuilder,
-    VR: ValuesRepository,
 {
     pub(super) opamp_client: Option<O>,
     sub_agent_builder: S,
     remote_config_hash_repository: &'a HR,
     agent_id: AgentID,
-    pub(super) sub_agent_remote_config_hash_repository: &'a HRS,
-    pub(super) remote_values_repo: VR,
     pub(super) sub_agents_config_store: SL,
 }
 
-impl<'a, S, O, HR, SL, HRS, VR> SuperAgent<'a, S, O, HR, SL, HRS, VR>
+impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,
     S: SubAgentBuilder,
     SL: SubAgentsConfigStore,
-    HRS: HashRepository,
-    VR: ValuesRepository,
 {
     pub fn new(
         opamp_client: Option<O>,
         remote_config_hash_repository: &'a HR,
         sub_agent_builder: S,
         sub_agents_config_store: SL,
-        sub_agent_remote_config_hash_repository: &'a HRS,
-        values_repo: VR,
     ) -> Self {
         Self {
             opamp_client,
@@ -83,8 +66,6 @@ where
             // unwrap as we control content of the SUPER_AGENT_ID constant
             agent_id: AgentID::new_super_agent_id(),
             sub_agents_config_store,
-            sub_agent_remote_config_hash_repository,
-            remote_values_repo: values_repo,
         }
     }
 
@@ -122,9 +103,6 @@ where
                     self.set_config_hash_as_applied(&mut hash)?;
                 }
             }
-        } else {
-            // Delete remote values
-            self.remote_values_repo.delete_remote_all()?;
         }
 
         info!("Starting the supervisor group.");
@@ -273,6 +251,21 @@ where
                         drop(tx); //drop the main channel sender to stop listener
                         break sub_agents.stop()?;
                 },
+                recv(sub_agent_pub_sub.1.as_ref()) -> sub_agent_event_res => {
+                    match sub_agent_event_res {
+                        Err(_) => {
+                            // TODO is it worth to log this?
+                            debug!("channel closed");
+                        },
+                        Ok(sub_agent_event) => {
+                            match sub_agent_event{
+                                SubAgentEvent::ConfigUpdated(agent_id) => {
+                                    self.sub_agent_config_updated(agent_id,tx.clone(),sub_agent_pub_sub.0.clone(),&mut sub_agents)?
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         Ok(())
@@ -409,17 +402,17 @@ mod tests {
         AgentID, AgentTypeFQN, SubAgentConfig, SubAgentsConfig,
     };
     use crate::event::channel::pub_sub;
-    use crate::event::{OpAMPEvent, SuperAgentEvent};
+    use crate::event::{OpAMPEvent, SubAgentEvent, SuperAgentEvent};
     use crate::opamp::client_builder::test::MockStartedOpAMPClientMock;
     use crate::opamp::remote_config::{ConfigMap, RemoteConfig};
     use crate::opamp::remote_config_hash::test::MockHashRepositoryMock;
     use crate::opamp::remote_config_hash::{Hash, HashRepository};
-    use crate::sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock;
-    use crate::sub_agent::values::values_repository::ValuesRepository;
     use crate::sub_agent::{test::MockSubAgentBuilderMock, SubAgentBuilder};
     use crate::super_agent::super_agent::SuperAgent;
     use mockall::predicate;
 
+    use crate::sub_agent::collection::StartedSubAgents;
+    use crate::sub_agent::test::{MockNotStartedSubAgent, MockStartedSubAgent};
     use opamp_client::StartedClient;
     use std::collections::HashMap;
     use std::sync::mpsc;
@@ -431,22 +424,18 @@ mod tests {
     ////////////////////////////////////////////////////////////////////////////////////
     // Custom Agent constructor for tests
     ////////////////////////////////////////////////////////////////////////////////////
-    impl<'a, S, O, HR, SL, HRS, VR> SuperAgent<'a, S, O, HR, SL, HRS, VR>
+    impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
     where
         O: StartedClient<SuperAgentCallbacks>,
         HR: HashRepository,
         S: SubAgentBuilder,
         SL: SubAgentsConfigStore,
-        HRS: HashRepository,
-        VR: ValuesRepository,
     {
         pub fn new_custom(
             opamp_client: Option<O>,
             remote_config_hash_repository: &'a HR,
             sub_agent_builder: S,
             sub_agents_config_store: SL,
-            sub_agent_remote_config_hash_repository: &'a HRS,
-            sub_agent_values_repo: VR,
         ) -> Self {
             SuperAgent {
                 opamp_client,
@@ -454,16 +443,12 @@ mod tests {
                 sub_agent_builder,
                 agent_id: AgentID::new_super_agent_id(),
                 sub_agents_config_store,
-                sub_agent_remote_config_hash_repository,
-                remote_values_repo: sub_agent_values_repo,
             }
         }
     }
 
     #[test]
     fn run_and_stop_supervisors_no_agents() {
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
         let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
         let mut hash_repository_mock = MockHashRepositoryMock::new();
         let mut started_client = MockStartedOpAMPClientMock::new();
@@ -486,8 +471,6 @@ mod tests {
             &hash_repository_mock,
             MockSubAgentBuilderMock::new(),
             sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
         );
 
         let (super_agent_publisher, super_agent_consumer) = pub_sub();
@@ -501,8 +484,6 @@ mod tests {
 
     #[test]
     fn run_and_stop_supervisors() {
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
         let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
         let mut hash_repository_mock = MockHashRepositoryMock::new();
         let mut sub_agent_builder = MockSubAgentBuilderMock::new();
@@ -532,8 +513,6 @@ mod tests {
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
         );
 
         let (super_agent_publisher, super_agent_consumer) = pub_sub();
@@ -547,8 +526,6 @@ mod tests {
 
     #[test]
     fn receive_opamp_remote_config() {
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
         let mut hash_repository_mock = MockHashRepositoryMock::new();
         let mut sub_agent_builder = MockSubAgentBuilderMock::new();
 
@@ -615,8 +592,6 @@ mod tests {
                     &hash_repository_mock,
                     sub_agent_builder,
                     sub_agents_config_store,
-                    &sub_agent_hash_repository_mock,
-                    sub_agent_values_repo,
                 );
                 agent.run(super_agent_consumer, (opamp_publisher, opamp_consumer))
             }
@@ -826,10 +801,6 @@ agents:
 
     #[test]
     fn create_stop_sub_agents_from_remote_config() {
-        // Mocked services
-        let sub_agent_hash_repository_mock = MockHashRepositoryMock::new();
-        let sub_agent_values_repo = MockRemoteValuesRepositoryMock::new();
-
         // Sub Agents
         let sub_agents_config = sub_agents_default_config();
 
@@ -883,8 +854,6 @@ agents:
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
-            &sub_agent_hash_repository_mock,
-            sub_agent_values_repo,
         );
 
         let (tx, _) = mpsc::channel();
@@ -985,5 +954,110 @@ agents:
             ),
         ])
         .into()
+    }
+
+    #[test]
+    fn test_sub_agent_config_updated_should_recreate_sub_agent() {
+        let (tx, _) = std::sync::mpsc::channel();
+        let hash_repository_mock = MockHashRepositoryMock::new();
+        let mut sub_agent_builder = MockSubAgentBuilderMock::new();
+        let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
+
+        // Given that we have 3 running Sub Agents
+        let sub_agent_id = AgentID::new("infra_agent").unwrap();
+        let mut sub_agents = StartedSubAgents::from(HashMap::from([
+            (
+                AgentID::new("fluent_bit").unwrap(),
+                MockStartedSubAgent::new(),
+            ),
+            (sub_agent_id.clone(), MockStartedSubAgent::new()),
+            (AgentID::new("nrdot").unwrap(), MockStartedSubAgent::new()),
+        ]));
+
+        let sub_agents_config = SubAgentsConfig::from(HashMap::from([
+            (
+                AgentID::new("nrdot").unwrap(),
+                SubAgentConfig {
+                    agent_type: AgentTypeFQN::from("fqn_rdot"),
+                },
+            ),
+            (
+                sub_agent_id.clone(),
+                SubAgentConfig {
+                    agent_type: AgentTypeFQN::from("fqn_infra_agent"),
+                },
+            ),
+            (
+                AgentID::new("fluent_bit").unwrap(),
+                SubAgentConfig {
+                    agent_type: AgentTypeFQN::from("fqn_fluent_bit"),
+                },
+            ),
+        ]));
+
+        sub_agents_config_store.should_load(&sub_agents_config);
+        // And the Sub Agent should be stopped
+        sub_agents.get(&sub_agent_id).should_stop();
+        // And the Sub Agent should be re-created
+        let mut not_started_sub_agent = MockNotStartedSubAgent::default();
+        // and it will be started
+        let mut started_sub_agent = MockStartedSubAgent::default();
+        // and will be stopped in the end
+        started_sub_agent.should_stop();
+
+        not_started_sub_agent.should_run(started_sub_agent);
+
+        sub_agent_builder.should_build_not_started(
+            &sub_agent_id,
+            SubAgentConfig {
+                agent_type: AgentTypeFQN::from("fqn_infra_agent"),
+            },
+            not_started_sub_agent,
+        );
+        // And all the Sub Agents should stop on Stopping the Super Agent
+        sub_agents
+            .get(&AgentID::new("nrdot").unwrap())
+            .should_stop();
+        sub_agents
+            .get(&AgentID::new("fluent_bit").unwrap())
+            .should_stop();
+
+        let (super_agent_publisher, super_agent_consumer) = pub_sub();
+        let (sub_agent_publisher, sub_agent_consumer) = pub_sub();
+        let (_super_agent_opamp_publisher, super_agent_opamp_consumer) = pub_sub();
+
+        // Create the Super Agent and run Sub Agents
+        let super_agent = SuperAgent::new_custom(
+            Some(MockStartedOpAMPClientMock::new()),
+            &hash_repository_mock,
+            sub_agent_builder,
+            sub_agents_config_store,
+        );
+
+        let sub_agent_publisher_clone = sub_agent_publisher.clone();
+        let super_agent_publisher_clone = super_agent_publisher.clone();
+        spawn(move || {
+            sleep(Duration::from_millis(20));
+
+            sub_agent_publisher_clone
+                .publish(SubAgentEvent::ConfigUpdated(
+                    AgentID::new("infra_agent").unwrap(),
+                ))
+                .unwrap();
+
+            super_agent_publisher_clone
+                .publish(SuperAgentEvent::StopRequested)
+                .unwrap();
+        });
+
+        super_agent
+            .process_events(
+                super_agent_consumer,
+                super_agent_opamp_consumer,
+                (sub_agent_publisher, sub_agent_consumer),
+                sub_agents,
+                tx,
+            )
+            .unwrap();
     }
 }


### PR DESCRIPTION
This PR adds
* OpAMP PubSub for Sub Agents
* an Event Loop to the Sub Agents to listen OpAMP Events
* SubAgent PubSub that will be published by the Sub Agent and listened by the Super Agent

The Sub Agent OpAMP Client will publish OpAMP Events and the Sub Agent will react to these events (persist config, delete config...) and it will publish Sub Agent events to be listened by the Super Agent

The Event Processing will be done by a new struct Event Processor.

