### PR TITLE
feat: disable HelmRelease --wait (NR-216425)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -137,5 +137,5 @@ helm_resource(
   # Required to force build the image
   image_deps=['tilt.local/super-agent-dev'],
   image_keys=[('image.registry', 'image.repository', 'image.tag')],
-  resource_deps=['super-agent','build-binary'],
+  resource_deps=['flux','build-binary'],
 )

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -216,15 +216,23 @@ deployment:
                 name: ${nr-sub:agent_id}
               interval: 3m
           install:
+            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
+            disableWait: true
+            disableWaitForJobs: true
             remediation:
               retries: 3
             replace: true
           upgrade:
+            disableWait: true
+            disableWaitForJobs: true
             cleanupOnFail: true
             force: true
             remediation:
               retries: 3
               strategy: rollback
+          rollback:
+            disableWait: true
+            disableWaitForJobs: true
           values:
             ${nr-var:chart_values}
 "#;


### PR DESCRIPTION
If trying to delete or change a  "reconciling" HelmRelease, the helm-controller will wait until the install/upgrade succeed or the timeout (5m by default) is reached.

In other words there [is no way](https://github.com/fluxcd/flux2/discussions/1000) to quickly stops and delete/modify an installation/upgrade when using the `disableWait=false`

This might be an issue specially when trying to modify a sub-agent configuration that is causing the actual failure itself, posible scenarios:
- Image error
- Resource Constraints
- Volume Mount error
- Env Variables error
- etc..

Disabling the `wait` (which is the same as the `helm install --wait`) we loose this "helath check" but as a trade-off modification/deletions of the sub-agent configuration will not be block improving the UX. Also the is planned to check the health of sub-agent independently of this feature.