### PR TITLE
enable info level logging for all crates

### DIFF
--- a/super-agent/src/logging/config.rs
+++ b/super-agent/src/logging/config.rs
@@ -120,7 +120,7 @@ impl LoggingConfig {
         let level = self.level.as_level().to_string().to_lowercase();
 
         Ok(EnvFilter::builder()
-            .with_default_directive(LevelFilter::OFF.into())
+            .with_default_directive(LevelFilter::INFO.into())
             .parse_lossy("")
             .add_directive(
                 format!("newrelic_super_agent={}", level)
@@ -200,7 +200,7 @@ mod test {
             TestCase {
                 name: "everything default",
                 config: Default::default(),
-                expected: "newrelic_super_agent=info,off",
+                expected: "newrelic_super_agent=info,info",
             },
             TestCase {
                 name: "insecure fine grained overrides any logging",


### PR DESCRIPTION
Enable Log Level `INFO` for all crates.