### PR TITLE
[NR-312879] update subagents lifecycle

### DIFF
--- a/super-agent/src/sub_agent/collection.rs
+++ b/super-agent/src/sub_agent/collection.rs
@@ -73,6 +73,20 @@ where
     pub(crate) fn get(&self, agent_id: &AgentID) -> Option<&S> {
         self.0.get(agent_id)
     }
+
+    pub(crate) fn apply_config_update(
+        &mut self,
+        agent_id: &AgentID,
+    ) -> Result<(), SubAgentCollectionError> {
+        let sub_agent =
+            self.0
+                .get_mut(agent_id)
+                .ok_or(SubAgentCollectionError::SubAgentNotFound(
+                    agent_id.to_string(),
+                ))?;
+        sub_agent.apply_config_update();
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/super-agent/src/sub_agent/k8s/sub_agent.rs
+++ b/super-agent/src/sub_agent/k8s/sub_agent.rs
@@ -6,14 +6,19 @@ use opamp_client::operation::callbacks::Callbacks;
 use opamp_client::StartedClient;
 use tracing::error;
 
+use crate::agent_type::environment::Environment;
 use crate::event::channel::EventPublisher;
 use crate::event::SubAgentInternalEvent;
 use crate::opamp::operations::stop_opamp_client;
+use crate::sub_agent::effective_agents_assembler::{
+    EffectiveAgent, EffectiveAgentsAssembler, EffectiveAgentsAssemblerError,
+};
 use crate::sub_agent::event_processor::SubAgentEventProcessor;
 use crate::sub_agent::k8s::NotStartedSupervisor;
+use crate::sub_agent::supervisor::SupervisorBuilder;
 use crate::sub_agent::{NotStarted, Started};
 use crate::sub_agent::{NotStartedSubAgent, StartedSubAgent};
-use crate::super_agent::config::{AgentID, AgentTypeFQN};
+use crate::super_agent::config::{AgentID, AgentTypeFQN, SubAgentConfig};
 
 use super::supervisor::log_and_report_unhealthy;
 use super::supervisor::StartedSupervisor;
@@ -21,12 +26,14 @@ use super::supervisor::StartedSupervisor;
 ////////////////////////////////////////////////////////////////////////////////////
 // SubAgent On K8s
 ////////////////////////////////////////////////////////////////////////////////////
-pub struct SubAgentK8s<S, V, C, CB> {
+pub struct SubAgentK8s<'a, S, V, C, CB, A, B> {
     agent_id: AgentID,
-    agent_type: AgentTypeFQN,
+    agent_cfg: SubAgentConfig,
     supervisor: Option<V>,
     sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     maybe_opamp_client: Arc<Option<C>>,
+    effective_agent_assembler: &'a A,
+    supervisor_builder: B,
     state: S,
 
     // This is needed to ensure the generic type parameter CB is used in the struct.
@@ -34,47 +41,75 @@ pub struct SubAgentK8s<S, V, C, CB> {
     _opamp_callbacks: PhantomData<CB>,
 }
 
-impl<E, C, CB> SubAgentK8s<NotStarted<E>, NotStartedSupervisor, C, CB>
+impl<'a, E, C, CB, A, B> SubAgentK8s<'a, NotStarted<E>, StartedSupervisor, C, CB, A, B>
 where
     E: SubAgentEventProcessor,
     C: StartedClient<CB>,
     CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<Supervisor = NotStartedSupervisor, OpAMPClient = C>,
 {
     pub fn new(
         agent_id: AgentID,
-        agent_type: AgentTypeFQN,
+        agent_cfg: SubAgentConfig,
         event_processor: E,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
-        supervisor: Option<NotStartedSupervisor>,
         maybe_opamp_client: Arc<Option<C>>,
+        effective_agent_assembler: &'a A,
+        supervisor_builder: B,
     ) -> Self {
         SubAgentK8s {
             agent_id,
-            agent_type,
-            supervisor,
+            agent_cfg,
+            supervisor: None,
             sub_agent_internal_publisher,
             maybe_opamp_client,
+            effective_agent_assembler,
+            supervisor_builder,
             state: NotStarted { event_processor },
             _opamp_callbacks: PhantomData,
         }
     }
 }
 
-impl<E, C, CB> NotStartedSubAgent for SubAgentK8s<NotStarted<E>, NotStartedSupervisor, C, CB>
+impl<'a, S, C, CB, A, B> SubAgentK8s<'a, S, StartedSupervisor, C, CB, A, B>
 where
-    E: SubAgentEventProcessor,
     C: StartedClient<CB>,
     CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<Supervisor = NotStartedSupervisor, OpAMPClient = C>,
 {
-    type StartedSubAgent = SubAgentK8s<Started, StartedSupervisor, C, CB>;
+    fn assemble_agent(&self) -> Result<EffectiveAgent, EffectiveAgentsAssemblerError> {
+        self.effective_agent_assembler.assemble_agent(
+            &self.agent_id,
+            &self.agent_cfg,
+            &Environment::K8s,
+        )
+    }
 
-    // Run has two main duties:
-    // - it starts the supervisor if any
-    // - it starts processing events (internal and opamp ones)
-    fn run(self) -> Self::StartedSubAgent {
+    fn build_supervisor(
+        &self,
+        effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+    ) -> Option<NotStartedSupervisor> {
+        self.supervisor_builder
+            .build_supervisor(effective_agent_result, self.maybe_opamp_client.as_ref())
+            .inspect_err(
+                |err| error!(agent_id=%self.agent_id, %err, "Error building the k8s supervisor"),
+            )
+            .unwrap_or_default()
+    }
+
+    fn build_supervisor_from_persisted_values(&self) -> Option<NotStartedSupervisor> {
+        let effective_agent_result = self.assemble_agent();
+        self.build_supervisor(effective_agent_result)
+    }
+
+    fn start_supervisor(
+        &self,
+        maybe_not_started_supervisor: Option<NotStartedSupervisor>,
+    ) -> Option<StartedSupervisor> {
         let start_time = SystemTime::now();
-        let maybe_started_supervisor = self
-            .supervisor
+        maybe_not_started_supervisor
             .map(|s| s.start(self.sub_agent_internal_publisher.clone(), start_time))
             .transpose()
             .inspect_err(|err| {
@@ -85,49 +120,94 @@ where
                     start_time,
                 )
             })
-            .unwrap_or(None);
+            .unwrap_or(None)
+    }
+
+    fn stop_supervisor(agent_id: &AgentID, maybe_started_supervisor: Option<StartedSupervisor>) {
+        if let Some(s) = maybe_started_supervisor {
+            let _ = s
+                .stop()
+                .map(|join_handle| {
+                    let _ = join_handle.join().inspect_err(|_| {
+                        error!(
+                            agent_id = %agent_id,
+                            "Error stopping k8s supervisor thread"
+                        );
+                    });
+                })
+                .inspect_err(|err| {
+                    error!(
+
+                            agent_id = %agent_id,
+                            %err,
+                            "Error stopping k8s supervisor"
+                    );
+                });
+        }
+    }
+}
+
+impl<'a, E, C, CB, A, B> NotStartedSubAgent
+    for SubAgentK8s<'a, NotStarted<E>, StartedSupervisor, C, CB, A, B>
+where
+    E: SubAgentEventProcessor,
+    C: opamp_client::StartedClient<CB>,
+    CB: opamp_client::operation::callbacks::Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<Supervisor = NotStartedSupervisor, OpAMPClient = C>,
+{
+    type StartedSubAgent = SubAgentK8s<'a, Started, StartedSupervisor, C, CB, A, B>;
+
+    /// Builds and starts the supervisor (if any) and starts the event processor.
+    fn run(self) -> Self::StartedSubAgent {
+        let maybe_not_started_supervisor = self.build_supervisor_from_persisted_values();
+        let maybe_started_supervisor = self.start_supervisor(maybe_not_started_supervisor);
 
         let event_loop_handle = self.state.event_processor.process();
 
         SubAgentK8s {
             agent_id: self.agent_id,
-            agent_type: self.agent_type,
+            agent_cfg: self.agent_cfg,
             supervisor: maybe_started_supervisor,
             sub_agent_internal_publisher: self.sub_agent_internal_publisher,
             maybe_opamp_client: self.maybe_opamp_client,
+            effective_agent_assembler: self.effective_agent_assembler,
+            supervisor_builder: self.supervisor_builder,
             state: Started { event_loop_handle },
             _opamp_callbacks: PhantomData,
         }
     }
 }
 
-impl<C, CB> StartedSubAgent for SubAgentK8s<Started, StartedSupervisor, C, CB>
+impl<'a, C, CB, A, B> StartedSubAgent for SubAgentK8s<'a, Started, StartedSupervisor, C, CB, A, B>
 where
     C: StartedClient<CB>,
     CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<Supervisor = NotStartedSupervisor, OpAMPClient = C>,
 {
     fn agent_id(&self) -> AgentID {
         self.agent_id.clone()
     }
 
     fn agent_type(&self) -> AgentTypeFQN {
-        self.agent_type.clone()
+        self.agent_cfg.agent_type.clone()
+    }
+
+    fn apply_config_update(&mut self) {
+        // Stop the current supervisor if any
+        let maybe_current_supervisor = self.supervisor.take();
+        Self::stop_supervisor(&self.agent_id, maybe_current_supervisor);
+        // Build a new supervisor from the persisted values
+        let maybe_not_started_supervisor = self.build_supervisor_from_persisted_values();
+        // Start the new supervisor if any
+        self.supervisor = self.start_supervisor(maybe_not_started_supervisor);
     }
 
     // Stop does not delete directly the CR. It will be the garbage collector doing so if needed.
     fn stop(self) {
         // stop the k8s object supervisor
-        let _ = self
-            .supervisor
-            .map(|s| s.stop())
-            .transpose()
-            .map_err(|err| {
-                error!(
-                    agent_id = %self.agent_id,
-                    %err,
-                    "Error stopping k8s supervisor"
-                )
-            });
+        Self::stop_supervisor(&self.agent_id, self.supervisor);
 
         // Stop processing events
         let _ = self
@@ -161,13 +241,15 @@ where
 #[cfg(test)]
 pub mod test {
     use crate::agent_type::health_config::K8sHealthConfig;
+    use crate::agent_type::runtime_config::{Deployment, Runtime};
     use crate::event::channel::{pub_sub, EventPublisher};
     use crate::event::SubAgentInternalEvent;
     use crate::k8s::client::MockSyncK8sClient;
-    use crate::k8s::error::K8sError;
     use crate::opamp::callbacks::AgentCallbacks;
     use crate::opamp::client_builder::test::MockStartedOpAMPClientMock;
     use crate::opamp::effective_config::loader::tests::MockEffectiveConfigLoaderMock;
+    use crate::sub_agent::effective_agents_assembler::tests::MockEffectiveAgentAssemblerMock;
+    use crate::sub_agent::error::SubAgentBuilderError;
     use crate::sub_agent::event_processor::test::MockEventProcessorMock;
     use crate::sub_agent::k8s::builder::test::k8s_sample_runtime_config;
     use crate::sub_agent::k8s::sub_agent::SubAgentK8s;
@@ -179,17 +261,48 @@ pub mod test {
     use std::time::Duration;
     use tracing_test::traced_test;
 
-    const TEST_K8S_ISSUE: &str = "random issue";
     pub const TEST_AGENT_ID: &str = "k8s-test";
     pub const TEST_GENT_FQN: &str = "ns/test:0.1.2";
+
+    use super::*;
+    use mockall::{mock, predicate};
+
+    // Mock for the k8s supervisor builder (the associated type needs to be set, therefore we cannot define a generic mock).
+    mock! {
+        pub SupervisorBuilderK8s {}
+
+        impl SupervisorBuilder for SupervisorBuilderK8s {
+            type Supervisor = NotStartedSupervisor;
+            type OpAMPClient = MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>;
+
+            fn build_supervisor(
+                &self,
+                effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+                maybe_opamp_client: &Option<MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>>,
+            ) -> Result<Option<NotStartedSupervisor>, SubAgentBuilderError>;
+        }
+    }
+
+    // Testing type to make usage more readable
+    type SubAgentK8sForTesting<'a> = SubAgentK8s<
+        'a,
+        NotStarted<MockEventProcessorMock>,
+        StartedSupervisor,
+        MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>,
+        AgentCallbacks<MockEffectiveConfigLoaderMock>,
+        MockEffectiveAgentAssemblerMock,
+        MockSupervisorBuilderK8s,
+    >;
 
     #[traced_test]
     #[test]
     fn k8s_sub_agent_start_and_stop() {
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
 
+        let mut assembler = MockEffectiveAgentAssemblerMock::new();
+
         let started_agent =
-            create_k8s_sub_agent_successfully(sub_agent_internal_publisher, false).run();
+            testing_k8s_sub_agent(sub_agent_internal_publisher, &mut assembler, || None).run();
 
         started_agent.stop();
 
@@ -201,8 +314,9 @@ pub mod test {
     fn k8s_sub_agent_start_and_fail_stop() {
         let (sub_agent_internal_publisher, _) = pub_sub();
 
+        let mut assembler = MockEffectiveAgentAssemblerMock::new();
         let started_agent =
-            create_k8s_sub_agent_successfully(sub_agent_internal_publisher, false).run();
+            testing_k8s_sub_agent(sub_agent_internal_publisher, &mut assembler, || None).run();
 
         started_agent.stop();
         // This error is triggered since the consumer is dropped and therefore the channel is closed
@@ -237,23 +351,25 @@ pub mod test {
                 data: Default::default(),
             })))
         });
+        let mock_k8s_client = Arc::new(mock_client);
 
-        let mut processor = MockEventProcessorMock::new();
-        processor.should_process();
+        let mut assembler = MockEffectiveAgentAssemblerMock::new();
 
-        let supervisor =
-            NotStartedSupervisor::new(agent_id.clone(), agent_fqn, Arc::new(mock_client), k8s_obj);
+        let agent_id_for_builder = agent_id.clone();
+
+        let supervisor_fn = move || {
+            Some(NotStartedSupervisor::new(
+                agent_id_for_builder.clone(),
+                agent_fqn.clone(),
+                mock_k8s_client.clone(),
+                k8s_obj.clone(),
+            ))
+        };
 
         // If the started subagent is dropped, then the underlying supervisor is also dropped (and the underlying tasks are stopped)
-        let _started_subagent = SubAgentK8s::new(
-            agent_id.clone(),
-            AgentTypeFQN::try_from(TEST_GENT_FQN).unwrap(),
-            processor,
-            sub_agent_internal_publisher.clone(),
-            Some(supervisor),
-            Arc::new(none_mock_opamp_client()),
-        )
-        .run();
+        let _started_subagent =
+            testing_k8s_sub_agent(sub_agent_internal_publisher, &mut assembler, supervisor_fn)
+                .run();
 
         let timeout = Duration::from_secs(3);
 
@@ -269,47 +385,46 @@ pub mod test {
         }
     }
 
-    fn create_k8s_sub_agent_successfully(
+    /// Sets up a k8s sub agent for testing and the corresponding underlying mocks. The supervisor builder will
+    /// call the provided `supervisor_fn` to return the corresponding supervisor.
+    fn testing_k8s_sub_agent<F: Fn() -> Option<NotStartedSupervisor> + Send + 'static>(
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
-        k8s_client_should_fail: bool,
-    ) -> SubAgentK8s<
-        NotStarted<MockEventProcessorMock>,
-        NotStartedSupervisor,
-        MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>,
-        AgentCallbacks<MockEffectiveConfigLoaderMock>,
-    > {
+        assembler: &mut MockEffectiveAgentAssemblerMock,
+        supervisor_fn: F,
+    ) -> SubAgentK8sForTesting<'_> {
         let agent_id = AgentID::new(TEST_AGENT_ID).unwrap();
         let agent_fqn = AgentTypeFQN::try_from(TEST_GENT_FQN).unwrap();
-
-        // instance K8s client mock
-        let mut mock_client = MockSyncK8sClient::default();
-        mock_client
-            .expect_apply_dynamic_object_if_changed()
-            .returning(move |_| match k8s_client_should_fail {
-                true => Err(K8sError::GetDynamic(TEST_K8S_ISSUE.to_string())),
-                false => Ok(()),
-            });
-        mock_client
-            .expect_default_namespace()
-            .return_const("default".to_string());
+        let agent_cfg = SubAgentConfig {
+            agent_type: agent_fqn.clone(),
+        };
+        let k8s_config = k8s_sample_runtime_config(true);
+        let runtime_config = Runtime {
+            deployment: Deployment {
+                k8s: Some(k8s_config),
+                ..Default::default()
+            },
+        };
+        let effective_agent =
+            EffectiveAgent::new(agent_id.clone(), agent_fqn.clone(), runtime_config.clone());
+        assembler.should_assemble_agent(&agent_id, &agent_cfg, &Environment::K8s, effective_agent);
 
         let mut processor = MockEventProcessorMock::new();
         processor.should_process();
 
-        let supervisor = NotStartedSupervisor::new(
-            agent_id.clone(),
-            agent_fqn,
-            Arc::new(mock_client),
-            k8s_sample_runtime_config(true),
-        );
+        let mut supervisor_builder = MockSupervisorBuilderK8s::new();
+        supervisor_builder
+            .expect_build_supervisor()
+            .with(predicate::always(), predicate::always())
+            .returning(move |_, _| Ok(supervisor_fn()));
 
         SubAgentK8s::new(
             agent_id.clone(),
-            AgentTypeFQN::try_from("namespace/test:0.0.1").unwrap(),
+            agent_cfg.clone(),
             processor,
             sub_agent_internal_publisher.clone(),
-            Some(supervisor),
             Arc::new(none_mock_opamp_client()),
+            assembler,
+            supervisor_builder,
         )
     }
 

--- a/super-agent/src/sub_agent/on_host/sub_agent.rs
+++ b/super-agent/src/sub_agent/on_host/sub_agent.rs
@@ -1,104 +1,264 @@
+use std::marker::PhantomData;
+use std::sync::Arc;
+
 use super::health_checker::{HealthChecker, HealthCheckerNotStarted, HealthCheckerStarted};
 use super::supervisor::command_supervisor;
 use super::supervisor::command_supervisor::SupervisorOnHost;
+use crate::agent_type::environment::Environment;
 use crate::event::channel::EventPublisher;
 use crate::event::SubAgentInternalEvent;
+use crate::opamp::operations::stop_opamp_client;
+use crate::sub_agent::effective_agents_assembler::{
+    EffectiveAgent, EffectiveAgentsAssembler, EffectiveAgentsAssemblerError,
+};
 use crate::sub_agent::event_processor::SubAgentEventProcessor;
+use crate::sub_agent::supervisor::SupervisorBuilder;
 use crate::sub_agent::{NotStarted, Started};
 use crate::sub_agent::{NotStartedSubAgent, StartedSubAgent};
-use crate::super_agent::config::{AgentID, AgentTypeFQN};
+use crate::super_agent::config::{AgentID, AgentTypeFQN, SubAgentConfig};
+use opamp_client::operation::callbacks::Callbacks;
+use opamp_client::StartedClient;
 use tracing::{debug, error};
 
 ////////////////////////////////////////////////////////////////////////////////////
 // SubAgent On Host
 ////////////////////////////////////////////////////////////////////////////////////
-pub struct SubAgentOnHost<S, V, H> {
+pub struct SubAgentOnHost<'a, S, V, H, A, C, CB, B> {
     supervisor: Option<SupervisorOnHost<V>>,
     agent_id: AgentID,
-    agent_type: AgentTypeFQN,
+    agent_cfg: SubAgentConfig,
     // would make sense to move it to state and share implementation with k8s?
     health_checker: Option<HealthChecker<H>>,
     sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
+    effective_agent_assembler: &'a A,
+    maybe_opamp_client: Arc<Option<C>>,
+    supervisor_builder: B,
     state: S,
+
+    // This is needed to ensure the generic type parameter CB is used in the struct.
+    // Else Rust will reject this, complaining that the type parameter is not used.
+    _opamp_callbacks: PhantomData<CB>,
 }
 
-impl<E> SubAgentOnHost<NotStarted<E>, command_supervisor::NotStarted, HealthCheckerNotStarted>
+impl<'a, E, A, C, CB, B>
+    SubAgentOnHost<
+        'a,
+        NotStarted<E>,
+        command_supervisor::NotStarted,
+        HealthCheckerNotStarted,
+        A,
+        C,
+        CB,
+        B,
+    >
 where
     E: SubAgentEventProcessor,
+    C: StartedClient<CB>,
+    CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<
+        Supervisor = SupervisorOnHost<command_supervisor::NotStarted>,
+        OpAMPClient = C,
+    >,
 {
     pub fn new(
         agent_id: AgentID,
-        agent_type: AgentTypeFQN,
-        health: Option<HealthChecker<HealthCheckerNotStarted>>,
-        supervisor: Option<SupervisorOnHost<command_supervisor::NotStarted>>,
+        agent_cfg: SubAgentConfig,
         event_processor: E,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
-    ) -> SubAgentOnHost<NotStarted<E>, command_supervisor::NotStarted, HealthCheckerNotStarted>
-    {
-        SubAgentOnHost {
-            supervisor,
+        effective_agent_assembler: &'a A,
+        maybe_opamp_client: Arc<Option<C>>,
+        supervisor_builder: B,
+    ) -> Self {
+        Self {
             agent_id,
-            agent_type,
-            health_checker: health,
+            agent_cfg,
             sub_agent_internal_publisher,
             state: NotStarted { event_processor },
+            effective_agent_assembler,
+            maybe_opamp_client,
+            supervisor_builder,
+            supervisor: None,
+            health_checker: None,
+            _opamp_callbacks: PhantomData,
         }
     }
 }
 
-impl<E> NotStartedSubAgent
-    for SubAgentOnHost<NotStarted<E>, command_supervisor::NotStarted, HealthCheckerNotStarted>
+impl<'a, S, V, H, A, C, CB, B> SubAgentOnHost<'a, S, V, H, A, C, CB, B>
 where
-    E: SubAgentEventProcessor,
+    C: StartedClient<CB>,
+    CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<
+        Supervisor = SupervisorOnHost<command_supervisor::NotStarted>,
+        OpAMPClient = C,
+    >,
 {
-    type StartedSubAgent =
-        SubAgentOnHost<Started, command_supervisor::Started, HealthCheckerStarted>;
+    fn assemble_agent(&self) -> Result<EffectiveAgent, EffectiveAgentsAssemblerError> {
+        self.effective_agent_assembler.assemble_agent(
+            &self.agent_id,
+            &self.agent_cfg,
+            &Environment::OnHost,
+        )
+    }
 
-    fn run(self) -> SubAgentOnHost<Started, command_supervisor::Started, HealthCheckerStarted> {
-        let started_supervisor = self.supervisor.map(|s| {
+    fn build_supervisor(
+        &self,
+        effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+    ) -> Option<SupervisorOnHost<command_supervisor::NotStarted>> {
+        self.supervisor_builder
+            .build_supervisor(effective_agent_result, self.maybe_opamp_client.as_ref())
+            .inspect_err(
+                |err| error!(agent_id=%self.agent_id, %err, "Error building the onhost supervisor"),
+            )
+            .unwrap_or_default()
+    }
+
+    fn start_supervisor(
+        &self,
+        maybe_not_started_supervisor: Option<SupervisorOnHost<command_supervisor::NotStarted>>,
+    ) -> Option<SupervisorOnHost<command_supervisor::Started>> {
+        maybe_not_started_supervisor.map(|s| {
             debug!("Running supervisor {} for {}", s.id(), self.agent_id);
             s.run(self.sub_agent_internal_publisher.clone())
-        });
+        })
+    }
+
+    fn stop_supervisor(
+        agent_id: &AgentID,
+        maybe_started_supervisor: Option<SupervisorOnHost<command_supervisor::Started>>,
+    ) {
+        if let Some(s) = maybe_started_supervisor {
+            let _ = s.stop().join().inspect_err(|_| {
+                error!(
+                    agent_id = %agent_id,
+                    "Error stopping supervisor thread"
+                );
+            });
+        };
+    }
+
+    fn build_health_checker(
+        &self,
+        effective_agent_result: &Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+    ) -> Option<HealthChecker<HealthCheckerNotStarted>> {
+        effective_agent_result
+            .as_ref()
+            .ok()?
+            .get_onhost_config()
+            .inspect_err(|err| {
+                error!(
+                    %self.agent_id,
+                    %err,
+                    "could not launch health checker, using default",
+                )
+            })
+            .ok()?
+            .health
+            .as_ref()
+            .and_then(|health_config| {
+                HealthChecker::try_new(
+                    self.agent_id.clone(),
+                    self.sub_agent_internal_publisher.clone(),
+                    health_config.clone(),
+                )
+                .inspect_err(|err| {
+                    error!(
+                        %self.agent_id,
+                        %err,
+                        "could not launch health checker, using default",
+                    )
+                })
+                .ok()
+            })
+    }
+
+    fn start_health_checker(
+        maybe_health_checker: Option<HealthChecker<HealthCheckerNotStarted>>,
+    ) -> Option<HealthChecker<HealthCheckerStarted>> {
+        maybe_health_checker.map(|h| h.start())
+    }
+
+    fn stop_health_checker(maybe_health_checker: Option<HealthChecker<HealthCheckerStarted>>) {
+        if let Some(health_checker) = maybe_health_checker {
+            health_checker.stop();
+        }
+    }
+}
+
+impl<'a, E, A, C, CB, B> NotStartedSubAgent
+    for SubAgentOnHost<
+        'a,
+        NotStarted<E>,
+        command_supervisor::NotStarted,
+        HealthCheckerNotStarted,
+        A,
+        C,
+        CB,
+        B,
+    >
+where
+    E: SubAgentEventProcessor,
+    C: StartedClient<CB>,
+    CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<
+        Supervisor = SupervisorOnHost<command_supervisor::NotStarted>,
+        OpAMPClient = C,
+    >,
+{
+    type StartedSubAgent =
+        SubAgentOnHost<'a, Started, command_supervisor::Started, HealthCheckerStarted, A, C, CB, B>;
+
+    fn run(self) -> Self::StartedSubAgent {
+        let effective_agent_result = self.assemble_agent();
+        let maybe_not_started_health_checker = self.build_health_checker(&effective_agent_result);
+        let maybe_not_started_supervisor = self.build_supervisor(effective_agent_result);
+
+        let started_supervisor = self.start_supervisor(maybe_not_started_supervisor);
 
         let event_loop_handle = self.state.event_processor.process();
 
-        let started_health_checker = self.health_checker.map(|h| h.start());
+        let started_health_checker = Self::start_health_checker(maybe_not_started_health_checker);
 
         SubAgentOnHost {
             supervisor: started_supervisor,
             agent_id: self.agent_id,
-            agent_type: self.agent_type,
+            agent_cfg: self.agent_cfg,
             health_checker: started_health_checker,
             sub_agent_internal_publisher: self.sub_agent_internal_publisher,
             state: Started { event_loop_handle },
+            effective_agent_assembler: self.effective_agent_assembler,
+            maybe_opamp_client: self.maybe_opamp_client,
+            supervisor_builder: self.supervisor_builder,
+            _opamp_callbacks: PhantomData,
         }
     }
 }
 
-impl StartedSubAgent
-    for SubAgentOnHost<Started, command_supervisor::Started, HealthCheckerStarted>
+impl<'a, A, C, CB, B> StartedSubAgent
+    for SubAgentOnHost<'a, Started, command_supervisor::Started, HealthCheckerStarted, A, C, CB, B>
+where
+    C: StartedClient<CB>,
+    CB: Callbacks,
+    A: EffectiveAgentsAssembler,
+    B: SupervisorBuilder<
+        Supervisor = SupervisorOnHost<command_supervisor::NotStarted>,
+        OpAMPClient = C,
+    >,
 {
     fn agent_id(&self) -> AgentID {
         self.agent_id.clone()
     }
 
     fn agent_type(&self) -> AgentTypeFQN {
-        self.agent_type.clone()
+        self.agent_cfg.agent_type.clone()
     }
 
     fn stop(self) {
-        if let Some(h) = self.health_checker {
-            h.stop();
-        }
-
-        if let Some(s) = self.supervisor {
-            let _ = s.stop().join().inspect_err(|_| {
-                error!(
-                    agent_id = %self.agent_id,
-                    "Error stopping supervisor thread"
-                );
-            });
-        };
+        Self::stop_health_checker(self.health_checker);
+        Self::stop_supervisor(&self.agent_id, self.supervisor);
 
         let _ = self
             .sub_agent_internal_publisher
@@ -118,43 +278,135 @@ impl StartedSubAgent
                     );
                 });
             });
+
+        // Stop the OpAMP client in case it wasn't previously stopped by the event handler
+        if let Some(maybe_opamp_client) = Arc::into_inner(self.maybe_opamp_client) {
+            let _ = stop_opamp_client(maybe_opamp_client, &self.agent_id).inspect_err(|err| {
+                error!(agent_id= %self.agent_id, %err, "Error stopping the OpAMP client");
+            });
+        }
+    }
+
+    fn apply_config_update(&mut self) {
+        // Stop the current supervisor and health checker
+        Self::stop_health_checker(self.health_checker.take());
+        Self::stop_supervisor(&self.agent_id, self.supervisor.take());
+        // Build new supervisor and health checker from persisted values
+        let effective_agent_result = self.assemble_agent();
+        let maybe_not_started_health_checker = self.build_health_checker(&effective_agent_result);
+        let maybe_not_started_supervisor = self.build_supervisor(effective_agent_result);
+        // Start the new supervisor and health checker if any
+        self.supervisor = self.start_supervisor(maybe_not_started_supervisor);
+        self.health_checker = Self::start_health_checker(maybe_not_started_health_checker);
     }
 }
 
 #[cfg(test)]
 mod test {
+    use mockall::{mock, predicate};
+
+    use crate::agent_type::runtime_config::{Deployment, OnHost, Runtime};
     use crate::event::channel::pub_sub;
+    use crate::opamp::callbacks::AgentCallbacks;
+    use crate::opamp::client_builder::test::MockStartedOpAMPClientMock;
+    use crate::opamp::effective_config::loader::tests::MockEffectiveConfigLoaderMock;
+    use crate::sub_agent::effective_agents_assembler::tests::MockEffectiveAgentAssemblerMock;
+    use crate::sub_agent::error::SubAgentBuilderError;
     use crate::sub_agent::event_processor::test::MockEventProcessorMock;
     use crate::sub_agent::on_host::sub_agent::SubAgentOnHost;
-    use crate::sub_agent::{NotStartedSubAgent, StartedSubAgent};
+    use crate::sub_agent::on_host::supervisor::command_supervisor::SupervisorOnHost;
+    use crate::sub_agent::supervisor::SupervisorBuilder;
     use crate::super_agent::config::{AgentID, AgentTypeFQN};
     use std::thread::sleep;
     use std::time::Duration;
 
+    use super::*;
+
+    // Mock for the OnHost supervisor builder (the associated type needs to be set, therefore we cannot define a generic mock).
+    mock! {
+        pub SupervisorBuilderOnhost {}
+
+        impl SupervisorBuilder for SupervisorBuilderOnhost {
+            type Supervisor = SupervisorOnHost<command_supervisor::NotStarted>;
+            type OpAMPClient = MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>;
+
+            fn build_supervisor(
+                &self,
+                effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+                maybe_opamp_client: &Option<MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>>,
+            ) -> Result<Option<SupervisorOnHost<command_supervisor::NotStarted>>, SubAgentBuilderError>;
+        }
+    }
+
     #[test]
     fn test_events_are_processed() {
         let agent_id = AgentID::new("some-agent-id").unwrap();
-        let agent_type = AgentTypeFQN::try_from("namespace/some-agent-type:0.0.1").unwrap();
+        let agent_cfg = SubAgentConfig {
+            agent_type: AgentTypeFQN::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+        };
 
         let mut event_processor = MockEventProcessorMock::default();
         event_processor.should_process();
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
-        let sub_agent = SubAgentOnHost::new(
-            agent_id,
-            agent_type,
-            None,
-            None,
-            event_processor,
-            sub_agent_internal_publisher,
+
+        let effective_agent = on_host_final_agent(agent_id.clone(), agent_cfg.agent_type.clone());
+        let mut assembler = MockEffectiveAgentAssemblerMock::new();
+        assembler.should_assemble_agent(
+            &agent_id,
+            &agent_cfg,
+            &Environment::OnHost,
+            effective_agent.clone(),
         );
 
+        let mut supervisor_builder = MockSupervisorBuilderOnhost::new();
+        supervisor_builder
+            .expect_build_supervisor()
+            .with(
+                predicate::function(move |e: &Result<EffectiveAgent, _>| {
+                    e.as_ref().is_ok_and(|x| *x == effective_agent)
+                }),
+                predicate::always(),
+            )
+            .returning(|_, _| Ok(None));
+
+        let sub_agent = SubAgentOnHost::new(
+            agent_id,
+            agent_cfg,
+            event_processor,
+            sub_agent_internal_publisher,
+            &assembler,
+            Arc::new(none_mock_opamp_client()),
+            supervisor_builder,
+        );
         let started_agent = sub_agent.run();
+        //let started_agent = sub_agent.run();
         sleep(Duration::from_millis(20));
         // close the OpAMP Publisher
-
         started_agent.stop();
+    }
 
-        println!("END")
+    fn on_host_final_agent(agent_id: AgentID, agent_fqn: AgentTypeFQN) -> EffectiveAgent {
+        use crate::agent_type::definition::TemplateableValue;
+
+        EffectiveAgent::new(
+            agent_id,
+            agent_fqn,
+            Runtime {
+                deployment: Deployment {
+                    on_host: Some(OnHost {
+                        executable: None,
+                        enable_file_logging: TemplateableValue::new(false),
+                        health: None,
+                    }),
+                    k8s: None,
+                },
+            },
+        )
+    }
+
+    fn none_mock_opamp_client(
+    ) -> Option<MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>> {
+        None
     }
 }

--- a/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
+++ b/super-agent/src/super_agent/event_handler/sub_agent/config_updated.rs
@@ -2,7 +2,7 @@ use crate::opamp::effective_config::loader::EffectiveConfigLoader;
 use crate::opamp::hash_repository::HashRepository;
 use crate::sub_agent::collection::StartedSubAgents;
 use crate::sub_agent::{NotStartedSubAgent, SubAgentBuilder};
-use crate::super_agent::config::{AgentID, SuperAgentConfigError};
+use crate::super_agent::config::AgentID;
 use crate::super_agent::config_storer::loader_storer::{
     SuperAgentDynamicConfigDeleter, SuperAgentDynamicConfigLoader, SuperAgentDynamicConfigStorer,
 };
@@ -27,10 +27,6 @@ where
             <S::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
         >,
     ) -> Result<(), AgentError> {
-        let super_agent_dynamic_config = self.sa_dynamic_config_store.load()?;
-        let agent_config = super_agent_dynamic_config.agents.get(&agent_id).ok_or(
-            SuperAgentConfigError::SubAgentNotFound(agent_id.to_string()),
-        )?;
-        self.recreate_sub_agent(agent_id, agent_config, sub_agents)
+        Ok(sub_agents.apply_config_update(&agent_id)?)
     }
 }

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -1,5 +1,4 @@
 use crate::agent_type::variable::definition::VariableDefinition;
