### PR TITLE
Revert "enable info level logging for all crates (#771)"

### DIFF
--- a/super-agent/src/logging/config.rs
+++ b/super-agent/src/logging/config.rs
@@ -117,7 +117,7 @@ impl LoggingConfig {
         let level = self.level.as_level().to_string().to_lowercase();
 
         Ok(EnvFilter::builder()
-            .with_default_directive(LevelFilter::INFO.into())
+            .with_default_directive(LevelFilter::OFF.into())
             .parse_lossy("")
             .add_directive(
                 format!("newrelic_super_agent={}", level)
@@ -197,7 +197,7 @@ mod test {
             TestCase {
                 name: "everything default",
                 config: Default::default(),
-                expected: "newrelic_super_agent=info,info",
+                expected: "newrelic_super_agent=info,off",
             },
             TestCase {
                 name: "insecure fine grained overrides any logging",


### PR DESCRIPTION
This reverts commit 065ed044ddb7f4d446c0da358b3e90d3889cc32c.

# Why not have this enabled by default?
- Dependency logs might have poor context, so we ended up printing logs that are not relevant
- They might contain sensible information, so we would not be honoring `insecure_fine_grained_level`
- They could be spammy 
- Dependency bumps could introduce any of the mentioned points in just a patch version 

some examples that triggered this:
```
//tokio log
2024-10-23T16:15:30  INFO Tokio runtime found; starting in existing Tokio runtime
//kube-rs log
2024-10-23T16:16:52  WARN Unsuccessful data error parse: 404 page not found
```