### PR TITLE
fix: honor defaults for yaml variable kind (NR-329462)

### DIFF
--- a/super-agent/src/agent_type/error.rs
+++ b/super-agent/src/agent_type/error.rs
@@ -7,10 +7,12 @@ use thiserror::Error;
 pub enum AgentTypeError {
     #[error("Error while parsing: `{0}`")]
     SerdeYaml(#[from] serde_yaml::Error),
-    #[error("Missing required key in agent type config values: `{0}`")]
-    MissingRequiredKey(String),
+    #[error("Missing value for key: `{0}`")]
+    MissingValue(String),
     #[error("Unexpected key in agent type config values: {0}")]
     UnexpectedValueKey(String),
+    #[error("Unexpected value for key: key({0}) val({1})")]
+    UnexpectedValueForKey(String, String),
     #[error("I/O error: `{0}`")]
     IOError(#[from] io::Error),
     #[error("Missing required template key: `{0}`")]

--- a/super-agent/src/agent_type/variable/definition.rs
+++ b/super-agent/src/agent_type/variable/definition.rs
@@ -86,6 +86,15 @@ mod test {
 
     use super::VariableDefinition;
 
+    impl From<KindValue<serde_yaml::Value>> for VariableDefinition {
+        fn from(kind_value: KindValue<serde_yaml::Value>) -> Self {
+            Self {
+                description: String::new(),
+                kind: Kind::Yaml(kind_value),
+            }
+        }
+    }
+
     impl VariableDefinition {
         pub(crate) fn new<T>(
             description: String,


### PR DESCRIPTION
Whenever a yaml kind of variable was being used without a defined value in the config, there was a panic.

example of variable:
```yaml
variables:
  k8s:
    my-var:
      description: ""
      type: yaml
      required: false
      default: 
        enabled: true
deployment:
  k8s:
    objects:
      release:
        values:
            ${nr-var:my-var}
```
