### PR TITLE
chore: improve unhealthy error log

### DIFF
--- a/super-agent/src/sub_agent/event_processor.rs
+++ b/super-agent/src/sub_agent/event_processor.rs
@@ -157,7 +157,7 @@ where
                             },
                             Ok(SubAgentInternalEvent::AgentBecameUnhealthy(unhealthy, start_time))=>{
                                 debug!(select_arm = "sub_agent_internal_consumer", "UnhealthyAgent");
-                                warn!(agent_id = %self.agent_id, "sub agent became unhealthy!");
+                                warn!(agent_id = %self.agent_id, last_error= %unhealthy.last_error(), "sub agent became unhealthy!");
                                 let _ = self.on_health(HealthWithStartTime::new(unhealthy.into(), start_time))
                                     .inspect_err(|e| error!(error = %e, select_arm = "sub_agent_internal_consumer", "processing unhealthy status"));
                             }


### PR DESCRIPTION
Add last error context to log when a sub-agent is unhealth
before 
```
T16:51:48  INFO Starting the agents supervisor runtime
2024-10-24T16:51:48  INFO Agents supervisor runtime successfully started
2024-10-24T16:52:18  WARN sub agent became unhealthy!, agent_id: nri-k8s
```
After
```
2024-10-24T17:05:03  INFO Starting the agents supervisor runtime
2024-10-24T17:05:03  INFO Agents supervisor runtime successfully started
2024-10-24T17:05:33  WARN sub agent became unhealthy!, agent_id: nri-k8s, last_error: HelmRelease not ready: Helm install failed for release default/nri-k8s with chart nri-bundle@5.0.95: execution error at (nri-bundle/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml:25:34): There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required.
```