### PR TITLE
refact: Use Option for HashRepository trait get fn

### DIFF
--- a/super-agent/src/opamp/hash_repository/k8s/config_map.rs
+++ b/super-agent/src/opamp/hash_repository/k8s/config_map.rs
@@ -12,9 +12,6 @@ use tracing::debug;
 pub enum HashRepositoryError {
     #[error("failed to persist on Config Map {0}")]
     FailedToPersistK8s(#[from] k8s::Error),
-
-    #[error("entry not found")]
-    NotFound,
 }
 
 pub struct HashRepositoryConfigMap {
@@ -36,13 +33,12 @@ impl HashRepository for HashRepositoryConfigMap {
         Ok(())
     }
 
-    fn get(&self, agent_id: &AgentID) -> Result<Hash, HashRepositoryError> {
+    fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
         debug!("getting remote config hash of agent_id: {}", agent_id);
 
-        if let Some(hash) = self.k8s_store.get(agent_id, STORE_KEY_REMOTE_CONFIG_HASH)? {
-            return Ok(hash);
+        match self.k8s_store.get(agent_id, STORE_KEY_REMOTE_CONFIG_HASH)? {
+            Some(hash) => Ok(Some(hash)),
+            None => Ok(None),
         }
-
-        Err(HashRepositoryError::NotFound)
     }
 }

--- a/super-agent/src/opamp/hash_repository/on_host/file.rs
+++ b/super-agent/src/opamp/hash_repository/on_host/file.rs
@@ -86,7 +86,7 @@ where
         Ok(writing_result?)
     }
 
-    fn get(&self, agent_id: &AgentID) -> Result<Hash, HashRepositoryError> {
+    fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
         let mut conf_path = self.conf_path.clone();
         let hash_path = self.hash_file_path(agent_id, &mut conf_path);
         debug!("Reading hash file at {}", hash_path.to_string_lossy());
@@ -198,6 +198,6 @@ state: applied
         assert!(result.is_ok());
 
         let result = hash_repository.get(&agent_id);
-        assert_eq!(hash, result.unwrap());
+        assert_eq!(Some(hash), result.unwrap());
     }
 }

--- a/super-agent/src/opamp/hash_repository/repository.rs
+++ b/super-agent/src/opamp/hash_repository/repository.rs
@@ -4,7 +4,7 @@ use crate::super_agent::config::AgentID;
 
 pub trait HashRepository {
     fn save(&self, agent_id: &AgentID, hash: &Hash) -> Result<(), HashRepositoryError>;
-    fn get(&self, agent_id: &AgentID) -> Result<Hash, HashRepositoryError>;
+    fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError>;
 }
 
 #[cfg(test)]
@@ -19,7 +19,7 @@ pub mod test {
 
             fn save(&self, agent_id: &AgentID, hash:&Hash) -> Result<(), HashRepositoryError>;
 
-            fn get(&self, agent_id: &AgentID) -> Result<Hash, HashRepositoryError>;
+            fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError>;
         }
     }
 
@@ -28,7 +28,7 @@ pub mod test {
             self.expect_get()
                 .with(predicate::eq(agent_id.clone()))
                 .once()
-                .returning(move |_| Ok(hash.clone()));
+                .returning(move |_| Ok(Some(hash.clone())));
         }
         pub fn should_save_hash(&mut self, agent_id: &AgentID, hash: &Hash) {
             self.expect_save()

--- a/super-agent/test/k8s/store.rs
+++ b/super-agent/test/k8s/store.rs
@@ -73,14 +73,16 @@ fn k8s_hash_repository_config_map() {
 
     let hash_repository = HashRepositoryConfigMap::new(k8s_store);
 
+    assert_eq!(None, hash_repository.get(&agent_id_1).unwrap());
+
     let hash_1 = Hash::new("hash-test".to_string());
     hash_repository.save(&agent_id_1, &hash_1).unwrap();
-    let loaded_hash_1 = hash_repository.get(&agent_id_1).unwrap();
+    let loaded_hash_1 = hash_repository.get(&agent_id_1).unwrap().unwrap();
     assert_eq!(hash_1, loaded_hash_1);
 
     let hash2 = Hash::new("hash-test2".to_string());
     hash_repository.save(&agent_id_2, &hash2).unwrap();
-    let loaded_hash_2 = hash_repository.get(&agent_id_2).unwrap();
+    let loaded_hash_2 = hash_repository.get(&agent_id_2).unwrap().unwrap();
     assert_eq!(hash2, loaded_hash_2);
 
     let cm_client: Api<ConfigMap> =
@@ -114,7 +116,7 @@ fn k8s_multiple_store_entries() {
     let instance_id_created = instance_id_getter.get(&agent_id).unwrap();
 
     // Assert from loaded entries
-    assert_eq!(hash, hash_repository.get(&agent_id).unwrap());
+    assert_eq!(Some(hash), hash_repository.get(&agent_id).unwrap());
     assert_eq!(
         instance_id_created,
         instance_id_getter.get(&agent_id).unwrap()


### PR DESCRIPTION
Given that the SA could start for the first time and there no Hash stored in the Repository, It is expected that there is no Hash when calling `get`. To be consistent with the agreed style guide we return an Option as result in this kind of scenarios giving.

This PR modifies the HashRepository Trait to be consistent with this style and other traits in the code like the `instace_id` storer.

Note: There should be no change in the behaviour of the SA except for reporting an error when there is one fetching the remote config Hash.