### PR TITLE
fix: status server fail to start (NR-270390)

### DIFF
--- a/super-agent/src/opamp/callbacks.rs
+++ b/super-agent/src/opamp/callbacks.rs
@@ -97,9 +97,9 @@ impl AgentCallbacks {
         let _ = self
             .publisher
             .publish(OpAMPEvent::Connected)
-            .inspect_err(|e| {
+            .inspect_err(|err| {
                 error!(
-                    error_msg = e.to_string(),
+                    error_msg = %err,
                     "error publishing opamp_event.connected"
                 )
             });
@@ -115,10 +115,10 @@ impl AgentCallbacks {
         let _ = self
             .publisher
             .publish(OpAMPEvent::ConnectFailed(code, reason))
-            .inspect_err(|e| {
+            .inspect_err(|err| {
                 error!(
                     %self.agent_id,
-                    error_msg = e.to_string(),
+                    error_msg = %err,
                     "error publishing opamp_event.connected"
                 )
             });

--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -157,10 +157,9 @@ pub(crate) fn spawn_health_checker<H>(
         debug!(%agent_id, "starting to check health with the configured checker");
         match health_checker.check_health() {
             Ok(health) => publish_health_event(&health_publisher, health.into()),
-            Err(e) => {
-                let last_error_msg = e.to_string();
-                debug!(%agent_id, last_error = last_error_msg, "the configured health check failed");
-                publish_health_event(&health_publisher, Unhealthy::from(e).into())
+            Err(err) => {
+                debug!(%agent_id, last_error = %err, "the configured health check failed");
+                publish_health_event(&health_publisher, Unhealthy::from(err).into())
             }
         }
     });

--- a/super-agent/src/super_agent/http_server/async_bridge.rs
+++ b/super-agent/src/super_agent/http_server/async_bridge.rs
@@ -14,16 +14,16 @@ pub fn run_async_sync_bridge(
     thread::spawn(move || loop {
         match super_agent_consumer.as_ref().recv() {
             Ok(super_agent_event) => {
-                let _ = async_publisher.send(super_agent_event).inspect_err(|e| {
+                let _ = async_publisher.send(super_agent_event).inspect_err(|err| {
                     error!(
-                        error_msg = e.to_string(),
+                        error_msg = %err,
                         "cannot forward super agent event"
                     );
                 });
             }
-            Err(e) => {
+            Err(err) => {
                 debug!(
-                    error_msg = e.to_string(),
+                    error_msg = %err,
                     "status server bridge channel closed"
                 );
                 break;

--- a/super-agent/src/super_agent/http_server/runner.rs
+++ b/super-agent/src/super_agent/http_server/runner.rs
@@ -69,7 +69,7 @@ impl Runner {
                     maybe_opamp_client_config,
                 ))
                 .inspect_err(|err| {
-                    error!(error_msg = err.to_string(), "error running status server");
+                    error!(error_msg = %err, "error running status server");
                 });
 
             // Wait until the bridge is closed
@@ -83,9 +83,9 @@ impl Runner {
                 Ok(_) => {
                     //do nothing
                 }
-                Err(e) => {
+                Err(err) => {
                     debug!(
-                        error_msg = e.to_string(),
+                        error_msg = %err,
                         "http server event drain processor closed"
                     );
                     break;

--- a/super-agent/src/super_agent/http_server/server.rs
+++ b/super-agent/src/super_agent/http_server/server.rs
@@ -50,7 +50,7 @@ pub async fn run_status_server(
         let _ = run_server(server_config, server_handle_publisher, status_clone)
             .await
             .inspect_err(|err| {
-                error!(error_msg = err.to_string(), "starting HTTP server");
+                error!(error_msg = %err, "starting HTTP server");
             });
     });
 


### PR DESCRIPTION
Problem:
When the HTTP server fails to start, `run_server(..)` was returning an error closing the `server_handle_consumer` and the error showed was that instead of the root cause of the fail: 
```
ERROR error running status server, error_msg: "error receiving server handle `receiving on a closed channel`"
```
Also gracefully shut down was not working since that error was throw again.

This PR fixes this by moving the order of shutdown process and printing the error of `run_server(..)` on the thread.