### PR TITLE
NR-232672: migrate to cargo deny v2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,9 @@
+[output]
+feature-depth = 1
+
+[graph]
 all-features = false
 no-default-features = false
-feature-depth = 1
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
@@ -10,23 +13,13 @@ feature-depth = 1
 db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -54,10 +47,6 @@ allow = [
 
     #"Apache-2.0 WITH LLVM-exception",
 ]
-# Lint level for licenses considered copyleft
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 # [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.8
 


### PR DESCRIPTION
Current cargo-deny config is deprecated, see: https://github.com/EmbarkStudios/cargo-deny/pull/606

We are using the default values for the deprecated fields, thus we can safely remove them.