### PR TITLE
NR-216426: Update HelmRepository interval

### DIFF
--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -198,7 +198,11 @@ deployment:
         metadata:
           name: ${nr-sub:agent_id}
         spec:
-          interval: 3m
+          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
+          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
+          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
+          # delaying the application of important updates.
+          interval: 30m
           url: https://open-telemetry.github.io/opentelemetry-helm-charts
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2beta2


### PR DESCRIPTION
Update the `HelmRepository` interval from `3m` to `30m` since it's not as prone to frequent changes as `HelmRelease` objects might be.