### PR TITLE
[NR-312879] share opamp_client between subagent and event processor

### DIFF
--- a/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
+++ b/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
@@ -29,7 +29,7 @@ where
     /// When the configuration is empty, the values are deleted instead (an empty configuration means that the remote
     /// configuration should not apply anymore).
     pub(crate) fn remote_config(&self, remote_config: RemoteConfig) -> Result<(), SubAgentError> {
-        let Some(opamp_client) = &self.maybe_opamp_client else {
+        let Some(opamp_client) = self.maybe_opamp_client.as_ref() else {
             unreachable!("got remote config without OpAMP being enabled")
         };
 
@@ -534,7 +534,7 @@ mod tests {
                 sub_agent_publisher,
                 sub_agent_opamp_consumer.into(),
                 sub_agent_internal_consumer,
-                Some(test_values.opamp_client),
+                Arc::new(Some(test_values.opamp_client)),
                 Arc::new(test_values.hash_repository),
                 Arc::new(test_values.yaml_config_repository),
                 Arc::new(

--- a/super-agent/src/sub_agent/event_processor_builder.rs
+++ b/super-agent/src/sub_agent/event_processor_builder.rs
@@ -24,7 +24,7 @@ where
         sub_agent_publisher: EventPublisher<SubAgentEvent>,
         sub_agent_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
         sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
-        maybe_opamp_client: Option<C>,
+        maybe_opamp_client: Arc<Option<C>>,
     ) -> Self::SubAgentEventProcessor;
 }
 
@@ -69,7 +69,7 @@ where
         sub_agent_publisher: EventPublisher<SubAgentEvent>,
         sub_agent_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
         sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
-        maybe_opamp_client: Option<C>,
+        maybe_opamp_client: Arc<Option<C>>,
     ) -> EventProcessor<C, H, Y, G>
     where
         G: EffectiveConfigLoader,
@@ -102,6 +102,7 @@ pub mod test {
     use crate::super_agent::config::{AgentID, AgentTypeFQN};
     use mockall::mock;
     use opamp_client::StartedClient;
+    use std::sync::Arc;
     use std::thread;
 
     mock! {
@@ -124,7 +125,7 @@ pub mod test {
                 sub_agent_publisher: EventPublisher<SubAgentEvent>,
                 sub_agent_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
                 sub_agent_internal_consumer: EventConsumer<SubAgentInternalEvent>,
-                maybe_opamp_client: Option<C>,
+                maybe_opamp_client: Arc<Option<C>>,
             ) -><Self as SubAgentEventProcessorBuilder<C, MockEffectiveConfigLoaderMock>>::SubAgentEventProcessor;
 
         }

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -90,8 +90,12 @@ where
     A: EffectiveAgentsAssembler,
     E: SubAgentEventProcessorBuilder<O::Client, G>,
 {
-    type NotStartedSubAgent =
-        SubAgentK8s<NotStarted<E::SubAgentEventProcessor>, NotStartedSupervisor>;
+    type NotStartedSubAgent = SubAgentK8s<
+        NotStarted<E::SubAgentEventProcessor>,
+        NotStartedSupervisor,
+        O::Client,
+        SubAgentCallbacks<G>,
+    >;
 
     fn build(
         &self,
@@ -150,13 +154,15 @@ where
             },
         )?;
 
+        let maybe_opamp_client = Arc::new(maybe_opamp_client);
+
         let event_processor = self.event_processor_builder.build(
             agent_id.clone(),
             agent_fqn,
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             sub_agent_internal_consumer,
-            maybe_opamp_client,
+            maybe_opamp_client.clone(),
         );
 
         Ok(SubAgentK8s::new(
@@ -165,6 +171,7 @@ where
             event_processor,
             sub_agent_internal_publisher,
             supervisor,
+            maybe_opamp_client.clone(),
         ))
     }
 }

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -208,7 +208,7 @@ where
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             sub_agent_internal_consumer,
-            maybe_opamp_client,
+            Arc::new(maybe_opamp_client),
         );
 
         Ok(SubAgentOnHost::new(


### PR DESCRIPTION
### Context

This PR updates the subagent event processor to use an `Arc<Option<Client>>` instead of an `Option<Client>`, the change is needed because, in a follow-up PR, the sub agent will stop being re-created each time a sub agent configuration is received. As a result, the sub-agent will be responsible for assembling the configuration and building the corresponding supervisor which needs the OpAMP client to report the corresponding messages.

### Summary of changes

* Update the subagent's event processor to use the `Arc`.
* Assure the OpAMP client is properly stopped (its reference will be shared between two different threads).
* As example, inject the OpAMP client in the k8s sub-agent (even if it not used yet).