### PR TITLE
chore(valueRepository): rename to YAMLConfigRepository

### DIFF
--- a/super-agent/src/sub_agent/error.rs
+++ b/super-agent/src/sub_agent/error.rs
@@ -4,8 +4,8 @@ use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::repository::HashRepositoryError;
 use crate::opamp::remote_config::RemoteConfigError;
 use crate::super_agent::config::SuperAgentConfigError;
-use crate::values::values_repository::ValuesRepositoryError;
 use crate::values::yaml_config::YAMLConfigError;
+use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
 use opamp_client::StartedClientError;
 use opamp_client::{ClientError, NotStartedClientError};
 use std::time::SystemTimeError;
@@ -35,8 +35,8 @@ pub enum SubAgentError {
     SuperAgentConfigError(#[from] SuperAgentConfigError),
     #[error("config assembler error: `{0}`")]
     ConfigAssemblerError(#[from] EffectiveAgentsAssemblerError),
-    #[error("sub agent values error: `{0}`")]
-    ValuesError(#[from] ValuesRepositoryError),
+    #[error("sub agent yaml config repository error: `{0}`")]
+    YAMLConfigRepositoryError(#[from] YAMLConfigRepositoryError),
     #[error("sub agent values error: `{0}`")]
     ValuesUnserializeError(#[from] YAMLConfigError),
     #[error("remote config error: `{0}`")]

--- a/super-agent/src/sub_agent/event_handler/on_health.rs
+++ b/super-agent/src/sub_agent/event_handler/on_health.rs
@@ -5,7 +5,7 @@ use crate::sub_agent::error::SubAgentError;
 use crate::sub_agent::event_processor::EventProcessor;
 use crate::sub_agent::health::with_start_time::HealthWithStartTime;
 use crate::sub_agent::SubAgentCallbacks;
-use crate::values::values_repository::ValuesRepository;
+use crate::values::yaml_config_repository::YAMLConfigRepository;
 use opamp_client::StartedClient;
 use tracing::error;
 
@@ -14,7 +14,7 @@ where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository,
-    R: ValuesRepository,
+    R: YAMLConfigRepository,
 {
     pub(crate) fn on_health(&self, health: HealthWithStartTime) -> Result<(), SubAgentError> {
         if let Some(client) = self.maybe_opamp_client.as_ref() {

--- a/super-agent/src/sub_agent/event_processor_builder.rs
+++ b/super-agent/src/sub_agent/event_processor_builder.rs
@@ -5,7 +5,7 @@ use crate::opamp::hash_repository::HashRepository;
 use crate::sub_agent::event_processor::{EventProcessor, SubAgentEventProcessor};
 use crate::sub_agent::SubAgentCallbacks;
 use crate::super_agent::config::AgentID;
-use crate::values::values_repository::ValuesRepository;
+use crate::values::yaml_config_repository::YAMLConfigRepository;
 use opamp_client::StartedClient;
 use std::sync::Arc;
 
@@ -29,20 +29,23 @@ where
 pub struct EventProcessorBuilder<H, R>
 where
     H: HashRepository,
-    R: ValuesRepository,
+    R: YAMLConfigRepository,
 {
     hash_repository: Arc<H>,
-    values_repository: Arc<R>,
+    yaml_config_repository: Arc<R>,
 }
 
 impl<H, R> EventProcessorBuilder<H, R>
 where
     H: HashRepository,
-    R: ValuesRepository,
+    R: YAMLConfigRepository,
 {
-    pub fn new(hash_repository: Arc<H>, values_repository: Arc<R>) -> EventProcessorBuilder<H, R> {
+    pub fn new(
+        hash_repository: Arc<H>,
+        yaml_config_repository: Arc<R>,
+    ) -> EventProcessorBuilder<H, R> {
         EventProcessorBuilder {
-            values_repository,
+            yaml_config_repository,
             hash_repository,
         }
     }
@@ -53,7 +56,7 @@ where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository + Send + Sync + 'static,
-    R: ValuesRepository + Send + Sync + 'static,
+    R: YAMLConfigRepository + Send + Sync + 'static,
 {
     type SubAgentEventProcessor = EventProcessor<C, H, R, G>;
 
@@ -76,7 +79,7 @@ where
             sub_agent_internal_consumer,
             maybe_opamp_client,
             self.hash_repository.clone(),
-            self.values_repository.clone(),
+            self.yaml_config_repository.clone(),
         )
     }
 }

--- a/super-agent/src/super_agent/error.rs
+++ b/super-agent/src/super_agent/error.rs
@@ -9,7 +9,7 @@ use crate::opamp::remote_config::RemoteConfigError;
 use crate::sub_agent::effective_agents_assembler::EffectiveAgentsAssemblerError;
 use crate::sub_agent::error::{SubAgentBuilderError, SubAgentCollectionError, SubAgentError};
 use crate::sub_agent::persister::config_persister::PersistError;
-use crate::values::values_repository::ValuesRepositoryError;
+use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
 use fs::file_reader::FileReaderError;
 use opamp_client::{ClientError, NotStartedClientError, StartedClientError};
 use std::fmt::Debug;
@@ -79,7 +79,7 @@ pub enum AgentError {
     RemoteConfigError(#[from] RemoteConfigError),
 
     #[error("sub agent remote config error: `{0}`")]
-    SubAgentRemoteConfigError(#[from] ValuesRepositoryError),
+    SubAgentRemoteConfigError(#[from] YAMLConfigRepositoryError),
 
     #[error("External module error: `{0}`")]
     ExternalError(String),

--- a/super-agent/src/values.rs
+++ b/super-agent/src/values.rs
@@ -1,5 +1,5 @@
-pub mod values_repository;
 pub mod yaml_config;
+pub mod yaml_config_repository;
 
 #[cfg(feature = "k8s")]
 pub mod k8s;

--- a/super-agent/src/values/k8s.rs
+++ b/super-agent/src/values/k8s.rs
@@ -2,19 +2,19 @@ use crate::agent_type::definition::AgentType;
 use crate::k8s;
 use crate::k8s::store::{K8sStore, STORE_KEY_LOCAL_DATA_CONFIG, STORE_KEY_OPAMP_DATA_CONFIG};
 use crate::super_agent::config::AgentID;
-use crate::values::values_repository::{ValuesRepository, ValuesRepositoryError};
 use crate::values::yaml_config::YAMLConfig;
+use crate::values::yaml_config_repository::{YAMLConfigRepository, YAMLConfigRepositoryError};
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::debug;
 
-pub struct ValuesRepositoryConfigMap {
+pub struct YAMLConfigRepositoryConfigMap {
     k8s_store: Arc<K8sStore>,
     remote_enabled: bool,
 }
 
 #[derive(Error, Debug)]
-pub enum K8sValuesRepositoryError {
+pub enum K8sYAMLConfigRepositoryError {
     #[error("error from k8s storer while loading SubAgentConfig: {0}")]
     FailedToPersistK8s(#[from] k8s::Error),
     #[cfg(test)]
@@ -22,7 +22,7 @@ pub enum K8sValuesRepositoryError {
     Generic,
 }
 
-impl ValuesRepositoryConfigMap {
+impl YAMLConfigRepositoryConfigMap {
     pub fn new(k8s_store: Arc<K8sStore>) -> Self {
         Self {
             k8s_store,
@@ -36,46 +36,49 @@ impl ValuesRepositoryConfigMap {
     }
 }
 
-impl ValuesRepository for ValuesRepositoryConfigMap {
-    fn load_local(&self, agent_id: &AgentID) -> Result<Option<YAMLConfig>, ValuesRepositoryError> {
+impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
+    fn load_local(
+        &self,
+        agent_id: &AgentID,
+    ) -> Result<Option<YAMLConfig>, YAMLConfigRepositoryError> {
         self.k8s_store
             .get_local_data::<YAMLConfig>(agent_id, STORE_KEY_LOCAL_DATA_CONFIG)
-            .map_err(|err| ValuesRepositoryError::LoadError(err.to_string()))
+            .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
     fn load_remote(
         &self,
         agent_id: &AgentID,
         agent_type: &AgentType,
-    ) -> Result<Option<YAMLConfig>, ValuesRepositoryError> {
+    ) -> Result<Option<YAMLConfig>, YAMLConfigRepositoryError> {
         if !self.remote_enabled || !agent_type.has_remote_management() {
             return Ok(None);
         }
 
         self.k8s_store
             .get_opamp_data::<YAMLConfig>(agent_id, STORE_KEY_OPAMP_DATA_CONFIG)
-            .map_err(|err| ValuesRepositoryError::LoadError(err.to_string()))
+            .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
     fn store_remote(
         &self,
         agent_id: &AgentID,
         yaml_config: &YAMLConfig,
-    ) -> Result<(), ValuesRepositoryError> {
+    ) -> Result<(), YAMLConfigRepositoryError> {
         debug!(agent_id = agent_id.to_string(), "saving remote config");
 
         self.k8s_store
             .set_opamp_data(agent_id, STORE_KEY_OPAMP_DATA_CONFIG, yaml_config)
-            .map_err(|err| ValuesRepositoryError::StoreError(err.to_string()))?;
+            .map_err(|err| YAMLConfigRepositoryError::StoreError(err.to_string()))?;
         Ok(())
     }
 
-    fn delete_remote(&self, agent_id: &AgentID) -> Result<(), ValuesRepositoryError> {
+    fn delete_remote(&self, agent_id: &AgentID) -> Result<(), YAMLConfigRepositoryError> {
         debug!(agent_id = agent_id.to_string(), "deleting remote config");
 
         self.k8s_store
             .delete_opamp_data(agent_id, STORE_KEY_OPAMP_DATA_CONFIG)
-            .map_err(|err| ValuesRepositoryError::DeleteError(err.to_string()))?;
+            .map_err(|err| YAMLConfigRepositoryError::DeleteError(err.to_string()))?;
         Ok(())
     }
 }

--- a/super-agent/tests/k8s/store.rs
+++ b/super-agent/tests/k8s/store.rs
@@ -26,10 +26,10 @@ use newrelic_super_agent::{
 };
 use newrelic_super_agent::{
     agent_type::definition::{AgentType, VariableTree},
-    values::values_repository::ValuesRepository,
+    values::yaml_config_repository::YAMLConfigRepository,
 };
 use newrelic_super_agent::{
-    values::k8s::ValuesRepositoryConfigMap, values::yaml_config::YAMLConfig,
+    values::k8s::YAMLConfigRepositoryConfigMap, values::yaml_config::YAMLConfig,
 };
 use semver::Version;
 use serde_yaml::from_str;
@@ -117,7 +117,7 @@ fn k8s_hash_repository_config_map() {
 #[test]
 #[ignore = "needs k8s cluster"]
 fn k8s_value_repository_config_map() {
-    // This test covers the happy path of ValuesRepositoryConfigMap on K8s.
+    // This test covers the happy path of YAMLConfigRepositoryConfigMap on K8s.
 
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
@@ -138,7 +138,7 @@ fn k8s_value_repository_config_map() {
         Runtime::default(),
     );
 
-    let mut value_repository = ValuesRepositoryConfigMap::new(k8s_store);
+    let mut value_repository = YAMLConfigRepositoryConfigMap::new(k8s_store);
     let default_values = YAMLConfig::default();
 
     // without values the default is expected

--- a/super-agent/tests/on_host/mod.rs
+++ b/super-agent/tests/on_host/mod.rs
@@ -9,4 +9,4 @@ mod remote_config;
 mod restarting_processes;
 mod supervisor;
 mod tools;
-mod values_repository;
+mod yaml_config_repository;

--- a/super-agent/tests/on_host/yaml_config_repository.rs
+++ b/super-agent/tests/on_host/yaml_config_repository.rs
@@ -1,8 +1,8 @@
 use ::fs::directory_manager::{DirectoryManager, DirectoryManagerFs};
 use newrelic_super_agent::super_agent::config::AgentID;
-use newrelic_super_agent::values::on_host::ValuesRepositoryFile;
-use newrelic_super_agent::values::values_repository::ValuesRepository;
+use newrelic_super_agent::values::on_host::YAMLConfigRepositoryFile;
 use newrelic_super_agent::values::yaml_config::YAMLConfig;
+use newrelic_super_agent::values::yaml_config_repository::YAMLConfigRepository;
 use std::fs;
 use std::fs::Permissions;
 #[cfg(target_family = "unix")]
@@ -26,7 +26,7 @@ fn test_store_remote_no_mocks() {
     let res = dir_manager.create(remote_dir.as_path(), Permissions::from_mode(0o700));
     assert!(res.is_ok());
 
-    let values_repo = ValuesRepositoryFile::default()
+    let values_repo = YAMLConfigRepositoryFile::default()
         .with_remote_conf_path(remote_dir.to_str().unwrap().to_string());
 
     let agent_id = AgentID::new("some-agent-id").unwrap();


### PR DESCRIPTION
Following up on https://github.com/newrelic/newrelic-super-agent/pull/746.

After changing agentValues -> YAMLConfig we are changing now valuesRepository to YAMLConfigRepository