### PR TITLE
[NR-250014] feat: use reflectors in daemon-set health-checker

### DIFF
--- a/super-agent/src/k8s/client.rs
+++ b/super-agent/src/k8s/client.rs
@@ -319,13 +319,6 @@ impl AsyncK8sClient {
     pub fn default_namespace(&self) -> &str {
         self.client.default_namespace()
     }
-
-    pub async fn list_daemon_set(&self) -> Result<ObjectList<DaemonSet>, K8sError> {
-        let ss_client: Api<DaemonSet> = Api::<DaemonSet>::default_namespaced(self.client.clone());
-        let list_daemon_set = ss_client.list(&ListParams::default()).await?;
-
-        Ok(list_daemon_set)
-    }
 }
 
 //  delete_collection has been moved outside the client to be able to use mockall in the client

--- a/super-agent/src/sub_agent/health/k8s/daemon_set.rs
+++ b/super-agent/src/sub_agent/health/k8s/daemon_set.rs
@@ -1,4 +1,4 @@
-use super::items::{flux_release_filter, items_health_check};
+use super::items::{check_health_for_items, flux_release_filter};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::IntOrPercentage;
@@ -57,7 +57,7 @@ impl HealthChecker for K8sHealthDaemonSet {
             .into_iter()
             .filter(flux_release_filter(self.release_name.clone()));
 
-        items_health_check(target_daemon_sets, Self::check_health_single_daemon_set)
+        check_health_for_items(target_daemon_sets, Self::check_health_single_daemon_set)
     }
 }
 
@@ -669,7 +669,7 @@ pub mod test {
         );
         assert!(
             unhealthy.last_error().contains("unhealthy-daemon-set"),
-            "The unhealthy message point to the unhealthy daemon-set, got {:?}",
+            "The unhealthy message should point to the unhealthy daemon-set, got {:?}",
             unhealthy
         );
     }

--- a/super-agent/src/sub_agent/health/k8s/items.rs
+++ b/super-agent/src/sub_agent/health/k8s/items.rs
@@ -13,7 +13,7 @@ use std::{any::Any, sync::Arc};
 /// It returns:
 /// * A healthy result if the result of execution is healthy for all the items.
 /// * The first encountered error or unhealthy result, otherwise.
-pub fn items_health_check<K, F>(
+pub fn check_health_for_items<K, F>(
     items: impl Iterator<Item = K>,
     health_check_fn: F,
 ) -> Result<Health, HealthCheckerError>
@@ -55,7 +55,7 @@ mod test {
 
     #[test]
     fn test_items_health_check_healthy() {
-        let result = items_health_check(vec!["a", "b", "c", "d"].into_iter(), |_| {
+        let result = check_health_for_items(vec!["a", "b", "c", "d"].into_iter(), |_| {
             Ok(Healthy::default().into())
         })
         .unwrap_or_else(|err| panic!("unexpected error {err} when all items are healthy"));
@@ -65,7 +65,7 @@ mod test {
             "Expected healthy when all items are healthy"
         );
 
-        let result = items_health_check(Vec::new().into_iter(), |_: &str| {
+        let result = check_health_for_items(Vec::new().into_iter(), |_: &str| {
             Err(HealthCheckerError::Generic("fail!".to_string()))
         })
         .unwrap_or_else(|err| panic!("unexpected error {err} when there are no items"));
@@ -78,7 +78,7 @@ mod test {
 
     #[test]
     fn test_items_health_check_unhealthy() {
-        let result = items_health_check(vec!["a", "b", "c", "d"].into_iter(), |s| match s {
+        let result = check_health_for_items(vec!["a", "b", "c", "d"].into_iter(), |s| match s {
             "a" | "b" => Ok(Healthy::default().into()),
             _ => Ok(Health::unhealthy_with_last_error(s.to_string())),
         })
@@ -95,7 +95,7 @@ mod test {
 
     #[test]
     fn test_items_health_check_err() {
-        let result = items_health_check(vec!["a", "b", "c", "d"].into_iter(), |s| match s {
+        let result = check_health_for_items(vec!["a", "b", "c", "d"].into_iter(), |s| match s {
             "a" | "b" => Ok(Healthy::default().into()),
             _ => Err(HealthCheckerError::Generic(s.to_string())),
         })

--- a/super-agent/src/sub_agent/health/k8s/stateful_set.rs
+++ b/super-agent/src/sub_agent/health/k8s/stateful_set.rs
@@ -1,4 +1,4 @@
-use super::items::{flux_release_filter, items_health_check};
+use super::items::{check_health_for_items, flux_release_filter};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::{
@@ -24,7 +24,7 @@ impl HealthChecker for K8sHealthStatefulSet {
             .into_iter()
             .filter(flux_release_filter(self.release_name.clone()));
 
-        items_health_check(target_stateful_sets, Self::stateful_set_health)
+        check_health_for_items(target_stateful_sets, Self::stateful_set_health)
     }
 }
 


### PR DESCRIPTION
This PR updates the daemon-set health-checker to use reflectors.

* K8s client is updated to expose a function to list daemon-sets through reflectors.
* K8s client is function signatures to list reflectors are renamed.
* The daemon-set health-checkers uses reflectors instead of an API call.
* A new test is added to the daemon-set health checker to check to assure it works when the client returns a list of daemon-sets.

### Out of scope

(to be addressed in folow-up PRs)

* Refactors to use the same helpers in all the health-checkers.
* Reflectors usage in the deployment health-checker.