-use crate::event::channel::pub_sub;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};

--- a/super-agent/tests/common/effective_config.rs
+++ b/super-agent/tests/common/effective_config.rs
@@ -16,7 +16,7 @@ pub fn check_latest_effective_config_is_expected(
             .to_vec();
         if expected_config.as_bytes() != cfg_body {
             return Err(format!(
-                "Super agent config not as expected, Expected: {:?}, Found: {:?}",
+                "Effective config not as expected, Expected: {:?}, Found: {:?}",
                 expected_config,
                 String::from_utf8(cfg_body).unwrap(),
             )

--- a/super-agent/tests/on_host/scenarios/opamp.rs
+++ b/super-agent/tests/on_host/scenarios/opamp.rs
@@ -671,7 +671,8 @@ status_time_unix_nano: 1725444001
 }
 
 /// Given a super-agent with a sub-agent without supervised executables, it should be able
-/// to persist the remote config messages from OpAMP
+/// to persist the remote config messages from OpAMP. Furthermore, the corresponding
+/// effective config should be properly reported.
 #[cfg(unix)]
 #[test]
 fn test_config_without_supervisor() {
@@ -714,16 +715,25 @@ fn test_config_without_supervisor() {
         ConfigResponse::from(first_remote_config),
     );
 
+    let sub_agent_instance_id = get_instance_id(
+        &AgentID::new(&sub_agent_id).unwrap(),
+        base_paths_copy.clone(),
+    );
+
     retry(30, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &sub_agent_instance_id,
+            first_remote_config.to_string(),
+        )?;
         let remote_config = crate::on_host::tools::config::get_remote_config_content(
             &sub_agent_id,
             base_paths_copy.clone(),
         )?;
         if remote_config != first_remote_config {
-            Err("not the expected content".into())
-        } else {
-            Ok(())
+            return Err("not the expected content for first config".into());
         }
+        Ok(())
     });
 
     // Send another configuration
@@ -734,15 +744,20 @@ fn test_config_without_supervisor() {
     );
 
     retry(30, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &sub_agent_instance_id,
+            second_remote_config.to_string(),
+        )?;
+
         let remote_config = crate::on_host::tools::config::get_remote_config_content(
             &sub_agent_id,
             base_paths_copy.clone(),
         )?;
         if remote_config != second_remote_config {
-            Err("not the expected content".into())
-        } else {
-            Ok(())
+            return Err("not the expected content for second config".into());
         }
+        Ok(())
     });
 
     application_event_publisher
