### PR TITLE
NR-185443 sec: enable buffer security check

### DIFF
--- a/build/rust.Dockerfile
+++ b/build/rust.Dockerfile
@@ -21,7 +21,7 @@ ENV CARGO_HOME=/usr/src/app/.cargo
 
 ENV ARCH_NAME=${ARCH_NAME} \
     # Generate static builds
-    RUSTFLAGS="-C target-feature=+crt-static" \
+    RUSTFLAGS="-C target-feature=+crt-static -C stack-protector=strong" \
     # Use the correct linker for targets
     # x86_64
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-gnu-gcc \


### PR DESCRIPTION
**Vulnerability**
When Buffer Security Check (Stack Cookies) are enabled the compiler recognizes functions that are potentially subject to buffer overrun problems and leaves space before the return address for a security cookie that is computed once when the module is loaded. This cookie is then checked when the function returns during run time and a different value indicates that an overwrite of the stack may have occurred. If a different value is detected, the process is terminated. Terminating the process prevents malicious code injected into the process due to a memory corruption vulnerability from gaining control of the execution flow of the application.

**Remediation Steps**

Enable Stack Cookies for the affected binaries. In Rust,



RUSTFLAGS="-C stack-protector=strong" cargo build --release