### PR TITLE
refact: remove global variables from resource detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -1283,24 +1283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
-name = "deadpool"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
-dependencies = [
- "async-trait",
- "deadpool-runtime",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,25 +1782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.1.0",
- "indexmap 2.2.6",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,7 +1971,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2031,11 +1994,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2803,7 +2764,6 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
- "wiremock",
 ]
 
 [[package]]
@@ -4253,7 +4213,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.29",
@@ -4966,30 +4926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wiremock"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
-dependencies = [
- "assert-json-diff",
- "async-trait",
- "base64 0.21.7",
- "deadpool",
- "futures",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.3.1",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -225,13 +225,6 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## atomic-waker https://crates.io/crates/atomic-waker
-
-Distributed under the following license(s):
-* Apache-2.0
-* MIT
-
-
 ## autocfg https://crates.io/crates/autocfg
 
 Distributed under the following license(s):
@@ -823,12 +816,6 @@ Distributed under the following license(s):
 
 
 ## globwalk https://crates.io/crates/globwalk
-
-Distributed under the following license(s):
-* MIT
-
-
-## h2 https://crates.io/crates/h2
 
 Distributed under the following license(s):
 * MIT

--- a/resource-detection/src/cloud/aws/detector.rs
+++ b/resource-detection/src/cloud/aws/detector.rs
@@ -1,28 +1,25 @@
 //! AWS EC2 instance id detector implementation
-use std::time::Duration;
-
+use super::metadata::AWSMetadata;
+use crate::cloud::http_client::{
+    HttpClient, HttpClientError, HttpClientUreq, DEFAULT_CLIENT_TIMEOUT,
+};
+use crate::{cloud::AWS_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
 use thiserror::Error;
 
-use crate::cloud::http_client::{HttpClient, HttpClientError, HttpClientUreq};
-use crate::{cloud::AWS_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
-
-use super::metadata::{AWSMetadata, IPV4_METADATA_ENDPOINT};
+/// The default AWS instance metadata endpoint.
+pub const AWS_IPV4_METADATA_ENDPOINT: &str =
+    "http://169.254.169.254/latest/dynamic/instance-identity/document";
 
 /// The `AWSDetector` struct encapsulates an HTTP client used to retrieve the instance metadata.
 pub struct AWSDetector<C: HttpClient> {
     http_client: C,
 }
 
-const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
-
-impl Default for AWSDetector<HttpClientUreq> {
-    fn default() -> Self {
+impl AWSDetector<HttpClientUreq> {
+    /// Returns a new instance of AWSDetector
+    pub fn new(metadata_endpoint: String) -> Self {
         Self {
-            http_client: HttpClientUreq::new(
-                IPV4_METADATA_ENDPOINT.to_string(),
-                DEFAULT_CLIENT_TIMEOUT,
-                None,
-            ),
+            http_client: HttpClientUreq::new(metadata_endpoint, DEFAULT_CLIENT_TIMEOUT, None),
         }
     }
 }

--- a/resource-detection/src/cloud/aws/metadata.rs
+++ b/resource-detection/src/cloud/aws/metadata.rs
@@ -1,10 +1,5 @@
 use serde::Deserialize;
 
-pub(crate) const IPV4_METADATA_ENDPOINT: &str = konst::option::unwrap_or!(
-    option_env!("TEST_IPV4_METADATA_ENDPOINT"),
-    "http://169.254.169.254/latest/dynamic/instance-identity/document"
-);
-
 #[derive(Deserialize)]
 pub(super) struct AWSMetadata {
     #[serde(rename = "instanceId")]

--- a/resource-detection/src/cloud/azure/detector.rs
+++ b/resource-detection/src/cloud/azure/detector.rs
@@ -1,26 +1,27 @@
 //! Azure EC2 instance id detector implementation
+use super::metadata::AzureMetadata;
+use crate::cloud::http_client::{
+    HttpClient, HttpClientError, HttpClientUreq, DEFAULT_CLIENT_TIMEOUT,
+};
+use crate::{cloud::AZURE_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
 use http::HeaderMap;
-use std::time::Duration;
-
 use thiserror::Error;
 
-use crate::cloud::http_client::{HttpClient, HttpClientError, HttpClientUreq};
-use crate::{cloud::AZURE_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
-
-use super::metadata::{AzureMetadata, IPV4_METADATA_ENDPOINT};
+/// The default Azure instance metadata endpoint.
+pub const AZURE_IPV4_METADATA_ENDPOINT: &str =
+    "http://169.254.169.254/metadata/instance?api-version=2021-02-01";
 
 /// The `AzureDetector` struct encapsulates an HTTP client used to retrieve the instance metadata.
-
 pub struct AzureDetector<C: HttpClient> {
     http_client: C,
 }
 
-const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 const HEADER_KEY: &str = "Metadata";
 const HEADER_VALUE: &str = "true";
 
-impl Default for AzureDetector<HttpClientUreq> {
-    fn default() -> Self {
+impl AzureDetector<HttpClientUreq> {
+    /// Returns a new instance of AzureDetector
+    pub fn new(metadata_endpoint: String) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(
             HEADER_KEY,
@@ -29,7 +30,7 @@ impl Default for AzureDetector<HttpClientUreq> {
 
         Self {
             http_client: HttpClientUreq::new(
-                IPV4_METADATA_ENDPOINT.to_string(),
+                metadata_endpoint,
                 DEFAULT_CLIENT_TIMEOUT,
                 Some(headers),
             ),

--- a/resource-detection/src/cloud/azure/metadata.rs
+++ b/resource-detection/src/cloud/azure/metadata.rs
@@ -1,10 +1,5 @@
 use serde::Deserialize;
 
-pub(crate) const IPV4_METADATA_ENDPOINT: &str = konst::option::unwrap_or!(
-    option_env!("TEST_IPV4_METADATA_ENDPOINT"),
-    "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
-);
-
 #[derive(Deserialize)]
 pub(super) struct AzureMetadataCompute {
     #[serde(rename = "vmId")]

--- a/resource-detection/src/cloud/cloud_id/detector.rs
+++ b/resource-detection/src/cloud/cloud_id/detector.rs
@@ -19,18 +19,23 @@ pub struct CloudIdDetector<AWS: Detector, AZURE: Detector, GCP: Detector> {
     gcp_detector: GCP,
 }
 
-impl Default
-    for CloudIdDetector<
+impl
+    CloudIdDetector<
         AWSDetector<HttpClientUreq>,
         AzureDetector<HttpClientUreq>,
         GCPDetector<HttpClientUreq>,
     >
 {
-    fn default() -> Self {
+    /// Returns a new instance of CloudIdDetector
+    pub fn new(
+        aws_metadata_endpoint: String,
+        azure_metadata_endpoint: String,
+        gcp_metadata_endpoint: String,
+    ) -> Self {
         Self {
-            aws_detector: AWSDetector::default(),
-            azure_detector: AzureDetector::default(),
-            gcp_detector: GCPDetector::default(),
+            aws_detector: AWSDetector::new(aws_metadata_endpoint),
+            azure_detector: AzureDetector::new(azure_metadata_endpoint),
+            gcp_detector: GCPDetector::new(gcp_metadata_endpoint),
         }
     }
 }

--- a/resource-detection/src/cloud/gcp/metadata.rs
+++ b/resource-detection/src/cloud/gcp/metadata.rs
@@ -1,11 +1,6 @@
 use serde::Deserialize;
 use serde_json::Number;
 
-pub(crate) const IPV4_METADATA_ENDPOINT: &str = konst::option::unwrap_or!(
-    option_env!("TEST_IPV4_METADATA_ENDPOINT"),
-    "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true"
-);
-
 #[derive(Deserialize)]
 pub(super) struct GCPMetadata {
     #[serde(rename = "id")]

--- a/resource-detection/src/cloud/http_client.rs
+++ b/resource-detection/src/cloud/http_client.rs
@@ -3,6 +3,9 @@ use std::time::Duration;
 use thiserror::Error;
 use tracing::error;
 
+/// The default timeout for the HTTP client.
+pub const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// An enumeration of potential errors related to the HTTP client.
 #[derive(Error, Debug)]
 pub enum HttpClientError {

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -72,7 +72,6 @@ tracing-test = { workspace = true }
 jsonwebtoken = { workspace = true }
 fs = { path = "../fs", features = ["mocks"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
-wiremock = "0.6.0"
 fake = { version = "2.9.2", features = ["derive", "http"] }
 prost = "0.12.6"
 httpmock = "0.7.0"

--- a/super-agent/Makefile
+++ b/super-agent/Makefile
@@ -6,4 +6,4 @@ CARGO_CMD ?= "test"
 .PHONY: onhost/cargo
 onhost/cargo:
 	@echo "testing-machine-id" > /tmp/machine-id
-	TEST_MACHINE_ID_PATH="/tmp/machine-id" TEST_IPV4_METADATA_ENDPOINT="http://127.0.0.1:4343/testing_metadata_endpoint" cargo $(CARGO_CMD) $(CARGO_ARGS)
+	TEST_MACHINE_ID_PATH="/tmp/machine-id" cargo $(CARGO_CMD) $(CARGO_ARGS)

--- a/super-agent/src/opamp/instance_id/on_host/getter.rs
+++ b/super-agent/src/opamp/instance_id/on_host/getter.rs
@@ -1,8 +1,8 @@
 use crate::opamp::instance_id::on_host::storer::StorerError;
-use resource_detection::cloud::aws::detector::AWSDetector;
-use resource_detection::cloud::azure::detector::AzureDetector;
+use resource_detection::cloud::aws::detector::{AWSDetector, AWS_IPV4_METADATA_ENDPOINT};
+use resource_detection::cloud::azure::detector::{AzureDetector, AZURE_IPV4_METADATA_ENDPOINT};
 use resource_detection::cloud::cloud_id::detector::CloudIdDetector;
-use resource_detection::cloud::gcp::detector::GCPDetector;
+use resource_detection::cloud::gcp::detector::{GCPDetector, GCP_IPV4_METADATA_ENDPOINT};
 use resource_detection::cloud::http_client::HttpClientUreq;
 use resource_detection::cloud::CLOUD_INSTANCE_ID;
 use resource_detection::system::{HOSTNAME_KEY, MACHINE_ID_KEY};
@@ -61,7 +61,11 @@ impl Default for IdentifiersProvider {
     fn default() -> Self {
         Self {
             system_detector: SystemDetector::default(),
-            cloud_id_detector: CloudIdDetector::default(),
+            cloud_id_detector: CloudIdDetector::new(
+                AWS_IPV4_METADATA_ENDPOINT.to_string(),
+                AZURE_IPV4_METADATA_ENDPOINT.to_string(),
+                GCP_IPV4_METADATA_ENDPOINT.to_string(),
+            ),
             host_id: String::default(),
             fleet_id: String::default(),
         }


### PR DESCRIPTION
removes default initialisation of cloud resource detectors, and testing hacks 