### PR TITLE
style: align commented config

### DIFF
--- a/build/package/config.yaml
+++ b/build/package/config.yaml
@@ -1,10 +1,10 @@
 # opamp:
-#  endpoint: https://opamp.service.newrelic.com/v1/opamp
-#  headers:
-#    api-key: API_KEY_HERE
+#   endpoint: https://opamp.service.newrelic.com/v1/opamp
+#   headers:
+#     api-key: API_KEY_HERE
 
 # agents:
-#  nr-infra-agent:
-#    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.1"
-#  nr-otel-collector:
-#    agent_type: "newrelic/io.opentelemetry.collector:0.0.1"
+#   nr-infra-agent:
+#     agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.1"
+#   nr-otel-collector:
+#     agent_type: "newrelic/io.opentelemetry.collector:0.0.1"


### PR DESCRIPTION
This is a really stupid change, but I always get on my nerves when I see it while testing installs 😆 . It can mess with the parsing when uncommenting (e.g. if you leave the `agents` key with the additional space given that there was no space in `opamp`)