### PR TITLE
[NR-287364] remove globals from embedded-registry

### DIFF
--- a/super-agent/src/sub_agent/effective_agents_assembler.rs
+++ b/super-agent/src/sub_agent/effective_agents_assembler.rs
@@ -92,9 +92,9 @@ impl<D>
 where
     D: ValuesRepository,
 {
-    pub fn new(values_repository: Arc<D>) -> Self {
+    pub fn new(values_repository: Arc<D>, registry: EmbeddedRegistry) -> Self {
         LocalEffectiveAgentsAssembler {
-            registry: EmbeddedRegistry::default(),
+            registry,
             values_repository,
             renderer: TemplateRenderer::default(),
         }

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -87,14 +87,6 @@ generate_const_getter!(
     )
 );
 generate_const_getter!(
-    DYNAMIC_AGENT_TYPE,
-    format!(
-        "{}/{}",
-        SUPER_AGENT_LOCAL_DATA_DIR(),
-        DYNAMIC_AGENT_TYPE_FILENAME()
-    )
-);
-generate_const_getter!(
     SUPER_AGENT_IDENTIFIERS_PATH,
     format!("{}/{}", SUPER_AGENT_DATA_DIR(), IDENTIFIERS_FILENAME()).as_str()
 );

--- a/super-agent/src/super_agent/run.rs
+++ b/super-agent/src/super_agent/run.rs
@@ -1,6 +1,8 @@
 use super::config::OpAMPClientConfig;
 use super::config_storer::store::SuperAgentConfigStore;
+use super::defaults::{DYNAMIC_AGENT_TYPE_FILENAME, SUPER_AGENT_LOCAL_DATA_DIR};
 use super::http_server::config::ServerConfig;
+use crate::agent_type::embedded_registry::EmbeddedRegistry;
 use crate::event::channel::pub_sub;
 use crate::event::{
     channel::{EventConsumer, EventPublisher},
@@ -14,6 +16,7 @@ use k8s::run_super_agent;
 #[cfg(feature = "onhost")]
 use on_host::run_super_agent;
 use std::error::Error;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info, trace};
@@ -98,12 +101,16 @@ pub struct SuperAgentRunner {
 /// Run the super agent with the provided data
 impl SuperAgentRunner {
     pub fn run(self) -> Result<(), Box<dyn Error>> {
+        let agent_type_registry = EmbeddedRegistry::new(
+            PathBuf::from(SUPER_AGENT_LOCAL_DATA_DIR()).join(DYNAMIC_AGENT_TYPE_FILENAME()),
+        );
         Ok(run_super_agent(
             self.runtime.clone(),
             self.config_storer,
             self.application_event_consumer,
             self.opamp_http_builder,
             self.super_agent_publisher,
+            agent_type_registry,
         )?)
     }
 }

--- a/super-agent/src/super_agent/run/k8s.rs
+++ b/super-agent/src/super_agent/run/k8s.rs
@@ -1,3 +1,4 @@
+use crate::agent_type::embedded_registry::EmbeddedRegistry;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
@@ -39,6 +40,7 @@ pub fn run_super_agent<C: HttpClientBuilder>(
     application_event_consumer: EventConsumer<ApplicationEvent>,
     opamp_http_builder: Option<C>,
     super_agent_publisher: EventPublisher<SuperAgentEvent>,
+    agent_type_registry: EmbeddedRegistry,
 ) -> Result<(), AgentError> {
     info!("Starting the k8s client");
     let config = sa_local_config_storer.load()?;
@@ -89,7 +91,8 @@ pub fn run_super_agent<C: HttpClientBuilder>(
         )
     });
 
-    let agents_assembler = LocalEffectiveAgentsAssembler::new(values_repository.clone());
+    let agents_assembler =
+        LocalEffectiveAgentsAssembler::new(values_repository.clone(), agent_type_registry);
     let hash_repository = Arc::new(HashRepositoryConfigMap::new(k8s_store.clone()));
     let sub_agent_event_processor_builder =
         EventProcessorBuilder::new(hash_repository.clone(), values_repository.clone());

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -1,3 +1,4 @@
+use crate::agent_type::embedded_registry::EmbeddedRegistry;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};
@@ -42,6 +43,7 @@ pub fn run_super_agent<C: HttpClientBuilder>(
     application_events_consumer: EventConsumer<ApplicationEvent>,
     opamp_http_builder: Option<C>,
     super_agent_publisher: EventPublisher<SuperAgentEvent>,
+    agent_type_registry: EmbeddedRegistry,
 ) -> Result<(), AgentError> {
     // enable remote config store
     let config_storer = if opamp_http_builder.is_some() {
@@ -85,11 +87,12 @@ pub fn run_super_agent<C: HttpClientBuilder>(
 
     let instance_id_getter = InstanceIDWithIdentifiersGetter::new(instance_id_storer, identifiers);
 
-    let agents_assembler = LocalEffectiveAgentsAssembler::new(values_repository.clone())
-        .with_renderer(
-            TemplateRenderer::default()
-                .with_config_persister(ConfigurationPersisterFile::default()),
-        );
+    let agents_assembler =
+        LocalEffectiveAgentsAssembler::new(values_repository.clone(), agent_type_registry)
+            .with_renderer(
+                TemplateRenderer::default()
+                    .with_config_persister(ConfigurationPersisterFile::default()),
+            );
 
     // TODO move these dirs one layer up
     let super_agent_hash_repository = Arc::new(HashRepositoryFile::new(

--- a/super-agent/tests/on_host/tools/super_agent.rs
+++ b/super-agent/tests/on_host/tools/super_agent.rs
@@ -1,4 +1,6 @@
 use http::HeaderMap;
+use newrelic_super_agent::agent_type::agent_type_registry;
+use newrelic_super_agent::agent_type::embedded_registry::EmbeddedRegistry;
 use newrelic_super_agent::event::channel::pub_sub;
 use newrelic_super_agent::event::SuperAgentEvent;
 use newrelic_super_agent::opamp::auth::token_retriever::{TokenRetrieverImpl, TokenRetrieverNoop};
@@ -6,7 +8,7 @@ use newrelic_super_agent::opamp::http::builder::UreqHttpClientBuilder;
 use newrelic_super_agent::super_agent::config::OpAMPClientConfig;
 use newrelic_super_agent::super_agent::config_storer::store::SuperAgentConfigStore;
 use newrelic_super_agent::super_agent::run::on_host::run_super_agent;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use url::Url;
 
@@ -36,11 +38,15 @@ pub fn start_super_agent_with_custom_config(config_path: &Path, opamp_endpoint: 
 
     let config_storer = SuperAgentConfigStore::new(config_path);
 
+    // TODO: do we need to load dynamic-agent-type?
+    let agent_type_registry = EmbeddedRegistry::default();
+
     _ = run_super_agent(
         runtime.clone(),
         config_storer,
         application_event_consumer,
         Some(http_builder),
         super_agent_publisher,
+        agent_type_registry,
     );
 }


### PR DESCRIPTION
This PR updates the Agent Type's embedded registry to stop using a global variable to get the dynamic-agent-type. Besides, the agent-type registry now is built before running the super-agent.