### PR TITLE
Add organization id to e2e

### DIFF
--- a/test/canaries/Makefile
+++ b/test/canaries/Makefile
@@ -27,13 +27,28 @@ ifndef NR_OTEL_COLLECTOR_OTLP_ENDPOINT
 	@echo "NR_OTEL_COLLECTOR_OTLP_ENDPOINT variable must be provided for test/canaries"
 	exit 1
 endif
+ifndef NR_ORGANIZATION_ID
+	@echo "NR_ORGANIZATION_ID variable must be provided for test/e2e"
+	exit 1
+endif
+ifndef NEW_RELIC_ACCOUNT_ID
+	@echo "NEW_RELIC_ACCOUNT_ID variable must be provided for test/e2e"
+	exit 1
+endif
+ifndef NEW_RELIC_API_KEY
+	@echo "NEW_RELIC_API_KEY variable must be provided for test/e2e"
+	exit 1
+endif
 
 	$(MAKE) ansible/dependencies ANSIBLE_FOLDER=$(ANSIBLE_FOLDER)
 	@ANSIBLE_DISPLAY_SKIPPED_HOSTS=NO ANSIBLE_DISPLAY_OK_HOSTS=NO ansible-playbook -f $(ANSIBLE_FORKS) \
  		-i $(ANSIBLE_INVENTORY) \
  		--limit=$(LIMIT) \
  		-e nr_license_key=$(NR_LICENSE_KEY_CANARIES) \
+ 		-e nr_api_key=$(NEW_RELIC_API_KEY) \
+        -e nr_account_id=$(NEW_RELIC_ACCOUNT_ID) \
  		-e nr_otel_collector_license_key=$(NR_LICENSE_KEY_CANARIES) \
  		-e nr_otel_collector_otlp_endpoint=$(NR_OTEL_COLLECTOR_OTLP_ENDPOINT) \
  		-e nr_otel_collector_memory_limit=$(NR_OTEL_COLLECTOR_MEMORY_LIMIT) \
+ 		-e organization_id=$(NR_ORGANIZATION_ID) \
  		$(ANSIBLE_FOLDER)/deploy_canaries.yml

--- a/test/canaries/ansible/deploy_canaries.yml
+++ b/test/canaries/ansible/deploy_canaries.yml
@@ -4,46 +4,17 @@
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
-  vars:
-    newrelic_super_agent_version: "{{ lookup('ansible.builtin.env', 'NEWRELIC_SUPER_AGENT_VERSION') }}"
-    process_user: "root"
-
-  pre_tasks:
-    - name: Update package repositories
-      include_role:
-        name: caos.ansible_roles.package_repo_update
 
   tasks:
-    - name: Install The Super Agent
-      vars:
-
-      block:
-
-        - name: Newrelic Super Agent
-          include_role:
-            name: newrelic-super-agent
-            apply:
-              environment:
-                NRDOT_MODE: "{{ 'ROOT' if (install_mode is defined and install_mode == 'ROOT') | default(omit) }}"
-          vars:
-            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
-            target_version: "{{ newrelic_super_agent_version }}"
-
-        - name: Setup Infra Agent config
-          include_role:
-            name: infra-agent-config
-
-        - name: Setup NR Otel Collector config
-          include_role:
-            name:  nr-otel-collector-config
-
-        - name: Setup NR Super Agent config
-          include_role:
-            name: super-agent-config
-
-        - name: Restart New Relic Super Agent
-          ansible.builtin.service:
-            name: newrelic-super-agent
-            state: restarted
+    - name: guided install
+      shell: |
+        curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
+        && NEW_RELIC_CLI_SKIP_CORE=1 \
+        NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+        NEW_RELIC_API_KEY={{ nr_api_key }} \
+        NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
+        NEW_RELIC_REGION=STAGING \ 
+        NEW_RELIC_ORGANIZATION={{ organization_id }} \
+        /usr/local/bin/newrelic install -n super-agent -y
 
 ...

--- a/test/canaries/ansible/requirements.yml
+++ b/test/canaries/ansible/requirements.yml
@@ -1,4 +1,6 @@
 collections:
-  # this is just a stab for future
   - name: git+https://github.com/newrelic-experimental/caos-ansible-roles.git#/caos.ansible_roles/
     type: git
+
+roles:
+  - name: newrelic.newrelic_install

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -25,6 +25,10 @@ ifndef NEW_RELIC_API_KEY
 	@echo "NEW_RELIC_API_KEY variable must be provided for test/e2e"
 	exit 1
 endif
+ifndef NR_ORGANIZATION_ID
+	@echo "NR_ORGANIZATION_ID variable must be provided for test/e2e"
+	exit 1
+endif
 
 # if you want to hide OK, add ANSIBLE_DISPLAY_OK_HOSTS=NO
 	$(MAKE) ansible/dependencies ANSIBLE_FOLDER=$(ANSIBLE_FOLDER)
@@ -35,6 +39,7 @@ endif
         -e nr_api_key=$(NEW_RELIC_API_KEY) \
         -e nr_account_id=$(NEW_RELIC_ACCOUNT_ID) \
         -e repo_endpoint=$(REPOSITORY_ENDPOINT) \
+        -e organization_id=$(NR_ORGANIZATION_ID) \
         -e nr_otel_collector_otlp_endpoint=$(NR_OTEL_COLLECTOR_OTLP_ENDPOINT) \
         -e opamp_endpoint=${OPAMP_ENDPOINT} \
  		$(ANSIBLE_FOLDER)/$(ANSIBLE_PLAYBOOK)

--- a/test/e2e/ansible/migration_script_execution.yaml
+++ b/test/e2e/ansible/migration_script_execution.yaml
@@ -21,18 +21,17 @@
           NEW_RELIC_DOWNLOAD_URL: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
 
     - name: Install super agent and run migration
-      include_tasks: ./tasks/install_recipe.yaml
-      vars:
-        targets:
-          - super-agent
-        env_vars:
-          NEW_RELIC_API_KEY: "{{ nr_api_key }}"
-          NEW_RELIC_ACCOUNT_ID: "{{ nr_account_id | int }}"
-          NEW_RELIC_REGION: "STAGING"
-          NEW_RELIC_DOWNLOAD_URL: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
-          NR_CLI_FLEET_ENABLED: true
-          NR_CLI_HOST_MONITORING_SOURCE: newrelic
-          NR_SA_MIGRATE_INFRA_CONFIG: true
+      shell: |
+        curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
+        && NEW_RELIC_CLI_SKIP_CORE=1 \
+        NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+        NEW_RELIC_API_KEY={{ nr_api_key }} \
+        NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
+        NEW_RELIC_REGION=STAGING \ 
+        NR_CLI_FLEET_ENABLED=true \
+        NR_SA_MIGRATE_INFRA_CONFIG=true \
+        NEW_RELIC_ORGANIZATION={{ organization_id }} \
+        /usr/local/bin/newrelic install -n super-agent -y
 
     - name: Modify infra-agent type to 0.1.2
       include_role:

--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -104,6 +104,7 @@ module "super_agent_infra" {
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_nr_api_key}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_username}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_password}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}",


### PR DESCRIPTION
This PR:
* adds organization id to canaries and e2e installations to create identity for the SA
* switches from using recipe ansible to guided install command to be able to use org id
* does not work yet