### PR TITLE
chore: update .gitignore to ignore root bin folder only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ test/k8s/.kubeconfig-dev
 
 # local build
 .cargo
-bin/
+/bin/
 
 # local directory for testing purposes
 local/


### PR DESCRIPTION
## Context

When adding changes to `super-agent/src/bin` the git client complains because it is an ignored path:

```bash
❯ git add super-agent/src/bin/newrelic-super-agent.rs
The following paths are ignored by one of your .gitignore files:
super-agent/src/bin
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
```

This PR updates the `.gitignore` file to ignore `bin` folder in the root directory only.