### PR TITLE
[NR-302871] ansible task to perform super-agent guided installation

### DIFF
--- a/test/e2e/ansible/migration_script_execution.yaml
+++ b/test/e2e/ansible/migration_script_execution.yaml
@@ -20,16 +20,8 @@
           NEW_RELIC_REGION: "STAGING"
           NEW_RELIC_DOWNLOAD_URL: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
 
-    - name: Install super agent and run migration
-      shell: |
-        curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
-        && NEW_RELIC_CLI_SKIP_CORE=1 \
-        NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
-        NEW_RELIC_API_KEY={{ nr_api_key }} \
-        NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
-        NEW_RELIC_REGION=STAGING \ 
-        NEW_RELIC_ORGANIZATION={{ organization_id }} \
-        /usr/local/bin/newrelic install -n super-agent -y
+    - name: Install super-agent through guided install (which will run migration)
+      include_tasks: ./tasks/super_agent_guided_installation.yaml
 
     - name: Check infra-agent values file exists
       stat:

--- a/test/e2e/ansible/tasks/super_agent_guided_installation.yaml
+++ b/test/e2e/ansible/tasks/super_agent_guided_installation.yaml
@@ -1,0 +1,22 @@
+---
+
+# TODO: replace "tasks/install.yaml" usages with "tasks/super_agent_guided_installation.yaml"
+# TODO: Check if install_recipe supports all needed variables and use it instead.
+# TODO: make NEWRELIC_DOWNLOAD_URL configurable if it is really needed
+- name: Execute super-agent guided install
+  shell: |
+    curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
+    && NEW_RELIC_CLI_SKIP_CORE=1 \
+    NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+    NEW_RELIC_API_KEY={{ nr_api_key }} \
+    NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
+    NEW_RELIC_REGION=STAGING \
+    NEW_RELIC_ORGANIZATION={{ organization_id }} \
+    /usr/local/bin/newrelic install -n super-agent -y
+
+- name: Assert service status
+  include_role:
+    name: caos.ansible_roles.assert_service_status
+  vars:
+    services_running:
+      - "newrelic-super-agent.service"

--- a/test/e2e/ansible/temp_sa_guided_installation.yaml
+++ b/test/e2e/ansible/temp_sa_guided_installation.yaml
@@ -1,0 +1,15 @@
+---
+# TODO: Playbook to check that ./tasks/super_agent_guided_installation.yaml
+# works as expected. Can be removed when it replaces ./tasks/install.yaml
+- name: Testing super-agent guided installation
+  hosts: testing_hosts_linux
+  become: true
+  gather_facts: yes
+
+  tasks:
+
+    - name: Cleanup
+      include_tasks: ./tasks/clean_all.yaml
+
+    - name:
+      include_tasks: ./tasks/super_agent_guided_installation.yaml


### PR DESCRIPTION
This PR includes a task for Ansible's e2e test to perform the super-agent installation though guided install, using this prevent us from creating identities manually (since the identity creation is already handled by the guided installation).

## Notes for reviewers:
* The new task `super_agent_guided_installation.yaml` is supposed to replace the current `install.yaml` but, since the playbooks using it aren't working yet, it has not been replaced.
* The `temp_sa_guided_installation.yaml` playbook was included to check that the task is working as expected. As stated in the TODO comment, it can be removed when it replaces the `install.yaml` task.