### PR TITLE
refact: HashRepository and InstanceId global dirs (NR-287364)

### DIFF
--- a/super-agent/src/opamp/hash_repository/on_host.rs
+++ b/super-agent/src/opamp/hash_repository/on_host.rs
@@ -1,7 +1,6 @@
 use crate::opamp::hash_repository::repository::{HashRepository, HashRepositoryError};
 use crate::opamp::remote_config_hash::Hash;
 use crate::super_agent::config::AgentID;
-use crate::super_agent::defaults::{REMOTE_AGENT_DATA_DIR, SUPER_AGENT_DATA_DIR};
 use fs::directory_manager::DirectoryManagementError;
 use fs::directory_manager::{DirectoryManager, DirectoryManagerFs};
 use fs::file_reader::FileReader;
@@ -51,18 +50,12 @@ where
 impl HashRepositoryFile<LocalFile, DirectoryManagerFs> {
     // HashGetterPersisterFile with default writer and reader
     // and config path
-    fn new(data_dir: String) -> Self {
+    pub fn new(data_dir: String) -> Self {
         HashRepositoryFile {
             file_rw: LocalFile,
             conf_path: PathBuf::from(data_dir),
             directory_manager: DirectoryManagerFs::default(),
         }
-    }
-}
-
-impl Default for HashRepositoryFile {
-    fn default() -> Self {
-        HashRepositoryFile::new(SUPER_AGENT_DATA_DIR().to_string())
     }
 }
 
@@ -120,12 +113,6 @@ where
         // We attempt to parse the `Hash` from the String if we got it, failing if we cannot parse.
         let result = contents.map(|s| serde_yaml::from_str(&s)).transpose();
         Ok(result?)
-    }
-}
-
-impl HashRepositoryFile {
-    pub fn new_sub_agent_repository() -> Self {
-        HashRepositoryFile::new(REMOTE_AGENT_DATA_DIR().to_string())
     }
 }
 

--- a/super-agent/src/opamp/instance_id/on_host/getter.rs
+++ b/super-agent/src/opamp/instance_id/on_host/getter.rs
@@ -1,5 +1,4 @@
-use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
-use crate::opamp::instance_id::on_host::storer::{Storer, StorerError};
+use crate::opamp::instance_id::on_host::storer::StorerError;
 use resource_detection::cloud::aws::detector::AWSDetector;
 use resource_detection::cloud::azure::detector::AzureDetector;
 use resource_detection::cloud::cloud_id::detector::CloudIdDetector;
