### PR TITLE
Add on_host effective config integration tests for sub agents

### DIFF
--- a/super-agent/src/opamp/effective_config/sub_agent.rs
+++ b/super-agent/src/opamp/effective_config/sub_agent.rs
@@ -161,7 +161,7 @@ mod test {
             TestCase {
                 name: "empty config",
                 yaml_config: "",
-                expected_config: "{}\n",
+                expected_config: "",
             },
         ];
 

--- a/super-agent/src/values/yaml_config.rs
+++ b/super-agent/src/values/yaml_config.rs
@@ -50,6 +50,10 @@ impl TryFrom<YAMLConfig> for String {
     type Error = YAMLConfigError;
 
     fn try_from(value: YAMLConfig) -> Result<Self, Self::Error> {
+        //serde_yaml::to_string returns "{}\n" if value is empty
+        if value.0.is_empty() {
+            return Ok("".to_string());
+        }
         Ok(serde_yaml::to_string(&value)?)
     }
 }

--- a/super-agent/tests/common/effective_config.rs
+++ b/super-agent/tests/common/effective_config.rs
@@ -1,0 +1,30 @@
+use crate::common::opamp::FakeServer;
+use newrelic_super_agent::opamp::instance_id::InstanceID;
+use std::error::Error;
+
+pub fn check_latest_effective_config_is_expected(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected_config: String,
+) -> Result<(), Box<dyn Error>> {
+    // When opamp asks to get the effective config from the callback
+    let effective_config = opamp_server.get_effective_config(instance_id.clone());
+
+    if let Some(effective_cfg) = effective_config.clone() {
+        let cfg_body = effective_cfg.config_map.clone().unwrap().config_map[""]
+            .body
+            .to_vec();
+        if expected_config.as_bytes() != cfg_body {
+            return Err(format!(
+                "Super agent config not as expected, Expected: {:?}, Found: {:?}",
+                expected_config,
+                String::from_utf8(cfg_body).unwrap(),
+            )
+            .into());
+        }
+    } else {
+        return Err("No effective config created".into());
+    }
+
+    Ok(())
+}

--- a/super-agent/tests/common/mod.rs
+++ b/super-agent/tests/common/mod.rs
@@ -1,7 +1,8 @@
 /// Includes a OpAMP mock server to test scenarios involving OpAMP.
+pub(super) mod effective_config;
 pub(super) mod health;
 pub(super) mod opamp;
+pub(super) mod remote_config_status;
+pub(super) mod retry;
 /// Includes helpers to handle the _async_ code execution in non-tokio-tests.
 pub(super) mod runtime;
-
-pub(super) mod retry;

--- a/super-agent/tests/common/remote_config_status.rs
+++ b/super-agent/tests/common/remote_config_status.rs
@@ -1,0 +1,26 @@
+use crate::common::opamp::FakeServer;
+use newrelic_super_agent::opamp::instance_id::InstanceID;
+use std::error::Error;
+
+pub fn check_latest_remote_config_status_is_expected(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected_config_status: i32,
+) -> Result<(), Box<dyn Error>> {
+    // When opamp asks to get the effective config from the callback
+    let remote_config_status = opamp_server.get_remote_config_status(instance_id.clone());
+
+    if let Some(config_status) = remote_config_status.clone() {
+        if expected_config_status != config_status.status {
+            return Err(format!(
+                "Remote config status not as expected, Expected: {:?}, Found: {:?}",
+                expected_config_status, config_status.status,
+            )
+            .into());
+        }
+    } else {
+        return Err("No Remote config statuses created".into());
+    }
+
+    Ok(())
+}

--- a/super-agent/tests/k8s/opamp.rs
+++ b/super-agent/tests/k8s/opamp.rs
@@ -13,6 +13,7 @@ use super::tools::{
         start_super_agent_with_testdata_config, wait_until_super_agent_with_opamp_is_started,
     },
 };
