### PR TITLE
Add placeholders to config file (NR-273901)

### DIFF
--- a/build/package/config.yaml
+++ b/build/package/config.yaml
@@ -2,5 +2,10 @@
 #   endpoint: https://opamp.service.newrelic.com/v1/opamp
 #   headers:
 #     api-key: API_KEY_HERE
+#   auth_config:
+#     token_url: PLACEHOLDER
+#     client_id: PLACEHOLDER
+#     provider: PLACEHOLDER
+#     private_key_path: PLACEHOLDER
 
 agents: {}


### PR DESCRIPTION
This allows New Relic CLI to `sed` the config file with the parameters needed to use the system identity.