### PR TITLE
refact: replace `SubAgentYAMLConfigRepository` with fn

### DIFF
--- a/super-agent/src/opamp/effective_config/loader.rs
+++ b/super-agent/src/opamp/effective_config/loader.rs
@@ -2,7 +2,7 @@ use super::error::LoaderError;
 use super::sub_agent::SubAgentEffectiveConfigLoader;
 use crate::opamp::remote_config::ConfigurationMap;
 use crate::super_agent::config::AgentID;
-use crate::values::yaml_config_repository::SubAgentYAMLConfigRepository;
+use crate::values::yaml_config_repository::YAMLConfigRepository;
 use std::sync::Arc;
 
 /// Trait for effective configuration loaders.
@@ -18,29 +18,29 @@ pub trait EffectiveConfigLoaderBuilder {
 }
 
 /// Builder for effective configuration loaders.
-pub struct DefaultEffectiveConfigLoaderBuilder<R>
+pub struct DefaultEffectiveConfigLoaderBuilder<Y>
 where
-    R: SubAgentYAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
-    yaml_config_repository: Arc<R>,
+    yaml_config_repository: Arc<Y>,
 }
 
-impl<R> DefaultEffectiveConfigLoaderBuilder<R>
+impl<Y> DefaultEffectiveConfigLoaderBuilder<Y>
 where
-    R: SubAgentYAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
-    pub fn new(yaml_config_repository: Arc<R>) -> Self {
+    pub fn new(yaml_config_repository: Arc<Y>) -> Self {
         Self {
             yaml_config_repository,
         }
     }
 }
 
-impl<R> EffectiveConfigLoaderBuilder for DefaultEffectiveConfigLoaderBuilder<R>
+impl<Y> EffectiveConfigLoaderBuilder for DefaultEffectiveConfigLoaderBuilder<Y>
 where
-    R: SubAgentYAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
-    type Loader = EffectiveConfigLoaderImpl<R>;
+    type Loader = EffectiveConfigLoaderImpl<Y>;
 
     fn build(&self, agent_id: AgentID) -> Self::Loader {
         if agent_id.is_super_agent_id() {
@@ -55,18 +55,18 @@ where
 }
 
 /// Enumerates all implementations for `EffectiveConfigLoader` for static dispatching reasons.
-pub enum EffectiveConfigLoaderImpl<R>
+pub enum EffectiveConfigLoaderImpl<Y>
 where
-    R: SubAgentYAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     // TODO this will be replaced with the actual super agent effective config loader.
     SuperAgent(NoOpEffectiveConfigLoader),
-    SubAgent(SubAgentEffectiveConfigLoader<R>),
+    SubAgent(SubAgentEffectiveConfigLoader<Y>),
 }
 
-impl<R> EffectiveConfigLoader for EffectiveConfigLoaderImpl<R>
+impl<Y> EffectiveConfigLoader for EffectiveConfigLoaderImpl<Y>
 where
