### PR TITLE
refactor(health): fallible health checks

### DIFF
--- a/super-agent/src/event/mod.rs
+++ b/super-agent/src/event/mod.rs
@@ -1,6 +1,7 @@
 pub mod channel;
 
 use crate::opamp::{LastErrorCode, LastErrorMessage};
+use crate::sub_agent::health::health_checker::{Health, Healthy, Unhealthy};
 use crate::super_agent::config::AgentTypeFQN;
 /// EVENTS
 use crate::{opamp::remote_config::RemoteConfig, super_agent::config::AgentID};
@@ -19,10 +20,10 @@ pub enum ApplicationEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SuperAgentEvent {
-    SuperAgentBecameUnhealthy(LastErrorMessage),
-    SuperAgentBecameHealthy,
-    SubAgentBecameUnhealthy(AgentID, AgentTypeFQN, LastErrorMessage),
-    SubAgentBecameHealthy(AgentID, AgentTypeFQN),
+    SuperAgentBecameUnhealthy(Unhealthy),
+    SuperAgentBecameHealthy(Healthy),
+    SubAgentBecameUnhealthy(AgentID, AgentTypeFQN, Unhealthy),
+    SubAgentBecameHealthy(AgentID, AgentTypeFQN, Healthy),
     SubAgentRemoved(AgentID),
     SuperAgentStopped,
     OpAMPConnected,
@@ -32,13 +33,34 @@ pub enum SuperAgentEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub enum SubAgentEvent {
     ConfigUpdated(AgentID),
-    SubAgentBecameHealthy(AgentID),
-    SubAgentBecameUnhealthy(AgentID, LastErrorMessage),
+    SubAgentBecameHealthy(AgentID, Healthy),
+    SubAgentBecameUnhealthy(AgentID, Unhealthy),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SubAgentInternalEvent {
     StopRequested,
-    AgentBecameUnhealthy(LastErrorMessage),
-    AgentBecameHealthy,
+    AgentBecameUnhealthy(Unhealthy),
+    AgentBecameHealthy(Healthy),
+}
+
+impl From<Unhealthy> for SubAgentInternalEvent {
+    fn from(unhealthy: Unhealthy) -> Self {
+        SubAgentInternalEvent::AgentBecameUnhealthy(unhealthy)
+    }
+}
+
+impl From<Healthy> for SubAgentInternalEvent {
+    fn from(healthy: Healthy) -> Self {
+        SubAgentInternalEvent::AgentBecameHealthy(healthy)
+    }
+}
+
+impl From<Health> for SubAgentInternalEvent {
+    fn from(health: Health) -> Self {
+        match health {
+            Health::Healthy(healthy) => healthy.into(),
+            Health::Unhealthy(unhealthy) => unhealthy.into(),
+        }
+    }
 }

--- a/super-agent/src/sub_agent/event_handler/on_became_healthy.rs
+++ b/super-agent/src/sub_agent/event_handler/on_became_healthy.rs
@@ -2,6 +2,7 @@ use crate::event::SubAgentEvent::SubAgentBecameHealthy;
 use crate::opamp::hash_repository::HashRepository;
 use crate::sub_agent::error::SubAgentError;
 use crate::sub_agent::event_processor::EventProcessor;
+use crate::sub_agent::health::health_checker::Healthy;
 use crate::sub_agent::values::values_repository::ValuesRepository;
 use crate::sub_agent::SubAgentCallbacks;
 use crate::utils::time::get_sys_time_nano;
@@ -13,11 +14,12 @@ where
     H: HashRepository,
     R: ValuesRepository,
 {
-    pub(crate) fn on_became_healthy(&self) -> Result<(), SubAgentError> {
+    pub(crate) fn on_became_healthy(&self, healthy: Healthy) -> Result<(), SubAgentError> {
         if let Some(client) = self.maybe_opamp_client.as_ref() {
             let health = opamp_client::opamp::proto::ComponentHealth {
                 healthy: true,
                 start_time_unix_nano: get_sys_time_nano()?,
+                status: healthy.status().to_string(),
                 last_error: "".to_string(),
                 ..Default::default()
             };
@@ -25,6 +27,6 @@ where
         }
         Ok(self
             .sub_agent_publisher
-            .publish(SubAgentBecameHealthy(self.agent_id()))?)
+            .publish(SubAgentBecameHealthy(self.agent_id(), healthy))?)
     }
 }

--- a/super-agent/src/sub_agent/event_handler/on_became_unhealthy.rs
+++ b/super-agent/src/sub_agent/event_handler/on_became_unhealthy.rs
@@ -1,8 +1,8 @@
 use crate::event::SubAgentEvent::SubAgentBecameUnhealthy;
 use crate::opamp::hash_repository::HashRepository;
-use crate::opamp::LastErrorMessage;
 use crate::sub_agent::error::SubAgentError;
 use crate::sub_agent::event_processor::EventProcessor;
+use crate::sub_agent::health::health_checker::Unhealthy;
 use crate::sub_agent::values::values_repository::ValuesRepository;
 use crate::sub_agent::SubAgentCallbacks;
 use crate::utils::time::get_sys_time_nano;
@@ -14,21 +14,19 @@ where
     H: HashRepository,
     R: ValuesRepository,
 {
-    pub(crate) fn on_became_unhealthy(
-        &self,
-        error_message: LastErrorMessage,
-    ) -> Result<(), SubAgentError> {
+    pub(crate) fn on_became_unhealthy(&self, unhealthy: Unhealthy) -> Result<(), SubAgentError> {
         if let Some(client) = self.maybe_opamp_client.as_ref() {
             let health = opamp_client::opamp::proto::ComponentHealth {
                 healthy: false,
                 start_time_unix_nano: get_sys_time_nano()?,
-                last_error: error_message.clone(),
+                last_error: unhealthy.last_error().to_string(),
+                status: unhealthy.status().to_string(),
                 ..Default::default()
             };
             client.set_health(health)?;
         }
         Ok(self
             .sub_agent_publisher
-            .publish(SubAgentBecameUnhealthy(self.agent_id(), error_message))?)
+            .publish(SubAgentBecameUnhealthy(self.agent_id(), unhealthy))?)
     }
 }

--- a/super-agent/src/sub_agent/event_processor.rs
+++ b/super-agent/src/sub_agent/event_processor.rs
@@ -137,14 +137,14 @@ where
                                 debug!("sub_agent_internal_consumer :: StopRequested");
                                 break;
                             },
-                            Ok(SubAgentInternalEvent::AgentBecameUnhealthy(msg))=>{
+                            Ok(SubAgentInternalEvent::AgentBecameUnhealthy(unhealthy))=>{
                                 debug!("sub_agent_internal_consumer :: UnhealthyAgent");
-                                let _ = self.on_became_unhealthy(msg).inspect_err(|e| error!("error processing unhealthy status: {}",e));
+                                let _ = self.on_became_unhealthy(unhealthy).inspect_err(|e| error!("error processing unhealthy status: {}",e));
 
                             }
-                            Ok(SubAgentInternalEvent::AgentBecameHealthy)=>{
+                            Ok(SubAgentInternalEvent::AgentBecameHealthy(healthy))=>{
                                 debug!("sub_agent_internal_consumer :: HealthyAgent");
-                               let _ = self.on_became_healthy().inspect_err(|e| error!("error processing healthy status: {}",e));
+                               let _ = self.on_became_healthy(healthy).inspect_err(|e| error!("error processing healthy status: {}",e));
                             }
                          }
                     }

--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -1,17 +1,105 @@
 use std::time::Duration;
 
+use thiserror::Error;
+
 use crate::agent_type::health_config::{HealthCheck, HealthConfig};
 
 use super::http::HttpHealthChecker;
 
+#[derive(Debug)]
+pub enum Health {
+    Healthy(Healthy),
+    Unhealthy(Unhealthy),
+}
+
+impl From<Healthy> for Health {
+    fn from(healthy: Healthy) -> Self {
+        Health::Healthy(healthy)
+    }
+}
+
+impl From<Unhealthy> for Health {
+    fn from(unhealthy: Unhealthy) -> Self {
+        Health::Unhealthy(unhealthy)
+    }
+}
+
+/// A HealthCheckerError also means the agent is unhealthy.
+impl From<HealthCheckerError> for Health {
+    fn from(err: HealthCheckerError) -> Self {
+        Health::Unhealthy(err.into())
+    }
+}
+
+impl From<HealthCheckerError> for Unhealthy {
+    fn from(err: HealthCheckerError) -> Self {
+        Unhealthy {
+            last_error: err.0,
+            status: Default::default(),
+        }
+    }
+}
+
+/// Represents the healthy state of the agent and its associated data.
+/// See OpAMP's [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealthstatus)
+/// for more details.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Healthy {
+    pub status: String,
+}
+
+impl Healthy {
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+}
+
+/// Represents the unhealthy state of the agent and its associated data.
+/// See OpAMP's [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealthstatus)
+/// for more details.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Unhealthy {
+    pub status: String,
+    pub last_error: String,
+}
+
+impl Unhealthy {
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+
+    pub fn last_error(&self) -> &str {
+        &self.last_error
+    }
+}
+
+impl Health {
+    pub fn status(&self) -> &str {
+        match self {
+            Health::Healthy(healthy) => healthy.status(),
+            Health::Unhealthy(unhealthy) => unhealthy.status(),
+        }
+    }
+
+    pub fn is_healthy(&self) -> bool {
+        matches!(self, Health::Healthy { .. })
+    }
+
+    pub fn last_error(&self) -> Option<&str> {
+        if let Health::Unhealthy(unhealthy) = self {
+            Some(unhealthy.last_error())
+        } else {
+            None
+        }
+    }
+}
+
 /// A type that implements a health checking mechanism.
 pub trait HealthChecker {
-    /// Check the health of the agent. `Ok(())` means the agent is healthy. Otherwise,
-    /// we will have an `Err(e)` where `e` is the error with agent-specific semantics
-    /// with which we will build the OpAMP's `ComponentHealth.status` contents.
+    /// Check the health of the agent.
     /// See OpAMP's [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealthstatus)
     /// for more details.
-    fn check_health(&self) -> Result<(), HealthCheckerError>;
+    fn check_health(&self) -> Result<Health, HealthCheckerError>;
 
     fn interval(&self) -> Duration;
 }
