### PR TITLE
NR-235867 Adapt e2e tests for Collector Agent Type 0.1.0

### DIFF
--- a/test/caos-ansible-roles/nr-otel-collector-config/tasks/config-Linux.yaml
+++ b/test/caos-ansible-roles/nr-otel-collector-config/tasks/config-Linux.yaml
@@ -1,20 +1,21 @@
 ---
-- name: ensure config folder exists
+
+- name: Ensure the folder for values file exists
   file:
-    path: "{{ nr_otel_collector_config_path_linux | dirname }}"
+    path: "{{ nr_otel_collector_values_file | dirname }}"
     state: directory
 
-- name: Copy values file
+- name: Copy NR Otel Collector example values config
   file:
-    src: /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml
-    path: "{{ nr_otel_collector_config_path_linux }}"
+    src: "{{ super_agent_examples_path }}/{{ nr_otel_collector_example_conf }}"
+    path: "{{ nr_otel_collector_values_file }}"
     state: hard
 
-- name: Replace the env variables in nr-otel-collector config
-  ansible.builtin.replace:
-    path: "{{ nr_otel_collector_config_path_linux }}"
-    regexp: "{{ item.name }}"
-    replace: '{{ item.val }}'
+- name: Ensure the necessary env variables are present in the Super Agent Systemd config file
+  ansible.builtin.lineinfile:
+    path: "{{ super_agent_service_config_path }}"
+    regexp: '^{{ item.name }}='
+    line: "{{ item.name }}={{ item.val }}"
   loop: "{{ nr_otel_collector_config_vars }}"
   no_log: true
 

--- a/test/caos-ansible-roles/nr-otel-collector-config/vars/main.yaml
+++ b/test/caos-ansible-roles/nr-otel-collector-config/vars/main.yaml
@@ -1,6 +1,11 @@
 ---
-# config path
-nr_otel_collector_config_path_linux: "/etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml"
+# config file
+super_agent_examples_path: "/etc/newrelic-super-agent/examples"
+super_agent_service_config_path: "/etc/newrelic-super-agent/newrelic-super-agent.conf"
+nr_otel_collector_agent_name: "nr-otel-collector"
+nr_otel_collector_agent_type_version: "0.1.0"
+nr_otel_collector_values_file: "/etc/newrelic-super-agent/fleet/agents.d/{{ nr_otel_collector_agent_name }}/values/values.yaml"
+nr_otel_collector_example_conf: "values-nr-otel-collector-agent-linux-{{ nr_otel_collector_agent_type_version }}.yaml"
 
 # nr-otel-collector config:
 nr_otel_collector_memory_limit: 100
@@ -9,11 +14,11 @@ nr_otel_collector_license_key: ""
 
 
 nr_otel_collector_config_vars:
-  - name: '\$\{NEW_RELIC_MEMORY_LIMIT_MIB\}'
+  - name: 'NEW_RELIC_MEMORY_LIMIT_MIB'
     val: "{{ nr_otel_collector_memory_limit }}"
-  - name: '\$\{OTEL_EXPORTER_OTLP_ENDPOINT\}'
+  - name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
     val: "{{ nr_otel_collector_otlp_endpoint }}"
-  - name: '\$\{NEW_RELIC_LICENSE_KEY\}'
-    val: "{{ nr_otel_collector_license_key }}"
+  - name: 'NEW_RELIC_LICENSE_KEY'
+    val: "{{ nr_license_key }}"
 
 ...

--- a/test/caos-ansible-roles/super-agent-config/templates/empty-super-agent.yaml.j2
+++ b/test/caos-ansible-roles/super-agent-config/templates/empty-super-agent.yaml.j2
@@ -8,6 +8,6 @@
 #
 
 opamp:
-  endpoint: https://opamp.staging-service.newrelic.com/v1/opamp
+  endpoint: {{ opamp_endpoint }}
   headers:
     api-key: {{ nr_license_key }}

--- a/test/caos-ansible-roles/super-agent-config/templates/newrelic-super-agent.yaml.j2
+++ b/test/caos-ansible-roles/super-agent-config/templates/newrelic-super-agent.yaml.j2
@@ -8,7 +8,7 @@
 #
 
 opamp:
-  endpoint: https://opamp.staging-service.newrelic.com/v1/opamp
+  endpoint: {{ opamp_endpoint }}
   headers:
     api-key: {{ nr_license_key }}
 

--- a/test/caos-ansible-roles/super-agent-config/vars/main.yaml
+++ b/test/caos-ansible-roles/super-agent-config/vars/main.yaml
@@ -4,5 +4,6 @@ super_agent_config_path_linux: "/etc/newrelic-super-agent/config.yaml"
 infra_agent_type_version: "0.0.1"
 otel_agent_type_version: "0.0.1"
 empty_agents: false
