### PR TITLE
NR-293537 don't crash the Super Agent if hash file is corrupted

### DIFF
--- a/super-agent/src/opamp/hash_repository/k8s.rs
+++ b/super-agent/src/opamp/hash_repository/k8s.rs
@@ -28,12 +28,12 @@ impl HashRepositoryConfigMap {
 impl HashRepository for HashRepositoryConfigMap {
     fn save(&self, agent_id: &AgentID, hash: &Hash) -> Result<(), HashRepositoryError> {
         self._save(agent_id, hash)
-            .map_err(|err| HashRepositoryError::LoadError(err.to_string()))
+            .map_err(|err| HashRepositoryError::PersistError(err.to_string()))
     }
 
     fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
         self._get(agent_id)
-            .map_err(|err| HashRepositoryError::PersistError(err.to_string()))
+            .map_err(|err| HashRepositoryError::LoadError(err.to_string()))
     }
 }
 

--- a/super-agent/src/opamp/hash_repository/on_host.rs
+++ b/super-agent/src/opamp/hash_repository/on_host.rs
@@ -66,12 +66,12 @@ where
 {
     fn save(&self, agent_id: &AgentID, hash: &Hash) -> Result<(), HashRepositoryError> {
         self._save(agent_id, hash)
-            .map_err(|err| HashRepositoryError::LoadError(err.to_string()))
+            .map_err(|err| HashRepositoryError::PersistError(err.to_string()))
     }
 
     fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
         self._get(agent_id)
-            .map_err(|err| HashRepositoryError::PersistError(err.to_string()))
+            .map_err(|err| HashRepositoryError::LoadError(err.to_string()))
     }
 }
 

--- a/super-agent/src/opamp/hash_repository/repository.rs
+++ b/super-agent/src/opamp/hash_repository/repository.rs
@@ -1,7 +1,7 @@
 use crate::opamp::remote_config_hash::Hash;
 use crate::super_agent::config::AgentID;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum HashRepositoryError {
     #[error("error persisting hash: `{0}`")]
     PersistError(String),
@@ -31,18 +31,36 @@ pub mod test {
     }
 
     impl MockHashRepositoryMock {
-        #[allow(dead_code)]
         pub fn should_get_hash(&mut self, agent_id: &AgentID, hash: Hash) {
             self.expect_get()
                 .with(predicate::eq(agent_id.clone()))
                 .once()
-                .returning(move |_| Ok(Some(hash.clone())));
+                .return_once(move |_| Ok(Some(hash)));
         }
+
+        pub fn should_not_get_hash(&mut self, agent_id: &AgentID) {
+            self.expect_get()
+                .with(predicate::eq(agent_id.clone()))
+                .once()
+                .return_once(move |_| Ok(None));
+        }
+
         pub fn should_save_hash(&mut self, agent_id: &AgentID, hash: &Hash) {
             self.expect_save()
                 .with(predicate::eq(agent_id.clone()), predicate::eq(hash.clone()))
                 .once()
                 .returning(move |_, _| Ok(()));
+        }
+
+        pub fn should_return_error_on_get(
+            &mut self,
+            agent_id: &AgentID,
+            error: HashRepositoryError,
+        ) {
+            self.expect_get()
+                .with(predicate::eq(agent_id.clone()))
+                .once()
+                .return_once(move |_| Err(error));
         }
     }
 }


### PR DESCRIPTION
This PR:
* Fixes the errors returned by HashRepository (they were swapped)
* Avoid crashing the Super Agent when the hash file is incorrect