### PR TITLE
feat(health): adding basic check

### DIFF
--- a/super-agent/src/opamp/client_builder.rs
+++ b/super-agent/src/opamp/client_builder.rs
@@ -115,6 +115,13 @@ pub(crate) mod test {
             self.expect_set_health().times(times).returning(|_| Ok(()));
         }
 
+        pub fn should_set_specific_health(&mut self, times: usize, health: AgentHealth) {
+            self.expect_set_health()
+                .with(predicate::eq(health))
+                .times(times)
+                .returning(|_| Ok(()));
+        }
+
         #[allow(dead_code)]
         pub fn should_not_set_health(&mut self, times: usize, status_code: u16, error_msg: String) {
             self.expect_set_health().times(times).returning(move |_| {


### PR DESCRIPTION
With this PR, we:
 - set `health = false` whenever the creation of a subAgent fails
 - close the opamp client whenever the creation of a subAgent fails
 - adds a small test to check "failed creation" case