+opamp_endpoint: https://opamp.staging-service.newrelic.com/v1/opamp
 
 ...

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -8,6 +8,8 @@ ANSIBLE_INVENTORY ?= $(ANSIBLE_FOLDER)/inventory.ec2
 ANSIBLE_PLAYBOOK ?= test.yaml
 LIMIT ?= "testing_hosts_linux"
 REPOSITORY_ENDPOINT ?= "https://download.newrelic.com/preview"
+NR_OTEL_COLLECTOR_OTLP_ENDPOINT ?= "staging-otlp.nr-data.net:4317"
+OPAMP_ENDPOINT ?= "https://opamp.staging-service.newrelic.com/v1/opamp"
 
 .PHONY: e2e
 e2e:
@@ -33,6 +35,8 @@ endif
         -e nr_api_key=$(NEW_RELIC_API_KEY) \
         -e nr_account_id=$(NEW_RELIC_ACCOUNT_ID) \
         -e repo_endpoint=$(REPOSITORY_ENDPOINT) \
+        -e nr_otel_collector_otlp_endpoint=$(NR_OTEL_COLLECTOR_OTLP_ENDPOINT) \
+        -e opamp_endpoint=${OPAMP_ENDPOINT} \
  		$(ANSIBLE_FOLDER)/$(ANSIBLE_PLAYBOOK)
 
 .PHONY: clean

--- a/test/e2e/ansible/agents_registration_unregistration.yaml
+++ b/test/e2e/ansible/agents_registration_unregistration.yaml
@@ -1,5 +1,5 @@
 ---
-- name: test configuration
+- name: Agents registration/unregistration
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
@@ -9,6 +9,7 @@
       include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
       vars:
         infra_agent_type_version: "0.1.0"
+        otel_agent_type_version: "0.1.0"
 
     - name: Get NR Super Agent ULID
       include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
@@ -58,7 +59,7 @@
         name: fleet_api_request
       vars:
         assert_agents_health:
-          ulids: ["{{ infra_agent_ulid }}", "{{ otel_agent_ulid }}"]
+          ulids: [ "{{ infra_agent_ulid }}", "{{ otel_agent_ulid }}" ]
           host: "{{ hostname }}"
           healthy: false
 
@@ -67,6 +68,6 @@
         name: fleet_api_request
       vars:
         assert_agents_health:
-          ulids: ["{{ super_agent_ulid }}"]
+          ulids: [ "{{ super_agent_ulid }}" ]
           host: "{{ hostname }}"
           healthy: true

--- a/test/e2e/ansible/migration_script_execution.yaml
+++ b/test/e2e/ansible/migration_script_execution.yaml
@@ -1,10 +1,13 @@
 ---
-- name: test configuration
+- name: Migration script execution
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
 
   tasks:
+    - name: Cleanup
+      include_tasks: ./tasks/clean_all.yaml
+
     - name: Install infra-agent then super-agent recipe
       include_tasks: ./tasks/install_recipe.yaml
       vars:

--- a/test/e2e/ansible/sub_agent_invalid_remote_config.yaml
+++ b/test/e2e/ansible/sub_agent_invalid_remote_config.yaml
@@ -1,122 +1,123 @@
 ---
 
-- name: test invalid remote config for a sub agent
+- name: Sub Agents invalid remote config
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
 
   tasks:
 
-      - name: Fresh Super Agent installation
-        include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
-        vars:
-          infra_agent_type_version: "0.1.0"
+    - name: Fresh Super Agent installation
+      include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
+      vars:
+        infra_agent_type_version: "0.1.0"
+        otel_agent_type_version: "0.1.0"
 
-      - name: Assert Super Agent and Agents are running
-        include_role:
-          name: caos.ansible_roles.assert_process_running
-        vars:
-          processes_running:
-            - "^/usr/bin/newrelic-super-agent"
-            - "^/usr/bin/newrelic-infra"
-            - "^/usr/bin/nr-otel-collector"
+    - name: Assert Super Agent and Agents are running
+      include_role:
+        name: caos.ansible_roles.assert_process_running
+      vars:
+        processes_running:
+          - "^/usr/bin/newrelic-super-agent"
+          - "^/usr/bin/newrelic-infra"
+          - "^/usr/bin/nr-otel-collector"
 
-      - name: set remote config name
-        set_fact:
-          remote_config_name: "caos-e2e-invalid-sub-agent-config-{{ ansible_date_time.iso8601_micro | to_uuid }}"
+    - name: set remote config name
+      set_fact:
+        remote_config_name: "caos-e2e-invalid-sub-agent-config-{{ ansible_date_time.iso8601_micro | to_uuid }}"
 
