### PR TITLE
infra agent status port configurable in agent type

### DIFF
--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.3.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.3.yaml
@@ -1,0 +1,55 @@
+namespace: newrelic
+name: com.newrelic.infrastructure_agent
+version: 0.1.3
+variables:
+  on_host:
+    config_agent:
+      description: "Newrelic infra configuration"
+      type: file
+      required: false
+      default: ""
+      file_path: "newrelic-infra.yml"
+    config_integrations:
+      description: "map of YAML configs for the OHIs"
+      type: map[string]file
+      required: false
+      default: { }
+      file_path: "integrations.d"
+    config_logging:
+      description: "map of YAML config for logging"
+      type: map[string]file
+      required: false
+      default: { }
+      file_path: "logging.d"
+    backoff_delay:
+      description: "seconds until next retry if agent fails to start"
+      type: string
+      required: false
+      default: 20s
+    enable_file_logging:
+      description: "enable logging the on host executables' logs to files"
+      type: bool
+      required: false
+      default: false
+    health_port:
+      description: "port for the Infra Agent status server"
+      type: number
+      required: false
+      default: 18003
+deployment:
+  on_host:
+    enable_file_logging: ${nr-var:enable_file_logging}
+    executables:
+      - path: /usr/bin/newrelic-infra
+        args: "--config=${nr-var:config_agent}"
+        env: "NRIA_PLUGIN_DIR=${nr-var:config_integrations} NRIA_LOGGING_CONFIGS_DIR=${nr-var:config_logging} NRIA_STATUS_SERVER_ENABLED=true NRIA_STATUS_SERVER_PORT=${nr-var:health_port}"
+        restart_policy:
+          backoff_strategy:
+            type: fixed
+            backoff_delay: ${nr-var:backoff_delay}
+        health:
+          interval: 5s
+          timeout: 5s
+          http:
+            path: "/v1/status"
+            port: ${nr-var:health_port}


### PR DESCRIPTION
Infra Agent AgentType version 0.1.2 has hardcoded the port for the Infra Agent status server and it's not the same as the guided install one.

Guided install sets port `18003` and the Infra Agent default one is `8003`

https://github.com/newrelic/open-install-library/blob/v0.68.2/recipes/newrelic/infrastructure/super-agent/debian.yml#L213

This PR creates a new Agent Type (0.1.3) with the same port as Guided Install and making it a variable so the customer could overwrite it.

Pending to confirm with @josemore 