### PR TITLE
fix: AWS metadata endpoint in json format

### DIFF
--- a/resource-detection/src/cloud/aws/metadata.rs
+++ b/resource-detection/src/cloud/aws/metadata.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
-pub(crate) const IPV4_METADATA_ENDPOINT: &str = "http://169.254.169.254/latest/meta-data/";
+pub(crate) const IPV4_METADATA_ENDPOINT: &str =
+    "http://169.254.169.254/latest/dynamic/instance-identity/document";
 
 #[derive(Deserialize)]
 pub(super) struct AWSMetadata {


### PR DESCRIPTION
Fixes the metdata url for the valid JSON endpoint