### PR TITLE
test: fix flay `shutdown_custom_timeout` test (NR-288881)

### DIFF
--- a/super-agent/src/sub_agent/on_host/command/shutdown.rs
+++ b/super-agent/src/sub_agent/on_host/command/shutdown.rs
@@ -100,7 +100,9 @@ mod tests {
             .spawn();
 
         let pid = trap_cmd.as_mut().unwrap().id();
-        let one_second = Duration::from_millis(100);
+
+        // Warm-up time for the trap sub-process to start and be able to catch the signal
+        let one_second = Duration::from_secs(1);
         sleep(one_second);
 
         let terminator = ProcessTerminator::new(pid);


### PR DESCRIPTION
`trap` needs some time to start and be able to catch the Signal , if a SIGTERM is sent before that warmup finishes the trap will not catch the SIGNAL as we saw on the flaky executions:
```
failures:

---- sub_agent::on_host::command::shutdown::tests::shutdown_custom_timeout stdout ----
thread 'sub_agent::on_host::command::shutdown::tests::shutdown_custom_timeout' panicked at super-agent/src/sub_agent/on_host/command/shutdown.rs:125:9:
assertion `left == right` failed
  left: "signal: 9 (SIGKILL)"
 right: "signal: 15 (SIGTERM)"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```