### PR TITLE
fix: clarify error for unknown keys in agent type values

### DIFF
--- a/super-agent/src/agent_type/definition.rs
+++ b/super-agent/src/agent_type/definition.rs
@@ -304,7 +304,7 @@ fn update_specs(
     for (ref k, v) in values.into_iter() {
         let spec = agent_vars
             .get_mut(k)
-            .ok_or_else(|| AgentTypeError::MissingAgentKey(k.clone()))?;
+            .ok_or_else(|| AgentTypeError::UnexpectedValueKey(k.clone()))?;
 
         match spec {
             VariableDefinitionTree::End(e) => e.merge_with_yaml_value(v)?,

--- a/super-agent/src/agent_type/error.rs
+++ b/super-agent/src/agent_type/error.rs
@@ -11,8 +11,8 @@ use super::trivial_value::TrivialValue;
 pub enum AgentTypeError {
     #[error("Error while parsing: `{0}`")]
     SerdeYaml(#[from] serde_yaml::Error),
-    #[error("Missing required key in config: `{0}`")]
-    MissingAgentKey(String),
+    #[error("Missing required key in agent type config values: `{0}`")]
+    MissingRequiredKey(String),
     #[error(
         "Type mismatch while parsing. Expected type {expected_type}, got value {actual_value:?}"
     )]
@@ -20,8 +20,8 @@ pub enum AgentTypeError {
         expected_type: String,
         actual_value: TrivialValue,
     },
-    #[error("Found unexpected keys in config: {0:?}")]
-    UnexpectedKeysInConfig(Vec<String>),
+    #[error("Unexpected key in agent type config values: {0}")]
+    UnexpectedValueKey(String),
     #[error("I/O error: `{0}`")]
     IOError(#[from] io::Error),
     #[error("Attempted to store an invalid path on a FilePathWithContent object")]

--- a/super-agent/src/agent_type/runtime_config_templates.rs
+++ b/super-agent/src/agent_type/runtime_config_templates.rs
@@ -249,7 +249,7 @@ fn template_yaml_value_string(
     let var_spec = normalized_var(var_name, variables)?;
     let var_value = var_spec
         .get_template_value()
-        .ok_or(AgentTypeError::MissingAgentKey(var_name.to_string()))?;
+        .ok_or(AgentTypeError::MissingRequiredKey(var_name.to_string()))?;
     match var_spec.kind() {
         Kind::Yaml(y) => Ok(y
             .get_final_value()


### PR DESCRIPTION
The function `agent_type::definition::update_specs` was returning an inappropriate error when it attempted to get a certain value key from the agent type definition. The error could be misleading when troubleshooting these issues so I have leveraged the proper one. I also improved the wording in the previous error so it is more clear.