### PR TITLE
NR-199194 rename SuperAgentEvent to ApplicationEvent

### DIFF
--- a/super-agent/src/event/mod.rs
+++ b/super-agent/src/event/mod.rs
@@ -10,7 +10,7 @@ pub enum OpAMPEvent {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SuperAgentEvent {
+pub enum ApplicationEvent {
     StopRequested,
 }
 

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -378,12 +378,12 @@ mod test {
             k8s_config,
         );
 
-        let (super_agent_publisher, _super_agent_consumer) = pub_sub();
+        let (application_event_publisher, _application_event_consumer) = pub_sub();
         let started_agent = builder
             .build(
                 AgentID::new("k8s-test").unwrap(),
                 &sub_agent_config,
-                super_agent_publisher,
+                application_event_publisher,
             )
             .unwrap() // Not started agent
             .run()
@@ -477,12 +477,12 @@ mod test {
             k8s_config,
         );
 
-        let (super_agent_publisher, _super_agent_consumer) = pub_sub();
+        let (application_event_publisher, _application_event_consumer) = pub_sub();
         assert!(builder
             .build(
                 AgentID::new("k8s-test").unwrap(),
                 &sub_agent_config,
-                super_agent_publisher,
+                application_event_publisher,
             )
             .unwrap() // Not started agent
             .run()


### PR DESCRIPTION
This PR renames the current `SuperAgentEvent/SuperAgentPublisher/SuperAgentConsumer` to `ApplicationEvent/ApplicationEventPublisher/ApplicationEventConsumer`

Currently, these events are not published by the SuperAgent but published by the application (`stop ctrl+c`) and consumed by the SuperAgent so they should be considered Application Events.

Soon, for the Status HTTP Server, the Super Agent will publish its own SuperAgent events.