### PR TITLE
feat(health): remove interval from the trait

### DIFF
--- a/super-agent/src/sub_agent/effective_agents_assembler.rs
+++ b/super-agent/src/sub_agent/effective_agents_assembler.rs
@@ -193,19 +193,17 @@ pub fn build_agent_type(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::*;
     use crate::agent_type::agent_metadata::AgentMetadata;
-    use assert_matches::assert_matches;
-    use mockall::{mock, predicate};
-    use semver::Version;
-
     use crate::agent_type::agent_type_registry::tests::MockAgentRegistryMock;
     use crate::agent_type::agent_values::AgentValues;
     use crate::agent_type::definition::AgentTypeDefinition;
     use crate::agent_type::renderer::tests::MockRendererMock;
     use crate::agent_type::runtime_config;
     use crate::sub_agent::values::values_repository::test::MockRemoteValuesRepositoryMock;
-
-    use super::*;
+    use assert_matches::assert_matches;
+    use mockall::{mock, predicate};
+    use semver::Version;
 
     mock! {
         pub(crate) EffectiveAgentAssemblerMock {}
@@ -226,7 +224,7 @@ pub(crate) mod tests {
             agent_id: &AgentID,
             agent_cfg: &SubAgentConfig,
             environment: &Environment,
-            efective_agent: EffectiveAgent,
+            effective_agent: EffectiveAgent,
         ) {
             self.expect_assemble_agent()
                 .once()
@@ -235,7 +233,7 @@ pub(crate) mod tests {
                     predicate::eq(agent_cfg.clone()),
                     predicate::eq(environment.clone()),
                 )
-                .returning(move |_, _, _| Ok(efective_agent.clone()));
+                .returning(move |_, _, _| Ok(effective_agent.clone()));
         }
     }
 

--- a/super-agent/src/sub_agent/k8s/supervisor.rs
+++ b/super-agent/src/sub_agent/k8s/supervisor.rs
@@ -114,18 +114,14 @@ impl CRSupervisor {
     ) -> Result<Option<EventPublisher<()>>, SupervisorError> {
         if let Some(health_config) = self.k8s_config.health.clone() {
             let (stop_health_publisher, stop_health_consumer) = pub_sub();
-
-            let k8s_health_checker = K8sHealthChecker::try_new(
-                self.k8s_client.clone(),
-                resources,
-                health_config.interval,
-            )?;
+            let k8s_health_checker = K8sHealthChecker::try_new(self.k8s_client.clone(), resources)?;
 
             spawn_health_checker(
                 self.agent_id.clone(),
                 k8s_health_checker,
                 stop_health_consumer,
                 health_publisher,
+                health_config.interval,
             );
             return Ok(Some(stop_health_publisher));
         }

--- a/super-agent/src/super_agent/super_agent.rs
+++ b/super-agent/src/super_agent/super_agent.rs
@@ -246,7 +246,6 @@ where
                             .inspect_err(|e| error!(error_msg = e.to_string(),"cannot publish super_agent_event::super_agent_opamp_connect_failed"));
                         }
                     }
-
                 },
                 recv(application_event_consumer.as_ref()) -> _super_agent_event => {
                     debug!("stopping Super Agent event processor");


### PR DESCRIPTION
The main idea is to clean the health check trait so that the interval is no longer needed since we are using it as a constant everywhere.

```rust
/// A type that implements a health checking mechanism.
pub trait HealthChecker {
    /// Check the health of the agent.
    /// See OpAMP's [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealthstatus)
    /// for more details.
    fn check_health(&self) -> Result<Health, HealthCheckerError>;
}
```

In the future if we need it again we could add a further trait `IntervalGetter` and have spawn_health_checker asking for `HealthChecker+ IntervalGetter` unless we go for a unified behaviour

### Why

This helps us in the K8s usecase in which we have a main healthChecker wrapping multiple ones implementing HealthChecker that do not need to specify the interval 