### PR TITLE
report subagent versions on host

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,10 @@
 project_name: newrelic-super-agent
+env:
+  # Artifacts Versions
+  # Currently the only way to update the sub-agent versions is rebuild the binary of the super-agent
+  - NEWRELIC_INFRA_AGENT_VERSION=1.57.0
+  - NR_OTEL_COLLECTOR_VERSION=0.8.0
+  #
 builds:
   - id: newrelic-super-agent
     main: ./build/dummy.go
@@ -16,6 +22,8 @@ builds:
             - BUILD_FEATURE=onhost
             - BIN=newrelic-super-agent
             - SUPER_AGENT_VERSION={{ .Version }}
+            - NEWRELIC_INFRA_AGENT_VERSION={{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}
+            - NR_OTEL_COLLECTOR_VERSION={{ .Env.NR_OTEL_COLLECTOR_VERSION }}
             - PKG=newrelic_super_agent
         - cmd: sh ./build/scripts/replace_go_with_rust.sh
           env:
@@ -25,6 +33,7 @@ builds:
         - cmd: sh ./build/scripts/download_embedded.sh
           env:
             - ARCH={{ .Arch }}
+            - ARTIFACTS_VERSIONS={"newrelic-infra":"{{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}","nr-otel-collector":"{{ .Env.NR_OTEL_COLLECTOR_VERSION }}"}
         - cmd: sh ./build/scripts/download_collector_config.sh
   - id: newrelic-config-migrate
     main: ./build/dummy.go

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["NEWRELIC_INFRA_AGENT_VERSION", "NR_OTEL_COLLECTOR_VERSION"]

--- a/build/embedded/config_test.go
+++ b/build/embedded/config_test.go
@@ -27,13 +27,11 @@ destination: "./artifacts/{{.Arch}}"
 # artifacts
 artifacts:
   - name: newrelic-infra
-    version: 1.42.2
     files:
       - name: newrelic-infra binary
         src: newrelic-infra/usr/bin/newrelic-infra
 
   - name: nr-otel-collector
-    version: 0.1.0
     files:
       - name: nr-otel-collector-binary
         src: nr-otel-collector/usr/bin/nr-otel-collector
@@ -94,13 +92,11 @@ destination: "./artifacts/{{.Arch}}"
 # artifacts
 artifacts:
   - name: newrelic-infra
-    version: 1.42.2
     files:
       - name: newrelic-infra binary
         src: newrelic-infra/usr/bin/newrelic-infra
 
   - name: nr-otel-collector
-    version: 0.1.0
     files:
       - name: nr-otel-collector-binary
         src: nr-otel-collector/usr/bin/nr-otel-collector
@@ -161,13 +157,11 @@ destination: "./artifacts/{{.Arch}}"
 # artifacts
 artifacts:
   - name: newrelic-infra
-    version: 1.42.2
     files:
       - name: newrelic-infra binary
         src: newrelic-infra/usr/bin/newrelic-infra
 
   - name: nr-otel-collector
-    version: 0.1.0
     url: "http://www.some.url/and/path"
     files:
       - name: nr-otel-collector-binary
@@ -257,7 +251,12 @@ destination: ""
 	for i := range testCases {
 		testCase := testCases[i]
 		t.Run(testCase.name, func(t *testing.T) {
-			conf, err := config(testCase.staging, testCase.arch, []byte(testCase.content))
+			conf, err := config(
+				testCase.staging,
+				testCase.arch,
+				map[string]string{"newrelic-infra": "1.42.2", "nr-otel-collector": "0.1.0"},
+				[]byte(testCase.content),
+			)
 			if testCase.expectedErr == nil {
 				assert.NoError(t, err)
 				assert.Equal(t, testCase.expectedConf, conf)

--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -11,7 +11,7 @@ staging_url: https://nr-downloads-ohai-staging.s3.amazonaws.com/infrastructure_a
 # Individual entries may override any of the values defined above.
 artifacts:
   - name: newrelic-infra
-    version: 1.57.0
+    # Version now should be added in goreleaser.yaml global envs
     url: https://github.com/newrelic/infrastructure-agent/releases/download/{{.Version | trimv}}/newrelic-infra_systemd_{{.Version | trimv}}_{{.Arch}}.deb
     files:
       # infra-agent
@@ -56,7 +56,7 @@ artifacts:
         dest: artifacts/{{.Arch}}/fluent-bit
 
   - name: nr-otel-collector
-    version: 0.8.0
+    # Version now should be added in goreleaser.yaml global envs
     url: https://github.com/newrelic/opentelemetry-collector-releases/releases/download/nr-otel-collector-{{.Version | trimv}}/nr-otel-collector_{{.Version | trimv}}_linux_{{.Arch}}.deb
     files:
       - name: nt-otel-collector binary

--- a/build/embedded/main.go
+++ b/build/embedded/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -19,8 +20,18 @@ func main() {
 	arch := flag.String("arch", "amd64", "architecture")
 	flag.Parse()
 
+	var versionMap map[string]string
+	err := json.Unmarshal([]byte(os.Getenv("ARTIFACTS_VERSIONS")), &versionMap)
+	if err != nil {
+		log.Fatalf("cannot parse ARTIFACTS_VERSIONS env var: %v", err)
+	}
+
 	// Config
-	cnf, err := configFromFile(*staging, *arch)
+	cnf, err := configFromFile(
+		*staging,
+		*arch,
+		versionMap,
+	)
 	if err != nil {
 		log.Fatalf("cannot parse config: %v", err)
 	}

--- a/build/scripts/build_binary.sh
+++ b/build/scripts/build_binary.sh
@@ -27,6 +27,7 @@ export GIT_COMMIT=$( git rev-parse HEAD )
 export SUPER_AGENT_VERSION=${SUPER_AGENT_VERSION:-development}
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export RUSTFLAGS="-C target-feature=+crt-static"
+export CROSS_CONFIG=${CROSS_CONFIG:-"./Cross.toml"}
 
 cross build --target "${ARCH_NAME}-unknown-linux-musl" --profile "${BUILD_MODE}" --features "${BUILD_FEATURE}" --package "${PKG}" --bin "${BIN}"
 

--- a/build/scripts/download_embedded.sh
+++ b/build/scripts/download_embedded.sh
@@ -5,7 +5,7 @@ ARCH="${ARCH:-amd64}"
 GOCACHE=/tmp/.gocache
 
 # download assets
-docker run --rm --user "$(id -u)":"$(id -g)" -e GOCACHE="$GOCACHE" -e ARCH="$ARCH" -e STAGING="$STAGING" -v "$PWD":/usr/src/app -w /usr/src/app golang:1.20 make build/embedded
+docker run --rm --user "$(id -u)":"$(id -g)" -e GOCACHE="$GOCACHE" -e ARCH="$ARCH" -e STAGING="$STAGING" -e ARTIFACTS_VERSIONS="${ARTIFACTS_VERSIONS}" -v "$PWD":/usr/src/app -w /usr/src/app golang:1.20 make build/embedded
 
 # validate
 docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "apt-get update && apt-get install tree -y && tree ./build/embedded"

--- a/super-agent/src/cli/one_shot_operation.rs
+++ b/super-agent/src/cli/one_shot_operation.rs
@@ -1,4 +1,4 @@
-use crate::utils::binary_metadata::binary_metadata;
+use crate::utils::binary_metadata::{binary_metadata, sub_agent_versions};
 
 use super::Cli;
 
@@ -13,6 +13,8 @@ impl OneShotCommand {
         match self {
             OneShotCommand::PrintVersion => {
                 println!("{}", binary_metadata());
+                #[cfg(feature = "onhost")]
+                println!("{}", sub_agent_versions());
             }
             OneShotCommand::PrintDebugInfo(cli) => {
                 println!("Printing debug info");

--- a/super-agent/src/sub_agent/config_validator.rs
+++ b/super-agent/src/sub_agent/config_validator.rs
@@ -9,9 +9,7 @@ use crate::sub_agent::validation_regexes::{
     REGEX_NRI_FLEX, REGEX_OTEL_ENDPOINT, REGEX_VALID_OTEL_ENDPOINT,
 };
 use crate::super_agent::config::AgentTypeFQN;
-
-pub const FQN_NAME_INFRA_AGENT: &str = "com.newrelic.infrastructure_agent";
-pub const FQN_NAME_NRDOT: &str = "io.opentelemetry.collector";
+use crate::super_agent::defaults::{FQN_NAME_INFRA_AGENT, FQN_NAME_NRDOT};
 
 #[derive(Error, Debug)]
 pub enum ValidatorError {

--- a/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
+++ b/super-agent/src/sub_agent/event_handler/opamp/remote_config.rs
@@ -121,11 +121,10 @@ mod tests {
     use crate::opamp::effective_config::loader::tests::MockEffectiveConfigLoaderMock;
     use crate::opamp::hash_repository::repository::HashRepositoryError;
     use crate::opamp::remote_config::RemoteConfigError;
-    use crate::sub_agent::config_validator::{
-        ConfigValidator, ValidatorError, FQN_NAME_INFRA_AGENT,
-    };
+    use crate::sub_agent::config_validator::{ConfigValidator, ValidatorError};
     use crate::sub_agent::error::SubAgentError;
     use crate::super_agent::config::{AgentID, AgentTypeFQN};
+    use crate::super_agent::defaults::FQN_NAME_INFRA_AGENT;
     use crate::values::yaml_config::{YAMLConfig, YAMLConfigError};
     use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
     use crate::{

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -16,7 +16,7 @@ use crate::sub_agent::effective_agents_assembler::{
 use crate::sub_agent::supervisor::SupervisorBuilder;
 use crate::sub_agent::SubAgentCallbacks;
 use crate::super_agent::config::{AgentID, K8sConfig, SubAgentConfig};
-use crate::super_agent::defaults::CLUSTER_NAME_ATTRIBUTE_KEY;
+use crate::super_agent::defaults::{CLUSTER_NAME_ATTRIBUTE_KEY, OPAMP_SERVICE_VERSION};
 use crate::values::yaml_config_repository::YAMLConfigRepository;
 use crate::{
     opamp::client_builder::OpAMPClientBuilder,
@@ -112,6 +112,10 @@ where
                     self.instance_id_getter,
                     agent_id.clone(),
                     &sub_agent_config.agent_type,
+                    HashMap::from([(
+                        OPAMP_SERVICE_VERSION.to_string(),
+                        sub_agent_config.agent_type.version().into(),
+                    )]),
                     HashMap::from([(
                         CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
                         DescriptionValueType::String(self.k8s_config.cluster_name.to_string()),
@@ -462,6 +466,10 @@ pub mod test {
         let start_settings = start_settings(
             instance_id.clone(),
             &sub_agent_config.agent_type,
+            HashMap::from([(
+                OPAMP_SERVICE_VERSION.to_string(),
+                sub_agent_config.agent_type.version().into(),
+            )]),
             HashMap::from([
                 (
                     CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),

--- a/super-agent/src/sub_agent/validation_regexes.rs
+++ b/super-agent/src/sub_agent/validation_regexes.rs
@@ -68,10 +68,9 @@ mod test {
     use crate::opamp::remote_config::{ConfigurationMap, RemoteConfig};
     use crate::opamp::remote_config_hash::Hash;
     use crate::sub_agent::config_validator::test::VALID_ONHOST_NRDOT_CONFIG;
-    use crate::sub_agent::config_validator::{
-        ConfigValidator, ValidatorError, FQN_NAME_INFRA_AGENT, FQN_NAME_NRDOT,
-    };
+    use crate::sub_agent::config_validator::{ConfigValidator, ValidatorError};
     use crate::super_agent::config::{AgentID, AgentTypeFQN};
+    use crate::super_agent::defaults::{FQN_NAME_INFRA_AGENT, FQN_NAME_NRDOT};
     use assert_matches::assert_matches;
     use std::collections::HashMap;
 

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -1,11 +1,22 @@
 use opamp_client::capabilities;
 use opamp_client::opamp::proto::AgentCapabilities;
 use opamp_client::operation::capabilities::Capabilities;
+use opamp_client::operation::settings::DescriptionValueType;
 
 pub static SUPER_AGENT_ID: &str = "super-agent";
 pub static SUPER_AGENT_TYPE: &str = "com.newrelic.super_agent";
 pub static SUPER_AGENT_NAMESPACE: &str = "newrelic";
 pub static SUPER_AGENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub static NEWRELIC_INFRA_AGENT_VERSION: &str =
+    konst::option::unwrap_or!(option_env!("NEWRELIC_INFRA_AGENT_VERSION"), "0.0.0");
+pub static NR_OTEL_COLLECTOR_VERSION: &str =
+    konst::option::unwrap_or!(option_env!("NR_OTEL_COLLECTOR_VERSION"), "0.0.0");
+
+// Keys identifying attributes
+pub static OPAMP_SERVICE_NAME: &str = "service.name";
+pub static OPAMP_SERVICE_VERSION: &str = "service.version";
+pub static OPAMP_SERVICE_NAMESPACE: &str = "service.namespace";
+pub static OPAMP_AGENT_VERSION_ATTRIBUTE_KEY: &str = "agent.version";
 
 // Auth
 pub static AUTH_PRIVATE_KEY_FILE_NAME: &str = "auth_key";
@@ -52,4 +63,19 @@ pub fn default_capabilities() -> Capabilities {
         AgentCapabilities::ReportsRemoteConfig,
         AgentCapabilities::ReportsStatus
     )
+}
+
+pub const FQN_NAME_INFRA_AGENT: &str = "com.newrelic.infrastructure_agent";
+pub const FQN_NAME_NRDOT: &str = "io.opentelemetry.collector";
+
+pub fn sub_agent_version(agent_type: &str) -> Option<DescriptionValueType> {
+    match agent_type {
+        FQN_NAME_INFRA_AGENT => Some(DescriptionValueType::String(
+            NEWRELIC_INFRA_AGENT_VERSION.to_string(),
+        )),
+        FQN_NAME_NRDOT => Some(DescriptionValueType::String(
+            NR_OTEL_COLLECTOR_VERSION.to_string(),
+        )),
+        _ => None,
+    }
 }

--- a/super-agent/src/super_agent/run/k8s.rs
+++ b/super-agent/src/super_agent/run/k8s.rs
@@ -9,7 +9,10 @@ use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
 use crate::super_agent::config::AgentID;
 use crate::super_agent::config_storer::loader_storer::SuperAgentConfigLoader;
 use crate::super_agent::config_storer::store::SuperAgentConfigStore;
-use crate::super_agent::defaults::{FLEET_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY};
+use crate::super_agent::defaults::{
+    FLEET_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    SUPER_AGENT_VERSION,
+};
 use crate::super_agent::run::SuperAgentRunner;
 use crate::super_agent::{super_agent_fqn, SuperAgent};
 use crate::{
@@ -102,6 +105,10 @@ impl SuperAgentRunner {
                     &instance_id_getter,
                     AgentID::new_super_agent_id(),
                     &super_agent_fqn(),
+                    HashMap::from([(
+                        OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
+                        DescriptionValueType::String(SUPER_AGENT_VERSION.to_string()),
+                    )]),
                     non_identifying_attributes,
                 )
             })

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -8,7 +8,8 @@ use crate::super_agent::config::AgentID;
 use crate::super_agent::config_storer::loader_storer::SuperAgentConfigLoader;
 use crate::super_agent::config_storer::store::SuperAgentConfigStore;
 use crate::super_agent::defaults::{
-    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, SUB_AGENT_DIR,
+    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, SUB_AGENT_DIR, SUPER_AGENT_VERSION,
 };
 use crate::super_agent::run::SuperAgentRunner;
 use crate::super_agent::{super_agent_fqn, SuperAgent};
@@ -113,6 +114,10 @@ impl SuperAgentRunner {
                     &instance_id_getter,
                     AgentID::new_super_agent_id(),
                     &super_agent_fqn(),
+                    HashMap::from([(
+                        OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
+                        DescriptionValueType::String(SUPER_AGENT_VERSION.to_string()),
+                    )]),
                     non_identifying_attributes,
                 )
             })

--- a/super-agent/src/utils/binary_metadata.rs
+++ b/super-agent/src/utils/binary_metadata.rs
@@ -1,3 +1,7 @@
+use crate::super_agent::defaults::{
+    FQN_NAME_INFRA_AGENT, FQN_NAME_NRDOT, NEWRELIC_INFRA_AGENT_VERSION, NR_OTEL_COLLECTOR_VERSION,
+};
+
 pub(crate) const VERSION: &str =
     konst::option::unwrap_or!(option_env!("SUPER_AGENT_VERSION"), "development");
 pub(crate) const RUST_VERSION: &str =
@@ -9,4 +13,11 @@ pub(crate) const BUILD_DATE: &str =
 
 pub fn binary_metadata() -> String {
     format!("New Relic Super Agent Version: {VERSION}, Rust Version: {RUST_VERSION}, GitCommit: {GIT_COMMIT}, BuildDate: {BUILD_DATE}")
+}
+pub fn sub_agent_versions() -> String {
+    format!(
+        r#"New Relic Sub Agent Versions:
+    {FQN_NAME_INFRA_AGENT} : {NEWRELIC_INFRA_AGENT_VERSION}
+    {FQN_NAME_NRDOT} : {NR_OTEL_COLLECTOR_VERSION}"#
+    )
 }

--- a/super-agent/tests/common/attributes.rs
+++ b/super-agent/tests/common/attributes.rs
@@ -1,0 +1,108 @@
+use crate::common::opamp::FakeServer;
+use newrelic_super_agent::opamp::instance_id::InstanceID;
+use newrelic_super_agent::super_agent::defaults::{
+    HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_NAME,
+    OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, PARENT_AGENT_ID_ATTRIBUTE_KEY,
+};
+use nix::unistd::gethostname;
+use opamp_client::opamp::proto::any_value::Value;
+use opamp_client::opamp::proto::any_value::Value::BytesValue;
+use opamp_client::opamp::proto::{AnyValue, KeyValue};
+pub fn check_latest_identifying_attributes_match_expected(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected_identifying_attributes: Vec<KeyValue>,
+) -> Result<(), String> {
+    let current_attributes = opamp_server
+        .get_attributes(instance_id)
+        .ok_or_else(|| "Identifying attributes not found".to_string())?;
+
+    check_opamp_attributes(
+        expected_identifying_attributes.clone(),
+        current_attributes.identifying_attributes.clone(),
+    )
+    .map_err(|e| format!("Identifying {}", e))
+}
+pub fn check_latest_non_identifying_attributes_match_expected(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected_non_identifying_attributes: Vec<KeyValue>,
+) -> Result<(), String> {
+    let current_attributes = opamp_server
+        .get_attributes(instance_id)
+        .ok_or_else(|| "Non identifying attributes not found".to_string())?;
+
+    check_opamp_attributes(
+        expected_non_identifying_attributes.clone(),
+        current_attributes.non_identifying_attributes.clone(),
+    )
+    .map_err(|e| format!("Non identifying {}", e))
+}
+fn check_opamp_attributes(
+    mut expected_vec: Vec<KeyValue>,
+    mut current_vec: Vec<KeyValue>,
+) -> Result<(), String> {
+    expected_vec.sort_by(|a, b| a.key.cmp(&b.key));
+    current_vec.sort_by(|a, b| a.key.cmp(&b.key));
+    if expected_vec != current_vec {
+        return Err(format!(
+            "not as expected, Expected: {:?}, Found: {:?}",
+            expected_vec, current_vec
+        ));
+    }
+    Ok(())
+}
+pub fn get_expected_identifying_attributes(
+    namespace: String,
+    service_name: String,
+    service_version: String,
+    agent_version: Option<String>,
+) -> Vec<KeyValue> {
+    let mut y: Vec<KeyValue> = Vec::from([
+        (KeyValue {
+            key: OPAMP_SERVICE_NAMESPACE.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(namespace)),
+            }),
+        }),
+        (KeyValue {
+            key: OPAMP_SERVICE_NAME.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(service_name)),
+            }),
+        }),
+        (KeyValue {
+            key: OPAMP_SERVICE_VERSION.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(service_version)),
+            }),
+        }),
+    ]);
+    if let Some(agent_version) = agent_version {
+        y.push(KeyValue {
+            key: OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(agent_version)),
+            }),
+        })
+    }
+    y
+}
+pub fn get_expected_non_identifying_attributes(instace_id: InstanceID) -> Vec<KeyValue> {
+    Vec::from([
+        (KeyValue {
+            key: HOST_NAME_ATTRIBUTE_KEY.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(
+                    gethostname().unwrap_or_default().into_string().unwrap(),
+                )),
+            }),
+        }),
+        (KeyValue {
+            key: PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
+            value: Some(AnyValue {
+                value: Some(BytesValue(instace_id.into())),
+            }),
+        }),
+    ])
+}

--- a/super-agent/tests/common/mod.rs
+++ b/super-agent/tests/common/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod attributes;
 /// Includes a OpAMP mock server to test scenarios involving OpAMP.
 pub(super) mod effective_config;
 pub(super) mod global_logger;

--- a/super-agent/tests/on_host/scenarios.rs
+++ b/super-agent/tests/on_host/scenarios.rs
@@ -1,3 +1,4 @@
+mod attributes;
 mod health_check;
 mod opamp;
 mod restarting_processes;

--- a/super-agent/tests/on_host/scenarios/attributes.rs
+++ b/super-agent/tests/on_host/scenarios/attributes.rs
@@ -1,0 +1,141 @@
+use crate::common::attributes::{
+    check_latest_identifying_attributes_match_expected,
+    check_latest_non_identifying_attributes_match_expected, get_expected_identifying_attributes,
+    get_expected_non_identifying_attributes,
+};
+use crate::common::opamp::FakeServer;
+use crate::common::retry::retry;
+use crate::common::super_agent::start_super_agent_with_custom_config;
+use crate::on_host::tools::config::create_super_agent_config;
+use crate::on_host::tools::instance_id::get_instance_id;
+use newrelic_super_agent::super_agent::config::AgentID;
+use newrelic_super_agent::super_agent::defaults::FQN_NAME_INFRA_AGENT;
+use newrelic_super_agent::super_agent::run::BasePaths;
+use std::time::Duration;
+use tempfile::tempdir;
+
+const DEFAULT_VERSION: &str = "0.3.0";
+const DEFAULT_NAMESPACE: &str = "namespace";
+const DEFAULT_NAME: &str = "name";
+
+/// Given an agent type that we don't know we are going to check if the default
+/// identifying and non identifying attributes are what we expect.
+#[cfg(unix)]
+#[test]
+fn test_attributes_from_non_existing_agent_type() {
+    let opamp_server = FakeServer::start_new();
+
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    let agents = format!(
+        r#"
+  test-agent:
+    agent_type: "{}/{}:{}"
+"#,
+        DEFAULT_NAMESPACE, DEFAULT_NAME, DEFAULT_VERSION
+    );
+
+    create_super_agent_config(
+        opamp_server.endpoint(),
+        agents.to_string(),
+        local_dir.path().to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+    let _super_agent = start_super_agent_with_custom_config(base_paths.clone());
+
+    let super_agent_instance_id_ac =
+        get_instance_id(&AgentID::new_super_agent_id(), base_paths.clone());
+
+    let super_agent_instance_id =
+        get_instance_id(&AgentID::new("test-agent").unwrap(), base_paths.clone());
+
+    let expected_identifying_attributes = get_expected_identifying_attributes(
+        DEFAULT_NAMESPACE.to_string(),
+        DEFAULT_NAME.to_string(),
+        DEFAULT_VERSION.to_string(),
+        None,
+    );
+
+    let expected_non_identifying_attributes =
+        get_expected_non_identifying_attributes(super_agent_instance_id_ac);
+
+    retry(30, Duration::from_secs(1), || {
+        check_latest_identifying_attributes_match_expected(
+            &opamp_server,
+            &super_agent_instance_id,
+            expected_identifying_attributes.clone(),
+        )?;
+        check_latest_non_identifying_attributes_match_expected(
+            &opamp_server,
+            &super_agent_instance_id,
+            expected_non_identifying_attributes.clone(),
+        )?;
+        Ok(())
+    });
+}
+
+/// Given an agent type that we know we are going to check if the default
+/// identifying and non identifying attributes are what we expect plus
+/// the "agent.version" related with the agent type.
+#[cfg(unix)]
+#[test]
+fn test_attributes_from_an_existing_agent_type() {
+    let opamp_server = FakeServer::start_new();
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    let agents = format!(
+        r#"
+  test-agent:
+    agent_type: "{}/{}:{}"
+"#,
+        DEFAULT_NAMESPACE, FQN_NAME_INFRA_AGENT, DEFAULT_VERSION
+    );
+
+    create_super_agent_config(
+        opamp_server.endpoint(),
+        agents.to_string(),
+        local_dir.path().to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+
+    let _super_agent = start_super_agent_with_custom_config(base_paths.clone());
+    let super_agent_instance_id_ac =
+        get_instance_id(&AgentID::new_super_agent_id(), base_paths.clone());
+    let super_agent_instance_id =
+        get_instance_id(&AgentID::new("test-agent").unwrap(), base_paths.clone());
+    let expected_identifying_attributes = get_expected_identifying_attributes(
+        DEFAULT_NAMESPACE.to_string(),
+        FQN_NAME_INFRA_AGENT.to_string(),
+        DEFAULT_VERSION.to_string(),
+        Some("0.0.0".to_string()),
+    );
+
+    let expected_non_identifying_attributes =
+        get_expected_non_identifying_attributes(super_agent_instance_id_ac);
+
+    retry(30, Duration::from_secs(1), || {
+        check_latest_identifying_attributes_match_expected(
+            &opamp_server,
+            &super_agent_instance_id,
+            expected_identifying_attributes.clone(),
+        )?;
+        check_latest_non_identifying_attributes_match_expected(
+            &opamp_server,
+            &super_agent_instance_id,
+            expected_non_identifying_attributes.clone(),
+        )?;
+        Ok(())
+    })
+}


### PR DESCRIPTION
The idea is to have only one single point where the versions for the agents are informed:
- newrelic-infra (1.57.0)
- nr-otel-collector (0.8.0)

These versions were in embedded.yaml now are in .gorelease.yaml
<img width="333" alt="image" src="https://github.com/user-attachments/assets/4ada0b53-b25c-4266-84cf-1ac692799be5">

The current flow is from the .gorelease.yaml in env vars the version are spread to: 
 - GoReelase step
  
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/031b734f-ead5-435c-b530-c76cb21d424a">

- Build_binary.sh 
<img width="459" alt="image" src="https://github.com/user-attachments/assets/042c72d6-efad-471a-a5db-277ef833d9ce">

- - New Cross.toml
<img width="630" alt="image" src="https://github.com/user-attachments/assets/3d768425-d012-4c92-af3a-428c05fdeb9e">


Now the super agent on_host nows depends the agent type what field should be added to the 'identifying_attributes' field into the opam client.
<img width="749" alt="image" src="https://github.com/user-attachments/assets/10fc4001-5237-4f26-8068-4dfb73baee89">

And also now the version of the super agent is added in their identifying_attributes too deleting the Service.version label