### PR TITLE
Update Opamp-rs to latest version that deletes previous messsage sent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,8 +1765,8 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opamp-client"
-version = "0.1.0"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.13#d57fa36215a71ea72add7a29757ebc6ad6422c8e"
+version = "0.2.0"
+source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.14#eed5699b4ad936597d98991224f0d693fa897672"
 dependencies = [
  "async-trait",
  "crossbeam",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -951,7 +951,7 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.13
+## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.14
 
 Distributed under the following license(s):
 * Apache-2.0

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 ctrlc = { version = "3.4.0", features = ["termination"] }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.13", features = [
+opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.14", features = [
   "sync-http",
 ], default-features = false }
 futures = { version = "0.3.28", optional = true }


### PR DESCRIPTION
Update Opamp-rs to latest version that deletes previous messsage sent:
https://github.com/newrelic/opamp-rs/pull/48