### PR TITLE
feat(NR-199201): health checker interface

### DIFF
--- a/super-agent/src/agent_type/definition.rs
+++ b/super-agent/src/agent_type/definition.rs
@@ -602,6 +602,7 @@ restart_policy:
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
 
         let normalized_values = Map::from([
@@ -741,6 +742,7 @@ restart_policy:
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
 
         assert_eq!(exec_actual, exec_expected);
@@ -773,6 +775,7 @@ restart_policy:
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
 
         let normalized_values = Map::from([
@@ -854,6 +857,7 @@ restart_policy:
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
 
         assert_eq!(exec_actual, exec_expected);

--- a/super-agent/src/agent_type/runtime_config.rs
+++ b/super-agent/src/agent_type/runtime_config.rs
@@ -26,24 +26,28 @@ pub struct OnHost {
     pub executables: Vec<Executable>,
     #[serde(default)]
     pub enable_file_logging: TemplateableValue<bool>,
-    pub health: Option<HealthConfig>,
 }
 
 /* FIXME: This is not TEMPLATEABLE for the moment, we need to think what would be the strategy here and clarify:
 
 1. If we perform replacement with the template but the values are not of the expected type, what happens?
 2. Should we use an intermediate type with all the end nodes as `String` so we can perform the replacement?
-  - Add a sanitize or a fallible conversion from the raw intermediate type into into the end type?
+- Add a sanitize or a fallible conversion from the raw intermediate type into into the end type?
 */
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct Executable {
     pub path: TemplateableValue<String>, // make it templatable
+
     #[serde(default)]
     pub args: TemplateableValue<Args>, // make it templatable, it should be aware of the value type, if templated with array, should be expanded
+
     #[serde(default)]
     pub env: TemplateableValue<Env>, // make it templatable, it should be aware of the value type, if templated with array, should be expanded "STAGING=true ${variable_1}" variable_1 : VERBOSE=1
+
     #[serde(default)]
     pub restart_policy: RestartPolicyConfig,
+
+    pub health: Option<HealthConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]

--- a/super-agent/src/agent_type/runtime_config_templates.rs
+++ b/super-agent/src/agent_type/runtime_config_templates.rs
@@ -87,6 +87,10 @@ impl Templateable for Executable {
             args: self.args.template_with(variables)?,
             env: self.env.template_with(variables)?,
             restart_policy: self.restart_policy.template_with(variables)?,
+            health: self
+                .health
+                .map(|health| health.template_with(variables))
+                .transpose()?,
         })
     }
 }
@@ -117,10 +121,6 @@ impl Templateable for OnHost {
                 .map(|e| e.template_with(variables))
                 .collect::<Result<Vec<Executable>, AgentTypeError>>()?,
             enable_file_logging: self.enable_file_logging.template_with(variables)?,
-            health: self
-                .health
-                .map(|health| health.template_with(variables))
-                .transpose()?,
         })
     }
 }
@@ -442,6 +442,7 @@ mod tests {
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
         let expected_output = Executable {
             path: TemplateableValue::new("/usr/bin/myapp".to_string())
@@ -467,6 +468,7 @@ mod tests {
                 },
                 restart_exit_codes: vec![],
             },
+            health: None,
         };
         let actual_output = input.template_with(&variables).unwrap();
         assert_eq!(actual_output, expected_output);

--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use crate::agent_type::health_config::{HealthCheck, HealthConfig};
+
+use super::http::HttpHealthChecker;
+
+/// A type that implements a health checking mechanism.
+pub trait HealthChecker {
+    /// Check the health of the agent. `Ok(())` means the agent is healthy. Otherwise,
+    /// we will have an `Err(e)` where `e` is the error with agent-specific semantics
+    /// with which we will build the OpAMP's `ComponentHealth.status` contents.
+    /// See OpAMP's [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealthstatus)
+    /// for more details.
+    fn check_health(&self) -> Result<(), HealthCheckerError>;
+
+    fn interval(&self) -> Duration;
+}
+
+pub(crate) enum HealthCheckerType {
+    Http(HttpHealthChecker),
+}
+
+/// Health check errors. Its structure mimics the OpAMP's spec for containing relevant information
+#[derive(Debug)]
+pub struct HealthCheckerError {
+    /// Status contents using agent-specific semantics. This might be the response body of an HTTP
+    /// checker or the stdout/stderr of an exec checker.
+    status: String,
+
+    /// Error information in human-readable format. We could use this to specify what kind of checker
+    /// failed, e.g., "HTTP checker failed with error: {error}". While passing the raw error to the
+    /// `status` field.
+    last_error: String,
+}
+
+impl HealthCheckerError {
+    pub fn new(status: String, last_error: String) -> Self {
+        Self { status, last_error }
+    }
+
+    pub fn status(self) -> String {
+        self.status
+    }
+
+    pub fn last_error(self) -> String {
+        self.last_error
+    }
+}
+
+impl From<HealthConfig> for HealthCheckerType {
+    fn from(health_config: HealthConfig) -> Self {
+        let interval = health_config.interval;
+        let timeout = health_config.timeout;
+        match health_config.check {
+            HealthCheck::HttpHealth(http_config) => {
+                HealthCheckerType::Http(HttpHealthChecker::new(interval, timeout, http_config))
+            }
+        }
+    }
+}
+
+impl HealthChecker for HealthCheckerType {
+    fn check_health(&self) -> Result<(), HealthCheckerError> {
+        match self {
+            HealthCheckerType::Http(http_checker) => http_checker.check_health(),
+        }
+    }
+
+    fn interval(&self) -> Duration {
+        match self {
+            HealthCheckerType::Http(http_checker) => http_checker.interval(),
+        }
+    }
+}

