### PR TITLE
Style: unwrapping errors

### DIFF
--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -178,7 +178,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "invalid directory: `dots disallowed in path `some/path/../with/../dots``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -195,7 +195,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "invalid directory: `dots disallowed in path `some/path/../with/../dots``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 

--- a/fs/src/writer_file.rs
+++ b/fs/src/writer_file.rs
@@ -219,7 +219,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "invalid path: `dots disallowed in path `some/path/../../etc/passwd``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 }

--- a/super-agent/src/agent_type/definition.rs
+++ b/super-agent/src/agent_type/definition.rs
@@ -1166,7 +1166,7 @@ env:
             fn run(&self) {
                 let a: VariableTree = serde_yaml::from_str(self.a).unwrap();
                 let b: VariableTree = serde_yaml::from_str(self.b).unwrap();
-                let err = a.merge(b).err().unwrap();
+                let err = a.merge(b).unwrap_err();
                 assert_matches!(err, AgentTypeError::ConflictingVariableDefinition(k) => {
                     assert_eq!(self.conflicting_key, k, "{}", self.name);
                 })

--- a/super-agent/src/agent_type/renderer.rs
+++ b/super-agent/src/agent_type/renderer.rs
@@ -243,7 +243,7 @@ pub(crate) mod tests {
 
         let renderer: TemplateRenderer<ConfigurationPersisterFile> = TemplateRenderer::default();
         let result = renderer.render(&agent_id, agent_type, values, attributes);
-        assert_matches!(result.err().unwrap(), AgentTypeError::ValuesNotPopulated(vars) => {
+        assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
     }
@@ -257,7 +257,7 @@ pub(crate) mod tests {
 
         let renderer: TemplateRenderer<ConfigurationPersisterFile> = TemplateRenderer::default();
         let result = renderer.render(&agent_id, agent_type, values, attributes);
-        assert_matches!(result.err().unwrap(), AgentTypeError::ValuesNotPopulated(vars) => {
+        assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
     }

--- a/super-agent/src/agent_type/runtime_config_templates.rs
+++ b/super-agent/src/agent_type/runtime_config_templates.rs
@@ -781,7 +781,7 @@ mod tests {
             Kind::String(_)
         );
         let key = assert_matches!(
-            normalized_var("does.not.exists", &variables).err().unwrap(),
+            normalized_var("does.not.exists", &variables).unwrap_err(),
             AgentTypeError::MissingTemplateKey(s) => s);
         assert_eq!("does.not.exists".to_string(), key);
     }
@@ -806,7 +806,7 @@ mod tests {
             replace(re, "${nr-var:any}-${nr-var:other}", "any", &default_var).unwrap()
         );
         let key = assert_matches!(
-            replace(re, "${nr-var:any}-x", "any", &neither_value_nor_default).err().unwrap(),
+            replace(re, "${nr-var:any}-x", "any", &neither_value_nor_default).unwrap_err(),
             AgentTypeError::MissingTemplateKey(s) => s);
         assert_eq!("any".to_string(), key);
     }

--- a/super-agent/src/sub_agent/effective_agents_assembler.rs
+++ b/super-agent/src/sub_agent/effective_agents_assembler.rs
@@ -38,7 +38,7 @@ pub enum AgentTypeDefinitionError {
     EnvironmentError(AgentTypeError, Environment),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EffectiveAgent {
     agent_id: AgentID,
     runtime_config: Runtime,
@@ -345,7 +345,7 @@ pub(crate) mod tests {
         assert!(result.is_err());
         assert_eq!(
             "error assembling agents: `agent not found`",
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 

--- a/super-agent/src/sub_agent/persister/config_persister_file.rs
+++ b/super-agent/src/sub_agent/persister/config_persister_file.rs
@@ -494,7 +494,7 @@ mod test {
         assert!(result.is_err());
         assert_eq!(
             "directory error: `cannot delete directory: `oh now...``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -537,7 +537,7 @@ mod test {
         assert_eq!(
             "directory error: `cannot create directory `some/path/some-agent-id` : `oh now...``"
                 .to_string(),
-            persist_result.err().unwrap().to_string()
+            persist_result.unwrap_err().to_string()
         );
     }
 
@@ -575,7 +575,7 @@ mod test {
         assert_eq!(
             "directory error: `cannot create directory `some/path/some-agent-id` : `oh now...``"
                 .to_string(),
-            persist_result.err().unwrap().to_string()
+            persist_result.unwrap_err().to_string()
         );
     }
 
@@ -619,7 +619,7 @@ mod test {
         assert!(persist_result.is_err());
         assert_eq!(
             "file error: `error creating file: `permission denied``".to_string(),
-            persist_result.err().unwrap().to_string()
+            persist_result.unwrap_err().to_string()
         );
     }
 
@@ -677,7 +677,7 @@ mod test {
         assert!(persist_result.is_err());
         assert_eq!(
             "file error: `error creating file: `entity already exists``".to_string(),
-            persist_result.err().unwrap().to_string()
+            persist_result.unwrap_err().to_string()
         );
     }
 

--- a/super-agent/src/sub_agent/values/on_host/file.rs
+++ b/super-agent/src/sub_agent/values/on_host/file.rs
@@ -412,7 +412,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "file read error: `error reading contents: `permission denied``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -446,7 +446,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "file read error: `error reading contents: `permission denied``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -516,7 +516,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "directory manager error: `cannot delete directory: `oh now...``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -553,7 +553,7 @@ pub mod test {
         assert_eq!(
             "directory manager error: `cannot create directory `dir name` : `oh now...``"
                 .to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 
@@ -595,7 +595,7 @@ pub mod test {
         assert!(result.is_err());
         assert_eq!(
             "file write error: `error creating file: `permission denied``".to_string(),
-            result.err().unwrap().to_string()
+            result.unwrap_err().to_string()
         );
     }
 


### PR DESCRIPTION
I think it is better to do `unwrap_err()` instead of `err().unwrap()`.

If you agree I can update the style guide.
The main difference is that:
 -  the `.err().unwrap()` on the error does `unwrap_failed() -> panic("called Option::unwrap() on a None value")` 
 -  the `.unwrap_err()` prints some info about the ok `unwrap_failed("called Result::unwrap_err() on an Ok value", &t)`
