### PR TITLE
fix(tilt-file): taking into accound moved repos

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -49,7 +49,7 @@ helm_resource(
   'flux',
   chart+'super-agent',
   namespace=namespace,
-  release_name='sa',
+  release_name='flux',
   update_dependencies=update_dependencies,
   flags=[
     '--create-namespace',


### PR DESCRIPTION
After we moved to workspaces we did not update the tiltfile and it was not creating automatically the binary.

Moreover, I refactored a bit the names and added an "only" clause to build the image merely if the dockerfile or the binary changed