### PR TITLE
subAgent healthy only after healthchecker success

### DIFF
--- a/super-agent/src/sub_agent/event_processor.rs
+++ b/super-agent/src/sub_agent/event_processor.rs
@@ -6,15 +6,13 @@ use crate::sub_agent::error::SubAgentError;
 use crate::sub_agent::values::values_repository::ValuesRepository;
 use crate::sub_agent::SubAgentCallbacks;
 use crate::super_agent::config::AgentID;
-use crate::utils::time::get_sys_time_nano;
 use crossbeam::channel::never;
 use crossbeam::select;
-use opamp_client::opamp::proto::ComponentHealth;
 use opamp_client::StartedClient;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 // This trait is meant for testing, there are no multiple implementations expected
 // It cannot be doubled as the implementation has a lifetime constraint
@@ -83,20 +81,6 @@ where
                 agent_id = self.agent_id.to_string(),
                 "event processor started"
             );
-
-            //TODO: this will change when we define specific health events
-            if let Some(client) = &self.maybe_opamp_client {
-                info!(
-                    agent_id = &self.agent_id.to_string(),
-                    "reporting agent as healthy"
-                );
-                client.set_health(ComponentHealth {
-                    healthy: true,
-                    start_time_unix_nano: get_sys_time_nano()?,
-                    last_error: "".to_string(),
-                    ..Default::default()
-                })?;
-            }
 
             // The below two lines are used to create a channel that never receives any message
             // if the sub_agent_opamp_consumer is None. Thus, we avoid erroring if there is no
@@ -206,7 +190,6 @@ pub mod test {
         let values_repository = MockRemoteValuesRepositoryMock::default();
 
         //opamp client expects to be stopped
-        opamp_client.should_set_health(1);
         opamp_client.should_stop(1);
 
         let event_processor = EventProcessor::new(
@@ -258,7 +241,6 @@ pub mod test {
         let remote_config = RemoteConfig::new(agent_id.clone(), hash, Some(config_map));
 
         //opamp client expects to be stopped
-        opamp_client.should_set_health(1);
         opamp_client.should_stop(1);
 
         let event_processor = EventProcessor::new(


### PR DESCRIPTION
We should consider a subAgent Healthy only if a healthcheck succeeded.

Open question:
 - What should we do if no healthcheck is defined?  I think it is correct to surface that we do not know anything, instead of sending a `healthy`