### PR TITLE
feat: allow adding a "debug agent-type"

### DIFF
--- a/super-agent/src/agent_type/agent_type_registry.rs
+++ b/super-agent/src/agent_type/agent_type_registry.rs
@@ -4,6 +4,7 @@ use crate::{
         NEWRELIC_INFRA_TYPE_1, NEWRELIC_INFRA_TYPE_2, NEWRELIC_INFRA_TYPE_3, NRDOT_TYPE,
     },
 };
+use log::debug;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -42,6 +43,14 @@ impl Default for LocalRegistry {
         local_agent_type_repository
             .store_from_yaml(NRDOT_TYPE.as_bytes())
             .unwrap();
+
+        if let Ok(file) =
+            std::fs::read_to_string("/etc/newrelic-super-agent/dynamic-agent-type.yaml")
+        {
+            _ = local_agent_type_repository
+                .store_from_yaml(file.as_bytes())
+                .inspect_err(|e| debug!("Could not add dynamic-agent-type.yaml: {e}"));
+        }
 
         local_agent_type_repository
     }


### PR DESCRIPTION
This allows us to add a new agent type on demand for quick testing. If we put a file in `/etc/newrelic-super-agent/dynamic-agent-type.yaml` the super agent will pick it and store it in the agent type repository.

If the file cannot be stored in the agent type registry for any reason the super-agent will just log the error a debug level and continue running without changes.