### PR TITLE
fix: canaries and e2e (migration test only) (NR-302397)

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -9,9 +9,6 @@ on:
         required: true
 
     inputs:
-      TAG:
-        required: true
-        type: string
       UNIQUE_NAME:
         required: true
         type: string
@@ -25,7 +22,6 @@ on:
         default: "https://download.newrelic.com/preview"
 
 env:
-  TAG: ${{ inputs.TAG }}
   UNIQUE_NAME: ${{ inputs.UNIQUE_NAME }}
   EC2_FILTERS: ${{ inputs.EC2_FILTERS }}
 

--- a/.github/workflows/on_demand_onhost_e2e.yml
+++ b/.github/workflows/on_demand_onhost_e2e.yml
@@ -1,0 +1,33 @@
+name: ⏯️🚀💾 OnHost E2E test on demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      UNIQUE_NAME:
+        description: "name of the provisioned machines. default: ci-on-demand"
+        required: false
+        type: string
+      EC2_FILTERS:
+        required: false
+        description: "OS Flavors to test. default: ubuntu22.04"
+        type: string
+      REPOSITORY_ENDPOINT:
+        required: false
+        description: 'Repository endpoint to fetch packages from. default: staging'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  onhost-e2e:
+    uses: ./.github/workflows/component_onhost_e2e.yaml
+    with:
+      UNIQUE_NAME: ${{ inputs.UNIQUE_NAME || 'ci-on-demand' }}
+      EC2_FILTERS: ${{ inputs.EC2_FILTERS || '[\"ubuntu22.04\"]' }}
+      REPOSITORY_ENDPOINT: ${{ inputs.REPOSITORY_ENDPOINT || 'https://nr-downloads-ohai-staging.s3.amazonaws.com/'}}
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+

--- a/test/canaries/Makefile
+++ b/test/canaries/Makefile
@@ -15,8 +15,8 @@ all: canaries
 
 .PHONY: canaries
 canaries:
-ifndef NR_LICENSE_KEY_CANARIES
-	@echo "NR_LICENSE_KEY_CANARIES variable must be provided for test/canaries"
+ifndef NR_LICENSE_KEY
+	@echo "NR_LICENSE_KEY variable must be provided for test/canaries"
 	exit 1
 endif
 ifndef NR_OTEL_COLLECTOR_MEMORY_LIMIT
@@ -27,13 +27,28 @@ ifndef NR_OTEL_COLLECTOR_OTLP_ENDPOINT
 	@echo "NR_OTEL_COLLECTOR_OTLP_ENDPOINT variable must be provided for test/canaries"
 	exit 1
 endif
+ifndef NR_ORGANIZATION_ID
+	@echo "NR_ORGANIZATION_ID variable must be provided for test/e2e"
+	exit 1
+endif
+ifndef NEW_RELIC_ACCOUNT_ID
+	@echo "NEW_RELIC_ACCOUNT_ID variable must be provided for test/e2e"
+	exit 1
+endif
+ifndef NEW_RELIC_API_KEY
+	@echo "NEW_RELIC_API_KEY variable must be provided for test/e2e"
+	exit 1
+endif
 
 	$(MAKE) ansible/dependencies ANSIBLE_FOLDER=$(ANSIBLE_FOLDER)
 	@ANSIBLE_DISPLAY_SKIPPED_HOSTS=NO ANSIBLE_DISPLAY_OK_HOSTS=NO ansible-playbook -f $(ANSIBLE_FORKS) \
  		-i $(ANSIBLE_INVENTORY) \
  		--limit=$(LIMIT) \
- 		-e nr_license_key=$(NR_LICENSE_KEY_CANARIES) \
- 		-e nr_otel_collector_license_key=$(NR_LICENSE_KEY_CANARIES) \
+ 		-e nr_license_key=$(NR_LICENSE_KEY) \
+ 		-e nr_api_key=$(NEW_RELIC_API_KEY) \
+    -e nr_account_id=$(NEW_RELIC_ACCOUNT_ID) \
+ 		-e nr_otel_collector_license_key=$(NR_LICENSE_KEY) \
  		-e nr_otel_collector_otlp_endpoint=$(NR_OTEL_COLLECTOR_OTLP_ENDPOINT) \
  		-e nr_otel_collector_memory_limit=$(NR_OTEL_COLLECTOR_MEMORY_LIMIT) \
+ 		-e organization_id=$(NR_ORGANIZATION_ID) \
  		$(ANSIBLE_FOLDER)/deploy_canaries.yml

--- a/test/canaries/ansible/deploy_canaries.yml
+++ b/test/canaries/ansible/deploy_canaries.yml
@@ -4,46 +4,18 @@
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
-  vars:
-    newrelic_super_agent_version: "{{ lookup('ansible.builtin.env', 'NEWRELIC_SUPER_AGENT_VERSION') }}"
-    process_user: "root"
-
-  pre_tasks:
-    - name: Update package repositories
-      include_role:
-        name: caos.ansible_roles.package_repo_update
 
   tasks:
