### PR TITLE
[NR-277900]: chore: centralize how to handle tasks interval/cancelation

### DIFF
--- a/super-agent/src/event.rs
+++ b/super-agent/src/event.rs
@@ -1,3 +1,4 @@
+pub mod cancellation;
 pub mod channel;
 
 /// EVENTS

--- a/super-agent/src/event/cancellation.rs
+++ b/super-agent/src/event/cancellation.rs
@@ -1,0 +1,19 @@
+use super::channel::EventConsumer;
+use crossbeam::channel::RecvTimeoutError;
+use std::time::Duration;
+
+pub type CancellationMessage = ();
+
+impl EventConsumer<CancellationMessage> {
+    /// Check if the consumer is cancelled.
+    /// It returns true if the consumer received a cancellation message or received an error
+    /// before the provided timeout is elapsed. Otherwise it blocks until the timeout is elapsed
+    /// and returns false.
+    pub fn is_cancelled(&self, timeout: Duration) -> bool {
+        let timed_out = matches!(
+            self.as_ref().recv_timeout(timeout),
+            Err(RecvTimeoutError::Timeout)
+        );
+        !timed_out
+    }
+}

--- a/super-agent/src/sub_agent/k8s/sub_agent.rs
+++ b/super-agent/src/sub_agent/k8s/sub_agent.rs
@@ -184,7 +184,8 @@ pub mod test {
         let supervisor =
             NotStartedSupervisor::new(agent_id.clone(), agent_fqn, Arc::new(mock_client), k8s_obj);
 
-        SubAgentK8s::new(
+        // If the started subagent is dropped, then the underlying supervisor is also dropped (and the underlying tasks are stopped)
+        let _started_subagent = SubAgentK8s::new(
             agent_id.clone(),
             AgentTypeFQN::try_from(TEST_GENT_FQN).unwrap(),
             processor,


### PR DESCRIPTION
This PR updates how we handle interval / cancelation for some threads. Specifically:
* ~Use crossbeam's `select!` instead of `thread::sleep` to avoid waiting for the interval in case the process should be interrupted.~
* ~Uses [select's default](https://docs.rs/crossbeam/latest/crossbeam/macro.select.html#examples:~:text=Select%20over%20a%20set%20of%20operations%20with%20a%20timeout%3A) instead of crossbeam's tick in the k8s' garbage collector.~
* Centralizes how periodic tasks handle the cancelation signal.
* The execution is finished if the consumer is disconnected.
* The cancelation doesn't need to wait for the remaining time of the interval (This happened only when `thread::Sleep` was used)