### PR TITLE
fix: onhost supervisor gracefully shutdown (NR-295677)

### DIFF
--- a/super-agent/src/sub_agent/on_host/command/shutdown.rs
+++ b/super-agent/src/sub_agent/on_host/command/shutdown.rs
@@ -78,7 +78,8 @@ pub fn wait_exit_timeout(context: Context<bool>, exit_timeout: Duration) -> bool
     }
 }
 
-/// wait_exit_timeout_default calls wait_exit_timeout with the DEFAULT_EXIT_TIMEOUT of 2 seconds.
+/// waits on a condvar for a change in a boolean exit variable
+/// with a default timeout of DEFAULT_EXIT_TIMEOUT seconds
 pub fn wait_exit_timeout_default(context: Context<bool>) -> bool {
     wait_exit_timeout(context, DEFAULT_EXIT_TIMEOUT)
 }


### PR DESCRIPTION
- Fix restart the supervisor after gracefully shutdown
- Fix race condition where `wait_for_termination` is executed before pid is set, this causes that the `stop` fn returns the handle of the thread that runs the command which has started and not killed. This might cause that the SA freezes [when join that handle](https://github.com/newrelic/newrelic-super-agent/blob/86c1de39c029900e995c0222e7838c3a51c01b93/super-agent/src/sub_agent/on_host/sub_agent.rs#L87)

IMPORTANT this is a quick patch, IMO we should change the way data is being communicated between these threads and use channels instead of shared data + mutex