### PR TITLE
refact: sub-agent file logger remove global path var (NR-287364) 

### DIFF
--- a/super-agent/src/sub_agent/on_host/command/logging/file_logger.rs
+++ b/super-agent/src/sub_agent/on_host/command/logging/file_logger.rs
@@ -1,4 +1,7 @@
-use std::{io::Write, path::Path};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 use tracing::{level_filters::LevelFilter, subscriber::DefaultGuard};
 use tracing_appender::{
     non_blocking::{NonBlocking, WorkerGuard},
@@ -9,7 +12,7 @@ use tracing_subscriber::{
     FmtSubscriber,
 };
 
-use crate::super_agent::{config::AgentID, defaults::SUB_AGENT_LOG_DIR};
+use crate::super_agent::config::AgentID;
 
 pub(crate) struct FileSystemLoggers {
     out: FileLogger,
@@ -31,19 +34,8 @@ where
     W: Write + Send + 'static;
 
 impl FileAppender<RollingFileAppender> {
-    pub fn new(agent_id: &AgentID, file_prefix: impl AsRef<Path>) -> Self {
-        let logging_path = Path::new(SUB_AGENT_LOG_DIR()).join(agent_id);
-        let file_appender = tracing_appender::rolling::hourly(logging_path, file_prefix);
-        Self(file_appender)
-    }
-
-    pub fn new_with_fixed_file(
-        agent_id: &AgentID,
-        dir_path: impl AsRef<Path>,
-        file_prefix: impl AsRef<Path>,
-    ) -> Self {
-        let logging_path = dir_path.as_ref().join(agent_id);
-        let file_appender = tracing_appender::rolling::never(logging_path, file_prefix);
+    pub fn new(agent_id: &AgentID, path: PathBuf, file_prefix: impl AsRef<Path>) -> Self {
+        let file_appender = tracing_appender::rolling::hourly(path.join(agent_id), file_prefix);
         Self(file_appender)
     }
 }

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor.rs
@@ -17,6 +17,7 @@ use crate::sub_agent::on_host::supervisor::command_supervisor_config::Supervisor
 use crate::sub_agent::on_host::supervisor::restart_policy::BackoffStrategy;
 use crate::super_agent::config::AgentID;
 use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::time::SystemTime;
 use std::{
@@ -59,6 +60,9 @@ impl SupervisorOnHost<NotStarted> {
 
     pub fn logs_to_file(&self) -> bool {
         self.state.config.log_to_file
+    }
+    pub fn logging_path(&self) -> PathBuf {
+        self.state.config.logging_path.clone()
     }
 
     pub fn run(
@@ -209,6 +213,7 @@ impl SupervisorOnHost<NotStarted> {
             &self.state.config.args,
             &self.state.config.env,
             self.logs_to_file(),
+            self.logging_path(),
         )
     }
 }

--- a/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor/command_supervisor_config.rs
@@ -3,6 +3,7 @@ use crate::context::Context;
 use crate::sub_agent::on_host::supervisor::restart_policy::RestartPolicy;
 use crate::super_agent::config::AgentID;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct SupervisorConfigOnHost {
@@ -13,6 +14,7 @@ pub struct SupervisorConfigOnHost {
     pub(super) env: HashMap<String, String>,
     pub(super) restart_policy: RestartPolicy,
     pub(super) log_to_file: bool,
+    pub(super) logging_path: PathBuf,
     pub(super) health: Option<OnHostHealthConfig>,
 }
 
@@ -32,13 +34,15 @@ impl SupervisorConfigOnHost {
             env,
             restart_policy,
             log_to_file: false,
+            logging_path: PathBuf::default(),
             health: None,
         }
     }
 
-    pub fn with_file_logging(self, log_to_file: bool) -> Self {
+    pub fn with_file_logging(self, log_to_file: bool, logging_path: PathBuf) -> Self {
         Self {
             log_to_file,
+            logging_path,
             ..self
         }
     }

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -102,12 +102,7 @@ generate_const_getter!(
 );
 generate_const_getter!(
     SUB_AGENT_LOG_DIR,
-    format!(
-        "{}/{}/{}",
-        SUPER_AGENT_LOG_DIR(),
-        FLEET_DIR(),
-        SUB_AGENT_DIRECTORY()
-    )
+    format!("{}/{}", FLEET_DIR(), SUB_AGENT_DIRECTORY())
 );
 generate_const_getter!(DYNAMIC_AGENT_TYPE_FILENAME, "dynamic-agent-type.yaml");
 generate_const_getter!(IDENTIFIERS_FILENAME, "identifiers.yaml");

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -8,7 +8,8 @@ use crate::sub_agent::event_processor_builder::EventProcessorBuilder;
 use crate::super_agent::config::AgentID;
 use crate::super_agent::config_storer::loader_storer::SuperAgentConfigLoader;
 use crate::super_agent::defaults::{
-    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, REMOTE_AGENT_DATA_DIR,
+    SUB_AGENT_LOG_DIR, SUPER_AGENT_DATA_DIR, SUPER_AGENT_LOG_DIR,
 };
 use crate::super_agent::{super_agent_fqn, SuperAgent};
 use crate::{
@@ -81,8 +82,8 @@ pub fn run_super_agent<C: HttpClientBuilder>(
         LocalFile,
         DirectoryManagerFs::default(),
         // TODO move these dirs one layer up
-        PathBuf::from(crate::super_agent::defaults::SUPER_AGENT_DATA_DIR().to_string()),
-        PathBuf::from(crate::super_agent::defaults::REMOTE_AGENT_DATA_DIR().to_string()),
+        PathBuf::from(SUPER_AGENT_DATA_DIR()),
+        PathBuf::from(REMOTE_AGENT_DATA_DIR()),
     );
 
     let instance_id_getter = InstanceIDWithIdentifiersGetter::new(instance_id_storer, identifiers);
@@ -95,12 +96,10 @@ pub fn run_super_agent<C: HttpClientBuilder>(
             );
 
     // TODO move these dirs one layer up
-    let super_agent_hash_repository = Arc::new(HashRepositoryFile::new(
-        crate::super_agent::defaults::SUPER_AGENT_DATA_DIR().to_string(),
-    ));
-    let sub_agent_hash_repository = Arc::new(HashRepositoryFile::new(
-        crate::super_agent::defaults::REMOTE_AGENT_DATA_DIR().to_string(),
-    ));
+    let super_agent_hash_repository =
+        Arc::new(HashRepositoryFile::new(SUPER_AGENT_DATA_DIR().to_string()));
+    let sub_agent_hash_repository =
+        Arc::new(HashRepositoryFile::new(REMOTE_AGENT_DATA_DIR().to_string()));
 
     let sub_agent_event_processor_builder =
         EventProcessorBuilder::new(sub_agent_hash_repository.clone(), values_repository.clone());
@@ -112,6 +111,7 @@ pub fn run_super_agent<C: HttpClientBuilder>(
         &agents_assembler,
         &sub_agent_event_processor_builder,
         identifiers_provider,
+        PathBuf::from(SUPER_AGENT_LOG_DIR()).join(SUB_AGENT_LOG_DIR()),
     );
 
     let (maybe_client, maybe_sa_opamp_consumer) = opamp_client_builder

--- a/super-agent/tests/on_host/command/non_blocking_runner.rs
+++ b/super-agent/tests/on_host/command/non_blocking_runner.rs
@@ -5,6 +5,8 @@ use newrelic_super_agent::sub_agent::on_host::command::command::{
 };
 use newrelic_super_agent::sub_agent::on_host::command::command_os::{CommandOS, NotStarted};
 use newrelic_super_agent::sub_agent::on_host::command::shutdown::ProcessTerminator;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 // non blocking supervisor
 struct NonSupervisor<C = CommandOS<NotStarted>>
@@ -17,8 +19,6 @@ where
 #[cfg(unix)]
 #[test]
 fn non_blocking_runner() {
-    use std::collections::HashMap;
-
     let agent_id = "sleep-test".to_string().try_into().unwrap();
     let mut sleep_cmd = Command::new("sleep");
     sleep_cmd.arg("5");
@@ -30,6 +30,7 @@ fn non_blocking_runner() {
             ["5"],
             HashMap::from([("TEST", "TEST")]),
             false,
+            PathBuf::default(),
         ),
     };
 

--- a/super-agent/tests/on_host/tools/super_agent.rs
+++ b/super-agent/tests/on_host/tools/super_agent.rs
@@ -1,5 +1,4 @@
 use http::HeaderMap;
-use newrelic_super_agent::agent_type::agent_type_registry;
 use newrelic_super_agent::agent_type::embedded_registry::EmbeddedRegistry;
 use newrelic_super_agent::event::channel::pub_sub;
 use newrelic_super_agent::event::SuperAgentEvent;


### PR DESCRIPTION
Following #744 This PR refacts:
- File logging path of sub-agents to be configurable from main