### PR TITLE
Fix and enable back agents_registration_unregistration e2e test

### DIFF
--- a/test/caos-ansible-roles/fleet_api_request/README.md
+++ b/test/caos-ansible-roles/fleet_api_request/README.md
@@ -16,7 +16,7 @@ nr_api_key: "xxxxxxxxxxxxxxxx"
         name: caos.ansible_roles.fleet_api_request
       vars:
         assert_agents_health:
-          ulids: ["01HNN91DF9XE69BRYPK9DPHD34", "01HNN91C5XT16VQJ31J3TC7MYM"]
+          instance_ids: ["01HNN91DF9XE69BRYPK9DPHD34", "01HNN91C5XT16VQJ31J3TC7MYM"]
           host: "some-host.example.com"
           healthy: true
 
@@ -25,7 +25,7 @@ nr_api_key: "xxxxxxxxxxxxxxxx"
         name: caos.ansible_roles.fleet_api_request
       vars:
         assert_agents_health:
-          ulids: ["01HNN91CWC2D50AA4M8QXMH026", "01HNN6Y5J0WWAXSTK413Q27EFJ"]
+          instance_ids: ["01HNN91CWC2D50AA4M8QXMH026", "01HNN6Y5J0WWAXSTK413Q27EFJ"]
           host: "some-host.example.com"
           healthy: false
 

--- a/test/caos-ansible-roles/fleet_api_request/tasks/assert_agents_health.yml
+++ b/test/caos-ansible-roles/fleet_api_request/tasks/assert_agents_health.yml
@@ -2,32 +2,32 @@
 
 - include_tasks: get_agents.yml
 
-- name: Filter agents by provided ulids and host and being healthy
+- name: Filter agents by provided instance_ids and host and being healthy
   ansible.builtin.debug:
-    msg: "{{ response.json | to_json | from_json | community.general.json_query(server_name_query) }}"
+    msg: "{{ response.json | community.general.json_query(server_name_query) }}"
   vars:
-    server_name_query: "data.account.agents.results[?contains(`{{ assert_agents_health.ulids | to_json }}`, uid) && host.name=='{{assert_agents_health.host}}' && healthy]"
+    server_name_query: "data.account.agents.results[?contains(`{{ assert_agents_health.instance_ids | to_json }}`, uid) && host.name=='{{assert_agents_health.host}}' && healthy]"
   register: filtered_by_ulid_healthy
   when: assert_agents_health.healthy
 
 - name: "assert that agents matching expectations is as expected"
   assert:
-    that:  filtered_by_ulid_healthy.msg | length  == assert_agents_health.ulids | length
-    fail_msg: "Expected agents count to be '{{ assert_agents_health.ulids | length }}', but got {{ filtered_by_ulid_healthy.msg | length }}"
+    that:  filtered_by_ulid_healthy.msg | length  == assert_agents_health.instance_ids | length
+    fail_msg: "Expected agents count to be '{{ assert_agents_health.instance_ids | length }}', but got {{ filtered_by_ulid_healthy.msg | length }}"
   when: assert_agents_health.healthy
 
-- name: Filter agents by provided ulids and host and being unhealthy
+- name: Filter agents by provided instance_ids and host and being unhealthy
   ansible.builtin.debug:
-    msg: "{{ response.json | to_json | from_json | community.general.json_query(server_name_query) }}"
+    msg: "{{ response.json | community.general.json_query(server_name_query) }}"
   vars:
-    server_name_query: "data.account.agents.results[?contains(`{{ assert_agents_health.ulids | to_json }}`, uid) && host.name=='{{assert_agents_health.host}}' && !healthy]"
+    server_name_query: "data.account.agents.results[?contains(`{{ assert_agents_health.instance_ids | to_json }}`, uid) && host.name=='{{assert_agents_health.host}}' && !healthy]"
   register: filtered_by_ulid_unhealthy
   when: not assert_agents_health.healthy
 
 - name: "assert that agents matching expectations is as expected"
   assert:
-    that:  filtered_by_ulid_unhealthy.msg | length  == assert_agents_health.ulids | length
-    fail_msg: "Expected agents count to be '{{ assert_agents_health.ulids | length }}', but got {{ filtered_by_ulid_unhealthy.msg | length }}"
+    that:  filtered_by_ulid_unhealthy.msg | length  == assert_agents_health.instance_ids | length
+    fail_msg: "Expected agents count to be '{{ assert_agents_health.instance_ids | length }}', but got {{ filtered_by_ulid_unhealthy.msg | length }}"
   when: not assert_agents_health.healthy
 
 ...

