### PR TITLE
feat: add support for AWS IMDSv2 (NR-299079)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,9 +3347,11 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 name = "resource-detection"
 version = "0.0.1"
 dependencies = [
+ "assert_matches",
  "bytes",
  "fs",
  "http 1.1.0",
+ "httpmock",
  "konst",
  "mockall",
  "nix",
@@ -3358,6 +3360,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/resource-detection/Cargo.toml
+++ b/resource-detection/Cargo.toml
@@ -17,7 +17,10 @@ bytes = "1.6.0"
 ureq = { workspace = true, features = ["http-crate"] }
 fs = { path = "../fs" }
 konst = { workspace = true }
+url = { version = "2.5.0"}
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 fs = { path = "../fs", features = ["mocks"] }
 mockall = { workspace = true }
+httpmock = "0.7.0"

--- a/resource-detection/src/cloud/aws.rs
+++ b/resource-detection/src/cloud/aws.rs
@@ -1,3 +1,5 @@
 //! AWS EC2 instance id resource detector
 pub mod detector;
+/// AWS http client with authentication
+pub mod http_client;
 pub(crate) mod metadata;

--- a/resource-detection/src/cloud/aws/http_client.rs
+++ b/resource-detection/src/cloud/aws/http_client.rs
@@ -1,0 +1,185 @@
+use crate::cloud::http_client::{HttpClient, HttpClientError};
+use std::time::Duration;
+
+pub(crate) const TOKEN_HEADER: &str = "x-aws-ec2-metadata-token";
+pub(crate) const TTL_TOKEN_HEADER: &str = "x-aws-ec2-metadata-token-ttl-seconds";
+
+/// An implementation of the `HttpClient` trait using the ureq library and IMDv2 auth.
+pub struct AWSHttpClientUreq {
+    http_client: ureq::Agent,
+    token_endpoint: String,
+    token_ttl: Duration,
+    metadata_endpoint: String,
+}
+
+impl AWSHttpClientUreq {
+    /// Returns a new instance of AWSHttpClientUreq
+    pub fn new(
+        metadata_endpoint: String,
+        token_endpoint: String,
+        token_ttl: Duration,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            http_client: ureq::AgentBuilder::new()
+                .timeout_connect(timeout)
+                .timeout(timeout)
+                .build(),
+            metadata_endpoint,
+            token_endpoint,
+            token_ttl,
+        }
+    }
+
+    fn get_token(&self) -> Result<String, HttpClientError> {
+        let response = self
+            .http_client
+            .put(self.token_endpoint.as_str())
+            .set(
+                TTL_TOKEN_HEADER,
+                self.token_ttl.as_secs().to_string().as_str(),
+            )
+            .call()?;
+
+        let token = response.into_string().map_err(|err| {
+            HttpClientError::InternalError(format!("getting AWS IMDS token: {}", err))
+        })?;
+
+        Ok(token)
+    }
+}
+
+impl HttpClient for AWSHttpClientUreq {
+    fn get(&self) -> Result<http::Response<Vec<u8>>, HttpClientError> {
+        let token = self.get_token()?;
+
+        let req = self
+            .http_client
+            .get(&self.metadata_endpoint)
+            .set(TOKEN_HEADER, &token);
+
+        Ok(req.call()?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cloud::aws::http_client::{AWSHttpClientUreq, TOKEN_HEADER, TTL_TOKEN_HEADER};
+    use crate::cloud::http_client::{HttpClient, HttpClientError, DEFAULT_CLIENT_TIMEOUT};
+    use assert_matches::assert_matches;
+    use httpmock::MockServer;
+    use std::time::Duration;
+
+    const TTL_TOKEN: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn test_authenticated_request() {
+        let imds_server = MockServer::start();
+        let token_mock = imds_server.mock(|when, then| {
+            when.method("PUT")
+                .path("/token")
+                .header(TTL_TOKEN_HEADER, TTL_TOKEN.as_secs().to_string().as_str());
+            then.status(200).body("test_token");
+        });
+        let metadata_mock = imds_server.mock(|when, then| {
+            when.method("GET")
+                .path("/metadata")
+                .header(TOKEN_HEADER, "test_token");
+            then.status(200).body("test_metadata");
+        });
+
+        let http_client = AWSHttpClientUreq::new(
+            imds_server.url("/metadata"),
+            imds_server.url("/token"),
+            TTL_TOKEN,
+            DEFAULT_CLIENT_TIMEOUT,
+        );
+
+        let resp = http_client.get().unwrap();
+
+        assert_eq!(resp.body(), b"test_metadata");
+
+        token_mock.assert_hits(1);
+        metadata_mock.assert_hits(1);
+    }
+
+    #[test]
+    fn test_failed_metadata_endpoint() {
+        let imds_server = MockServer::start();
+        let token_mock = imds_server.mock(|when, then| {
+            when.method("PUT")
+                .path("/token")
+                .header(TTL_TOKEN_HEADER, TTL_TOKEN.as_secs().to_string().as_str());
+            then.status(200).body("test_token");
+        });
+        let metadata_mock = imds_server.mock(|when, then| {
+            when.method("GET")
+                .path("/metadata")
+                .header(TOKEN_HEADER, "test_token");
+            then.status(401).body("test_metadata");
+        });
+
+        let http_client = AWSHttpClientUreq::new(
+            imds_server.url("/metadata"),
+            imds_server.url("/token"),
+            TTL_TOKEN,
+            DEFAULT_CLIENT_TIMEOUT,
+        );
+
+        let err = http_client.get().unwrap_err();
+
+        assert_matches!(err, HttpClientError::ResponseError(401, _));
+
+        token_mock.assert_hits(1);
+        metadata_mock.assert_hits(1);
+    }
+
+    #[test]
+    fn test_fail_getting_token() {
+        let imds_server = MockServer::start();
+        let token_mock = imds_server.mock(|when, then| {
+            when.method("PUT")
+                .path("/token")
+                .header(TTL_TOKEN_HEADER, TTL_TOKEN.as_secs().to_string().as_str());
+            then.status(500);
+        });
+
+        let http_client = AWSHttpClientUreq::new(
+            imds_server.url("/metadata"),
+            imds_server.url("/token"),
+            TTL_TOKEN,
+            DEFAULT_CLIENT_TIMEOUT,
+        );
+
+        let err = http_client.get().unwrap_err();
+
+        assert_matches!(err, HttpClientError::ResponseError(500, _));
+
+        token_mock.assert_hits(1);
+    }
+    #[test]
+    fn test_fail_deserializing_token() {
+        let imds_server = MockServer::start();
+        let invalid_token = vec![0x89, 0x50, 0x4E, 0x47];
+
+        let token_mock = imds_server.mock(|when, then| {
+            when.method("PUT")
+                .path("/token")
+                .header(TTL_TOKEN_HEADER, TTL_TOKEN.as_secs().to_string().as_str());
+            then.status(200).body(invalid_token);
+        });
+
+        let http_client = AWSHttpClientUreq::new(
+            imds_server.url("/metadata"),
+            imds_server.url("/token"),
+            TTL_TOKEN,
+            DEFAULT_CLIENT_TIMEOUT,
+        );
+
+        let err = http_client.get().unwrap_err();
+
+        assert_matches!(err, HttpClientError::TransportError(_));
+
+        token_mock.assert_hits(1);
+    }
+}

--- a/resource-detection/src/cloud/azure/detector.rs
+++ b/resource-detection/src/cloud/azure/detector.rs
@@ -90,6 +90,7 @@ where
 mod test {
     use super::*;
     use crate::cloud::http_client::test::MockHttpClientMock;
+    use assert_matches::assert_matches;
 
     #[test]
     fn http_client_error() {
@@ -102,9 +103,11 @@ mod test {
         };
 
         let detect_error = detector.detect().unwrap_err();
-        assert_eq!(
-            "error detecting azure resources ``internal HTTP client error: `some error```",
-            detect_error.to_string()
+        assert_matches!(
+            detect_error,
+            DetectError::AzureError(AzureDetectorError::HttpError(
+                HttpClientError::TransportError(_)
+            ))
         );
     }
 
@@ -123,9 +126,10 @@ mod test {
         };
 
         let detect_error = detector.detect().unwrap_err();
-        assert_eq!(
-            "error detecting azure resources `Status code: `503` Canonical reason: `Service Unavailable``",
-            detect_error.to_string()
+
+        assert_matches!(
+            detect_error,
+            DetectError::AzureError(AzureDetectorError::UnsuccessfulResponse(503, _))
         );
     }
 
@@ -144,9 +148,10 @@ mod test {
         };
 
         let detect_error = detector.detect().unwrap_err();
-        assert_eq!(
-            "error detecting azure resources `error deserializing json: `expected value at line 1 column 1``",
-            detect_error.to_string()
+
+        assert_matches!(
+            detect_error,
+            DetectError::AzureError(AzureDetectorError::JsonError(_))
         );
     }
 

--- a/resource-detection/src/cloud/cloud_id/detector.rs
+++ b/resource-detection/src/cloud/cloud_id/detector.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::cloud::aws::detector::AWSDetector;
+use crate::cloud::aws::http_client::AWSHttpClientUreq;
 use crate::cloud::azure::detector::AzureDetector;
 use crate::cloud::gcp::detector::GCPDetector;
 use crate::cloud::http_client::HttpClientUreq;
@@ -21,7 +22,7 @@ pub struct CloudIdDetector<AWS: Detector, AZURE: Detector, GCP: Detector> {
 
 impl
     CloudIdDetector<
-        AWSDetector<HttpClientUreq>,
+        AWSDetector<AWSHttpClientUreq>,
         AzureDetector<HttpClientUreq>,
         GCPDetector<HttpClientUreq>,
     >
@@ -29,11 +30,12 @@ impl
     /// Returns a new instance of CloudIdDetector
     pub fn new(
         aws_metadata_endpoint: String,
+        aws_token_endpoint: String,
         azure_metadata_endpoint: String,
         gcp_metadata_endpoint: String,
     ) -> Self {
         Self {
-            aws_detector: AWSDetector::new(aws_metadata_endpoint),
+            aws_detector: AWSDetector::new(aws_metadata_endpoint, aws_token_endpoint),
             azure_detector: AzureDetector::new(azure_metadata_endpoint),
             gcp_detector: GCPDetector::new(gcp_metadata_endpoint),
         }

--- a/resource-detection/src/cloud/gcp/detector.rs
+++ b/resource-detection/src/cloud/gcp/detector.rs
@@ -91,6 +91,7 @@ where
 mod test {
     use super::*;
     use crate::cloud::http_client::test::MockHttpClientMock;
+    use assert_matches::assert_matches;
 
     #[test]
     fn detect_gcp_metadata() {
@@ -187,14 +188,12 @@ mod test {
 
         let result = detector.detect();
 
-        match result {
-            Err(e) => assert_eq!(
-                "error detecting gcp resources `Status code: `404` Canonical reason: `Not Found``"
-                    .to_string(),
-                e.to_string()
-            ),
-            _ => unreachable!(),
-        }
+        assert_matches!(
+            result,
+            Err(DetectError::GCPError(
+                GCPDetectorError::UnsuccessfulResponse(404, _)
+            ))
+        );
     }
 
     #[test]
@@ -213,13 +212,9 @@ mod test {
 
         let result = detector.detect();
 
-        match result {
-            Err(e) => assert_eq!(
-                "error detecting gcp resources ``key must be a string at line 1 column 3``"
-                    .to_string(),
-                e.to_string()
-            ),
-            _ => unreachable!(),
-        }
+        assert_matches!(
+            result,
+            Err(DetectError::GCPError(GCPDetectorError::JsonError(_)))
+        );
     }
 }

--- a/super-agent/src/opamp/instance_id/on_host/getter.rs
+++ b/super-agent/src/opamp/instance_id/on_host/getter.rs
@@ -1,5 +1,8 @@
 use crate::opamp::instance_id::on_host::storer::StorerError;
-use resource_detection::cloud::aws::detector::{AWSDetector, AWS_IPV4_METADATA_ENDPOINT};
+use resource_detection::cloud::aws::detector::{
+    AWSDetector, AWS_IPV4_METADATA_ENDPOINT, AWS_IPV4_METADATA_TOKEN_ENDPOINT,
+};
+use resource_detection::cloud::aws::http_client::AWSHttpClientUreq;
 use resource_detection::cloud::azure::detector::{AzureDetector, AZURE_IPV4_METADATA_ENDPOINT};
 use resource_detection::cloud::cloud_id::detector::CloudIdDetector;
 use resource_detection::cloud::gcp::detector::{GCPDetector, GCP_IPV4_METADATA_ENDPOINT};
@@ -43,7 +46,7 @@ pub enum IdentifiersProviderError {
 pub struct IdentifiersProvider<
     D = SystemDetector,
     D2 = CloudIdDetector<
-        AWSDetector<HttpClientUreq>,
+        AWSDetector<AWSHttpClientUreq>,
         AzureDetector<HttpClientUreq>,
         GCPDetector<HttpClientUreq>,
     >,
@@ -63,6 +66,7 @@ impl Default for IdentifiersProvider {
             system_detector: SystemDetector::default(),
             cloud_id_detector: CloudIdDetector::new(
                 AWS_IPV4_METADATA_ENDPOINT.to_string(),
+                AWS_IPV4_METADATA_TOKEN_ENDPOINT.to_string(),
                 AZURE_IPV4_METADATA_ENDPOINT.to_string(),
                 GCP_IPV4_METADATA_ENDPOINT.to_string(),
             ),


### PR DESCRIPTION
Adds the support of [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) on the current AWS detector.

Notes:
- Instance data is not cached at the moment so this is why i didn't add cache for the token. Hits to this endpoint happens upon build of SA and sub-agents so I don't think caching will be needed. 