### PR TITLE
feat: add fleet id (NR-256771)

### DIFF
--- a/build/examples/super-agent-config-all-agents.yaml
+++ b/build/examples/super-agent-config-all-agents.yaml
@@ -3,6 +3,8 @@
 #   headers:
 #     api-key: API_KEY_HERE
 
+# fleet_id: FLEET_ID_HERE
+
 agents:
   nr-infra-agent:
     agent_type: "newrelic/com.newrelic.infrastructure_agent:0.1.1"

--- a/build/examples/super-agent-config-no-agents.yaml
+++ b/build/examples/super-agent-config-no-agents.yaml
@@ -3,4 +3,6 @@
 #   headers:
 #     api-key: API_KEY_HERE
 
+# fleet_id: FLEET_ID_HERE
+
 agents: {}

--- a/super-agent/src/opamp/instance_id/getter.rs
+++ b/super-agent/src/opamp/instance_id/getter.rs
@@ -222,6 +222,7 @@ pub mod test {
         #[cfg(all(not(feature = "onhost"), feature = "k8s"))]
         return Identifiers {
             cluster_name: "test".to_string(),
+            fleet_id: "test".to_string(),
         };
 
         #[cfg(feature = "onhost")]

--- a/super-agent/src/opamp/instance_id/k8s/getter.rs
+++ b/super-agent/src/opamp/instance_id/k8s/getter.rs
@@ -9,16 +9,24 @@ use std::sync::Arc;
 #[derive(Default, Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct Identifiers {
     pub cluster_name: String,
+    pub fleet_id: String,
 }
 
 impl Display for Identifiers {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "cluster_name = '{}'", self.cluster_name)
+        write!(
+            f,
+            "cluster_name = '{}', fleet_id = '{}'",
+            self.cluster_name, self.fleet_id
+        )
     }
 }
 
-pub fn get_identifiers(cluster_name: String) -> Identifiers {
-    Identifiers { cluster_name }
+pub fn get_identifiers(cluster_name: String, fleet_id: String) -> Identifiers {
+    Identifiers {
+        cluster_name,
+        fleet_id,
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/super-agent/src/opamp/instance_id/on_host/getter.rs
+++ b/super-agent/src/opamp/instance_id/on_host/getter.rs
@@ -29,14 +29,15 @@ pub struct Identifiers {
     pub machine_id: String,
     pub cloud_instance_id: String,
     pub host_id: String,
+    pub fleet_id: String,
 }
 
 impl Display for Identifiers {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "hostname = '{}', machine_id = '{}', cloud_instance_id = '{}', host_id = '{}'",
-            self.hostname, self.machine_id, self.cloud_instance_id, self.host_id
+            "hostname = '{}', machine_id = '{}', cloud_instance_id = '{}', host_id = '{}', fleet_id = '{}'",
+            self.hostname, self.machine_id, self.cloud_instance_id, self.host_id,self.fleet_id,
         )
     }
 }
@@ -55,6 +56,7 @@ pub struct IdentifiersProvider<
     system_detector: D,
     cloud_id_detector: D2,
     host_id: String,
+    fleet_id: String,
 }
 
 impl Default for IdentifiersProvider {
@@ -63,6 +65,7 @@ impl Default for IdentifiersProvider {
             system_detector: SystemDetector::default(),
             cloud_id_detector: CloudIdDetector::default(),
             host_id: String::default(),
+            fleet_id: String::default(),
         }
     }
 }
@@ -76,11 +79,16 @@ where
         Self { host_id, ..self }
     }
 
+    pub fn with_fleet_id(self, fleet_id: String) -> Self {
+        Self { fleet_id, ..self }
+    }
+
     pub fn new(system_detector: D, cloud_id_detector: D2) -> Self {
         Self {
             system_detector,
             cloud_id_detector,
             host_id: String::default(),
+            fleet_id: String::default(),
         }
     }
 
@@ -120,6 +128,7 @@ where
             hostname,
             machine_id,
             cloud_instance_id,
+            fleet_id: self.fleet_id.clone(),
         })
     }
 
@@ -223,6 +232,7 @@ pub mod test {
             system_detector: system_detector_mock,
             cloud_id_detector: cloud_id_detector_mock,
             host_id: String::new(),
+            fleet_id: String::new(),
         };
         let identifiers = identifiers_provider.provide().unwrap();
 
