### PR TITLE
Bump chart version for otel agentType

### DIFF
--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -201,7 +201,7 @@ deployment:
           chart:
             spec:
               chart: opentelemetry-collector
-              version: 0.67.0
+              version: 0.78.3
               sourceRef:
                 kind: HelmRepository
                 name: open-telemetry # TODO now sub-agent name must be "open-telemetry" for this to work.


### PR DESCRIPTION
We were using an old chart and an old image. This creates issues when looking for docs and creating configs