--- a/super-agent/src/sub_agent/health/http.rs
+++ b/super-agent/src/sub_agent/health/http.rs
@@ -1,0 +1,39 @@
+use super::health_checker::{HealthChecker, HealthCheckerError};
+use crate::agent_type::health_config::HttpHealth;
+use std::time::Duration;
+
+#[derive(Debug, Default)]
+pub(crate) struct HttpHealthChecker {
+    host: String,
+    path: String,
+    port: u16,
+    interval: Duration,
+    timeout: Duration,
+}
+
+impl HttpHealthChecker {
+    pub fn new(interval: Duration, timeout: Duration, http_config: HttpHealth) -> Self {
+        let host = http_config.host.get().into();
+        let path = http_config.path.get().into();
+        let port = http_config.port.get().into();
+        let headers = http_config.headers;
+        let healthy_status_codes = http_config.healthy_status_codes;
+        Self {
+            host,
+            path,
+            port,
+            interval,
+            timeout,
+        }
+    }
+}
+
+impl HealthChecker for HttpHealthChecker {
+    fn check_health(&self) -> Result<(), HealthCheckerError> {
+        Ok(())
+    }
+
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+}

--- a/super-agent/src/sub_agent/health/mod.rs
+++ b/super-agent/src/sub_agent/health/mod.rs
@@ -1,0 +1,2 @@
+pub mod health_checker;
+pub mod http;

--- a/super-agent/src/sub_agent/mod.rs
+++ b/super-agent/src/sub_agent/mod.rs
@@ -9,6 +9,9 @@ pub mod persister;
 pub mod restart_policy;
 pub mod values;
 
+#[cfg(feature = "onhost")]
+mod health;
+
 #[cfg(feature = "k8s")]
 pub mod k8s;
 #[cfg(feature = "onhost")]

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-
+use crate::agent_type::health_config::HealthConfig;
 use crate::context::Context;
 use crate::sub_agent::restart_policy::RestartPolicy;
 use crate::super_agent::config::AgentID;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct SupervisorConfigOnHost {
@@ -13,6 +13,7 @@ pub struct SupervisorConfigOnHost {
     pub(super) env: HashMap<String, String>,
     pub(super) restart_policy: RestartPolicy,
     pub(super) log_to_file: bool,
+    pub(super) health: Option<HealthConfig>,
 }
 
 impl SupervisorConfigOnHost {
@@ -21,7 +22,6 @@ impl SupervisorConfigOnHost {
         exec: ExecutableData,
         ctx: Context<bool>,
         restart_policy: RestartPolicy,
-        log_to_file: bool,
     ) -> Self {
         let ExecutableData { bin, args, env } = exec;
         SupervisorConfigOnHost {
@@ -31,7 +31,22 @@ impl SupervisorConfigOnHost {
             args,
             env,
             restart_policy,
+            log_to_file: false,
+            health: None,
+        }
+    }
+
+    pub fn with_file_logging(self, log_to_file: bool) -> Self {
+        Self {
             log_to_file,
+            ..self
+        }
+    }
+
+    pub fn with_health_check(self, health: HealthConfig) -> Self {
+        Self {
+            health: Some(health),
+            ..self
         }
     }
 }

--- a/super-agent/test/on_host/supervisor.rs
+++ b/super-agent/test/on_host/supervisor.rs
@@ -34,13 +34,8 @@ fn test_supervisors() {
     let exec = ExecutableData::new("sh".to_string())
         .with_args(vec!["-c".to_string(), "sleep 2".to_string()]);
 
-    let conf = SupervisorConfigOnHost::new(
-        agent_id,
-        exec,
-        Context::new(),
-        RestartPolicy::default(),
-        false,
-    );
+    let conf =
+        SupervisorConfigOnHost::new(agent_id, exec, Context::new(), RestartPolicy::default());
 
     // Create 50 supervisors
     let agents: Vec<SupervisorOnHost<NotStarted>> = (0..10)


### PR DESCRIPTION
- Adds the infrastructure for health checking (on-host only).
  - For the moment, only a `check_health` method that returns a `Result` and an `interval` that returns a `Duration` are defined.
  - The `Result` returned by `check_health` involves that its `Ok` variant means healthy and its `Err` means unhealhy. This is subject to discussion/iteration.
- Tested with mocks.
-  I have also included some changes regarding previous work (for example, the existing config for HTTP health checks in agent types was called `httpGet` following K8s convention. We don't actually follow this convention in our codebase and configs so I renamed it to only `http`. Also, there was an existing config for defining a  "run command" health check (called `exec`) but this won't be implemented yet, so I have commented it out to avoid leaving dummy implementations.