### PR TITLE
bump opamp-rs to 0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,8 +2100,8 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opamp-client"
-version = "0.0.16"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.16#d780be1c7bea5cb65a18c2027b0093c4cfc4044d"
+version = "0.0.17"
+source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.17#31caea77640d7849a738c13406e918b9f23b6732"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -2325,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2335,15 +2335,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1149,7 +1149,7 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.16
+## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.17
 
 Distributed under the following license(s):
 * Apache-2.0

--- a/resource-detection/src/cloud/azure/detector.rs
+++ b/resource-detection/src/cloud/azure/detector.rs
@@ -93,7 +93,7 @@ mod test {
     #[test]
     fn http_client_error() {
         let mut client_mock = MockHttpClientMock::new();
-        let error = HttpClientError::UreqError(String::from("some error"));
+        let error = HttpClientError::TransportError(String::from("some error"));
         client_mock.should_not_get(error);
 
         let detector = AzureDetector {

--- a/resource-detection/src/cloud/http_client.rs
+++ b/resource-detection/src/cloud/http_client.rs
@@ -6,15 +6,15 @@ use tracing::error;
 /// An enumeration of potential errors related to the HTTP client.
 #[derive(Error, Debug)]
 pub enum HttpClientError {
-    /// Represents Ureq crate error.
+    /// Represents HTTP Transport error.
     #[error("internal HTTP client error: `{0}`")]
-    UreqError(String),
+    TransportError(String),
 }
 
 /// The `HttpClient` trait defines the HTTP get interface to be implemented
 /// by HTTP clients.
 pub trait HttpClient {
-    /// Returns a `http::Response<Vec<u8>>` structure as the HTPP response or
+    /// Returns a `http::Response<Vec<u8>>` structure as the HTTP response or
     /// HttpClientError if an error was found.
     fn get(&self) -> Result<http::Response<Vec<u8>>, HttpClientError>;
 }
@@ -56,7 +56,7 @@ impl HttpClient for HttpClientUreq {
 
         Ok(req
             .call()
-            .map_err(|e| HttpClientError::UreqError(e.to_string()))?
+            .map_err(|e| HttpClientError::TransportError(e.to_string()))?
             .into())
     }
 }

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 ctrlc = { version = "3.4.0", features = ["termination"] }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.16", features = [
+opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.17", features = [
   "sync-http",
 ], default-features = false }
 futures = { version = "0.3.28", optional = true }
@@ -69,7 +69,7 @@ fs = { path = "../fs", features = ["mocks"] }
 tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros"] }
 wiremock = "0.6.0"
 fake = { version = "2.9.2", features = ["derive", "http"] }
-prost = "0.11.8"
+prost = "0.12.4"
 
 [build-dependencies]
 glob = "0.3.1"

--- a/super-agent/src/opamp/callbacks.rs
+++ b/super-agent/src/opamp/callbacks.rs
@@ -259,7 +259,7 @@ pub(crate) mod tests {
 
         // When an error without status code and reason is received
         callbacks.on_connect_failed(ConnectionError::HTTPClientError(
-            HttpClientError::UreqError("Some transport error".to_string()),
+            HttpClientError::TransportError("Some transport error".to_string()),
         ));
 
         let _ = event_consumer

--- a/super-agent/src/opamp/http/client.rs
+++ b/super-agent/src/opamp/http/client.rs
@@ -64,7 +64,7 @@ impl HttpClient for HttpClientUreq {
 
         match req.send(Cursor::new(body)) {
             Ok(response) | Err(ureq::Error::Status(_, response)) => build_response(response),
-            Err(ureq::Error::Transport(e)) => Err(HttpClientError::UreqError(e.to_string())),
+            Err(ureq::Error::Transport(e)) => Err(HttpClientError::TransportError(e.to_string())),
         }
     }
 }

--- a/super-agent/test/k8s/tools/opamp.rs
+++ b/super-agent/test/k8s/tools/opamp.rs
@@ -151,7 +151,7 @@ async fn config_handler(
 /// Checks if the remote is applied according to the agent message
 fn remote_config_is_applied(message: &opamp::proto::AgentToServer) -> bool {
     if let Some(remote_config_status) = message.clone().remote_config_status {
-        return opamp::proto::RemoteConfigStatuses::from_i32(remote_config_status.status).unwrap()
+        return opamp::proto::RemoteConfigStatuses::try_from(remote_config_status.status).unwrap()
             == opamp::proto::RemoteConfigStatuses::Applied;
     }
     false


### PR DESCRIPTION
This PR:
* Bumps opamp-rs to 0.0.17
* Adapts the necessary code (remove references to ureq in traits)