### PR TITLE
Allow new agent_type versions to use latest lower agent_type to not have to repeat for each entry.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "predicates",
  "regex",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/config-migrate/Cargo.toml
+++ b/config-migrate/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 serde_yaml = { workspace = true }
 newrelic_super_agent = { path = "../super-agent" }
 fs = { path = "../fs" }
+semver = "1.0.22"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/config-migrate/src/bin/main.rs
+++ b/config-migrate/src/bin/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     info!("Starting conversion tool...");
 
-    let config: MigrationConfig = serde_yaml::from_str(NEWRELIC_INFRA_AGENT_TYPE_CONFIG_MAPPING)?;
+    let config: MigrationConfig = MigrationConfig::parse(NEWRELIC_INFRA_AGENT_TYPE_CONFIG_MAPPING)?;
 
     let cli = Cli::init_config_migrate_cli();
     let local_config_path = cli.get_config_path();

--- a/config-migrate/src/migration/agent_config_getter.rs
+++ b/config-migrate/src/migration/agent_config_getter.rs
@@ -3,12 +3,15 @@ use newrelic_super_agent::super_agent::config::{
 };
 use newrelic_super_agent::super_agent::config_storer::storer::SuperAgentDynamicConfigLoader;
 use newrelic_super_agent::super_agent::config_storer::SuperAgentConfigStoreFile;
+use semver::{Version, VersionReq};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ConversionError {
     #[error("`{0}`")]
     SuperAgentConfigError(#[from] SuperAgentConfigError),
+    #[error("Error comparing versions `{0}`")]
+    SemverError(#[from] semver::Error),
     #[error("No agents of type found on config")]
     NoAgentsFound,
 }
@@ -30,14 +33,30 @@ where
             sub_agents_config_loader,
         }
     }
