### PR TITLE
feat: allow host.id to be an expandable variable on agent_type (NR-250194)

### DIFF
--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -56,7 +56,7 @@ artifacts:
         dest: artifacts/{{.Arch}}/fluent-bit
 
   - name: nr-otel-collector
-    version: 0.7.1
+    version: 0.8.0
     url: https://github.com/newrelic/opentelemetry-collector-releases/releases/download/nr-otel-collector-{{.Version | trimv}}/nr-otel-collector_{{.Version | trimv}}_linux_{{.Arch}}.deb
     files:
       - name: nt-otel-collector binary

--- a/build/examples/super-agent-config-all-agents.yaml
+++ b/build/examples/super-agent-config-all-agents.yaml
@@ -17,4 +17,4 @@ agents:
   nr-infra-agent:
     agent_type: "newrelic/com.newrelic.infrastructure_agent:0.1.3"
   nr-otel-collector:
-    agent_type: "newrelic/io.opentelemetry.collector:0.1.0"
+    agent_type: "newrelic/io.opentelemetry.collector:0.2.0"

--- a/build/scripts/download_collector_config.sh
+++ b/build/scripts/download_collector_config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script will download the nr-otel-collector config and use it to create the values.yaml sample
-COLLECTOR_VERSION="0.5.0"
+COLLECTOR_VERSION="0.8.0"
 AGENT_TYPE_VERSION="0.1.0"
 BUILD_TMP_FOLDER=build-tmp
 URL="https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/nr-otel-collector-${COLLECTOR_VERSION}/configs"

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.0.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.0.1.yaml
@@ -12,7 +12,8 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_file}"
+        args: >-
+          --config=${nr-var:config_file}
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.0.2.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.0.2.yaml
@@ -31,10 +31,12 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_agent}"
+        args: >-
+          --config=${nr-var:config_agent}
         env:
           NRIA_PLUGIN_DIR: "${nr-var:config_ohis}"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-var:logging}"
+          NR_HOST_ID: "${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.0.yaml
@@ -30,10 +30,12 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_agent}"
+        args: >-
+          --config=${nr-var:config_agent}
         env:
           NRIA_PLUGIN_DIR: "${nr-var:config_integrations}"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-var:config_logging}"
+          NR_HOST_ID: "${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.1.yaml
@@ -36,10 +36,12 @@ deployment:
     enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_agent}"
+        args: >-
+          --config=${nr-var:config_agent}
         env:
           NRIA_PLUGIN_DIR: "${nr-var:config_integrations}"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-var:config_logging}"
+          NR_HOST_ID: "${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.2.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.2.yaml
@@ -36,11 +36,13 @@ deployment:
     enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_agent}"
+        args: >-
+          --config=${nr-var:config_agent}
         env:
           NRIA_PLUGIN_DIR: "${nr-var:config_integrations}"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-var:config_logging}"
           NRIA_STATUS_SERVER_ENABLED: true
+          NR_HOST_ID: "${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.3.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.infrastructure_agent-0.1.3.yaml
@@ -41,12 +41,14 @@ deployment:
     enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - path: /usr/bin/newrelic-infra
-        args: "--config=${nr-var:config_agent}"
+        args: >-
+          --config=${nr-var:config_agent}
         env:
           NRIA_PLUGIN_DIR: "${nr-var:config_integrations}"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-var:config_logging}"
           NRIA_STATUS_SERVER_ENABLED: true
           NRIA_STATUS_SERVER_PORT: "${nr-var:health_port}"
+          NR_HOST_ID: "${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.0.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.0.1.yaml
@@ -37,10 +37,14 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/nr-otel-collector
-        args: "--config=${nr-var:config_file} --feature-gates=-pkg.translator.prometheus.NormalizeName"
+        args: >-
+          --config=${nr-var:config_file}
+          --feature-gates=-pkg.translator.prometheus.NormalizeName
         env:
           OTEL_EXPORTER_OTLP_ENDPOINT: "${nr-var:otel_exporter_otlp_endpoint}"
           NEW_RELIC_MEMORY_LIMIT_MIB: "${nr-var:new_relic_memory_limit_mib}"