@@ -157,12 +156,6 @@ where
 pub enum GetterError {
     #[error("failed to persist Data: `{0}`")]
     Persisting(#[from] StorerError),
-}
-
-impl Default for InstanceIDWithIdentifiersGetter<Storer> {
-    fn default() -> Self {
-        Self::new(Storer::default(), Identifiers::default())
-    }
 }
 
 #[cfg(test)]

--- a/super-agent/tests/on_host/tools/instance_id.rs
+++ b/super-agent/tests/on_host/tools/instance_id.rs
@@ -1,87 +1,12 @@
-use fs::directory_manager::{DirectoryManager, DirectoryManagerFs};
-use fs::file_reader::FileReader;
-use fs::writer_file::FileWriter;
+use fs::directory_manager::DirectoryManagerFs;
 use fs::LocalFile;
 use newrelic_super_agent::opamp::instance_id::getter::{
-    DataStored, InstanceIDGetter, InstanceIDWithIdentifiersGetter,
+    InstanceIDGetter, InstanceIDWithIdentifiersGetter,
 };
-use newrelic_super_agent::opamp::instance_id::storer::InstanceIDStorer;
-use newrelic_super_agent::opamp::instance_id::{IdentifiersProvider, InstanceID};
+use newrelic_super_agent::opamp::instance_id::{IdentifiersProvider, InstanceID, Storer};
 use newrelic_super_agent::super_agent::config::AgentID;
-use newrelic_super_agent::super_agent::defaults::{
-    REMOTE_AGENT_DATA_DIR, SUPER_AGENT_IDENTIFIERS_PATH,
-};
+use newrelic_super_agent::super_agent::defaults::{REMOTE_AGENT_DATA_DIR, SUPER_AGENT_DATA_DIR};
 use std::path::PathBuf;
-use tracing::debug;
-
-pub struct Storer<F = LocalFile, D = DirectoryManagerFs>
-where
-    D: DirectoryManager,
-    F: FileWriter + FileReader,
-{
-    file_rw: F,
-    _dir_manager: D,
-}
-
-fn get_instance_id_path(agent_id: &AgentID) -> PathBuf {
-    if agent_id.is_super_agent_id() {
-        PathBuf::from(SUPER_AGENT_IDENTIFIERS_PATH())
-    } else {
-        PathBuf::from(format!(
-            "{}/{}/identifiers.yaml",
-            REMOTE_AGENT_DATA_DIR(),
-            agent_id.get()
-        ))
-    }
-}
-
-impl<F, D> InstanceIDStorer for Storer<F, D>
-where
-    D: DirectoryManager,
-    F: FileWriter + FileReader,
-{
-    fn set(
-        &self,
-        _agent_id: &AgentID,
-        _ds: &DataStored,
-    ) -> Result<(), newrelic_super_agent::opamp::instance_id::StorerError> {
-        Ok(())
-    }
-
-    fn get(
-        &self,
-        agent_id: &AgentID,
-    ) -> Result<Option<DataStored>, newrelic_super_agent::opamp::instance_id::StorerError> {
-        self.read_contents(agent_id)
-    }
-}
-
-impl<F, D> Storer<F, D>
-where
-    D: DirectoryManager,
-    F: FileWriter + FileReader,
-{
-    fn read_contents(
-        &self,
-        agent_id: &AgentID,
-    ) -> Result<Option<DataStored>, newrelic_super_agent::opamp::instance_id::StorerError> {
-        let dest_path = get_instance_id_path(agent_id);
-        let file_str = match self.file_rw.read(dest_path.as_path()) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!("error reading file for agent {}: {}", agent_id, e);
-                return Ok(None);
-            }
-        };
-        match serde_yaml::from_str(&file_str) {
-            Ok(ds) => Ok(Some(ds)),
-            Err(e) => {
-                debug!("error deserializing data for agent {}: {}", agent_id, e);
-                Ok(None)
-            }
-        }
-    }
-}
 
 pub fn get_instance_id(agent_id: &AgentID) -> InstanceID {
     let identifiers_provider = IdentifiersProvider::default()
@@ -89,8 +14,14 @@ pub fn get_instance_id(agent_id: &AgentID) -> InstanceID {
         .with_fleet_id("integration".to_string());
     let identifiers = identifiers_provider.provide().unwrap_or_default();
 
-    let instance_id_getter =
-        InstanceIDWithIdentifiersGetter::default().with_identifiers(identifiers);
+    let instance_id_storer = Storer::new(
+        LocalFile,
+        DirectoryManagerFs::default(),
+        PathBuf::from(SUPER_AGENT_DATA_DIR().to_string()),
+        PathBuf::from(REMOTE_AGENT_DATA_DIR().to_string()),
+    );
+
+    let instance_id_getter = InstanceIDWithIdentifiersGetter::new(instance_id_storer, identifiers);
 
     instance_id_getter.get(agent_id).unwrap()
 }


### PR DESCRIPTION
As part of https://new-relic.atlassian.net/browse/NR-287364 we need to refactor components using directly or inderectly the global vars:
- `SUPER_AGENT_DATA_DIR`
- `SUPER_AGENT_LOCAL_DATA_DIR`
- `SUPER_AGENT_LOG_DIR`

This PR refactors:
- `HashRepository`
- `InstanceId`