@@ -20,28 +108,14 @@ pub(crate) enum HealthCheckerType {
     Http(HttpHealthChecker),
 }
 
-/// Health check errors. Its structure mimics the OpAMP's spec for containing relevant information
-#[derive(Debug)]
-pub struct HealthCheckerError {
-    /// Status contents using agent-specific semantics. This might be the response body of an HTTP
-    /// checker or the stdout/stderr of an exec checker.
-    #[allow(dead_code)]
-    /// The use of OpAMP status field on health is not implemented yet by the super-agent.
-    status: String,
-
-    /// Error information in human-readable format. We could use this to specify what kind of checker
-    /// failed, e.g., "HTTP checker failed with error: {error}". While passing the raw error to the
-    /// `status` field.
-    last_error: String,
-}
+/// Health check errors.
+#[derive(Debug, Error)]
+#[error("Health check error: {0}")]
+pub struct HealthCheckerError(String);
 
 impl HealthCheckerError {
-    pub fn new(status: String, last_error: String) -> Self {
-        Self { status, last_error }
-    }
-
-    pub fn last_error(self) -> String {
-        self.last_error
+    pub fn new(err: String) -> Self {
+        Self(err)
     }
 }
 
@@ -61,7 +135,7 @@ impl TryFrom<HealthConfig> for HealthCheckerType {
 }
 
 impl HealthChecker for HealthCheckerType {
-    fn check_health(&self) -> Result<(), HealthCheckerError> {
+    fn check_health(&self) -> Result<Health, HealthCheckerError> {
         match self {
             HealthCheckerType::Http(http_checker) => http_checker.check_health(),
         }

--- a/super-agent/src/sub_agent/mod.rs
+++ b/super-agent/src/sub_agent/mod.rs
@@ -9,8 +9,7 @@ pub mod persister;
 pub mod restart_policy;
 pub mod values;
 
-#[cfg(feature = "onhost")]
-mod health;
+pub mod health;
 
 #[cfg(feature = "k8s")]
 pub mod k8s;

--- a/super-agent/src/super_agent/event_handler/opamp/remote_config.rs
+++ b/super-agent/src/super_agent/event_handler/opamp/remote_config.rs
@@ -2,6 +2,7 @@ use opamp_client::StartedClient;
 use tracing::{error, info};
 
 use crate::event::SubAgentEvent;
+use crate::sub_agent::health::health_checker::{Healthy, Unhealthy};
 use crate::super_agent::config_storer::storer::{
     SuperAgentDynamicConfigDeleter, SuperAgentDynamicConfigLoader, SuperAgentDynamicConfigStorer,
 };
@@ -59,12 +60,15 @@ where
                     &remote_config.hash,
                     error_message.clone(),
                 )?;
-                Ok(self.report_unhealthy(error_message)?)
+                Ok(self.report_unhealthy(Unhealthy {
+                    last_error: error_message,
+                    ..Default::default()
+                })?)
             }
             Ok(()) => {
                 self.set_config_hash_as_applied(&mut remote_config.hash)?;
                 report_remote_config_status_applied(opamp_client, &remote_config.hash)?;
-                Ok(self.report_healthy()?)
+                Ok(self.report_healthy(Healthy::default())?)
             }
         }
     }

