### PR TITLE
Filter invalid config fields

### DIFF
--- a/super-agent/src/sub_agent.rs
+++ b/super-agent/src/sub_agent.rs
@@ -13,5 +13,7 @@ pub mod k8s;
 pub mod on_host;
 
 pub use sub_agent::*;
+mod config_validator;
 #[allow(clippy::module_inception)]
 mod sub_agent;
+mod validation_regexes;

--- a/super-agent/src/sub_agent/config_validator.rs
+++ b/super-agent/src/sub_agent/config_validator.rs
@@ -1,0 +1,127 @@
+use crate::opamp::remote_config::RemoteConfig;
+use crate::sub_agent::validation_regexes::{REGEX_COMMAND_FIELD, REGEX_EXEC_FIELD};
+use crate::super_agent::config::AgentTypeFQN;
+use regex::Regex;
+use std::collections::HashMap;
+use thiserror::Error;
+
+pub const FQN_NAME_INFRA_AGENT: &str = "com.newrelic.infrastructure_agent";
+
+#[derive(Error, Debug)]
+pub enum ValidatorError {
+    #[error("Invalid config: restricted values detected")]
+    InvalidConfig,
+
+    #[error("error compiling regex: `{0}`")]
+    RegexError(#[from] regex::Error),
+}
+
+#[derive(Debug, PartialEq, Hash, Eq)]
+struct AgentTypeFQNName(String);
+
+/// The Config validator is responsible for matching a series of regexes on the content
+/// of the retrieved remote config and returning an error if a match is found.
+/// If getting the unique remote config fails, the validator will return as valid
+/// because we leave that kind of error handling to the store_remote_config_hash_and_values
+/// on the event_processor.
+pub struct ConfigValidator {
+    rules: HashMap<AgentTypeFQNName, Vec<Regex>>,
+}
+
+impl ConfigValidator {
+    pub fn try_new() -> Result<Self, ValidatorError> {
+        Ok(Self {
+            rules: HashMap::from([(
+                AgentTypeFQNName(FQN_NAME_INFRA_AGENT.to_string()),
+                vec![
+                    Regex::new(REGEX_COMMAND_FIELD)?,
+                    Regex::new(REGEX_EXEC_FIELD)?,
+                ],
+            )]),
+        })
+    }
+    pub fn validate(
+        &self,
+        agent_type_fqn: &AgentTypeFQN,
+        remote_config: &RemoteConfig,
+    ) -> Result<(), ValidatorError> {
+        let agent_type_fqn_name = AgentTypeFQNName(agent_type_fqn.name());
+        if !self.rules.contains_key(&agent_type_fqn_name) {
+            return Ok(());
+        }
+
+        if let Ok(raw_config) = remote_config.get_unique() {
+            for regex in self.rules[&agent_type_fqn_name].iter() {
+                if regex.is_match(raw_config) {
+                    return Err(ValidatorError::InvalidConfig);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::opamp::remote_config::{ConfigurationMap, RemoteConfig};
+    use crate::opamp::remote_config_hash::Hash;
+    use crate::sub_agent::config_validator::{ConfigValidator, FQN_NAME_INFRA_AGENT};
+    use crate::super_agent::config::{AgentID, AgentTypeFQN};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_validate() {
+        let content = r#"
+        health_port: 18003
+        config_agent: |+
+          staging: true
+          enable_process_metrics: true
+          status_server_enabled: true
+          status_server_port: 18003
+          log:
+            level: info
+          license_key: {{NEW_RELIC_LICENSE_KEY}}
+          custom_attributes:
+            nr_deployed_by: newrelic-cli
+
+        config_integrations:
+          docker-config.yml: |
+            integrations:
+              - name: nri-docker
+                when:
+                  feature: docker_enabled
+                  file_exists: /var/run/docker.sock
+                interval: 15s
+              # This configuration is no longer included in nri-ecs images.
+              # it is kept for legacy reasons, but the new one is located in https://github.com/newrelic/nri-ecs
+              - name: nri-docker
+                when:
+                  feature: docker_enabled
+                  env_exists:
+                    FARGATE: "true"
+                interval: 15s
+                        integrations:
+              - name: nri-other
+                exec: /bin/crowdstrike-falcon
+                interval: 15s
+        "#;
+        let remote_config = RemoteConfig::new(
+            AgentID::new("invented").unwrap(),
+            Hash::new("this-is-a-hash".to_string()),
+            Some(ConfigurationMap::new(HashMap::from([(
+                "".to_string(),
+                content.to_string(),
+            )]))),
+        );
+        let validator = ConfigValidator::try_new().unwrap();
+        let agent_type_fqn =
+            AgentTypeFQN::try_from(format!("newrelic/{}:0.0.1", FQN_NAME_INFRA_AGENT).as_str())
+                .unwrap();
+        let validation_result = validator.validate(&agent_type_fqn, &remote_config);
+        assert_eq!(
+            validation_result.unwrap_err().to_string(),
+            "Invalid config: restricted values detected"
+        );
+    }
+}

--- a/super-agent/src/sub_agent/error.rs
+++ b/super-agent/src/sub_agent/error.rs
@@ -3,6 +3,7 @@ use crate::event::channel::EventPublisherError;
 use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::repository::HashRepositoryError;
 use crate::opamp::remote_config::RemoteConfigError;
+use crate::sub_agent::config_validator::ValidatorError;
 use crate::super_agent::config::SuperAgentConfigError;
 use crate::values::yaml_config::YAMLConfigError;
 use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
@@ -45,6 +46,8 @@ pub enum SubAgentError {
     EventPublisherError(#[from] EventPublisherError),
     #[error("Error handling thread: `{0}`")]
     PoisonError(String),
+    #[error("Validator error: `{0}`")]
+    ValidatorError(#[from] ValidatorError),
 }
 
 #[derive(Error, Debug)]

--- a/super-agent/src/sub_agent/event_processor_builder.rs
+++ b/super-agent/src/sub_agent/event_processor_builder.rs
@@ -2,6 +2,7 @@ use crate::event::channel::{EventConsumer, EventPublisher};
 use crate::event::{OpAMPEvent, SubAgentEvent, SubAgentInternalEvent};
 use crate::opamp::effective_config::loader::EffectiveConfigLoader;
 use crate::opamp::hash_repository::HashRepository;
+use crate::sub_agent::config_validator::ConfigValidator;
 use crate::sub_agent::event_processor::{EventProcessor, SubAgentEventProcessor};
 use crate::sub_agent::SubAgentCallbacks;
 use crate::super_agent::config::{AgentID, AgentTypeFQN};
@@ -83,6 +84,9 @@ where
             maybe_opamp_client,
             self.hash_repository.clone(),
             self.yaml_config_repository.clone(),
+            Arc::new(
+                ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
+            ),
         )
     }
 }

--- a/super-agent/src/sub_agent/validation_regexes.rs
+++ b/super-agent/src/sub_agent/validation_regexes.rs
@@ -1,0 +1,3 @@
+// TODO: this regexes need to be improved.
+pub static REGEX_COMMAND_FIELD: &str = "command";
+pub static REGEX_EXEC_FIELD: &str = "exec";


### PR DESCRIPTION
Sub Agents configurations will be parsed and checked against a set of REGEX. If any of the REGEX matches, the configuration will not be applied nor persisted, and we will report FAILED to OpAMP with a message similar to: 

the configuration contains disallowed directive

The system should handle REGEX per Agent Type (we should be able to define different REGEX for Infra Agent configs and Collector)