### PR TITLE
Refactor: move common pub_sub to SuperAgent object

### DIFF
--- a/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
+++ b/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
@@ -1,5 +1,3 @@
-use crate::event::channel::EventPublisher;
-use crate::event::SubAgentEvent;
 use crate::opamp::effective_config::loader::EffectiveConfigLoader;
 use crate::opamp::hash_repository::HashRepository;
 use crate::sub_agent::collection::StartedSubAgents;
@@ -25,7 +23,6 @@ where
     pub(crate) fn sub_agent_config_updated(
         &self,
         agent_id: AgentID,
-        sub_agent_publisher: EventPublisher<SubAgentEvent>,
         sub_agents: &mut StartedSubAgents<
             <S::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
         >,
@@ -34,6 +31,6 @@ where
         let agent_config = super_agent_dynamic_config.agents.get(&agent_id).ok_or(
             SuperAgentConfigError::SubAgentNotFound(agent_id.to_string()),
         )?;
-        self.recreate_sub_agent(agent_id, agent_config, sub_agents, sub_agent_publisher)
+        self.recreate_sub_agent(agent_id, agent_config, sub_agents)
     }
 }

--- a/super-agent/src/super_agent/run/k8s.rs
+++ b/super-agent/src/super_agent/run/k8s.rs
@@ -101,7 +101,7 @@ impl SuperAgentRunner {
             self.k8s_config.clone(),
         );
 
-        let (maybe_client, opamp_consumer) = opamp_client_builder
+        let (maybe_client, maybe_opamp_consumer) = opamp_client_builder
             .as_ref()
             .map(|builder| {
                 build_opamp_with_channel(
@@ -126,8 +126,10 @@ impl SuperAgentRunner {
             sub_agent_builder,
             config_storer,
             self.super_agent_publisher,
+            self.application_event_consumer,
+            maybe_opamp_consumer,
         )
-        .run(self.application_event_consumer, opamp_consumer)
+        .run()
     }
 }
 

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -1,4 +1,5 @@
 use crate::agent_type::variable::definition::VariableDefinition;
+use crate::event::channel::pub_sub;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};
@@ -126,15 +127,16 @@ impl SuperAgentRunner {
             .transpose()?
             .map(|(client, consumer)| (Some(client), Some(consumer)))
             .unwrap_or_default();
-
         SuperAgent::new(
             maybe_client,
             super_agent_hash_repository,
             sub_agent_builder,
             config_storer,
             self.super_agent_publisher,
+            self.application_event_consumer,
+            maybe_sa_opamp_consumer,
         )
-        .run(self.application_event_consumer, maybe_sa_opamp_consumer)
+        .run()
     }
 }
 


### PR DESCRIPTION
Currently every SuperAgent method passes around a series of channels.
 - `Run->process->apply->...->recreate`

Without these channels the superAgent does not work, therefore IMO it make sense to store them as attributes instead of moving them around

No functionality has been changed. I've simply moved around code