--- a/test/caos-ansible-roles/fleet_api_request/tasks/get_agents.yml
+++ b/test/caos-ansible-roles/fleet_api_request/tasks/get_agents.yml
@@ -13,10 +13,6 @@
               results{
                 type
                 healthy
-                authorization{
-                  state
-                  lastUpdated
-                }
                 host{
                   name
                 }

--- a/test/caos-ansible-roles/fleet_api_request/tasks/main.yml
+++ b/test/caos-ansible-roles/fleet_api_request/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: assert_agents_health.yml
-  when: assert_agents_health.ulids | length > 0
+  when: assert_agents_health.instance_ids | length > 0
 
 - include_tasks: create_configuration.yml
   when: create_remote_configuration.account_id | string | length > 0

--- a/test/caos-ansible-roles/fleet_api_request/vars/main.yaml
+++ b/test/caos-ansible-roles/fleet_api_request/vars/main.yaml
@@ -1,6 +1,6 @@
 ---
 assert_agents_health:
-  ulids: []
+  instance_ids: []
   host: ""
   healthy: true
 

--- a/test/e2e/ansible/agents_registration_unregistration.yaml
+++ b/test/e2e/ansible/agents_registration_unregistration.yaml
@@ -7,37 +7,6 @@
   tasks:
     - name: Fresh Super Agent installation with InfraAgent and NRDOT
       include_tasks: ./tasks/fresh_super_agent_installation_{{ ansible_system }}.yaml
-      vars:
-        infra_agent_type_version: "0.1.2"
-        otel_agent_type_version: "0.1.0"
-
-    - name: Get NR Super Agent InstanceID
-      include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
-      vars:
-        agent_identifier_path: "/var/lib/newrelic-super-agent/identifiers.yaml"
-        identifier_field: "instance_id"
-        identifier_field_fact: "super_agent_instance_id"
-
-    - name: Get Infra agent InstanceID
-      include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
-      vars:
-        agent_identifier_path: "/var/lib/newrelic-super-agent/fleet/agents.d/nr-infra-agent/identifiers.yaml"
-        identifier_field: "instance_id"
-        identifier_field_fact: "infra_agent_instance_id"
-
-    - name: Get NR Otel Collector InstanceID
-      include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
-      vars:
-        agent_identifier_path: "/var/lib/newrelic-super-agent/fleet/agents.d/nr-otel-collector/identifiers.yaml"
-        identifier_field: "instance_id"
-        identifier_field_fact: "otel_agent_instance_id"
-
-    - name: Get Hostname
-      include_tasks: ./tasks/get_identifier_field_{{ ansible_system }}.yaml
-      vars:
-        agent_identifier_path: "/var/lib/newrelic-super-agent/identifiers.yaml"
-        identifier_field: "hostname"
-        identifier_field_fact: "hostname"
 
     - name: Setup NR Super Agent config without any agent
       include_role:

--- a/test/e2e/ansible/tasks/fresh_super_agent_installation_Linux.yaml
+++ b/test/e2e/ansible/tasks/fresh_super_agent_installation_Linux.yaml
@@ -2,25 +2,8 @@
 - name: Cleanup
   include_tasks: ./clean_all.yaml
 
-- name: Installation
-  include_tasks: ./install.yaml
-
-- name: Setup Infra Agent config
-  include_role:
-    name: infra-agent-config
-
-- name: Setup NR Otel Collector config
-  include_role:
-    name: nr-otel-collector-config
-
-- name: Setup NR Super Agent config
-  include_role:
-    name: super-agent-config
-
-- name: Restart New Relic Super Agent
-  ansible.builtin.service:
-    name: newrelic-super-agent
-    state: restarted
+- name: Install super-agent through guided install (which will run migration)
+  include_tasks: ./tasks/super_agent_guided_installation.yaml
 
 - name: Get Hostname
   include_tasks: ./get_identifier_field_{{ ansible_system }}.yaml

--- a/test/e2e/ansible/tasks/get_identifier_field_Linux.yaml
+++ b/test/e2e/ansible/tasks/get_identifier_field_Linux.yaml
@@ -6,7 +6,7 @@
     timeout: 300
 
 - name: Get the identifier field provided
-  shell: "grep -Eo '^{{ identifier_field }}:\\s*([^[:space:]]+)' {{ agent_identifier_path }} | cut -d ' ' -f 2"
+  shell: "grep -Eo '^\\s*\\b{{ identifier_field }}:\\s*([^[:space:]]+)' {{ agent_identifier_path }} | cut -d ':' -f 2 | tr -d ' '"
   register: field_result
 
 # output facts

--- a/test/e2e/ansible/tasks/super_agent_guided_installation.yaml
+++ b/test/e2e/ansible/tasks/super_agent_guided_installation.yaml
@@ -7,7 +7,7 @@
   shell: |
     curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash \
     && NEW_RELIC_CLI_SKIP_CORE=1 \
-    NEW_RELIC_DOWNLOAD_URL="https://nr-downloads-ohai-staging.s3.amazonaws.com/" \
+    NEW_RELIC_DOWNLOAD_URL="{{ repo_endpoint }}" \
     NEW_RELIC_API_KEY={{ nr_api_key }} \
     NEW_RELIC_ACCOUNT_ID={{ nr_account_id | int }} \
     NEW_RELIC_REGION=STAGING \

--- a/test/e2e/ansible/test.yaml
+++ b/test/e2e/ansible/test.yaml
@@ -1,8 +1,9 @@
 ---
-# TODO <disabled until FM API gets stable>
-# - name: Agents registration/unregistration
-#   import_playbook: agents_registration_unregistration.yaml
 
+- name: Agents registration/unregistration
+  import_playbook: agents_registration_unregistration.yaml
+
+# TODO <disabled until FM API gets stable>
 #- name: Super Agent valid remote config
 #  import_playbook: super_agent_valid_remote_config.yaml
 #


### PR DESCRIPTION
Add fixes to the agents_registration_unregistration e2e test and enable it back:
- modify legacy ulid field for instance_id.
- fix regex not being able to get the hostname from the identifiers file.
- use the guided install for installation in order to have the identity creation.
- pass the repo to be used to the guided install so the nightly uses the testing bucket and prerelease the staging one. 