### PR TITLE
[NR-297255] strip debuginfo from release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,9 @@ ureq = "2.9.7"
 semver = "1.0.23"
 chrono = "0.4"
 jsonwebtoken = "9.3.0"
+
+[profile.release]
+# remove debug symbols from the release binary
+# After <https://github.com/rust-lang/cargo/pull/13257> this is the default
+# behavior for cargo, unless debuginfo is enabled for any compiled package
+strip = "debuginfo"

--- a/build/rust.Dockerfile
+++ b/build/rust.Dockerfile
@@ -53,5 +53,6 @@ CMD [ "sh", "-c", "\
      CMD_STRING=\"$CMD_STRING --target $ARCH_NAME-unknown-linux-musl\"; \
      CMD_STRING=\"$CMD_STRING --bin $BUILD_BIN_ENV\"; \
      CMD_STRING=\"$CMD_STRING --target-dir target-$BUILD_BIN_ENV\"; \
+     echo $CMD_STRING; \
      $CMD_STRING \
 "]


### PR DESCRIPTION
This PR updates the `release` profile in `Cargo.toml` to strip the debug information from the binary.

Since

> A malicious user can abuse these debugging details to gain a better understanding of how the application functions.

Security recommended using `--release` flag to remove most of the debugging information.

The `--release` flag was already used, but it is not enough since debug symbols are not stripped by default unless no dependency package includes debug symbols (check https://github.com/rust-lang/cargo/pull/13257 for details).

After this change:

```
$ file bin/newrelic-super-agent-arm64
bin/newrelic-super-agent-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=e7bc74e93b5bf3d403596ceb7fb6fe1038c40f0a, not stripped
```