### PR TITLE
feat: bump version of flux to 2.3 (NR-277895)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -57,8 +57,8 @@ k8s_resource(new_name='e2e test secret',objects=['test-env:secret'])
 
 ######## Feature Branch Workaround ########
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-chart_source = 'helm-repo' # local|branch|helm-repo
-feature_branch = ''
+chart_source = 'branch' # local|branch|helm-repo
+feature_branch = 'bump-flux'
 local_chart_repo = ''
 
 #### Set-up charts
@@ -67,6 +67,7 @@ load('ext://git_resource', 'git_checkout')
 update_dependencies = False
 deps=[]
 chart = ''
+extra_resource_deps=[]
 
 if chart_source == 'local':
   chart = local_chart_repo
@@ -84,6 +85,7 @@ elif chart_source == 'helm-repo':
     'https://helm-charts.newrelic.com',
     resource_name='newrelic-helm-repo',
     )
+  extra_resource_deps=['newrelic-helm-repo']
 
 #### Installs charts
 helm_resource(
@@ -101,5 +103,5 @@ helm_resource(
     ],
   image_deps=['tilt.local/super-agent-dev'],
   image_keys=[('super-agent-deployment.image.registry', 'super-agent-deployment.image.repository', 'super-agent-deployment.image.tag')],
-  resource_deps=['newrelic-helm-repo','build-binary']
+  resource_deps=['build-binary']+extra_resource_deps
 )

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.0.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.0.1.yaml
@@ -46,7 +46,7 @@ deployment:
   k8s:
     objects:
       repository:
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
           name: ${nr-sub:agent_id}
@@ -58,7 +58,7 @@ deployment:
           interval: 30m
           url: https://open-telemetry.github.io/opentelemetry-helm-charts
       release:
-        apiVersion: helm.toolkit.fluxcd.io/v2beta2
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ${nr-sub:agent_id}

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -37,7 +37,7 @@ deployment:
   k8s:
     objects:
       repository:
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
           name: ${nr-sub:agent_id}
@@ -50,7 +50,7 @@ deployment:
           provider: generic
           url: https://open-telemetry.github.io/opentelemetry-helm-charts
       release:
-        apiVersion: helm.toolkit.fluxcd.io/v2beta2
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ${nr-sub:agent_id}

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.1.yaml
@@ -59,7 +59,7 @@ deployment:
       interval: 30s
     objects:
       repository:
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
           name: ${nr-sub:agent_id}
@@ -72,7 +72,7 @@ deployment:
           provider: generic
           url: https://open-telemetry.github.io/opentelemetry-helm-charts
       release:
-        apiVersion: helm.toolkit.fluxcd.io/v2beta2
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ${nr-sub:agent_id}

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
@@ -59,7 +59,7 @@ deployment:
       interval: 30s
     objects:
       repository:
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
           name: ${nr-sub:agent_id}
@@ -72,7 +72,7 @@ deployment:
           provider: generic
           url: https://helm-charts.newrelic.com
       release:
-        apiVersion: helm.toolkit.fluxcd.io/v2beta2
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ${nr-sub:agent_id}

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -349,7 +349,7 @@ pub mod test {
         };
 
         let k8s_object = K8sObject {
-            api_version: "helm.toolkit.fluxcd.io/v2beta2".to_string(),
+            api_version: "helm.toolkit.fluxcd.io/v2".to_string(),
             kind,
             ..Default::default()
         };

--- a/super-agent/src/super_agent/config.rs
+++ b/super-agent/src/super_agent/config.rs
@@ -266,7 +266,7 @@ impl Default for K8sConfig {
 #[cfg(feature = "k8s")]
 pub fn helm_repository_type_meta() -> TypeMeta {
     TypeMeta {
-        api_version: "source.toolkit.fluxcd.io/v1beta2".to_string(),
+        api_version: "source.toolkit.fluxcd.io/v1".to_string(),
         kind: "HelmRepository".to_string(),
     }
 }
@@ -274,7 +274,7 @@ pub fn helm_repository_type_meta() -> TypeMeta {
 #[cfg(feature = "k8s")]
 pub fn helm_release_type_meta() -> TypeMeta {
     TypeMeta {
-        api_version: "helm.toolkit.fluxcd.io/v2beta2".to_string(),
+        api_version: "helm.toolkit.fluxcd.io/v2".to_string(),
         kind: "HelmRelease".to_string(),
     }
 }

--- a/super-agent/tests/k8s/Tiltfile
+++ b/super-agent/tests/k8s/Tiltfile
@@ -5,8 +5,8 @@ update_settings ( k8s_upsert_timeout_secs = 150)
 
 ######## Feature Branch Workaround ########
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-chart_source = 'helm-repo' # local|branch|helm-repo
-feature_branch = ''
+chart_source = 'branch' # local|branch|helm-repo
+feature_branch = 'bump-flux'
 local_chart_repo = ''
 
 #### Set-up charts
@@ -15,6 +15,7 @@ load('ext://git_resource', 'git_checkout')
 update_dependencies = False
 deps=[]
 chart = ''
+extra_resource_deps=[]
 
 if chart_source == 'local':
   chart = local_chart_repo
@@ -32,6 +33,7 @@ elif chart_source == 'helm-repo':
     'https://helm-charts.newrelic.com',
     resource_name='newrelic-helm-repo',
     )
+  extra_resource_deps=['newrelic-helm-repo']
 
 helm_resource(
   'flux',
@@ -46,5 +48,5 @@ helm_resource(
     '--set=flux2.watchAllNamespaces=true',
     '--set=super-agent-deployment.enabled=false',
     ],
-  resource_deps=['newrelic-helm-repo']
+  resource_deps=extra_resource_deps
 )

--- a/super-agent/tests/k8s/tools/k8s_api.rs
+++ b/super-agent/tests/k8s/tools/k8s_api.rs
@@ -42,7 +42,7 @@ pub async fn check_helmrelease_spec_values(
     expected_valus_as_yaml: &str,
 ) -> Result<(), Box<dyn Error>> {
     let expected_as_json: serde_json::Value = serde_yaml::from_str(expected_valus_as_yaml).unwrap();
-    let gvk = &GroupVersion::from_str("helm.toolkit.fluxcd.io/v2beta2")
+    let gvk = &GroupVersion::from_str("helm.toolkit.fluxcd.io/v2")
         .unwrap()
         .with_kind("HelmRelease");
     let (api_resource, _) = kube::discovery::pinned_kind(&k8s_client, gvk).await?;


### PR DESCRIPTION
A new version of Flux has been released [v2.3](https://fluxcd.io/blog/2024/05/flux-v2.3.0/) that bumps the CRDs version to an stable version.

Approach:

SA is not yet there to support multiple versions of Flux CRDs because of trade off decisions made. Even if some part of the SA k8s client handles multiple CRDs through the `cr_type_meta` config, some other uses [hardcoded](https://github.com/newrelic/newrelic-super-agent/blob/e10d0e252f2a6a370176e31cad34675a9395fae9/super-agent/src/k8s/client.rs#L140) types. 
Because of this and since the solution hasn't been released yet, the approach followed was a quick look&replace, this PR has linked helmchart [PR](https://github.com/newrelic/helm-charts/pull/1401)  