### PR TITLE
Fix signature of k8s instanceID getter

### DIFF
--- a/super-agent/src/bin/main.rs
+++ b/super-agent/src/bin/main.rs
@@ -276,7 +276,7 @@ fn run_super_agent<C: HttpClientBuilder>(
     );
 
     let instance_id_getter =
-        ULIDInstanceIDGetter::new_with_identifiers(k8s_store.clone(), identifiers);
+        ULIDInstanceIDGetter::new_k8s_instance_id_getter(k8s_store.clone(), identifiers);
 
     let mut vr = ValuesRepositoryConfigMap::new(k8s_store.clone());
     if opamp_client_builder.is_some() {

--- a/super-agent/src/opamp/instance_id/k8s/getter.rs
+++ b/super-agent/src/opamp/instance_id/k8s/getter.rs
@@ -39,7 +39,7 @@ pub enum GetterError {
 }
 
 impl ULIDInstanceIDGetter<Storer> {
-    pub fn new_with_identifiers(k8s_store: Arc<K8sStore>, identifiers: Identifiers) -> Self {
+    pub fn new_k8s_instance_id_getter(k8s_store: Arc<K8sStore>, identifiers: Identifiers) -> Self {
         Self::new(Storer::new(k8s_store), identifiers)
     }
 }

--- a/super-agent/test/k8s/garbage_collector.rs
+++ b/super-agent/test/k8s/garbage_collector.rs
@@ -99,7 +99,7 @@ metadata:
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
 
     let instance_id_getter =
-        ULIDInstanceIDGetter::new_with_identifiers(k8s_store.clone(), Identifiers::default());
+        ULIDInstanceIDGetter::new_k8s_instance_id_getter(k8s_store.clone(), Identifiers::default());
 
     // Creates ULID CM correctly tagged.
     let agent_ulid = instance_id_getter.get(agent_id).unwrap();
@@ -229,7 +229,7 @@ fn k8s_garbage_collector_does_not_remove_super_agent() {
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
 
     let instance_id_getter =
-        ULIDInstanceIDGetter::new_with_identifiers(k8s_store.clone(), Identifiers::default());
+        ULIDInstanceIDGetter::new_k8s_instance_id_getter(k8s_store.clone(), Identifiers::default());
 
     let sa_ulid = instance_id_getter.get(sa_id).unwrap();
 

--- a/super-agent/test/k8s/store.rs
+++ b/super-agent/test/k8s/store.rs
@@ -52,7 +52,7 @@ fn k8s_instance_id_store() {
     let agent_id_2 = AgentID::new(AGENT_ID_2).unwrap();
 
     let instance_id_getter =
-        ULIDInstanceIDGetter::new_with_identifiers(k8s_store, Identifiers::default());
+        ULIDInstanceIDGetter::new_k8s_instance_id_getter(k8s_store, Identifiers::default());
 
     let instance_id_created_1 = instance_id_getter.get(&agent_id_1).unwrap();
     let instance_id_1 = instance_id_getter.get(&agent_id_1).unwrap();
@@ -252,7 +252,7 @@ fn k8s_multiple_store_entries() {
     // Persisters sharing the ConfigMap
     let hash_repository = HashRepositoryConfigMap::new(k8s_store.clone());
     let instance_id_getter =
-        ULIDInstanceIDGetter::new_with_identifiers(k8s_store.clone(), Identifiers::default());
+        ULIDInstanceIDGetter::new_k8s_instance_id_getter(k8s_store.clone(), Identifiers::default());
 
     // Add entries to from all persisters
     let hash = Hash::new("hash-test".to_string());


### PR DESCRIPTION
No error can be returned, moreover the name was quite misleading since also the new gave the possibility to set identifiers