-    pub fn get_agents_of_type(
+    pub fn get_agents_of_type_between_versions(
         &self,
-        agent_type: AgentTypeFQN,
+        agent_type_min: AgentTypeFQN,
+        agent_type_max: Option<AgentTypeFQN>,
     ) -> Result<SuperAgentDynamicConfig, ConversionError> {
         let mut super_agent_dynamic_config = self.sub_agents_config_loader.load()?;
+        let agent_type_namespace = agent_type_min.namespace();
+        let agent_type_name = agent_type_min.name();
+
+        // we calculate the versionReq pattern following a structure like: ">=1.2.3, <1.8.0"
+        let version_req_min = format!(">={}", agent_type_min.version());
+        let version_req_max = agent_type_max
+            .map(|at| format!(", <{}", at.version()))
+            .unwrap_or_default();
+        let version_req =
+            VersionReq::parse(format!("{}{}", version_req_min, version_req_max).as_str())?;
 
         for agent in super_agent_dynamic_config.agents.clone() {
-            if agent.1.agent_type != agent_type {
+            let agent_version = Version::parse(agent.1.agent_type.version().as_str()).unwrap();
+
+            if agent.1.agent_type.namespace() != agent_type_namespace
+                || agent.1.agent_type.name() != agent_type_name
+                || !version_req.matches(&agent_version)
+            {
                 super_agent_dynamic_config.agents.remove(&agent.0);
             }
         }
@@ -66,66 +85,184 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn load_agents_of_type() {
-        let agent_type_fqn = AgentTypeFQN::from("com.newrelic.infrastructure_agent:0.0.2");
-        let agents_cfg = r#"
+    fn load_agents_of_type_between_versions() {
+        struct TestCase {
+            name: &'static str,
+            agent_type_fqn: AgentTypeFQN,
+            next: Option<AgentTypeFQN>,
+            agents_cfg: &'static str,
+            expected: SuperAgentDynamicConfig,
+        }
+        impl TestCase {
+            fn run(self) {
+                let mut config_loader = MockSuperAgentDynamicConfigLoaderMock::new();
+                config_loader.expect_load().times(1).returning(move || {
+                    Ok(serde_yaml::from_str::<SuperAgentDynamicConfig>(self.agents_cfg).unwrap())
+                });
+
+                let config_getter = AgentConfigGetter::new(config_loader);
+                let actual = config_getter
+                    .get_agents_of_type_between_versions(self.agent_type_fqn, self.next);
+
+                assert!(actual.is_ok());
+                assert_eq!(actual.unwrap(), self.expected, "{}", self.name);
+            }
+        }
+        let test_cases = vec![
+            TestCase {
+                name: "get only two matching between versions",
+                agent_type_fqn: AgentTypeFQN::from(
+                    "newrelic/com.newrelic.infrastructure_agent:0.0.1",
+                ),
+                next: Some(AgentTypeFQN::from(
+                    "newrelic/com.newrelic.infrastructure_agent:1.0.0",
+                )),
+                agents_cfg: r#"
 agents:
   infra-agent-a:
-    agent_type: "com.newrelic.infrastructure_agent:0.0.2"
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.2"
   infra-agent-b:
-    agent_type: "com.newrelic.infrastructure_agent:0.0.2"
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.3"
+  infra-agent-c:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:1.0.3"
   not-infra-agent:
-    agent_type: "io.opentelemetry.collector:0.0.1"
-"#;
-        let mut config_loader = MockSuperAgentDynamicConfigLoaderMock::new();
-        config_loader.expect_load().times(1).returning(move || {
-            Ok(serde_yaml::from_str::<SuperAgentDynamicConfig>(agents_cfg).unwrap())
-        });
-
-        let config_getter = AgentConfigGetter::new(config_loader);
-        let actual = config_getter.get_agents_of_type(agent_type_fqn);
-
-        let expected = SuperAgentDynamicConfig {
-            agents: HashMap::from([
-                (
-                    AgentID::new("infra-agent-a").unwrap(),
-                    SubAgentConfig {
-                        agent_type: AgentTypeFQN::from("com.newrelic.infrastructure_agent:0.0.2"),
-                    },
+    agent_type: "newrelic/io.opentelemetry.collector:0.0.1"
+"#,
+                expected: SuperAgentDynamicConfig {
+                    agents: HashMap::from([
+                        (
+                            AgentID::new("infra-agent-a").unwrap(),
+                            SubAgentConfig {
+                                agent_type: AgentTypeFQN::from(
+                                    "newrelic/com.newrelic.infrastructure_agent:0.0.2",
+                                ),
+                            },
+                        ),
+                        (
+                            AgentID::new("infra-agent-b").unwrap(),
+                            SubAgentConfig {
+                                agent_type: AgentTypeFQN::from(
+                                    "newrelic/com.newrelic.infrastructure_agent:0.0.3",
+                                ),
+                            },
+                        ),
+                    ]),
+                },
+            },
+            TestCase {
+                name: "get all three matching since version",
+                agent_type_fqn: AgentTypeFQN::from(
+                    "newrelic/com.newrelic.infrastructure_agent:0.0.1",
                 ),
-                (
-                    AgentID::new("infra-agent-b").unwrap(),
-                    SubAgentConfig {
-                        agent_type: AgentTypeFQN::from("com.newrelic.infrastructure_agent:0.0.2"),
-                    },
-                ),
-            ]),
-        };
+                next: None,
+                agents_cfg: r#"
+agents:
+  infra-agent-a:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.2"
+  infra-agent-b:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.3"
+  infra-agent-c:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:1.0.3"
+  not-infra-agent:
+    agent_type: "newrelic/io.opentelemetry.collector:0.0.1"
+"#,
+                expected: SuperAgentDynamicConfig {
+                    agents: HashMap::from([
+                        (
+                            AgentID::new("infra-agent-a").unwrap(),
+                            SubAgentConfig {
+                                agent_type: AgentTypeFQN::from(
+                                    "newrelic/com.newrelic.infrastructure_agent:0.0.2",
+                                ),
+                            },
+                        ),
+                        (
+                            AgentID::new("infra-agent-b").unwrap(),
+                            SubAgentConfig {
+                                agent_type: AgentTypeFQN::from(
+                                    "newrelic/com.newrelic.infrastructure_agent:0.0.3",
+                                ),
+                            },
+                        ),
+                        (
+                            AgentID::new("infra-agent-c").unwrap(),
+                            SubAgentConfig {
+                                agent_type: AgentTypeFQN::from(
+                                    "newrelic/com.newrelic.infrastructure_agent:1.0.3",
+                                ),
+                            },
+                        ),
+                    ]),
+                },
+            },
+        ];
 
-        assert!(actual.is_ok());
-        assert_eq!(actual.unwrap(), expected);
+        for test_case in test_cases {
+            test_case.run();
+        }
     }
 
     #[test]
     fn load_agents_of_type_error() {
-        let agent_type_fqn = AgentTypeFQN::from("com.newrelic.infrastructure_agent:0.1.0");
-        let agents_cfg = r#"
+        struct TestCase {
+            name: &'static str,
+            agent_type_fqn: AgentTypeFQN,
+            next: Option<AgentTypeFQN>,
+            agents_cfg: &'static str,
+        }
+        impl TestCase {
+            fn run(self) {
+                let mut config_loader = MockSuperAgentDynamicConfigLoaderMock::new();
+                config_loader.expect_load().times(1).returning(move || {
+                    Ok(serde_yaml::from_str::<SuperAgentDynamicConfig>(self.agents_cfg).unwrap())
+                });
+
+                let config_getter = AgentConfigGetter::new(config_loader);
+                let actual = config_getter
+                    .get_agents_of_type_between_versions(self.agent_type_fqn, self.next);
+
+                assert!(actual.is_err(), "{}", self.name)
+            }
+        }
+        let test_cases = vec![
+            TestCase {
+                name: "error no agents higher or equal to version",
+                agent_type_fqn: AgentTypeFQN::from(
+                    "newrelic/com.newrelic.infrastructure_agent:0.1.0",
+                ),
+                next: None,
+                agents_cfg: r#"
 agents:
   infra-agent-a:
-    agent_type: "com.newrelic.infrastructure_agent:0.0.2"
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.2"
   infra-agent-b:
-    agent_type: "com.newrelic.infrastructure_agent:0.0.2"
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.2"
   not-infra-agent:
-    agent_type: "io.opentelemetry.collector:0.0.1"
-"#;
-        let mut config_loader = MockSuperAgentDynamicConfigLoaderMock::new();
-        config_loader.expect_load().times(1).returning(move || {
-            Ok(serde_yaml::from_str::<SuperAgentDynamicConfig>(agents_cfg).unwrap())
-        });
+    agent_type: "newrelic/io.opentelemetry.collector:0.0.1"
+"#,
+            },
+            TestCase {
+                name: "error no agents of namespace",
+                agent_type_fqn: AgentTypeFQN::from(
+                    "francisco-partners/com.newrelic.infrastructure_agent:0.0.1",
+                ),
+                next: None,
+                agents_cfg: r#"
+agents:
+  infra-agent-a:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.2"
+  infra-agent-b:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:0.0.3"
+  infra-agent-c:
+    agent_type: "newrelic/com.newrelic.infrastructure_agent:1.0.3"
+  not-infra-agent:
+    agent_type: "newrelic/io.opentelemetry.collector:0.0.1"
+"#,
+            },
+        ];
 
-        let config_getter = AgentConfigGetter::new(config_loader);
-        let result = config_getter.get_agents_of_type(agent_type_fqn);
-
-        assert!(result.is_err())
+        for test_case in test_cases {
+            test_case.run();
+        }
     }
 }

--- a/config-migrate/src/migration/config.rs
+++ b/config-migrate/src/migration/config.rs
@@ -1,8 +1,11 @@
 use newrelic_super_agent::super_agent::config::AgentTypeFQN;
 use serde::Deserialize;
+use serde_yaml::Error;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
+use thiserror::Error;
+use tracing::error;
 
 pub const FILE_SEPARATOR: &str = ".";
 // Used to replace temporarily the . separator on files to not treat them as leafs on the hashmap
@@ -10,6 +13,15 @@ pub const FILE_SEPARATOR_REPLACE: &str = "#";
 
 pub type FilePath = String;
 pub type DirPath = String;
+
+#[derive(Error, Debug)]
+pub enum MigrationConfigError {
+    #[error("error parsing yaml: `{0}`")]
+    SerdeYaml(#[from] Error),
+
+    #[error("config mapping should not be empty`")]
+    EmptyConfigMapping,
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentTypeFieldFQN(String);
@@ -91,11 +103,41 @@ pub struct MigrationConfig {
     pub configs: Vec<MigrationAgentConfig>,
 }
 
+impl MigrationConfig {
+    pub fn parse(config_content: &str) -> Result<Self, MigrationConfigError> {
+        let mut config: MigrationConfig = serde_yaml::from_str(config_content)?;
+        config.configs.sort_by_key(|c| c.agent_type_fqn.to_string());
+        let last = config
+            .configs
+            .last()
+            .ok_or(MigrationConfigError::EmptyConfigMapping)?
+            .clone();
+        config.configs = config
+            .configs
+            .iter_mut()
+            .as_slice()
+            .windows(2)
+            .map(|c| {
+                let mut current = c[0].clone();
+                if c[0].agent_type_fqn.name() == c[1].agent_type_fqn.name()
+                    && c[0].agent_type_fqn.namespace() == c[1].agent_type_fqn.namespace()
+                {
+                    current.next = Some(c[1].agent_type_fqn.clone());
+                }
+                current
+            })
+            .chain([last])
+            .collect();
+        Ok(config)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Deserialize)]
 pub struct MigrationAgentConfig {
     pub agent_type_fqn: AgentTypeFQN,
     pub files_map: FilesMap,
     pub dirs_map: DirsMap,
+    pub next: Option<AgentTypeFQN>,
 }
 
 impl MigrationAgentConfig {
@@ -122,5 +164,85 @@ impl MigrationAgentConfig {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::migration::config::MigrationConfig;
+    use newrelic_super_agent::super_agent::config::AgentTypeFQN;
+
+    #[test]
+    fn config_parse() {
+        pub const DISORDERED_AGENT_TYPES: &str = r#"
+configs:
+  -
+    agent_type_fqn: newrelic/com.newrelic.infrastructure_agent:0.0.2
+    files_map:
+      config_agent: /etc/newrelic-infra.yml
+    dirs_map:
+      config_ohis: /etc/newrelic-infra/integrations.d
+      logging: /etc/newrelic-infra/logging.d
+  -
+    agent_type_fqn: newrelic/com.newrelic.another:1.0.0
+    files_map:
+      config_another: /etc/another.yml
+    dirs_map:
+  -
+    agent_type_fqn: newrelic/com.newrelic.infrastructure_agent:1.0.1
+    files_map:
+      config_agent: /etc/newrelic-infra.yml
+    dirs_map:
+      config_integrations: /etc/newrelic-infra/integrations.d
+      config_logging: /etc/newrelic-infra/logging.d
+  -
+    agent_type_fqn: francisco-partners/com.newrelic.another:0.0.2
+    files_map:
+      config_another: /etc/another.yml
+    dirs_map:
+  -
+    agent_type_fqn: newrelic/com.newrelic.infrastructure_agent:0.1.2
+    files_map:
+      config_agent: /etc/newrelic-infra.yml
+    dirs_map:
+      config_integrations: /etc/newrelic-infra/integrations.d
+      config_logging: /etc/newrelic-infra/logging.d
+  -
+    agent_type_fqn: newrelic/com.newrelic.another:0.0.1
+    files_map:
+      config_another: /etc/another.yml
+    dirs_map:
+"#;
+
+        let expected_fqns_in_order = vec![
+            "francisco-partners/com.newrelic.another:0.0.2".into(),
+            "newrelic/com.newrelic.another:0.0.1".into(),
+            "newrelic/com.newrelic.another:1.0.0".into(),
+            "newrelic/com.newrelic.infrastructure_agent:0.0.2".into(),
+            "newrelic/com.newrelic.infrastructure_agent:0.1.2".into(),
+            "newrelic/com.newrelic.infrastructure_agent:1.0.1".into(),
+        ];
+        let expected_next_fqns_in_order: Vec<Option<AgentTypeFQN>> = vec![
+            None,
+            Some("newrelic/com.newrelic.another:1.0.0".into()),
+            None,
+            Some("newrelic/com.newrelic.infrastructure_agent:0.1.2".into()),
+            Some("newrelic/com.newrelic.infrastructure_agent:1.0.1".into()),
+            None,
+        ];
+
+        let config = MigrationConfig::parse(DISORDERED_AGENT_TYPES).unwrap();
+        for (key, cfg) in config.configs.iter().enumerate() {
+            assert_eq!(cfg.agent_type_fqn, expected_fqns_in_order[key]);
+            assert_eq!(cfg.next, expected_next_fqns_in_order[key]);
+        }
+    }
+
+    #[test]
+    fn config_parse_error_empty_mapping() {
+        pub const EMPTY_AGENT_TYPES: &str = r#"
+configs: []
+"#;
+        assert!(MigrationConfig::parse(EMPTY_AGENT_TYPES).is_err())
     }
 }


### PR DESCRIPTION
Right now the migration script requires a new entry in the [defaults.rs](http://defaults.rs/) file when a new Agent_type version is released in order to work:

```
pub const NEWRELIC_INFRA_AGENT_TYPE_CONFIG_MAPPING: &str = r#"
configs:
  -
    agent_type_fqn: newrelic/com.newrelic.infrastructure_agent:0.0.2
    files_map:
      config_agent: /etc/newrelic-infra.yml
    dirs_map:
      config_ohis: /etc/newrelic-infra/integrations.d
      logging: /etc/newrelic-infra/logging.d
  -
    agent_type_fqn: newrelic/com.newrelic.infrastructure_agent:0.1.0
    files_map:
      config_agent: /etc/newrelic-infra.yml
    dirs_map:
      config_integrations: /etc/newrelic-infra/integrations.d
      config_logging: /etc/newrelic-infra/logging.d
"#;
```

This PR adds the functionality to be able to by default use the highest agent_type in this list.