-    - name: Install The Super Agent
-      vars:
-
-      block:
-
-        - name: Newrelic Super Agent
-          include_role:
-            name: newrelic-super-agent
-            apply:
-              environment:
-                NRDOT_MODE: "{{ 'ROOT' if (install_mode is defined and install_mode == 'ROOT') | default(omit) }}"
-          vars:
-            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
-            target_version: "{{ newrelic_super_agent_version }}"
-
-        - name: Setup Infra Agent config
-          include_role:
-            name: infra-agent-config
-
-        - name: Setup NR Otel Collector config
-          include_role:
-            name:  nr-otel-collector-config
-
-        - name: Setup NR Super Agent config
-          include_role:
-            name: super-agent-config
-
-        - name: Restart New Relic Super Agent
-          ansible.builtin.service:
-            name: newrelic-super-agent
-            state: restarted
+    - name: guided install
+      timeout: 300
+      shell: |
+        curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
+        && NEW_RELIC_CLI_SKIP_CORE=1 \
+        NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+        NEW_RELIC_API_KEY={{ nr_api_key }} \
+        NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
+        NEW_RELIC_REGION=STAGING \ 
+        NEW_RELIC_ORGANIZATION={{ organization_id }} \
+        /usr/local/bin/newrelic install -n super-agent -y
 
 ...

--- a/test/canaries/ansible/requirements.yml
+++ b/test/canaries/ansible/requirements.yml
@@ -1,4 +1,6 @@
 collections:
-  # this is just a stab for future
   - name: git+https://github.com/newrelic-experimental/caos-ansible-roles.git#/caos.ansible_roles/
     type: git
+
+roles:
+  - name: newrelic.newrelic_install

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -25,6 +25,10 @@ ifndef NEW_RELIC_API_KEY
 	@echo "NEW_RELIC_API_KEY variable must be provided for test/e2e"
 	exit 1
 endif
+ifndef NR_ORGANIZATION_ID
+	@echo "NR_ORGANIZATION_ID variable must be provided for test/e2e"
+	exit 1
+endif
 
 # if you want to hide OK, add ANSIBLE_DISPLAY_OK_HOSTS=NO
 	$(MAKE) ansible/dependencies ANSIBLE_FOLDER=$(ANSIBLE_FOLDER)
@@ -35,6 +39,7 @@ endif
         -e nr_api_key=$(NEW_RELIC_API_KEY) \
         -e nr_account_id=$(NEW_RELIC_ACCOUNT_ID) \
         -e repo_endpoint=$(REPOSITORY_ENDPOINT) \
+        -e organization_id=$(NR_ORGANIZATION_ID) \
         -e nr_otel_collector_otlp_endpoint=$(NR_OTEL_COLLECTOR_OTLP_ENDPOINT) \
         -e opamp_endpoint=${OPAMP_ENDPOINT} \
  		$(ANSIBLE_FOLDER)/$(ANSIBLE_PLAYBOOK)

--- a/test/e2e/Readme.md
+++ b/test/e2e/Readme.md
@@ -1,0 +1,29 @@
+# Local execution
+
+Create an inventory file `inventory.yml`. Example using a vagrant machine:
+```yaml
+testing_hosts_linux:
+  hosts:
+    ubuntu:
+      ansible_host: 10.211.55.51
+      ansible_ssh_extra_args: "-o IdentitiesOnly=yes"
+      ansible_ssh_user: vagrant
+      # usually a file `private_key` under .vagrant/machines/...
+      ansible_ssh_private_key_file: /path/to/vagrant/private/key
+```
+
+## Requirements
+The newrelic.install role requires the following collections:
+`ansible-galaxy collection install ansible.windows ansible.utils`
+
+## Execution
+```sh
+make test/e2e \
+  NR_LICENSE_KEY=$LICENSE_KEY \
+  NEW_RELIC_ACCOUNT_ID=$ACCOUNT_ID \
+  NEW_RELIC_API_KEY=$API_REST_KEY \
+  NR_ORGANIZATION_ID=$ORGANIZATION_ID \
+  REPOSITORY_ENDPOINT="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+  ANSIBLE_INVENTORY=./inventory.yml
+```
+

--- a/test/e2e/ansible/migration_script_execution.yaml
+++ b/test/e2e/ansible/migration_script_execution.yaml
@@ -21,35 +21,21 @@
           NEW_RELIC_DOWNLOAD_URL: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
 
     - name: Install super agent and run migration
