### PR TITLE
SA Health taking into account client creation

### DIFF
--- a/super-agent/src/k8s/client.rs
+++ b/super-agent/src/k8s/client.rs
@@ -282,6 +282,10 @@ impl AsyncK8sClient {
         if !self.has_dynamic_object_changed(obj).await? {
             return Ok(());
         }
+        debug!(
+            "The k8s resource changed, re-applying it {:?}",
+            obj.metadata.name
+        );
         self.apply_dynamic_object(obj).await
     }
 

--- a/super-agent/src/super_agent/event_handler/opamp/valid_remote_config.rs
+++ b/super-agent/src/super_agent/event_handler/opamp/valid_remote_config.rs
@@ -171,7 +171,7 @@ mod tests {
 
         // Create the Super Agent and rub Sub Agents
         let super_agent = SuperAgent::new_custom(
-            None,
+            &None,
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
@@ -254,7 +254,7 @@ mod tests {
 
         // Create the Super Agent and rub Sub Agents
         let super_agent = SuperAgent::new_custom(
-            None,
+            &None,
             &hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,

--- a/super-agent/src/super_agent/opamp/client_builder.rs
+++ b/super-agent/src/super_agent/opamp/client_builder.rs
@@ -42,13 +42,7 @@ impl OpAMPClientBuilder<SuperAgentCallbacks> for SuperAgentOpAMPHttpBuilder {
         let not_started_client = NotStartedHttpClient::new(http_client);
         let started_client = crate::runtime::tokio_runtime()
             .block_on(not_started_client.start(callbacks, start_settings))?;
-        // TODO remove opamp health from here, it should be done outside
-        // set OpAMP health
-        crate::runtime::tokio_runtime().block_on(started_client.set_health(AgentHealth {
-            healthy: true,
-            start_time_unix_nano: get_sys_time_nano()?,
-            last_error: "".to_string(),
-        }))?;
+
         Ok(started_client)
     }
 }


### PR DESCRIPTION
#### Before the change

If the Sa starts it was immediately considered healthy as it connects to Opamp. 
Then it was considered healthy till it was terminated.
 - This was an issue on K8s since even a crashing agent due to a wrong agent config was always considered healthy

#### After the change

The Sa is considered healthy only after the config is loaded and the clients are initialized.
Then it is considered unhealthy when exiting whenever it exits on error
The SA main loop is in charge of the whole lifecycle of the `opamp_client` instead of moving it to the SuperAgent main loop (that uses a reference instead)

