### PR TITLE
refact: opamp builder helper

### DIFF
--- a/super-agent/src/bin/main.rs
+++ b/super-agent/src/bin/main.rs
@@ -158,21 +158,13 @@ fn run_super_agent(
         identifiers_provider,
     );
 
-    let (maybe_client, maybe_sa_opamp_consumer) = opamp_client_builder
-        .as_ref()
-        .map(|builder| {
-            build_opamp_with_channel(
-                builder,
-                &instance_id_getter,
-                AgentID::new_super_agent_id(),
-                &super_agent_fqn(),
-                non_identifying_attributes,
-            )
-        })
-        // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
-        .transpose()?
-        .map(|(client, consumer)| (Some(client), Some(consumer)))
-        .unwrap_or_default();
+    let (maybe_client, maybe_sa_opamp_consumer) = build_opamp_with_channel(
+        opamp_client_builder.as_ref(),
+        &instance_id_getter,
+        AgentID::new_super_agent_id(),
+        &super_agent_fqn(),
+        non_identifying_attributes,
+    )?;
 
     SuperAgent::new(
         maybe_client,
@@ -265,21 +257,13 @@ fn run_super_agent(
         k8s_config.clone(),
     );
 
-    let (maybe_client, opamp_consumer) = opamp_client_builder
-        .as_ref()
-        .map(|builder| {
-            build_opamp_with_channel(
-                builder,
-                &instance_id_getter,
-                AgentID::new_super_agent_id(),
-                &super_agent_fqn(),
-                non_identifying_attributes,
-            )
-        })
-        // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
-        .transpose()?
-        .map(|(client, consumer)| (Some(client), Some(consumer)))
-        .unwrap_or_default();
+    let (maybe_client, opamp_consumer) = build_opamp_with_channel(
+        opamp_client_builder.as_ref(),
+        &instance_id_getter,
+        AgentID::new_super_agent_id(),
+        &super_agent_fqn(),
+        non_identifying_attributes,
+    )?;
 
     let sub_agents_config_storer =
         SubAgentsConfigStoreConfigMap::new(k8s_store.clone(), config.dynamic);

--- a/super-agent/src/opamp/operations.rs
+++ b/super-agent/src/opamp/operations.rs
@@ -22,18 +22,22 @@ use super::{
     instance_id::getter::InstanceIDGetter,
 };
 
+#[allow(clippy::type_complexity)]
 pub fn build_opamp_with_channel<CB, OB, IG>(
-    opamp_builder: &OB,
+    maybe_opamp_builder: Option<&OB>,
     instance_id_getter: &IG,
     agent_id: AgentID,
     agent_type: &AgentTypeFQN,
     non_identifying_attributes: HashMap<String, DescriptionValueType>,
-) -> Result<(OB::Client, EventConsumer<OpAMPEvent>), OpAMPClientBuilderError>
+) -> Result<(Option<OB::Client>, Option<EventConsumer<OpAMPEvent>>), OpAMPClientBuilderError>
 where
     CB: Callbacks,
     OB: OpAMPClientBuilder<CB>,
     IG: InstanceIDGetter,
 {
+    let Some(opamp_builder) = maybe_opamp_builder else {
+        return Ok((None, None));
+    };
     let (tx, rx) = pub_sub();
     let client = build_opamp_and_start_client(
         tx,
@@ -43,7 +47,7 @@ where
         agent_type,
         non_identifying_attributes,
     )?;
-    Ok((client, rx))
+    Ok((Some(client), Some(rx)))
 }
 
 pub fn build_opamp_and_start_client<CB, OB, IG>(

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -98,24 +98,16 @@ where
             &Environment::K8s,
         );
 
-        let (maybe_opamp_client, sub_agent_opamp_consumer) = self
-            .opamp_builder
-            .map(|builder| {
-                build_opamp_with_channel(
-                    builder,
-                    self.instance_id_getter,
-                    agent_id.clone(),
-                    &sub_agent_config.agent_type,
-                    HashMap::from([(
-                        "cluster.name".to_string(),
-                        DescriptionValueType::String(self.k8s_config.cluster_name.to_string()),
-                    )]),
-                )
-            })
-            // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
-            .transpose()?
-            .map(|(client, consumer)| (Some(client), Some(consumer)))
-            .unwrap_or_default();
+        let (maybe_opamp_client, sub_agent_opamp_consumer) = build_opamp_with_channel(
+            self.opamp_builder,
+            self.instance_id_getter,
+            agent_id.clone(),
+            &sub_agent_config.agent_type,
+            HashMap::from([(
+                "cluster.name".to_string(),
+                DescriptionValueType::String(self.k8s_config.cluster_name.to_string()),
+            )]),
+        )?;
 
         // A sub-agent can be started without supervisor, when running with opamp activated, in order to
         // be able to receive messages.

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -99,21 +99,13 @@ where
     ) -> Result<Self::NotStartedSubAgent, SubAgentBuilderError> {
         let (sub_agent_internal_publisher, sub_agent_internal_consumer) = pub_sub();
 
-        let (maybe_opamp_client, sub_agent_opamp_consumer) = self
-            .opamp_builder
-            .map(|builder| {
-                build_opamp_with_channel(
-                    builder,
-                    self.instance_id_getter,
-                    agent_id.clone(),
-                    &sub_agent_config.agent_type,
-                    HashMap::from([("host.name".to_string(), get_hostname().into())]),
-                )
-            })
-            // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
-            .transpose()?
-            .map(|(client, consumer)| (Some(client), Some(consumer)))
-            .unwrap_or_default();
+        let (maybe_opamp_client, sub_agent_opamp_consumer) = build_opamp_with_channel(
+            self.opamp_builder,
+            self.instance_id_getter,
+            agent_id.clone(),
+            &sub_agent_config.agent_type,
+            HashMap::from([("host.name".to_string(), get_hostname().into())]),
+        )?;
 
         // try to build effective agent
         let effective_agent_res = self.effective_agent_assembler.assemble_agent(


### PR DESCRIPTION
Moves the opamp client + channels assembler complexity to the helper which is used for SA and Sub agents in both features