@@ -231,6 +241,7 @@ pub mod test {
             machine_id: String::from("some machine id"),
             cloud_instance_id: String::from("abc"),
             host_id: String::from("abc"),
+            fleet_id: String::new(),
         };
         assert_eq!(expected_identifiers, identifiers);
         assert!(logs_with_scope_contain(
@@ -259,6 +270,7 @@ pub mod test {
             system_detector: system_detector_mock,
             cloud_id_detector: cloud_id_detector_mock,
             host_id: String::new(),
+            fleet_id: String::new(),
         };
         let identifiers = identifiers_provider.provide().unwrap();
 
@@ -267,6 +279,7 @@ pub mod test {
             machine_id: String::from(""),
             cloud_instance_id: String::from("abc"),
             host_id: String::from("abc"),
+            fleet_id: String::new(),
         };
         assert_eq!(expected_identifiers, identifiers);
         assert!(logs_with_scope_contain(
@@ -296,6 +309,7 @@ pub mod test {
             system_detector: system_detector_mock,
             cloud_id_detector: cloud_id_detector_mock,
             host_id: String::new(),
+            fleet_id: String::new(),
         };
         let identifiers = identifiers_provider.provide().unwrap();
 
@@ -304,6 +318,7 @@ pub mod test {
             machine_id: String::from("some machine id"),
             cloud_instance_id: String::from(""),
             host_id: String::from("some machine id"),
+            fleet_id: String::new(),
         };
         assert_eq!(expected_identifiers, identifiers);
     }
@@ -333,6 +348,7 @@ pub mod test {
             system_detector: system_detector_mock,
             cloud_id_detector: cloud_id_detector_mock,
             host_id: String::new(),
+            fleet_id: String::new(),
         };
         let identifiers = identifiers_provider.provide().unwrap();
 
@@ -341,6 +357,7 @@ pub mod test {
             machine_id: String::from("some machine-id"),
             cloud_instance_id: String::from("abc"),
             host_id: String::from("abc"),
+            fleet_id: String::new(),
         };
         assert_eq!(expected_identifiers, identifiers);
     }
@@ -369,6 +386,7 @@ pub mod test {
             system_detector: system_detector_mock,
             cloud_id_detector: cloud_id_detector_mock,
             host_id: String::new(),
+            fleet_id: String::new(),
         };
         // Add a host_id
         let identifiers_provider = identifiers_provider.with_host_id("some-host-id".to_string());

--- a/super-agent/src/opamp/instance_id/on_host/storer.rs
+++ b/super-agent/src/opamp/instance_id/on_host/storer.rs
@@ -163,23 +163,14 @@ mod test {
         let mut dir_manager = MockDirectoryManagerMock::default();
         let ds = DataStored {
             ulid: InstanceID::new("test-ULID".to_owned()),
-            identifiers: Identifiers {
-                hostname: "test-hostname".to_string(),
-                machine_id: "test-machine-id".to_string(),
-                cloud_instance_id: "test-instance-id".to_string(),
-                host_id: "test-instance-id".to_string(),
-            },
+            identifiers: test_identifiers(),
         };
 
         let ulid_path = get_uild_path(&agent_id);
 
         // Expectations
         dir_manager.should_create(ulid_path.parent().unwrap(), Permissions::from_mode(0o700));
-        file_rw.should_write(
-            &ulid_path,
-            String::from("ulid: test-ULID\nidentifiers:\n  hostname: test-hostname\n  machine_id: test-machine-id\n  cloud_instance_id: test-instance-id\n  host_id: test-instance-id\n"),
-            Permissions::from_mode(0o600),
-        );
+        file_rw.should_write(&ulid_path, expected_file(), Permissions::from_mode(0o600));
 
         let storer = Storer::new(file_rw, dir_manager);
         assert!(storer.set(&agent_id, &ds).is_ok());
@@ -193,22 +184,13 @@ mod test {
         let mut dir_manager = MockDirectoryManagerMock::default();
         let ds = DataStored {
             ulid: InstanceID::new("test-ULID".to_owned()),
-            identifiers: Identifiers {
-                hostname: "test-hostname".to_string(),
-                machine_id: "test-machine-id".to_string(),
-                cloud_instance_id: "test-instance-id".to_string(),
-                host_id: "test-instance-id".to_string(),
-            },
+            identifiers: test_identifiers(),
         };
 
         let ulid_path = get_uild_path(&agent_id);
 
         // Expectations
-        file_rw.should_not_write(
-            &ulid_path,
-            String::from("ulid: test-ULID\nidentifiers:\n  hostname: test-hostname\n  machine_id: test-machine-id\n  cloud_instance_id: test-instance-id\n  host_id: test-instance-id\n"),
-            Permissions::from_mode(0o600),
-        );
+        file_rw.should_not_write(&ulid_path, expected_file(), Permissions::from_mode(0o600));
         dir_manager.should_create(ulid_path.parent().unwrap(), Permissions::from_mode(0o700));
 
         let storer = Storer::new(file_rw, dir_manager);
@@ -223,12 +205,7 @@ mod test {
         let dir_manager = MockDirectoryManagerMock::default();
         let ds = DataStored {
             ulid: InstanceID::new("test-ULID".to_owned()),
-            identifiers: Identifiers {
-                hostname: "test-hostname".to_string(),
-                machine_id: "test-machine-id".to_string(),
-                cloud_instance_id: "test-instance-id".to_string(),
-                host_id: "test-instance-id".to_string(),
-            },
+            identifiers: test_identifiers(),
         };
         let expected = Some(ds.clone());
         let ulid_path = get_uild_path(&agent_id);
@@ -238,7 +215,7 @@ mod test {
             .expect_read()
             .with(predicate::function(move |p| p == ulid_path.as_path()))
             .once()
-            .return_once(|_| Ok(String::from("ulid: test-ULID\nidentifiers:\n  hostname: test-hostname\n  machine_id: test-machine-id\n  cloud_instance_id: test-instance-id\n  host_id: test-instance-id\n")));
+            .return_once(|_| Ok(expected_file()));
 
         let storer = Storer::new(file_rw, dir_manager);
         let actual = storer.get(&agent_id);
@@ -265,5 +242,21 @@ mod test {
         // As said above, we are not generatinc the error variant here
         assert!(expected.is_ok());
         assert!(expected.unwrap().is_none());
+    }
+
+    /// HELPERS
+
+    fn expected_file() -> String {
+        String::from("ulid: test-ULID\nidentifiers:\n  hostname: test-hostname\n  machine_id: test-machine-id\n  cloud_instance_id: test-instance-id\n  host_id: test-host-id\n  fleet_id: test-fleet-id\n")
+    }
+
+    fn test_identifiers() -> Identifiers {
+        Identifiers {
+            hostname: "test-hostname".to_string(),
+            machine_id: "test-machine-id".to_string(),
+            cloud_instance_id: "test-instance-id".to_string(),
+            host_id: "test-host-id".to_string(),
+            fleet_id: "test-fleet-id".to_string(),
+        }
     }
 }

--- a/super-agent/src/super_agent/config.rs
+++ b/super-agent/src/super_agent/config.rs
@@ -143,6 +143,10 @@ pub struct SuperAgentConfig {
     #[serde(default)]
     pub host_id: String,
 
+    /// Unique identifier for the fleet in which the super agent will join upon initialization.
+    #[serde(default)]
+    pub fleet_id: String,
+
     /// this is the only part of the config that can be changed with opamp.
     #[serde(flatten)]
     pub dynamic: SuperAgentDynamicConfig,
@@ -384,6 +388,11 @@ host_id: 123
 agents: {}
 "#;
 
+    const SUPERAGENT_FLEET_ID: &str = r#"
+fleet_id: 123
+agents: {}
+"#;
+
     impl From<HashMap<AgentID, SubAgentConfig>> for SuperAgentDynamicConfig {
         fn from(value: HashMap<AgentID, SubAgentConfig>) -> Self {
             Self { agents: value }
@@ -604,5 +613,11 @@ agents: {}
     fn host_id_config() {
         let config = serde_yaml::from_str::<SuperAgentConfig>(SUPERAGENT_HOST_ID).unwrap();
         assert_eq!(config.host_id, "123");
+    }
+
+    #[test]
+    fn fleet_id_config() {
+        let config = serde_yaml::from_str::<SuperAgentConfig>(SUPERAGENT_FLEET_ID).unwrap();
+        assert_eq!(config.fleet_id, "123");
     }
 }

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -12,6 +12,7 @@ pub const PARENT_AGENT_ID_ATTRIBUTE_KEY: &str = "parent.agent.id";
 pub const HOST_NAME_ATTRIBUTE_KEY: &str = opentelemetry_semantic_conventions::resource::HOST_NAME;
 pub const CLUSTER_NAME_ATTRIBUTE_KEY: &str = "cluster.name";
 pub const HOST_ID_ATTRIBUTE_KEY: &str = opentelemetry_semantic_conventions::resource::HOST_ID;
+pub const FLEET_ID_ATTRIBUTE_KEY: &str = "fleet.guid";
 
 // Paths
 cfg_if::cfg_if! {


### PR DESCRIPTION
Adds a new SA configuration that identifies the Fleet at which the SA will join upon initialization. 
This attribute is sent as a non-identifying OpAMP attr.
 