### PR TITLE
Clippy should provide a readable message

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,7 +66,7 @@ jobs:
           components: clippy
 
       - name: cargo clippy ${{ matrix.package }}
-        run: cargo clippy --package ${{ matrix.package }} --message-format=json --tests -- -D clippy::all
+        run: cargo clippy --package ${{ matrix.package }} --tests -- -D clippy::all
 
   clippy_super_agent:
     runs-on: ubuntu-latest
@@ -96,7 +96,7 @@ jobs:
           components: clippy
 
       - name: cargo clippy super agent (${{ matrix.feature }})
-        run: cargo clippy --package newrelic_super_agent --features=${{ matrix.feature }} --message-format=json --tests -- -D clippy::all
+        run: cargo clippy --package newrelic_super_agent --features=${{ matrix.feature }} --tests -- -D clippy::all
 
   doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
From:
```json
error: could not compile `newrelic_super_agent` (test "k8s") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
{"reason":"compiler-artifact","package_id":"path+file:///Users/pgallina/go/src/github.com/newrelic/newrelic-supervisor/super-agent#newrelic_super_agent@0.15.0","manifest_path":"/Users/pgallina/go/src/github.com/newrelic/newrelic-supervisor/super-agent/Cargo.toml","target":{"kind":
["lib"],"crate_types":["lib"],"name":"newrelic_super_agent","src_path":"/Users/pgallina/go/src/github.com/newrelic/newrelic-supervisor/super-agent/src/lib.rs","edition":"2021","doc":true,"doctest":true,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":
true,"overflow_checks":true,"test":true},"features":["k8s"],"filenames":["/Users/pgallina/go/src/github.com/newrelic/newrelic-supervisor/target/debug/deps/libnewrelic_super_agent-93400a048b6ae101.rmeta"],"executable":null,"fresh":false}
{"reason":"build-finished","success":false}

```

to
```
error: writing `&String` instead of `&str` involves a new object where a slice will do
  --> super-agent/test/k8s/tools/uuid.rs:10:35
   |
10 | pub fn get_instance_id(namespace: &String, agent_id: &AgentID) -> InstanceID {
   |                                   ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
   = note: `-D clippy::ptr-arg` implied by `-D clippy::all`
   = help: to override `-D clippy::all` add `#[allow(clippy::ptr_arg)]`
help: change this to
   |
10 ~ pub fn get_instance_id(namespace: &str, agent_id: &AgentID) -> InstanceID {
11 |     let k8s_client =
12 ~         Arc::new(SyncK8sClient::try_new(tokio_runtime(), namespace.to_owned(), Vec::new()).unwrap());
   |

```