### PR TITLE
test: fix flaky `custom_directory_as_root`

### DIFF
--- a/super-agent/tests/on_host/cli.rs
+++ b/super-agent/tests/on_host/cli.rs
@@ -225,7 +225,7 @@ agents:
     let remote_path = tmpdir_path.join("nrsa_remote");
     let logs_path = tmpdir_path.join("nrsa_logs");
 
-    retry(60, Duration::from_secs(1), || {
+    retry(90, Duration::from_secs(1), || {
         || -> Result<(), Box<dyn Error>> {
             if remote_path.exists() && logs_path.exists() {
                 return Ok(());
@@ -305,7 +305,7 @@ agents: {{}}
     // Assert the directory structure has been created
     let remote_path = tmpdir_path.join("nrsa_remote");
 
-    retry(60, Duration::from_secs(1), || {
+    retry(90, Duration::from_secs(1), || {
         || -> Result<(), Box<dyn Error>> {
             if remote_path.exists() && override_logs_path.exists() {
                 return Ok(());


### PR DESCRIPTION
From the CI logs I see that this test fails whenever the [compilation time is near 60s](https://github.com/newrelic/newrelic-super-agent/actions/runs/10053713586/job/27786982343#step:7:86), This happens on the first time the code is compiled on the tests. 
