### PR TITLE
feat(k8s): agents operator agent type

### DIFF
--- a/super-agent/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -11,7 +11,7 @@ variables:
       description: "New Relic Agents K8s Operator chart version"
       type: string
       required: true
-      default: "0.12.0"
+      default: "0.13.0"
 deployment:
   k8s:
     health:


### PR DESCRIPTION
This adds the K8s APM Agents Operator as a new agent type for Agent Control. I have tested the Operator deployed this way is able to instrument Java applications on a similar way as done [here](https://github.com/newrelic/k8s-agents-operator/blob/main/charts/k8s-agents-operator/README.md). Additional steps required for reproducing a working example, that we'll need to support from AC code, are:

- [Add a custom resource (already defined as part of deploying the operator chart) for the desired instrumentation languages.](https://github.com/newrelic/k8s-agents-operator/blob/main/charts/k8s-agents-operator/README.md#monitored-namespaces)