### PR TITLE
fix: last error message build (NR-263337)

### DIFF
--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -25,6 +25,8 @@ pub(crate) enum HealthCheckerType {
 pub struct HealthCheckerError {
     /// Status contents using agent-specific semantics. This might be the response body of an HTTP
     /// checker or the stdout/stderr of an exec checker.
+    #[allow(dead_code)]
+    /// The use of OpAMP status field on health is not implemented yet by the super-agent.
     status: String,
 
     /// Error information in human-readable format. We could use this to specify what kind of checker
@@ -36,10 +38,6 @@ pub struct HealthCheckerError {
 impl HealthCheckerError {
     pub fn new(status: String, last_error: String) -> Self {
         Self { status, last_error }
-    }
-
-    pub fn status(self) -> String {
-        self.status
     }
 
     pub fn last_error(self) -> String {

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
@@ -280,12 +280,11 @@ fn spawn_health_checker<H>(
                 publish_health_event(&health_publisher, SubAgentInternalEvent::AgentBecameHealthy)
             }
             Err(e) => {
-                let status = e.status();
-                debug!(%agent_id, status, "the configured health check failed");
+                let last_err_msg = e.last_error();
+                debug!(%agent_id, last_err_msg, "the configured health check failed");
                 publish_health_event(
                     &health_publisher,
-                    // TODO: Passing the raw status for now. Pass both `last_error` and `status`.
-                    SubAgentInternalEvent::AgentBecameUnhealthy(status),
+                    SubAgentInternalEvent::AgentBecameUnhealthy(last_err_msg),
                 )
             }
         }
@@ -526,8 +525,8 @@ pub mod sleep_supervisor_tests {
                 // Ensure the health checker will quit after the second loop
                 cancel_publisher.publish(()).unwrap();
                 Err(HealthCheckerError::new(
-                    "mocked health check error!".to_string(),
                     "".to_string(),
+                    "mocked health check error!".to_string(),
                 ))
             });
 
@@ -610,8 +609,8 @@ pub mod sleep_supervisor_tests {
             .in_sequence(&mut seq)
             .returning(|| {
                 Err(HealthCheckerError::new(
-                    "mocked health check error!".to_string(),
                     "".to_string(),
+                    "mocked health check error!".to_string(),
                 ))
             });
         health_checker
@@ -627,8 +626,8 @@ pub mod sleep_supervisor_tests {
                 // Ensure the health checker will quit after the second loop
                 cancel_publisher.publish(()).unwrap();
                 Err(HealthCheckerError::new(
-                    "mocked health check error!".to_string(),
                     "".to_string(),
+                    "mocked health check error!".to_string(),
                 ))
             });
 

--- a/super-agent/src/super_agent/super_agent.rs
+++ b/super-agent/src/super_agent/super_agent.rs
@@ -229,7 +229,6 @@ where
         loop {
             select! {
                 recv(&opamp_receiver.as_ref()) -> opamp_event => {
-                    debug!("Received OpAMP event");
                     match opamp_event.unwrap() {
                         OpAMPEvent::RemoteConfigReceived(remote_config) => {
                             let _ = self.remote_config(remote_config, sub_agent_publisher.clone(), &mut sub_agents )


### PR DESCRIPTION
This PR fixes:
- Status responses >300 are precessed as errors without response. [handling](https://github.com/newrelic/newrelic-super-agent/blob/0e1be15bed6bb59afc4ec61018a5ef7c3332805b/super-agent/src/sub_agent/health/http.rs#L101) the reponse of ureq that we fixed [here](https://github.com/newrelic/opamp-rs/pull/53/files).

- The values added to the [status and last error messages](https://github.com/newrelic/newrelic-super-agent/blob/0e1be15bed6bb59afc4ec61018a5ef7c3332805b/super-agent/src/sub_agent/health/http.rs#L101) are not consistent with the definitions: The use of OpAMP “status” field is not refined yet, and partially used by the current implementation. This PR remove all usage of it except on how is defined in the Health Error struct for future reference