### PR TITLE
NR-199052 (PoC) set up k8s objects name from agent values

### DIFF
--- a/super-agent/src/config/agent_type/agent_types.rs
+++ b/super-agent/src/config/agent_type/agent_types.rs
@@ -1470,6 +1470,8 @@ deployment:
       cr1:
         apiVersion: group/version
         kind: ObjectKind
+        metadata:
+          name: cr1-name
         spec:
           values: ${config.values}
 "#;

--- a/super-agent/src/config/agent_type/runtime_config.rs
+++ b/super-agent/src/config/agent_type/runtime_config.rs
@@ -82,9 +82,7 @@ pub struct K8sObject {
     #[serde(rename = "apiVersion")]
     pub api_version: String,
     pub kind: String,
-    // Is expected that metadata is populated inside the SA so is allowed
-    // to be empty on the config.
-    pub metadata: Option<K8sObjectMeta>,
+    pub metadata: K8sObjectMeta,
     #[serde(default, flatten)]
     pub fields: serde_yaml::Mapping,
 }
@@ -94,6 +92,7 @@ pub struct K8sObject {
 pub struct K8sObjectMeta {
     #[serde(default)]
     pub labels: std::collections::BTreeMap<String, String>,
+    pub name: String,
 }
 
 #[cfg(test)]
@@ -107,20 +106,27 @@ deployment:
       cr1:
         apiVersion: super_agent.version/v0beta1
         kind: Foo
+        metadata:
+          name: foo
         spec:
           anyKey: any-value
       cr2:
         apiVersion: super_agent.version/v0beta1
         kind: Foo2
+        metadata:
+          name: foo
         # no additional fields
       cr3:
         apiVersion: super_agent.version/v0beta1
         kind: Foo
+        metadata:
+          name: foo
         key: value # no spec field
       cr4:
         apiVersion: super_agent.version/v0beta1
         kind: Foo
         metadata:
+          name: foo
           labels:
             foo: bar
         key: value # no spec field
@@ -154,7 +160,7 @@ deployment:
 
         assert_eq!(
             "bar",
-            &k8s.objects["cr4"].metadata.clone().unwrap().labels["foo"].clone()
+            &k8s.objects["cr4"].metadata.clone().labels["foo"].clone()
         );
     }
 }

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -135,8 +135,12 @@ name: io.k8s.opentelemetry.collector # Changed to avoid collisions with the uppe
 version: 0.0.1
 variables:
   config_file:
-    description: "Newrelic otel collector configuration path"
+    description: "Newrelic otel collector configuration content"
     type: yaml
+    required: true
+  agent_name: # TODO: This value uniqueness relies on the value set by the user, consider changing the approach.
+    description: "Name of the k8s resources, should be unique for each agent and a valid DNS subdomain name"
+    type: string
     required: true
 deployment:
   k8s:
@@ -144,12 +148,16 @@ deployment:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1beta2
         kind: HelmRepository
+        metadata:
+          name: ${agent_name}
         spec:
           interval: 3m
           url: https://open-telemetry.github.io/opentelemetry-helm-charts
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2beta2
         kind: HelmRelease
+        metadata:
+          name: ${agent_name}
         spec:
           interval: 3m
           chart:
@@ -158,7 +166,7 @@ deployment:
               version: 0.67.0
               sourceRef:
                 kind: HelmRepository
-                name: open-telemetry # TODO now sub-agent name must be "open-telemetry" for this to work.
+                name: ${agent_name}
               interval: 3m
           install:
             remediation:


### PR DESCRIPTION
## Context

This PR updates the kubernetes agent-type to set up the kubernetes objects names from an agent value. Consequently, the `metadata.name` field is mandatory for any object in `deployment.k8s.objects` in agent-types (this should be explicit, even if we eventually use the `agent_id` instead of a variable from agent values).

As a result of this change, testing agent values for k8s need to include an additional `agent_name` field. Example:

```yaml
agent_name: collector-1
config_file: |
  extensions: {}
```