-      include_tasks: ./tasks/install_recipe.yaml
-      vars:
-        targets:
-          - super-agent
-        env_vars:
-          NEW_RELIC_API_KEY: "{{ nr_api_key }}"
-          NEW_RELIC_ACCOUNT_ID: "{{ nr_account_id | int }}"
-          NEW_RELIC_REGION: "STAGING"
-          NEW_RELIC_DOWNLOAD_URL: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
-          NR_CLI_FLEET_ENABLED: true
-          NR_CLI_HOST_MONITORING_SOURCE: newrelic
-          NR_SA_MIGRATE_INFRA_CONFIG: true
-
-    - name: Modify infra-agent type to 0.1.2
-      include_role:
-        name: super-agent-config
-      vars:
-        infra_agent_type_version: "0.1.2"
+      shell: |
+        curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
+        && NEW_RELIC_CLI_SKIP_CORE=1 \
+        NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+        NEW_RELIC_API_KEY={{ nr_api_key }} \
+        NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
+        NEW_RELIC_REGION=STAGING \ 
+        NEW_RELIC_ORGANIZATION={{ organization_id }} \
+        /usr/local/bin/newrelic install -n super-agent -y
 
     - name: Check infra-agent values file exists
       stat:
         path: "/etc/newrelic-super-agent/fleet/agents.d/nr-infra-agent/values/values.yaml"
       register: infra_agent_values
       failed_when: not infra_agent_values.stat.exists
-
-    - name: Restart New Relic Super Agent
-      ansible.builtin.service:
-        name: newrelic-super-agent
-        state: restarted
 
     - name: Assert nr-infra-agent auto-generated file is the same as migrated
       include_tasks: ./tasks/assert_generated_file_same_as_migrated.yaml
@@ -68,10 +54,6 @@
       vars:
         generated_file_path: "/var/lib/newrelic-super-agent/auto-generated/nr-infra-agent/logging.d/logging.yml"
         migrated_file_path: "/etc/newrelic-infra/logging.d.bck/logging.yml"
-
-    - name: give it some time to restart
-      ansible.builtin.pause:
-        seconds: 20
 
     - name: Assert Super Agent and Agents are running
       include_role:

--- a/test/provision/Makefile
+++ b/test/provision/Makefile
@@ -26,4 +26,3 @@ clean: terraform/backend ansible/clean
 	terraform -chdir=$(TERRAFORM_DIR) init -reconfigure && \
     terraform -chdir=$(TERRAFORM_DIR) destroy -auto-approve && \
 	rm "$(TERRAFORM_DIR)/terraform.backend.tf" "$(TERRAFORM_DIR)/caos.auto.tfvars"
-	$(MAKE) ansible/clean ANSIBLE_FOLDER=$(ANSIBLE_FOLDER)

--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -33,29 +33,27 @@ module "super_agent_infra" {
     task_container_name = var.task_container_name
     task_name_prefix = var.task_name_prefix
     task_secrets = [
-        {
-          "name" : "SSH_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}"
-        },
+        # All canaries, e2e and packaging tests points to the same account.
         {
           "name" : "NR_LICENSE_KEY",
           "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}"
         },
         {
-          "name" : "NR_LICENSE_KEY_CANARIES",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_canaries}"
-        },
-        {
           "name" : "NEW_RELIC_ACCOUNT_ID",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account}"
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}"
         },
         {
           "name" : "NEW_RELIC_API_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api}"
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}"
         },
         {
-          "name" : "NR_API_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_nr_api_key}"
+          "name" : "NR_ORGANIZATION_ID",
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}"
+        },
+        ####
+        {
+          "name" : "SSH_KEY",
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}"
         },
         {
           "name" : "DOCKER_USERNAME",
@@ -96,10 +94,9 @@ module "super_agent_infra" {
                 "Resource" : [
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_canaries}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_nr_api_key}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_username}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_password}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}",

--- a/test/terraform/fargate/vars.tf
+++ b/test/terraform/fargate/vars.tf
@@ -31,29 +31,27 @@ variable "task_command" {
     "test/automated-run"
   ]
 }
+# Account secrets
+variable "secret_name_license" {
+  default = "agent_control/canaries/license_key-33qwzE"
+}
+
+variable "secret_name_account_id" {
+  default = "agent_control/canaries/account_id-fCpTng"
+}
+
+variable "secret_name_api_key" {
+  default = "agent_control/canaries/nr_api_key-62y4Xp"
+}
+
+variable "secret_name_organization_id" {
+  default = "agent_control/canaries/organization_id-EPEqrL"
+}
+
+####
 
 variable "secret_name_ssh" {
   default = "caos/canaries/ssh_key-UBSKNA"
-}
-
-variable "secret_name_license" {
-  default = "caos/canaries/license-f9eYwe"
-}
-
-variable "secret_name_license_canaries" {
-  default = "caos/canaries/license_canaries-1DCE1L"
-}
-
-variable "secret_name_account" {
-  default = "caos/canaries/account-kKFMGP"
-}
-
-variable "secret_name_api" {
-  default = "caos/canaries/api-9q0NPb"
-}
-
-variable "secret_name_nr_api_key" {
-  default = "caos/canaries/nr_api_key-xadBYJ"
 }
 
 variable "secret_name_docker_username" {


### PR DESCRIPTION
superseds #800 and #804

The goal of the PR is to make the canaries and the e2e (only migration test) work again. They were failing because of the Auth setup.

Now both are using the Staging Admin account we have for the Super-agent.

I'll add some comments on the PR as reference for some changes