@@ -795,16 +810,25 @@ fn test_invalid_config_without_supervisor() {
         ConfigResponse::from(first_remote_config),
     );
 
+    let sub_agent_instance_id = get_instance_id(
+        &AgentID::new(&sub_agent_id).unwrap(),
+        base_paths_copy.clone(),
+    );
+
     retry(30, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &sub_agent_instance_id,
+            "".to_string(), // The effective config should not be updated, since the configuration failed
+        )?;
         let remote_config = crate::on_host::tools::config::get_remote_config_content(
             &sub_agent_id,
             base_paths_copy.clone(),
         )?;
         if remote_config != first_remote_config {
-            Err("not the expected content".into())
-        } else {
-            Ok(())
+            return Err("not the expected content".into());
         }
+        Ok(())
     });
 
     // Send another configuration
@@ -815,15 +839,19 @@ fn test_invalid_config_without_supervisor() {
     );
 
     retry(30, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &sub_agent_instance_id,
+            second_remote_config.to_string(), // Correct config leads to updated effective config
+        )?;
         let remote_config = crate::on_host::tools::config::get_remote_config_content(
             &sub_agent_id,
             base_paths_copy.clone(),
         )?;
         if remote_config != second_remote_config {
-            Err("not the expected content".into())
-        } else {
-            Ok(())
+            return Err("not the expected content".into());
         }
