### PR TITLE
chore: allow read-only write lock

### DIFF
--- a/super-agent/src/k8s/store.rs
+++ b/super-agent/src/k8s/store.rs
@@ -84,6 +84,7 @@ impl K8sStore {
         T: serde::Serialize,
     {
         // clippy complains because we are not changing the lock's content
+        // TODO: check RwLock is being used efficiently for this use-case.
         #[allow(clippy::readonly_write_lock)]
         let _write_guard = self.rw_lock.write().unwrap();
 
@@ -100,6 +101,7 @@ impl K8sStore {
     /// Delete data in the specified StoreKey of an Agent store.
     pub fn delete_opamp_data(&self, agent_id: &AgentID, key: &StoreKey) -> Result<(), Error> {
         // clippy complains because we are not changing the lock's content
+        // TODO: check RwLock is being used efficiently for this use-case.
         #[allow(clippy::readonly_write_lock)]
         let _write_guard = self.rw_lock.write().unwrap();
 

--- a/super-agent/src/super_agent/config_storer/file.rs
+++ b/super-agent/src/super_agent/config_storer/file.rs
@@ -43,6 +43,7 @@ impl SuperAgentDynamicConfigDeleter for SuperAgentConfigStoreFile {
             unreachable!("we should not write into local paths");
         };
         // clippy complains because we are not changing the lock's content
+        // TODO: check RwLock is being used efficiently for this use-case.
         #[allow(clippy::readonly_write_lock)]
         let _write_guard = self.rw_lock.write().unwrap();
         if remote_path_file.exists() {
@@ -56,6 +57,7 @@ impl SuperAgentDynamicConfigStorer for SuperAgentConfigStoreFile {
     fn store(&self, sub_agents: &SuperAgentDynamicConfig) -> Result<(), SuperAgentConfigError> {
         //TODO we should inject DirectoryManager and ensure the directory exists
         // clippy complains because we are not changing the lock's content
+        // TODO: check RwLock is being used efficiently for this use-case.
         #[allow(clippy::readonly_write_lock)]
         let _write_guard = self.rw_lock.write().unwrap();
         let Some(remote_path_file) = &self.remote_path else {


### PR DESCRIPTION
`clippy` complains when using `write` and there is no _write operation_ (we are not changing the lock's content), we need to allow this here because we are writing to files/config-maps and the lock content is actually empty.