+          # sets the otel-collector "env" source resource detector 
+          OTEL_RESOURCE_ATTRIBUTES: "host.id=${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -28,7 +28,12 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/nr-otel-collector
-        args: "--config=${nr-var:config} --feature-gates=-pkg.translator.prometheus.NormalizeName"
+        args: >-
+          --config=${nr-var:config}
+          --feature-gates=-pkg.translator.prometheus.NormalizeName
+        env:
+          # sets the otel-collector "env" source resource detector 
+          OTEL_RESOURCE_ATTRIBUTES: "host.id=${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.1.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.1.yaml
@@ -42,7 +42,12 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/nr-otel-collector
-        args: "--config=${nr-var:config} --feature-gates=-pkg.translator.prometheus.NormalizeName"
+        args: >-
+          --config=${nr-var:config}
+          --feature-gates=-pkg.translator.prometheus.NormalizeName
+        env:
+        # sets the otel-collector "env" source resource detector 
+          OTEL_RESOURCE_ATTRIBUTES: "host.id=${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
@@ -42,7 +42,12 @@ deployment:
   on_host:
     executables:
       - path: /usr/bin/nr-otel-collector
-        args: "--config=${nr-var:config} --feature-gates=-pkg.translator.prometheus.NormalizeName"
+        args: >-
+          --config=${nr-var:config}
+          --feature-gates=-pkg.translator.prometheus.NormalizeName
+        env:
+          # sets the otel-collector "env" source resource detector 
+          OTEL_RESOURCE_ATTRIBUTES: "host.id=${nr-sa:host_id}"
         restart_policy:
           backoff_strategy:
             type: fixed