-      - name: create remote configuration
-        include_role:
-          name: fleet_api_request
-        vars:
-          create_remote_configuration:
-            account_id: "{{ nr_account_id | int }}"
-            config_name: "{{ remote_config_name }}"
-            config_id_fact: "created_config_id"
+    - name: create remote configuration
+      include_role:
+        name: fleet_api_request
+      vars:
+        create_remote_configuration:
+          account_id: "{{ nr_account_id | int }}"
+          config_name: "{{ remote_config_name }}"
+          config_id_fact: "created_config_id"
 
-      - name: create invalid YAML config for the infra agent
-        include_role:
-          name: fleet_api_request
-        vars:
-          create_remote_configuration_revision:
-            account_id: "{{ nr_account_id | int }}"
-            config_id: "{{ created_config_id }}"
-            content: 'this:is_invalid_yaml'
-            config_revision_fact: "created_config_revision"
+    - name: create invalid YAML config for the infra agent
+      include_role:
+        name: fleet_api_request
+      vars:
+        create_remote_configuration_revision:
+          account_id: "{{ nr_account_id | int }}"
+          config_id: "{{ created_config_id }}"
+          content: 'this:is_invalid_yaml'
+          config_revision_fact: "created_config_revision"
 
-      - name: get fleet guid for Super Agent
-        include_tasks: ./tasks/fleet_guid_by_agent_type.yaml
-        vars:
-          fleet_guid_fact: fleet_guid
-          agent_type: "NEWRELIC_INFRA"
+    - name: get fleet guid for Super Agent
+      include_tasks: ./tasks/fleet_guid_by_agent_type.yaml
+      vars:
+        fleet_guid_fact: fleet_guid
+        agent_type: "NEWRELIC_INFRA"
 
-      - name: deploy config to fleet
-        include_role:
-          name: fleet_api_request
-        vars:
-          deploy_config_to_fleet:
-            account_id: "{{ nr_account_id | int }}"
-            fleet_guid: "{{ fleet_guid }}"
-            config_id: "{{ created_config_id | int }}"
-            config_revision: "{{ created_config_revision | int }}"
+    - name: deploy config to fleet
+      include_role:
+        name: fleet_api_request
+      vars:
+        deploy_config_to_fleet:
+          account_id: "{{ nr_account_id | int }}"
+          fleet_guid: "{{ fleet_guid }}"
+          config_id: "{{ created_config_id | int }}"
+          config_revision: "{{ created_config_revision | int }}"
 
-      - name: get the infra agent pid
-        include_tasks: ./tasks/process_pid_{{ ansible_system }}.yaml
-        vars:
-          command_line: "/usr/bin/newrelic-infra --config.*"
-          process_pid_fact: process_pid
+    - name: get the infra agent pid
+      include_tasks: ./tasks/process_pid_{{ ansible_system }}.yaml
+      vars:
+        command_line: "/usr/bin/newrelic-infra --config.*"
+        process_pid_fact: process_pid
 
-      - name: Get Infra Agent ULID
-        include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
-        vars:
-          agent_identifier_path: "{{ sub_agent_identifiers_file_tpl | replace('AGENT_ID','nr-infra-agent') }}"
-          identifier_field: "ulid"
-          identifier_field_fact: "infra_agent_ulid"
+    - name: Get Infra Agent ULID
+      include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
+      vars:
+        agent_identifier_path: "{{ sub_agent_identifiers_file_tpl | replace('AGENT_ID','nr-infra-agent') }}"
+        identifier_field: "ulid"
+        identifier_field_fact: "infra_agent_ulid"
 
-      - name: authorize Infra Agent
-        include_role:
-          name: fleet_api_request
-        vars:
-          authorize_agent:
-            account_id: "{{ nr_account_id | int }}"
-            agent_ulid: "{{ infra_agent_ulid }}"
+    - name: authorize Infra Agent
+      include_role:
+        name: fleet_api_request
+      vars:
+        authorize_agent:
+          account_id: "{{ nr_account_id | int }}"
+          agent_ulid: "{{ infra_agent_ulid }}"
 
-      - name: Wait for a few seconds for the config to be retrieved
-        ansible.builtin.pause:
-          seconds: 20
+    - name: Wait for a few seconds for the config to be retrieved
+      ansible.builtin.pause:
+        seconds: 20
 
-      - name: Check for sub agent remote config
-        stat:
-          path: "{{ sub_agent_remote_config_file_tpl | replace('AGENT_ID','nr-infra-agent') }}"
-        register: result
+    - name: Check for sub agent remote config
+      stat:
+        path: "{{ sub_agent_remote_config_file_tpl | replace('AGENT_ID','nr-infra-agent') }}"
+      register: result
 
-      - name: Assert that the config was not retrieved
-        assert:
-          that: not result.stat.exists
+    - name: Assert that the config was not retrieved
+      assert:
+        that: not result.stat.exists
 