--- a/super-agent/src/super_agent/http_server/async_bridge.rs
+++ b/super-agent/src/super_agent/http_server/async_bridge.rs
@@ -37,6 +37,7 @@ mod test {
     use crate::event::channel::pub_sub;
     use crate::event::SuperAgentEvent;
     use crate::event::SuperAgentEvent::{SubAgentBecameHealthy, SuperAgentBecameHealthy};
+    use crate::sub_agent::health::health_checker::Healthy;
     use crate::super_agent::config::{AgentID, AgentTypeFQN};
     use crate::super_agent::http_server::async_bridge::run_async_sync_bridge;
     use std::thread;
@@ -56,7 +57,7 @@ mod test {
         join_handles.push(thread::spawn(move || {
             for _ in 0..5 {
                 super_agent_publisher_clone
-                    .publish(SuperAgentBecameHealthy)
+                    .publish(SuperAgentBecameHealthy(Healthy::default()))
                     .unwrap();
             }
         }));
@@ -67,6 +68,7 @@ mod test {
                     .publish(SubAgentBecameHealthy(
                         AgentID::new("some-agent-id").unwrap(),
                         AgentTypeFQN::from("whatever"),
+                        Healthy::default(),
                     ))
                     .unwrap();
             }


### PR DESCRIPTION
This PR modifies the interface for the health checker to permit fallible checks that don't necessarily mean being in an unhealthy state. I am also including the status as part of both health statuses so it can be communicated as specified in the OpAMP protocol (agent-specific semantics such as the response body of the HTTP request, etc).