### PR TITLE
chore: bump opamp-rs 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,8 +2055,8 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opamp-client"
-version = "0.1.0"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.13#d57fa36215a71ea72add7a29757ebc6ad6422c8e"
+version = "0.15.0"
+source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.15#5b65bec832d9074b9dfc41e2817c00dbcea92093"
 dependencies = [
  "async-trait",
  "crossbeam",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1142,7 +1142,7 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.13
+## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.15
 
 Distributed under the following license(s):
 * Apache-2.0

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 ctrlc = { version = "3.4.0", features = ["termination"] }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.13", features = [
+opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.15", features = [
   "sync-http",
 ], default-features = false }
 futures = { version = "0.3.28", optional = true }


### PR DESCRIPTION
- bumps opamp-rs to the latest release
- adds support to compression to the fake opamp server in k8s test.
