### PR TITLE
chore: remove clones for filters

### DIFF
--- a/super-agent/src/sub_agent/health/k8s/deployment.rs
+++ b/super-agent/src/sub_agent/health/k8s/deployment.rs
@@ -257,11 +257,11 @@ impl K8sHealthDeployment {
     }
 }
 
-fn check_ownership(deployment_name: &String, rs: &Arc<ReplicaSet>) -> bool {
+fn check_ownership(deployment_name: &str, rs: &Arc<ReplicaSet>) -> bool {
     if let Some(owner_references) = &rs.metadata.owner_references {
         return owner_references
             .iter()
-            .any(|owner| owner.kind == Deployment::KIND && &owner.name == deployment_name);
+            .any(|owner| owner.kind == Deployment::KIND && owner.name == deployment_name);
     }
     false
 }


### PR DESCRIPTION
Perhaps will save some allocations.

I didn't implement the `try_fold`-based filtering because @paologallinaharbur mentioned we don't want to fail with error and just filter bad cases out, so it's fine that way.

Also, in case you want to use it the future, there's also the function `is_some_and` to avoid returning a boolean value explicitly:

```rust
fn check_ownership(deployment_name: &str, rs: &Arc<ReplicaSet>) -> bool {
    rs.metadata
        .owner_references
        .as_ref()
        .is_some_and(|owner_references| {
            owner_references
                .iter()
                .any(|owner| owner.kind == Deployment::KIND && &owner.name == deployment_name)
        })
}

fn check_pod_template(deployment_pod_template: &PodTemplateSpec, rs: &Arc<ReplicaSet>) -> bool {
    let Some(rs_template) = rs.spec.as_ref().and_then(|s| s.template.as_ref()) else {
        warn!(
            "the ReplicaSet/{:?} is missing the 'spec' or 'spec.template' field",
            rs.metadata.name
        );
        return false;
    };

    remove_hash_label_from_template(deployment_pod_template)
        == remove_hash_label_from_template(rs_template)
}
```