### PR TITLE
refactor: more robust health comparison

### DIFF
--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -108,8 +108,17 @@ pub struct Healthy {
 
 impl PartialEq for Healthy {
     fn eq(&self, other: &Self) -> bool {
-        // We cannot expect any two status_time to be equal
-        self.status == other.status
+        // We cannot expect any two status_time to be equal, so we don't compare them
+        let Self {
+            status_time: _,
+            status,
+        } = self;
+        let Self {
+            status_time: _,
+            status: other_status,
+        } = other;
+
+        status == other_status
     }
 }
 
@@ -141,8 +150,19 @@ pub struct Unhealthy {
 
 impl PartialEq for Unhealthy {
     fn eq(&self, other: &Self) -> bool {
-        // We cannot expect any two status_time to be equal
-        self.status == other.status && self.last_error == other.last_error
+        // We cannot expect any two status_time to be equal, so we don't compare them
+        let Self {
+            status_time: _,
+            status,
+            last_error,
+        } = self;
+        let Self {
+            status_time: _,
+            status: other_status,
+            last_error: other_last_error,
+        } = other;
+
+        status == other_status && last_error == other_last_error
     }
 }
 


### PR DESCRIPTION
This makes the `PartialEq` implementations for `Healthy` and `Unhealthy` complain when additional fields are added to these structs without accounting for them in the implementation.

Essentially, covering against adding `component_health_map` in the future and forgetting to do `==` on it 😆 .

Before, only an equality check was done on existing fields, but if new fields were added the compiler wouldn't complain, allowing a comparison to be inaccurate since the new fields were not accounted for.