### PR TITLE
NR-199194 Super Agent Events

### DIFF
--- a/super-agent/src/event/mod.rs
+++ b/super-agent/src/event/mod.rs
@@ -1,6 +1,7 @@
 pub mod channel;
 
 use crate::opamp::LastErrorMessage;
+use crate::super_agent::config::AgentTypeFQN;
 /// EVENTS
 use crate::{opamp::remote_config::RemoteConfig, super_agent::config::AgentID};
 
@@ -12,6 +13,16 @@ pub enum OpAMPEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ApplicationEvent {
     StopRequested,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SuperAgentEvent {
+    SuperAgentBecameUnhealthy(LastErrorMessage),
+    SuperAgentBecameHealthy,
+    SubAgentBecameUnhealthy(AgentID, AgentTypeFQN, LastErrorMessage),
+    SubAgentBecameHealthy(AgentID, AgentTypeFQN),
+    SubAgentRemoved(AgentID),
+    SuperAgentStopped,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/super-agent/src/sub_agent/collection.rs
+++ b/super-agent/src/sub_agent/collection.rs
@@ -78,6 +78,10 @@ where
             .into_iter()
             .try_for_each(|(agent_id, sub_agent)| Self::stop_agent(&agent_id, sub_agent))
     }
+
+    pub(crate) fn get(&self, agent_id: &AgentID) -> Option<&S> {
+        self.0.get(agent_id)
+    }
 }
 
 #[cfg(test)]

--- a/super-agent/src/sub_agent/sub_agent.rs
+++ b/super-agent/src/sub_agent/sub_agent.rs
@@ -73,6 +73,16 @@ pub mod test {
         pub fn should_stop(&mut self) {
             self.expect_stop().once().returning(|| Ok(Vec::new()));
         }
+
+        pub fn should_agent_id(&mut self, agent_id: AgentID) {
+            self.expect_agent_id().once().return_once(|| agent_id);
+        }
+
+        pub fn should_agent_type(&mut self, agent_type_fqn: AgentTypeFQN) {
+            self.expect_agent_type()
+                .once()
+                .return_once(|| agent_type_fqn);
+        }
     }
 
     mock! {

--- a/super-agent/src/super_agent/error.rs
+++ b/super-agent/src/super_agent/error.rs
@@ -2,6 +2,7 @@ use super::config::SuperAgentConfigError;
 use crate::agent_type::agent_type_registry::AgentRepositoryError;
 use crate::agent_type::agent_values::AgentValuesError;
 use crate::agent_type::error::AgentTypeError;
+use crate::event::channel::EventPublisherError;
 use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::HashRepositoryError;
 use crate::opamp::instance_id;
@@ -96,4 +97,7 @@ pub enum AgentError {
 
     #[error("invalid argument: `{0}`")]
     InvalidArgumentError(String),
+
+    #[error("error publishing event: `{0}`")]
+    EventPublisherError(#[from] EventPublisherError),
 }

--- a/super-agent/test/k8s/opamp.rs
+++ b/super-agent/test/k8s/opamp.rs
@@ -309,11 +309,14 @@ impl K8sOpAMPEnv {
             )
             .expect("Failed to build and start opamp client");
 
+            let (super_agent_publisher, _super_agent_consumer) = pub_sub();
+
             let super_agent = SuperAgent::new(
                 maybe_client.into(),
                 self.hash_repository.clone(),
                 sub_agent_builder,
                 self.config_storer.clone(),
+                super_agent_publisher,
             );
 
             super_agent


### PR DESCRIPTION
This PR adds SuperAgentEvents to expose the state of the Super Agent to other componets. 
The first one using it is the Status HTTP Server (coming next) but we could use a broadcaster and leverage this events in other services.

Current events:
```rust
pub enum SuperAgentEvent {
    SuperAgentBecameUnhealthy(LastErrorMessage),
    SuperAgentBecameHealthy,
    SubAgentBecameUnhealthy(AgentID, AgentTypeFQN, LastErrorMessage),
    SubAgentBecameHealthy(AgentID, AgentTypeFQN),
    SubAgentRemoved(AgentID),
    SuperAgentStopped,
}
```