### PR TITLE
Decouple restart_policy onhost module

### DIFF
--- a/super-agent/src/agent_type/restart_policy.rs
+++ b/super-agent/src/agent_type/restart_policy.rs
@@ -1,10 +1,7 @@
-use std::{str::FromStr, time::Duration};
-
-use crate::sub_agent::restart_policy::{Backoff, BackoffStrategy, RestartPolicy};
+use super::{definition::TemplateableValue, error::AgentTypeError};
 use duration_str::deserialize_duration;
 use serde::Deserialize;
-
-use super::{definition::TemplateableValue, error::AgentTypeError};
+use std::{str::FromStr, time::Duration};
 
 /// Defines the Restart Policy configuration.
 /// This policy outlines the procedures followed for restarting agents when their execution encounters failure.
@@ -114,9 +111,9 @@ impl From<MaxRetries> for usize {
 pub struct BackoffStrategyConfig {
     #[serde(rename = "type")]
     pub backoff_type: TemplateableValue<BackoffStrategyType>,
-    pub(super) backoff_delay: TemplateableValue<BackoffDelay>,
+    pub backoff_delay: TemplateableValue<BackoffDelay>,
     pub max_retries: TemplateableValue<MaxRetries>,
-    pub(super) last_retry_interval: TemplateableValue<BackoffLastRetryInterval>,
+    pub last_retry_interval: TemplateableValue<BackoffLastRetryInterval>,
 }
 
 impl BackoffStrategyConfig {
@@ -156,25 +153,6 @@ impl FromStr for BackoffStrategyType {
     }
 }
 
-impl From<RestartPolicyConfig> for RestartPolicy {
-    fn from(value: RestartPolicyConfig) -> Self {
-        RestartPolicy::new((&value.backoff_strategy).into(), value.restart_exit_codes)
-    }
-}
-
-impl From<&BackoffStrategyConfig> for BackoffStrategy {
-    fn from(value: &BackoffStrategyConfig) -> Self {
-        match value.clone().backoff_type.get() {
-            BackoffStrategyType::Fixed => BackoffStrategy::Fixed(realize_backoff_config(value)),
-            BackoffStrategyType::Linear => BackoffStrategy::Linear(realize_backoff_config(value)),
-            BackoffStrategyType::Exponential => {
-                BackoffStrategy::Exponential(realize_backoff_config(value))
-            }
-            BackoffStrategyType::None => BackoffStrategy::None,
-        }
-    }
-}
-
 impl Default for BackoffStrategyConfig {
     fn default() -> Self {
         Self {
@@ -184,13 +162,6 @@ impl Default for BackoffStrategyConfig {
             last_retry_interval: TemplateableValue::new(DEFAULT_BACKOFF_LAST_RETRY_INTERVAL.into()),
         }
     }
-}
-
-fn realize_backoff_config(i: &BackoffStrategyConfig) -> Backoff {
-    Backoff::new()
-        .with_initial_delay(i.backoff_delay.clone().get().into())
-        .with_max_retries(i.max_retries.clone().get().into())
-        .with_last_retry_interval(i.last_retry_interval.clone().get().into())
 }
 
 #[cfg(test)]

--- a/super-agent/src/sub_agent/mod.rs
+++ b/super-agent/src/sub_agent/mod.rs
@@ -1,15 +1,12 @@
-// Common subagent modules
 pub mod collection;
 pub mod effective_agents_assembler;
 pub mod error;
 mod event_handler;
 pub mod event_processor;
 pub mod event_processor_builder;
-pub mod persister;
-pub mod restart_policy;
-pub mod values;
-
 pub mod health;
+pub mod persister;
+pub mod values;
 
 #[cfg(feature = "k8s")]
 pub mod k8s;

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -18,6 +18,7 @@ use crate::opamp::remote_config_report::{
 use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssembler};
 use crate::sub_agent::event_processor_builder::SubAgentEventProcessorBuilder;
 use crate::sub_agent::on_host::supervisor::command_supervisor;
+use crate::sub_agent::on_host::supervisor::restart_policy::RestartPolicy;
 use crate::sub_agent::NotStarted;
 use crate::sub_agent::SubAgentCallbacks;
 use crate::super_agent::config::{AgentID, SubAgentConfig};
@@ -27,7 +28,6 @@ use crate::{
     opamp::client_builder::OpAMPClientBuilder,
     sub_agent::{
         error::{SubAgentBuilderError, SubAgentError},
-        restart_policy::RestartPolicy,
         SubAgentBuilder,
     },
 };

--- a/super-agent/src/sub_agent/on_host/mod.rs
+++ b/super-agent/src/sub_agent/on_host/mod.rs
@@ -1,5 +1,4 @@
 pub mod builder;
 pub mod command;
-pub mod supervisor;
-
 pub mod sub_agent;
+pub mod supervisor;

--- a/super-agent/src/sub_agent/on_host/supervisor/README.md
+++ b/super-agent/src/sub_agent/on_host/supervisor/README.md
@@ -1,1 +1,0 @@
-A Supervisor is the component that supervises an on-host command.

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
@@ -14,7 +14,7 @@ use crate::sub_agent::on_host::command::shutdown::{
     wait_exit_timeout, wait_exit_timeout_default, ProcessTerminator,
 };
 use crate::sub_agent::on_host::supervisor::command_supervisor_config::SupervisorConfigOnHost;
-use crate::sub_agent::restart_policy::BackoffStrategy;
+use crate::sub_agent::on_host::supervisor::restart_policy::BackoffStrategy;
 use crate::super_agent::config::AgentID;
 use std::process::ExitStatus;
 use std::{
@@ -330,7 +330,7 @@ pub mod sleep_supervisor_tests {
     use crate::event::channel::pub_sub;
     use crate::sub_agent::health::health_checker::{Health, HealthCheckerError, Healthy};
     use crate::sub_agent::on_host::supervisor::command_supervisor_config::ExecutableData;
-    use crate::sub_agent::restart_policy::{Backoff, BackoffStrategy, RestartPolicy};
+    use crate::sub_agent::on_host::supervisor::restart_policy::{Backoff, RestartPolicy};
     use mockall::{mock, Sequence};
     use std::time::{Duration, Instant};
     use tracing_test::traced_test;

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
@@ -1,6 +1,6 @@
 use crate::agent_type::health_config::HealthConfig;
 use crate::context::Context;
-use crate::sub_agent::restart_policy::RestartPolicy;
+use crate::sub_agent::on_host::supervisor::restart_policy::RestartPolicy;
 use crate::super_agent::config::AgentID;
 use std::collections::HashMap;
 

--- a/super-agent/src/sub_agent/on_host/supervisor/mod.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/mod.rs
@@ -1,3 +1,4 @@
 pub mod command_supervisor;
 pub mod command_supervisor_config;
 pub mod error;
+pub mod restart_policy;

--- a/super-agent/test/on_host/supervisor.rs
+++ b/super-agent/test/on_host/supervisor.rs
@@ -8,7 +8,7 @@ use newrelic_super_agent::sub_agent::on_host::supervisor::command_supervisor::{
     NotStarted, SupervisorOnHost,
 };
 use newrelic_super_agent::sub_agent::on_host::supervisor::command_supervisor_config::SupervisorConfigOnHost;
-use newrelic_super_agent::sub_agent::restart_policy::RestartPolicy;
+use newrelic_super_agent::sub_agent::on_host::supervisor::restart_policy::RestartPolicy;
 use std::sync::Once;
 
 static INIT_LOGGER: Once = Once::new();


### PR DESCRIPTION
This PR:
 - moves `restart_policy` under `onhost::supervisor` since it is the only module using it
 - moves some methods defined in `agent_type` to `onhost::supervisor` to decouple the two implementations
 