### PR TITLE
[NR-312879] refactor: introduce supervisor builder

### DIFF
--- a/super-agent/src/sub_agent.rs
+++ b/super-agent/src/sub_agent.rs
@@ -6,6 +6,7 @@ pub mod event_processor;
 pub mod event_processor_builder;
 pub mod health;
 pub mod persister;
+pub mod supervisor;
 
 #[cfg(feature = "k8s")]
 pub mod k8s;

--- a/super-agent/src/sub_agent/supervisor.rs
+++ b/super-agent/src/sub_agent/supervisor.rs
@@ -1,0 +1,15 @@
+use super::{
+    effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssemblerError},
+    error::SubAgentBuilderError,
+};
+
+pub trait SupervisorBuilder {
+    type Supervisor;
+    type OpAMPClient;
+
+    fn build_supervisor(
+        &self,
+        effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
+        maybe_opamp_client: &Option<Self::OpAMPClient>,
+    ) -> Result<Option<Self::Supervisor>, SubAgentBuilderError>;
+}


### PR DESCRIPTION
This PR introduces a new SupervisorBuilder trait to abstract the creation of supervisors for both onhost and k8s. Currently the SupervisorBuilder is simply created in each SubAgent builder, and then it is executed in order to create the corresponding supervisor. However, this abstraction will easy moving the supervisor creation responsibility to each particular sub-agent (which will be needed in a follow-up change).