### PR TITLE
Fix k8s feature for workspace `newrelic-super-agent`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Run tests config-migrate
-        run: cargo test --locked --package config-migrate --all-targets
+        run: cargo test --locked --package config-migrate --features=onhost --all-targets
 
       - name: Run tests fs
         run: cargo test --locked --package fs --all-targets

--- a/config-migrate/Cargo.toml
+++ b/config-migrate/Cargo.toml
@@ -17,7 +17,7 @@ nix = { workspace = true, features = ["signal", "user", "hostname"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing = { workspace = true }
 serde_yaml = { workspace = true }
-newrelic_super_agent = { path = "../super-agent", features = ["onhost"] }
+newrelic_super_agent = { path = "../super-agent" }
 fs = { path = "../fs" }
 semver = { workspace = true }
 

--- a/super-agent/src/lib.rs
+++ b/super-agent/src/lib.rs
@@ -10,9 +10,3 @@ pub mod utils;
 
 #[cfg(feature = "k8s")]
 pub mod k8s;
-
-#[cfg(all(feature = "onhost", feature = "k8s", not(feature = "ci")))]
-compile_error!("Feature \"onhost\" and feature \"k8s\" cannot be enabled at the same time");
-
-#[cfg(all(not(feature = "onhost"), not(feature = "k8s")))]
-compile_error!("Either feature \"onhost\" or feature \"k8s\" must be enabled");

--- a/super-agent/src/super_agent/config_storer/file.rs
+++ b/super-agent/src/super_agent/config_storer/file.rs
@@ -122,7 +122,6 @@ pub(crate) mod tests {
     use crate::super_agent::config::{
         AgentID, AgentTypeFQN, OpAMPClientConfig, SubAgentConfig, SuperAgentConfig,
     };
-    use http::HeaderMap;
     use std::{collections::HashMap, io::Write};
     use tempfile::NamedTempFile;
     use url::Url;


### PR DESCRIPTION
PR #660 introduced an issue where we are not able to enable the feature `k8s` at the whole project.

As `config-migrate` requires the feature to be `onhost` this safe check we has start failing:
```
#[cfg(all(feature = "onhost", feature = "k8s", not(feature = "ci")))]
compile_error!("Feature \"onhost\" and feature \"k8s\" cannot be enabled at the same time");
```

To be able to fix it, I removed the feature to be force for `onhost` on `config-migrate`. `config-migrate` uses resources that are not bound to onhost or k8s so it work with any feature enabled.

I would love anybody else (if possible with a different IDE, to test this as each IDE runs this in different ways and it seems that we are affected in a different way too.