-    R: SubAgentYAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     fn load(&self) -> Result<ConfigurationMap, LoaderError> {
         match self {

--- a/super-agent/src/sub_agent/event_handler/on_health.rs
+++ b/super-agent/src/sub_agent/event_handler/on_health.rs
@@ -9,12 +9,12 @@ use crate::values::yaml_config_repository::YAMLConfigRepository;
 use opamp_client::StartedClient;
 use tracing::error;
 
-impl<C, H, R, G> EventProcessor<C, H, R, G>
+impl<C, H, Y, G> EventProcessor<C, H, Y, G>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     pub(crate) fn on_health(&self, health: HealthWithStartTime) -> Result<(), SubAgentError> {
         if let Some(client) = self.maybe_opamp_client.as_ref() {

--- a/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
+++ b/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
@@ -17,12 +17,12 @@ use opamp_client::StartedClient;
 
 const ERROR_REMOTE_CONFIG: &str = "Error applying Sub Agent remote config";
 
-impl<C, S, R, G> EventProcessor<C, S, R, G>
+impl<C, S, Y, G> EventProcessor<C, S, Y, G>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     S: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     /// This method retrieves, stores the remote configuration (hash and values) and publish an event super-agent event
     /// in order that the super-agent handles it.

--- a/super-agent/src/sub_agent/event_processor.rs
+++ b/super-agent/src/sub_agent/event_processor.rs
@@ -23,12 +23,12 @@ pub trait SubAgentEventProcessor {
     fn process(self) -> JoinHandle<Result<(), SubAgentError>>;
 }
 
-pub struct EventProcessor<C, H, R, G>
+pub struct EventProcessor<C, H, Y, G>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     agent_id: AgentID,
     pub(crate) sub_agent_publisher: EventPublisher<SubAgentEvent>,
@@ -36,19 +36,19 @@ where
     pub(crate) sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
     pub(crate) maybe_opamp_client: Option<C>,
     pub(crate) sub_agent_remote_config_hash_repository: Arc<H>,
-    pub(crate) remote_values_repo: Arc<R>,
+    pub(crate) remote_values_repo: Arc<Y>,
 
     // This is needed to ensure the generic type parameter G is used in the struct.
     // Else Rust will reject this, complaining that the type parameter is not used.
     _effective_config_loader: PhantomData<G>,
 }
 
-impl<C, H, R, G> EventProcessor<C, H, R, G>
+impl<C, H, Y, G> EventProcessor<C, H, Y, G>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     pub fn new(
         agent_id: AgentID,
@@ -57,7 +57,7 @@ where
         sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
         maybe_opamp_client: Option<C>,
         sub_agent_remote_config_hash_repository: Arc<H>,
-        remote_values_repo: Arc<R>,
+        remote_values_repo: Arc<Y>,
     ) -> Self {
         EventProcessor {
             agent_id,
@@ -78,12 +78,12 @@ where
     }
 }
 
-impl<C, H, R, G> SubAgentEventProcessor for EventProcessor<C, H, R, G>
+impl<C, H, Y, G> SubAgentEventProcessor for EventProcessor<C, H, Y, G>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository + Send + Sync + 'static,
-    R: YAMLConfigRepository + Send + Sync + 'static,
+    Y: YAMLConfigRepository + Send + Sync + 'static,
 {
     // process will process the Sub Agent OpAMP events and will return the OpAMP client
     // when processing ends.

--- a/super-agent/src/sub_agent/event_processor_builder.rs
+++ b/super-agent/src/sub_agent/event_processor_builder.rs
@@ -26,24 +26,24 @@ where
     ) -> Self::SubAgentEventProcessor;
 }
 
-pub struct EventProcessorBuilder<H, R>
+pub struct EventProcessorBuilder<H, Y>
 where
     H: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     hash_repository: Arc<H>,
-    yaml_config_repository: Arc<R>,
+    yaml_config_repository: Arc<Y>,
 }
 
-impl<H, R> EventProcessorBuilder<H, R>
+impl<H, Y> EventProcessorBuilder<H, Y>
 where
     H: HashRepository,
-    R: YAMLConfigRepository,
+    Y: YAMLConfigRepository,
 {
     pub fn new(
         hash_repository: Arc<H>,
-        yaml_config_repository: Arc<R>,
-    ) -> EventProcessorBuilder<H, R> {
+        yaml_config_repository: Arc<Y>,
+    ) -> EventProcessorBuilder<H, Y> {
         EventProcessorBuilder {
             yaml_config_repository,
             hash_repository,
@@ -51,14 +51,14 @@ where
     }
 }
 
-impl<C, H, R, G> SubAgentEventProcessorBuilder<C, G> for EventProcessorBuilder<H, R>
+impl<C, H, Y, G> SubAgentEventProcessorBuilder<C, G> for EventProcessorBuilder<H, Y>
 where
     G: EffectiveConfigLoader,
     C: StartedClient<SubAgentCallbacks<G>> + 'static,
     H: HashRepository + Send + Sync + 'static,
-    R: YAMLConfigRepository + Send + Sync + 'static,
+    Y: YAMLConfigRepository + Send + Sync + 'static,
 {
-    type SubAgentEventProcessor = EventProcessor<C, H, R, G>;
+    type SubAgentEventProcessor = EventProcessor<C, H, Y, G>;
 
     fn build(
         &self,
@@ -67,7 +67,7 @@ where
         sub_agent_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
         sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
         maybe_opamp_client: Option<C>,
-    ) -> EventProcessor<C, H, R, G>
+    ) -> EventProcessor<C, H, Y, G>
     where
         G: EffectiveConfigLoader,
         C: StartedClient<SubAgentCallbacks<G>> + 'static,

--- a/super-agent/src/super_agent/run.rs
+++ b/super-agent/src/super_agent/run.rs
@@ -1,7 +1,7 @@
 use super::config::OpAMPClientConfig;
 use super::defaults::{
-    DYNAMIC_AGENT_TYPE_FILENAME, SUPER_AGENT_CONFIG_FILE, SUPER_AGENT_DATA_DIR,
-    SUPER_AGENT_LOCAL_DATA_DIR, SUPER_AGENT_LOG_DIR,
+    DYNAMIC_AGENT_TYPE_FILENAME, SUPER_AGENT_DATA_DIR, SUPER_AGENT_LOCAL_DATA_DIR,
+    SUPER_AGENT_LOG_DIR,
 };
 use super::http_server::config::ServerConfig;
 use crate::agent_type::embedded_registry::EmbeddedRegistry;

--- a/super-agent/src/values/file.rs
+++ b/super-agent/src/values/file.rs
@@ -1,9 +1,7 @@
 use crate::super_agent::config::AgentID;
 use crate::super_agent::defaults::{VALUES_DIR, VALUES_FILE};
 use crate::values::yaml_config::{has_remote_management, YAMLConfig};
-use crate::values::yaml_config_repository::{
-    SubAgentYAMLConfigRepository, YAMLConfigRepository, YAMLConfigRepositoryError,
-};
+use crate::values::yaml_config_repository::{YAMLConfigRepository, YAMLConfigRepositoryError};
 use fs::directory_manager::{DirectoryManagementError, DirectoryManager, DirectoryManagerFs};
 use fs::file_reader::{FileReader, FileReaderError};
 use fs::writer_file::{FileWriter, WriteError};
@@ -135,13 +133,6 @@ where
     }
 }
 
