### PR TITLE
Enable status server by default on examples

### DIFF
--- a/build/examples/super-agent-config-all-agents.yaml
+++ b/build/examples/super-agent-config-all-agents.yaml
@@ -10,6 +10,9 @@
 
 # fleet_id: FLEET_ID_HERE
 
+server:
+  enabled: true
+
 agents:
   nr-infra-agent:
     agent_type: "newrelic/com.newrelic.infrastructure_agent:0.1.3"

--- a/build/examples/super-agent-config-no-agents.yaml
+++ b/build/examples/super-agent-config-no-agents.yaml
@@ -10,4 +10,7 @@
 
 # fleet_id: FLEET_ID_HERE
 
+server:
+  enabled: true
+
 agents: {}


### PR DESCRIPTION
Changes the default configs provided on on-host to have the server.enabled setting to true