### PR TITLE
test: flaky k8s integration test fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,5 +118,8 @@ jobs:
           minikube version: v1.32.0
           kubernetes version: 'v1.28.1' # Should we support a specific range of versions?
           driver: docker
+      - name: Install Tilt
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
       - name: Run k8s integration tests
         run: make -C super-agent/test/k8s

--- a/super-agent/test/k8s/Makefile
+++ b/super-agent/test/k8s/Makefile
@@ -6,11 +6,8 @@ all: test-integration-minikube test-integration-k3s
 .PHONY: test-integration-minikube
 test-integration-minikube:
 	KUBECONFIG='./.kubeconfig-dev' minikube update-context
-	helm repo add newrelic https://helm-charts.newrelic.com
-	helm repo update
-	helm upgrade --install super-agent newrelic/super-agent --set helm.create=false --devel
+	tilt ci
 	cargo test --features k8s,custom-local-path k8s_ -- --nocapture --ignored
-	helm uninstall super-agent
 
 .PHONY: test-integration-k3s
 test-integration-k3s:

--- a/super-agent/test/k8s/Tiltfile
+++ b/super-agent/test/k8s/Tiltfile
@@ -1,0 +1,22 @@
+
+# -*- mode: Python -*-
+load('ext://helm_resource', 'helm_repo','helm_resource')
+helm_repo(
+  'newrelic',
+  'https://helm-charts.newrelic.com',
+  resource_name='newrelic-helm-repo',
+)
+  
+helm_resource(
+  'flux',
+  'newrelic/super-agent',
+  namespace='default',
+  release_name='flux',
+  flags=[
+    '--create-namespace',
+    '--version=>=0.0.0-beta',
+    
+    '--set=helm.create=false',
+    ],
+  resource_deps=['newrelic-helm-repo']
+)


### PR DESCRIPTION
Issue: there is a timeout when asserting the created sub-agent in the integration test

This PR changes the way Flux is being deployed before running the tests.
`tilt ci` will wait until Flux Pods are Ready before return, making the tests run faster 