### PR TITLE
Modify the Aud from the AuthConfig to be "https://www.newrelic.com"

### DIFF
--- a/super-agent/src/opamp/auth/token_retriever.rs
+++ b/super-agent/src/opamp/auth/token_retriever.rs
@@ -89,13 +89,10 @@ impl AuthConfig {
             url: self.token_url.clone(),
         };
 
-        Ok(TokenRetrieverWithCache::new(
-            self.client_id,
-            self.token_url,
-            jwt_signer,
-            authenticator_config.into(),
+        Ok(
+            TokenRetrieverWithCache::new(self.client_id, jwt_signer, authenticator_config.into())
+                .with_retries(self.retries),
         )
-        .with_retries(self.retries))
     }
 }
 


### PR DESCRIPTION
Modify the "aud" claid for the Auth to be "https://www.newrelic.com". 
The usage of the Rust URL type places a slash at the end when printing the URL claim to string ("https://www.newrelic.com/") but the backend now accepts both with and without that ending slash.