--- a/super-agent/src/agent_type/variable/namespace.rs
+++ b/super-agent/src/agent_type/variable/namespace.rs
@@ -1,21 +1,32 @@
+/// Holds the variable name prefixed with the namespace.
+/// Example: "nr-env:MY_ENV_VAR" for the environment variable "MY_ENV_VAR".
+pub type NamespacedVariableName = String;
+
 /// Namespace defines the supported namespace names for variables definition.
 pub enum Namespace {
     Variable,
     SubAgent,
     EnvironmentVariable,
+    SuperAgent,
 }
 
 impl Namespace {
     const PREFIX: &'static str = "nr-";
+    /// Encapsulates the variables defined in the agent-type
     const VARIABLE: &'static str = "var";
+    /// Encapsulates the environment variables that are available to the sub-agent
     const ENVIRONMENT_VARIABLE: &'static str = "env";
+    /// Encapsulates attributes related to the sub-agent
     const SUB_AGENT: &'static str = "sub";
+    /// Encapsulates attributes related to the super-agent
+    const SA: &'static str = "sa";
 
-    pub fn namespaced_name(&self, name: &str) -> String {
+    pub fn namespaced_name(&self, name: &str) -> NamespacedVariableName {
         let ns = match self {
             Self::Variable => Self::VARIABLE,
             Self::EnvironmentVariable => Self::ENVIRONMENT_VARIABLE,
             Self::SubAgent => Self::SUB_AGENT,
+            Self::SuperAgent => Self::SA,
         };
         format!("{}{}:{}", Self::PREFIX, ns, name)
     }
@@ -36,6 +47,10 @@ mod tests {
         assert_eq!(
             "nr-env:test".to_string(),
             Namespace::EnvironmentVariable.namespaced_name("test")
+        );
+        assert_eq!(
+            "nr-sa:test".to_string(),
+            Namespace::SuperAgent.namespaced_name("test")
         );
     }
 }

--- a/super-agent/src/opamp/auth/token_retriever.rs
+++ b/super-agent/src/opamp/auth/token_retriever.rs
@@ -16,7 +16,7 @@ const DEFAULT_AUTHENTICATOR_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Error, Debug)]
 pub enum TokenRetrieverImplError {
-    #[error("building JWT signer")]
+    #[error("building JWT signer: `{0}`")]
     JwtSignerBuildError(#[from] JwtSignerImplError),
 }
 

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -1,3 +1,5 @@
+use crate::agent_type::variable::definition::VariableDefinition;
+use crate::agent_type::variable::namespace::Namespace;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};
@@ -63,6 +65,11 @@ impl SuperAgentRunner {
         let non_identifying_attributes = super_agent_opamp_non_identifying_attributes(&identifiers);
         info!("Instance Identifiers: {:?}", identifiers);
 
+        let super_agent_variables = HashMap::from([(
+            "host_id".to_string(),
+            VariableDefinition::new_final_string_variable(identifiers.host_id.clone()),
+        )]);
+
         let instance_id_storer = Storer::new(
             LocalFile,
             DirectoryManagerFs::default(),
@@ -89,7 +96,8 @@ impl SuperAgentRunner {
         });
 
         let template_renderer = TemplateRenderer::new(self.base_paths.remote_dir.clone())
-            .with_config_persister(ConfigurationPersisterFile::new(&self.base_paths.remote_dir));
+            .with_config_persister(ConfigurationPersisterFile::new(&self.base_paths.remote_dir))
+            .with_super_agent_variables(super_agent_variables.into_iter());
 
         let agents_assembler = LocalEffectiveAgentsAssembler::new(
             sub_agent_repository.clone(),
@@ -108,7 +116,6 @@ impl SuperAgentRunner {
             sub_agent_hash_repository,
             &agents_assembler,
             &sub_agent_event_processor_builder,
-            identifiers_provider,
             self.base_paths.log_dir.join(SUB_AGENT_DIR),
         );
 

--- a/super-agent/tests/on_host/tools/config.rs
+++ b/super-agent/tests/on_host/tools/config.rs
@@ -14,8 +14,6 @@ pub fn create_super_agent_config(
 ) -> PathBuf {
     let config_file_path = local_dir.join(SUPER_AGENT_CONFIG_FILE);
 
-    let mut local_file =
-        File::create(config_file_path.clone()).expect("failed to create local config file");
     let super_agent_config = format!(
         r#"
 host_id: integration-test
@@ -25,9 +23,15 @@ agents: {}
 "#,
         opamp_server_endpoint, agents
     );
-    write!(local_file, "{}", super_agent_config).unwrap();
+
+    create_file(super_agent_config, config_file_path.clone());
 
     config_file_path
+}
+
+pub fn create_file(content: String, path: PathBuf) {
+    let mut local_file = File::create(path).expect("failed to create local config file");
+    write!(local_file, "{}", content).unwrap();
 }
 
 /// Creates a sub-agent values config for the agent_id provided on the base_dir
@@ -37,9 +41,7 @@ pub fn create_sub_agent_values(agent_id: String, config: String, base_dir: PathB
     create_dir_all(agent_values_dir_path.clone()).expect("failed to create values directory");
 
     let values_file_path = agent_values_dir_path.join(VALUES_FILE);
-    let mut local_values_file =
-        File::create(values_file_path.clone()).expect("failed to create local values file");
-    write!(local_values_file, "{}", config).unwrap();
 
+    create_file(config, values_file_path.clone());
     values_file_path
 }


### PR DESCRIPTION
- feat: adds a new namespace var on the agent type for super agent related data
- refact: refactors the code to set the infra-agent host.id from agent-type
- fix: sets host.id on the collector 

- modified all agent_types to be compatible with the super-agent since there is no version control implemented. 

kind of a POC PR i could split it in different ones separating fixes, features and refactors

This PR https://github.com/newrelic/opentelemetry-collector-releases/pull/116 will make the collector honor the `host.id` from the env vars 