### PR TITLE
fix: error on reading hash should allow the flow to continue

### DIFF
--- a/super-agent/src/opamp/hash_repository/on_host/file.rs
+++ b/super-agent/src/opamp/hash_repository/on_host/file.rs
@@ -89,11 +89,18 @@ where
     fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
         let mut conf_path = self.conf_path.clone();
         let hash_path = self.hash_file_path(agent_id, &mut conf_path);
-        debug!("Reading hash file at {}", hash_path.to_string_lossy());
-        // Reading and failing to get a hash should not interrupt the program execution,
+        debug!("reading hash file at {}", hash_path.to_string_lossy());
+        // Reading and failing to get a file should not interrupt the program execution,
         // but should indicate that there is no hash info available.
-        // Hence, we discard the error variant and transform it to a `None: Option<String>`.
-        let contents = self.file_rw.read(hash_path).ok();
+        // Hence, we discard this error and transform it to a `None: Option<String>`.
+        let contents = match self.file_rw.read(hash_path) {
+            Ok(c) => Some(c),
+            Err(FileReaderError::FileNotFound(e)) => {
+                debug!("no hash file found: {e}");
+                None
+            }
+            Err(e) => return Err(e.into()),
+        };
         // We attempt to parse the `Hash` from the String if we got it, failing if we cannot parse.
         let result = contents.map(|s| serde_yaml::from_str(&s)).transpose();
         Ok(result?)


### PR DESCRIPTION
If reading the hash file inside `get` fails (for example, if it's not there) we early exit on error and the calling function `build_supervisors_or_default` will also short-circuit with `Err`. We won't want this to happen, instead we want the reading of the hash to return `None` (`get` -> `Ok(None)`) so the Super Agent execution can continue on this branch.

This makes me wonder about the signature, as there won't be any failures to cover for in the `Result`. Should we force the `None` to happen only for some errors (for example, file is missing) and short-circuit for others (like permissions or something like disk space failures)?