### PR TITLE
Simplifying super_agent build using Arc

### DIFF
--- a/super-agent/src/super_agent/event_handler/opamp/invalid_remote_config.rs
+++ b/super-agent/src/super_agent/event_handler/opamp/invalid_remote_config.rs
@@ -10,7 +10,7 @@ use crate::{
 use opamp_client::opamp::proto::{RemoteConfigStatus, RemoteConfigStatuses};
 use opamp_client::StartedClient;
 
-impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
+impl<S, O, HR, SL> SuperAgent<S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,

--- a/super-agent/src/super_agent/event_handler/opamp/valid_remote_config.rs
+++ b/super-agent/src/super_agent/event_handler/opamp/valid_remote_config.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 
-impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
+impl<S, O, HR, SL> SuperAgent<S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,
@@ -98,6 +98,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use crate::{
         event::channel::pub_sub,
@@ -127,7 +128,7 @@ mod tests {
         // Mocked services
         let sub_agent_builder = MockSubAgentBuilderMock::new();
         let mut sub_agents_config_store = MockSubAgentsConfigStore::new();
-        let hash_repository_mock = MockHashRepositoryMock::new();
+        let hash_repository_mock = Arc::new(MockHashRepositoryMock::new());
         let mut started_client = MockStartedOpAMPClientMock::new();
 
         // Structs
@@ -167,7 +168,7 @@ mod tests {
         // Create the Super Agent and rub Sub Agents
         let super_agent = SuperAgent::new_custom(
             None,
-            &hash_repository_mock,
+            hash_repository_mock,
             sub_agent_builder,
             sub_agents_config_store,
         );
@@ -248,7 +249,7 @@ mod tests {
         // Create the Super Agent and rub Sub Agents
         let super_agent = SuperAgent::new_custom(
             None,
-            &hash_repository_mock,
+            Arc::new(hash_repository_mock),
             sub_agent_builder,
             sub_agents_config_store,
         );

--- a/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
+++ b/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
@@ -11,7 +11,7 @@ use crate::super_agent::store::{
 use crate::super_agent::{SuperAgent, SuperAgentCallbacks};
 use opamp_client::StartedClient;
 
-impl<'a, S, O, HR, SL> SuperAgent<'a, S, O, HR, SL>
+impl<S, O, HR, SL> SuperAgent<S, O, HR, SL>
 where
     O: StartedClient<SuperAgentCallbacks>,
     HR: HashRepository,


### PR DESCRIPTION
This PR simplifies the main and the superAgent signatures for https://github.com/newrelic/newrelic-super-agent/pull/465

By using ARC in the super_agent for `hash_repository` we can use the same object in k8s for the `sub_agent`, and get rid of the lifecycle.

Moreover, I broke the `sub_agent_pub_sub` touple, since accessing with indexes was confusing