### PR TITLE
refactor: optional receiver for OpAMP events (2)

### DIFF
--- a/super-agent/src/event/channel.rs
+++ b/super-agent/src/event/channel.rs
@@ -2,7 +2,19 @@ use crossbeam::channel::{unbounded, Receiver, Sender};
 use thiserror::Error;
 
 pub struct EventConsumer<E>(Receiver<E>);
+
+impl<E> From<Receiver<E>> for EventConsumer<E> {
+    fn from(value: Receiver<E>) -> Self {
+        Self(value)
+    }
+}
 pub struct EventPublisher<E>(Sender<E>);
+
+impl<E> From<Sender<E>> for EventPublisher<E> {
+    fn from(value: Sender<E>) -> Self {
+        Self(value)
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum EventPublisherError {

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -100,6 +100,8 @@ where
         let (sub_agent_opamp_publisher, sub_agent_opamp_consumer) = pub_sub();
         let (sub_agent_internal_publisher, sub_agent_internal_consumer) = pub_sub();
 
+        // If there's no OpAMP builder, `sub_agent_opamp_publisher` will be dropped leaving the
+        // consumer with no associated publisher. It will fail to receive any messages.
         let maybe_opamp_client = build_opamp_and_start_client(
             sub_agent_opamp_publisher,
             self.opamp_builder,


### PR DESCRIPTION
This is a simpler alternative to https://github.com/newrelic/newrelic-super-agent/pull/558. It does not change the signatures for the rest of the program but it's error prone (the OpAMP events channel is not tied to the existence of the OpAMP client).