-      - name: get latest logs from the Super Agent
-        shell: journalctl -u newrelic-super-agent --since "1min ago" | grep "error processing valid remote config"
-        register: journalctl_log
+    - name: get latest logs from the Super Agent
+      shell: journalctl -u newrelic-super-agent --since "1min ago" | grep "error processing valid remote config"
+      register: journalctl_log
 
-      - name: assert the incorrect config was logged
-        assert:
-          that: "journalctl_log.stdout is search ('sub agent values error: .invalid agent values format: .invalid type: string \"this:is_invalid_yaml\", expected a map..')"
+    - name: assert the incorrect config was logged
+      assert:
+        that: "journalctl_log.stdout is search ('sub agent values error: .invalid agent values format: .invalid type: string \"this:is_invalid_yaml\", expected a map..')"
 
-      - name: assert the infra agent is running
-        include_role:
-          name: caos.ansible_roles.assert_process_running
-        vars:
-          processes_running:
-            - "^/usr/bin/newrelic-infra"
+    - name: assert the infra agent is running
+      include_role:
+        name: caos.ansible_roles.assert_process_running
+      vars:
+        processes_running:
+          - "^/usr/bin/newrelic-infra"
 
-      - name: get the infra agent pid
-        include_tasks: ./tasks/process_pid_{{ ansible_system }}.yaml
-        vars:
-          command_line: "/usr/bin/newrelic-infra --config.*"
-          process_pid_fact: new_process_pid
+    - name: get the infra agent pid
+      include_tasks: ./tasks/process_pid_{{ ansible_system }}.yaml
+      vars:
+        command_line: "/usr/bin/newrelic-infra --config.*"
+        process_pid_fact: new_process_pid
 
-      - name: assert the previous and current pid are the same
-        assert:
-          that: "{{ new_process_pid == process_pid }}"
+    - name: assert the previous and current pid are the same
+      assert:
+        that: "{{ new_process_pid == process_pid }}"
 
 ...

--- a/test/e2e/ansible/sub_agent_valid_remote_config.yaml
+++ b/test/e2e/ansible/sub_agent_valid_remote_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: test configuration
+- name: Sub Agent valid remote config
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
@@ -10,6 +10,7 @@
       include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
       vars:
         infra_agent_type_version: "0.1.0"
+        otel_agent_type_version: "0.1.0"
 
     - name: Setup Infra Agent values
       include_role:

--- a/test/e2e/ansible/super_agent_valid_remote_config.yaml
+++ b/test/e2e/ansible/super_agent_valid_remote_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: test configuration
+- name: Super Agent Valid Remote Config
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
@@ -10,6 +10,7 @@
       include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
       vars:
         infra_agent_type_version: "0.1.0"
+        otel_agent_type_version: "0.1.0"
 
     - name: Assert Super Agent and Agents are running
       include_role:
@@ -175,7 +176,7 @@
         create_remote_configuration_revision:
           account_id: "{{ nr_account_id | int }}"
           config_id: "{{ created_config_id }}"
-          content: 'agents:\n  nr-otel-collector:\n    agent_type: \"newrelic/io.opentelemetry.collector:0.0.1\"\n'
+          content: 'agents:\n  nr-otel-collector:\n    agent_type: \"newrelic/io.opentelemetry.collector:0.1.0\"\n'
           config_revision_fact: "config_just_nrdot"
 
     - name: deploy config to fleet
@@ -199,7 +200,7 @@
       pause:
         seconds: 30
 
-    - name: Assert Super Agent and Infra Agent are running and Collector is not
+    - name: Assert Super Agent and Collector are running and Infra Agent is not 1
       include_role:
         name: caos.ansible_roles.assert_process_running
       vars:
@@ -213,7 +214,7 @@
       include_tasks: ./tasks/assert_full_file_content.yaml
       vars:
         file_path: "{{ super_agent_remote_config_file }}"
-        expected_content: "agents:\n  nr-otel-collector:\n    agent_type: newrelic/io.opentelemetry.collector:0.0.1"
+        expected_content: "agents:\n  nr-otel-collector:\n    agent_type: newrelic/io.opentelemetry.collector:0.1.0"
 
     # Let's restart the Super Agent and ensure it uses the remote config
     - name: Restart Super Agent
@@ -227,7 +228,7 @@
       pause:
         seconds: 30
 
-    - name: Assert Super Agent and Collector are running and Infra Agent is not
+    - name: Assert Super Agent and Collector are running and Infra Agent is not 2
       include_role:
         name: caos.ansible_roles.assert_process_running
       vars:

--- a/test/e2e/ansible/test.yaml
+++ b/test/e2e/ansible/test.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Agents registration new host
+- name: Agents registration/unregistration
   import_playbook: agents_registration_unregistration.yaml
 
 - name: Super Agent valid remote config


### PR DESCRIPTION
New Otel collector agent type does not use the default config “/etc/nr-otel-collector/config.yaml”, thus we would need to review and fix the current E2E.