### PR TITLE
chore: removing code-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence.
-
-* @newrelic/caos


### PR DESCRIPTION
As discussed, caos doesn't want to be notified by all pr opened in this shared repo (caos/coreint).
Pr review request must be assigned by the PR creator to the team depending on the modified context.