### PR TITLE
Add Kubernetes specific documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -235,7 +235,7 @@ The Super Agent currently only supports a HTTP interface (just because this is h
 
 If the Agent Type does not declare its health interface, the Supervisor uses its restart policy violations as a fallback. In this case, an unhealthy message is sent when the maximum number of retries has been reached. 
 
-In **Kubernetes**, we are leveraging health checks to its ecosystem because K8s already offers many built-in mechanisms to check the health of k8s objects. Therefore, the health information is obtained from the k8s objects related to each agent. Currently, only the interval can be configured in the Agent Type, but we could offer the customer the possibility of selecting what information should be retrieved in the future.
+In **Kubernetes**, we are leveraging health checks to its ecosystem because K8s already offers many built-in mechanisms to check the health of k8s objects. Therefore, the health information is obtained from the k8s objects related to each agent type. Currently, only the interval can be configured in the Agent Type, but we could offer the customer the possibility of selecting what information should be retrieved in the future.
 
 ℹ️ Again, refer to the [agent type](../super-agent/src/agent_type/README.md) development guide to know more. 
 


### PR DESCRIPTION
Update Agent Type documentation to include basic information about the Kubernetes deployments.