+use crate::common::effective_config::check_latest_effective_config_is_expected;
 use newrelic_super_agent::super_agent::config::AgentID;
 use std::time::Duration;
 
@@ -116,6 +117,18 @@ config:
             expected_spec_values,
         ))?;
 
+        let expected_config = r#"chart_values:
+  mode: deployment
+  config:
+    exporters:
+      logging: {}
+"#;
+
+        check_latest_effective_config_is_expected(
+            &server,
+            &instance_id.clone(),
+            expected_config.to_string(),
+        )?;
         check_latest_health_status_was_healthy(&server, &instance_id.clone())
     });
 
@@ -153,6 +166,20 @@ image:
             expected_spec_values,
         ))?;
 
+        let expected_config = r#"chart_values:
+  mode: deployment
+  config:
+    exporters:
+      logging: {}
+  image:
+    tag: latest
+"#;
+
+        check_latest_effective_config_is_expected(
+            &server,
+            &instance_id.clone(),
+            expected_config.to_string(),
+        )?;
         check_latest_health_status_was_healthy(&server, &instance_id.clone())
     });
 }

--- a/super-agent/tests/on_host/data/trap_term_sleep_60.sh
+++ b/super-agent/tests/on_host/data/trap_term_sleep_60.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+######################################################################################
+# This script is thought to be added for execution by the custom agent_type used on sub-agent's
+# integration tests, it traps the sigterm sent by the superagent when a new config is received
+# by the sub-agent's opamp so we don't restart the agent and we don't show an error log.
+######################################################################################
+
+trap "sleep 60;exit 0" TERM; sleep 60

--- a/super-agent/tests/on_host/mod.rs
+++ b/super-agent/tests/on_host/mod.rs
@@ -2,6 +2,7 @@ mod cli;
 mod command;
 mod config_persister;
 mod consts;
+mod effective_config;
 mod id;
 mod logging;
 mod opamp_auth;

--- a/super-agent/tests/on_host/remote_config.rs
+++ b/super-agent/tests/on_host/remote_config.rs
@@ -3,13 +3,13 @@ use crate::common::{
     opamp::{ConfigResponse, FakeServer},
     retry::retry,
 };
+use crate::on_host::tools::config::create_super_agent_config;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::super_agent::start_super_agent_with_custom_config;
 use newrelic_super_agent::super_agent::config::{AgentID, SuperAgentDynamicConfig};
+use newrelic_super_agent::super_agent::defaults::SUPER_AGENT_CONFIG_FILE;
 use newrelic_super_agent::super_agent::run::BasePaths;
 use std::error::Error;
-use std::fs::File;
-use std::io::Write;
 use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -23,20 +23,12 @@ fn onhost_opamp_superagent_configuration_change() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let config_file_path = local_dir.path().join("config.yaml");
