### PR TITLE
[NR-287812] rephrase config-migrate logs

### DIFF
--- a/config-migrate/src/bin/main.rs
+++ b/config-migrate/src/bin/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // init logging singleton
     LoggingConfig::default().try_init(PathBuf::from(SUPER_AGENT_LOG_DIR))?;
 
-    info!("Starting conversion tool...");
+    info!("Starting config conversion tool...");
 
     let config: MigrationConfig = MigrationConfig::parse(NEWRELIC_INFRA_AGENT_TYPE_CONFIG_MAPPING)?;
 
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 for (_, file_path) in cfg.files_map {
                     legacy_config_renamer.rename_path(file_path.as_path())?;
                 }
-                info!("Old config files and paths renamed");
+                debug!("Classic config files and paths renamed");
             }
             Err(MigratorError::AgentTypeNotFoundOnConfig) => {
                 debug!(
@@ -59,13 +59,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             Err(e) => {
                 warn!(
-                    "Could not apply migration for {}: {}",
+                    "Could not apply local config migration for {}: {}",
                     cfg.agent_type_fqn, e
                 );
             }
         }
     }
-    info!("Config files successfully converted");
+    info!("Local config files successfully created");
 
     Ok(())
 }

--- a/config-migrate/src/migration/migrator.rs
+++ b/config-migrate/src/migration/migrator.rs
@@ -79,13 +79,19 @@ impl
         };
 
         for (agent_id, _) in sub_agents_cfg.agents {
-            debug!("preparing to migrate agent_id: {}", agent_id);
+            debug!(
+                "preparing to migrate local config for agent_id: {}",
+                agent_id
+            );
             match self.config_converter.convert(cfg) {
                 Ok(agent_variables) => {
                     let values_content = serde_yaml::to_string(&agent_variables)?;
                     self.values_persister
                         .persist_values_file(&agent_id, values_content.as_str())?;
-                    info!("Config values files successfully created for {}", agent_id);
+                    info!(
+                        "Local config values files successfully created for {}",
+                        agent_id
+                    );
                 }
                 Err(e) => {
                     warn!("Old files or paths are renamed or not present");


### PR DESCRIPTION
As the conversion tool is now used both for upgrading from the infra-agent and also fresh installs, the current log lines can be a bit misleading. Eg:

```
2024-07-03T03:24:23  INFO Starting conversion tool...
2024-07-03T03:24:23  INFO Config values files successfully created for nr-infra-agent
2024-07-03T03:24:23  INFO Old config files and paths renamed
2024-07-03T03:24:23  INFO Config files successfully converted
```

Therefore, we are changing it to:

```
INFO Starting config conversion tool...
INFO Local config values files successfully created for nr-infra-agent
DEBUG Classic config files and path renamed # ---> not showed by default
INFO Local config files successfully created
```