### PR TITLE
feat: add health check status to FakeServer and k8s tests (NR-277838)

### DIFF
--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error};
 #[cfg(feature = "k8s")]
 use crate::k8s;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Health {
     Healthy(Healthy),
     Unhealthy(Unhealthy),

--- a/super-agent/tests/common/health.rs
+++ b/super-agent/tests/common/health.rs
@@ -1,0 +1,15 @@
+use crate::common::opamp::FakeServer;
+use newrelic_super_agent::opamp::instance_id::InstanceID;
+use std::error::Error;
+
+pub fn check_latest_health_status_was_healthy(
+    server: &FakeServer,
+    instance_id: &InstanceID,
+) -> Result<(), Box<dyn Error>> {
+    let health_status = server.get_health_status(instance_id.clone());
+    match health_status {
+        Some(status) if status.healthy => Ok(()),
+        None => Err("Health status not available".into()),
+        _ => Err("Expected healthy status, got unhealthy".into()),
+    }
+}

--- a/super-agent/tests/common/mod.rs
+++ b/super-agent/tests/common/mod.rs
@@ -1,4 +1,5 @@
 /// Includes a OpAMP mock server to test scenarios involving OpAMP.
+pub(super) mod health;
 pub(super) mod opamp;
 /// Includes helpers to handle the _async_ code execution in non-tokio-tests.
 pub(super) mod runtime;


### PR DESCRIPTION
This PR extends the FakeServer implementation and the associated k8s opamp integration tests by adding support for checking the health.

### Note for the reviewers
- I only extended the current integration tests for k8s with opamp, we need to define whether we should add new ones.
- onhost health check tests will be added in a follow up PR; we might only want to extend tests done in this PR https://github.com/newrelic/newrelic-super-agent/pull/708