-    let mut local_file =
-        File::create(config_file_path.clone()).expect("failed to create local config file");
-    let super_agent_config = format!(
-        r#"
-host_id: integration-test
-opamp:
-  endpoint: {}
-agents: {{}}    
-"#,
-        opamp_server.endpoint()
+    let agents = "{}";
+    let config_file_path = create_super_agent_config(
+        opamp_server.endpoint(),
+        agents.to_string(),
+        local_dir.path().to_path_buf(),
     );
-
-    write!(local_file, "{}", super_agent_config).unwrap();
 
     let base_paths = BasePaths {
         super_agent_local_config: config_file_path.as_path().to_path_buf(),
@@ -77,7 +69,7 @@ agents:
 
     retry(60, Duration::from_secs(1), || {
         || -> Result<(), Box<dyn Error>> {
-            let remote_file = remote_dir.path().join("config.yaml");
+            let remote_file = remote_dir.path().join(SUPER_AGENT_CONFIG_FILE);
             let content =
                 std::fs::read_to_string(remote_file.as_path()).unwrap_or("agents:".to_string());
             let content_parsed =
@@ -93,7 +85,4 @@ agents:
             check_latest_health_status_was_healthy(&opamp_server, &super_agent_instance_id)
         }()
     });
-
-    // TODO: Then OpAMP receives applied (& applying?) AgentToServer (check state on the server).
-    // TODO: Then the two agent processes are running (we should create custom agent_types for custom binary).
 }

--- a/super-agent/tests/on_host/tools.rs
+++ b/super-agent/tests/on_host/tools.rs
@@ -1,3 +1,5 @@
+pub mod config;
+pub mod custom_agent_type;
 pub mod global_logger;
 pub mod instance_id;
 pub mod super_agent;

--- a/super-agent/tests/on_host/tools/config.rs
+++ b/super-agent/tests/on_host/tools/config.rs
@@ -1,0 +1,45 @@
+use newrelic_super_agent::super_agent::defaults::{
+    SUB_AGENT_DIR, SUPER_AGENT_CONFIG_FILE, VALUES_DIR, VALUES_FILE,
+};
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Creates the super-agent config given an opamp_server_endpoint
+/// and a list of agents on the specified local_dir.
+pub fn create_super_agent_config(
+    opamp_server_endpoint: String,
+    agents: String,
+    local_dir: PathBuf,
+) -> PathBuf {
+    let config_file_path = local_dir.join(SUPER_AGENT_CONFIG_FILE);
+
+    let mut local_file =
+        File::create(config_file_path.clone()).expect("failed to create local config file");
+    let super_agent_config = format!(
+        r#"
+host_id: integration-test
+opamp:
+  endpoint: {}
+agents: {}
+"#,
+        opamp_server_endpoint, agents
+    );
+    write!(local_file, "{}", super_agent_config).unwrap();
+
+    config_file_path
+}
+
+/// Creates a sub-agent values config for the agent_id provided on the base_dir
+/// with the given content.
+pub fn create_sub_agent_values(agent_id: String, config: String, base_dir: PathBuf) -> PathBuf {
+    let agent_values_dir_path = base_dir.join(SUB_AGENT_DIR).join(agent_id).join(VALUES_DIR);
+    create_dir_all(agent_values_dir_path.clone()).expect("failed to create values directory");
+
+    let values_file_path = agent_values_dir_path.join(VALUES_FILE);
+    let mut local_values_file =
+        File::create(values_file_path.clone()).expect("failed to create local values file");
+    write!(local_values_file, "{}", config).unwrap();
+
+    values_file_path
+}

--- a/super-agent/tests/on_host/tools/custom_agent_type.rs
+++ b/super-agent/tests/on_host/tools/custom_agent_type.rs
@@ -1,0 +1,34 @@
+use newrelic_super_agent::super_agent::defaults::DYNAMIC_AGENT_TYPE_FILENAME;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub fn get_agent_type_custom(local_dir: PathBuf, path: &str, args: &str) -> String {
+    let agent_type_file_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+
+    let mut local_file =
+        File::create(agent_type_file_path.clone()).expect("failed to create local config file");
+    let custom_agent_type = format!(
+        r#"
+namespace: newrelic
+name: com.newrelic.custom_agent
+version: 0.1.0
+variables:
+  on_host:
+    backoff_delay:
+      description: "seconds until next retry if agent fails to start"
+      type: string
+      required: false
+      default: 1s
+deployment:
+  on_host:
+    executables:
+      - path: {}
+        args: {}
+"#,
+        path, args
+    );
+    write!(local_file, "{}", custom_agent_type).unwrap();
+
+    "newrelic/com.newrelic.custom_agent:0.1.0".to_string()
+}


### PR DESCRIPTION
Added:
ON_HOST:
- New helpers for configs on integration tests for on_host
- Local values get_effective_config integration test
- Local and remote values get_effective_config integration test
- Empty values get_effective_config integration test
- Remote config incorrect, effective_config still local test

K8S:
- Added effective config check to existing subagent opamp config change.