-impl<F, S> SubAgentYAMLConfigRepository for YAMLConfigRepositoryFile<F, S>
-where
-    S: DirectoryManager + Send + Sync + 'static,
-    F: FileWriter + FileReader + Send + Sync + 'static,
-{
-}
-
 impl<F, S> YAMLConfigRepository for YAMLConfigRepositoryFile<F, S>
 where
     S: DirectoryManager + Send + Sync + 'static,
@@ -222,7 +213,7 @@ pub mod test {
     use crate::super_agent::defaults::default_capabilities;
     use crate::values::yaml_config::YAMLConfig;
     use crate::values::yaml_config_repository::{
-        SubAgentYAMLConfigRepository, YAMLConfigRepository, YAMLConfigRepositoryError,
+        load_remote_fallback_local, YAMLConfigRepository, YAMLConfigRepositoryError,
     };
     use assert_matches::assert_matches;
     use fs::directory_manager::mock::MockDirectoryManagerMock;
@@ -288,7 +279,8 @@ pub mod test {
             remote_enabled,
         );
 
-        let yaml_config = repo.load(&agent_id, &default_capabilities()).unwrap();
+        let yaml_config =
+            load_remote_fallback_local(&repo, &agent_id, &default_capabilities()).unwrap();
 
         assert_eq!(yaml_config.get("some_config").unwrap(), &Value::Bool(true));
         assert_eq!(
@@ -323,7 +315,8 @@ pub mod test {
             remote_enabled,
         );
 
-        let yaml_config = repo.load(&agent_id, &default_capabilities()).unwrap();
+        let yaml_config =
+            load_remote_fallback_local(&repo, &agent_id, &default_capabilities()).unwrap();
 
         assert_eq!(yaml_config.get("some_config").unwrap(), &Value::Bool(true));
         assert_eq!(
@@ -363,7 +356,8 @@ pub mod test {
             remote_enabled,
         );
 
-        let yaml_config = repo.load(&agent_id, &default_capabilities()).unwrap();
+        let yaml_config =
+            load_remote_fallback_local(&repo, &agent_id, &default_capabilities()).unwrap();
 
         assert_eq!(yaml_config.get("some_config").unwrap(), &Value::Bool(true));
         assert_eq!(
@@ -396,7 +390,8 @@ pub mod test {
             remote_enabled,
         );
 
-        let yaml_config = repo.load(&agent_id, &default_capabilities()).unwrap();
+        let yaml_config =
+            load_remote_fallback_local(&repo, &agent_id, &default_capabilities()).unwrap();
 
         assert_eq!(yaml_config, YAMLConfig::default());
     }
@@ -424,7 +419,7 @@ pub mod test {
             remote_enabled,
         );
 
-        let result = repo.load(&agent_id, &default_capabilities());
+        let result = load_remote_fallback_local(&repo, &agent_id, &default_capabilities());
         let err = result.unwrap_err();
         assert_matches!(err, YAMLConfigRepositoryError::LoadError(s) => {
             assert!(s.contains("file read error"));
@@ -454,7 +449,7 @@ pub mod test {
             remote_enabled,
         );
 
-        let result = repo.load(&agent_id, &default_capabilities());
+        let result = load_remote_fallback_local(&repo, &agent_id, &default_capabilities());
         let err = result.unwrap_err();
         assert_matches!(err, YAMLConfigRepositoryError::LoadError(s) => {
             assert!(s.contains("error reading contents"));

--- a/super-agent/src/values/k8s.rs
+++ b/super-agent/src/values/k8s.rs
@@ -2,9 +2,7 @@ use crate::k8s;
 use crate::k8s::store::{K8sStore, STORE_KEY_LOCAL_DATA_CONFIG, STORE_KEY_OPAMP_DATA_CONFIG};
 use crate::super_agent::config::AgentID;
 use crate::values::yaml_config::{has_remote_management, YAMLConfig};
-use crate::values::yaml_config_repository::{
-    SubAgentYAMLConfigRepository, YAMLConfigRepository, YAMLConfigRepositoryError,
-};
+use crate::values::yaml_config_repository::{YAMLConfigRepository, YAMLConfigRepositoryError};
 use opamp_client::operation::capabilities::Capabilities;
 use std::sync::Arc;
 use thiserror::Error;
@@ -84,5 +82,3 @@ impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
         Ok(())
     }
 }
-
-impl SubAgentYAMLConfigRepository for YAMLConfigRepositoryConfigMap {}


### PR DESCRIPTION
While working on the super-agent effective config #763 I found that the `load` fn that is on the `SubAgentYAMLConfigRepository` is also needed for that specific case of the super-agent so is not longer a sub-agent thing. 
This PR extract that logic into an standalone function.
- Removes the Trait `SubAgentYAMLConfigRepository`
- Rename some generics to fit the renamed ValuesRepository