+        Ok(())
     });
 
     application_event_publisher


### PR DESCRIPTION
This PR updates the sub-agent lifecycle to avoid removing and re-creating the sub-agent when a sub-agent remote configuration is received. Summary of the new lifecycle:
- The sub-agent's event processor receives an OpAMP message with the configuration change.
- A message is sent to the super-agent
- The super-agent does not stop and re-create the sub-agent anymore. It used a new `apply_config_update` method exposed by the sub agent trait.

## Summary of changes

- Update the sub-agent trait to expose the new `apply_config_update` method.
- Update the super-agent to use the new method instead of re-creating the sub-agent
- Update both onHost and k8s sub-agent implementations to:
  * Create the supervisor and health-checker in the sub-agent instead of the sub-agent builder
  * Create and start the supervisor and health-checker when the sub-agent is started (before they were only started).
  * Implement the new method to apply the configuration changes.
- Assure the sub-agent's effective config is updated when it is set to as _Applied_.
- Fix an issue in the OpAMP server mock (we were discarding configuration messages when config was not applied)
- Extend two on-host integration tests scenarios to check that effective config is properly set when remote configuration is applied (both for valid and invalid configurations).

## Future work (out of scope)

- Make the sub-agent responsible of handling its own configuration changes (it doesn't need to tell the sub-agent that the configuration has changed in order that the super-agent executes `apply_config_update`). This is already planned and should simplify how the sub-agent configuration is handled. When this is done, we can change back the SubAgent trait and keep `apply_config_update` private.
- The on-host and k8s sub-agent code is really similar. If we introduced a common abstraction for the supervisor we should be able to share most of the code.