### PR TITLE
test: add cr based agent type test (NR-320004)

### DIFF
--- a/super-agent/tests/k8s/client.rs
+++ b/super-agent/tests/k8s/client.rs
@@ -1,6 +1,6 @@
 use super::tools::{
-    foo_crd::{create_foo_cr, foo_type_meta, get_dynamic_api_foo, Foo, FooSpec},
     k8s_env::K8sEnv,
+    test_crd::{create_foo_cr, foo_type_meta, get_dynamic_api_foo, Foo, FooSpec},
 };
 use assert_matches::assert_matches;
 use kube::api::{Api, DeleteParams, TypeMeta};

--- a/super-agent/tests/k8s/data/bar_cr_agent_type.yml
+++ b/super-agent/tests/k8s/data/bar_cr_agent_type.yml
@@ -1,0 +1,24 @@
+namespace: newrelic
+name: com.newrelic.bar-cr-agent
+version: 0.0.1
+variables:
+  k8s:
+    data:
+      description: "bar data"
+      type: string
+      required: false
+      default: "default"
+deployment:
+  k8s:
+    health:
+      interval: 30s
+    objects:
+      bar_cr:
+        # This CRD is created in the cluster when initializing the test environment.
+        apiVersion: newrelic.com/v1
+        kind: Bar
+        metadata:
+          name: ${nr-sub:agent_id}
+        spec:
+          data: ${nr-var:data}
+

--- a/super-agent/tests/k8s/data/foo_cr_agent_type.yml
+++ b/super-agent/tests/k8s/data/foo_cr_agent_type.yml
@@ -1,0 +1,24 @@
+namespace: newrelic
+name: com.newrelic.foo-cr-agent
+version: 0.0.1
+variables:
+  k8s:
+    data:
+      description: "foo data"
+      type: string
+      required: false
+      default: "default"
+deployment:
+  k8s:
+    health:
+      interval: 30s
+    objects:
+      foo_cr:
+        # This CRD is created in the cluster when initializing the test environment.
+        apiVersion: newrelic.com/v1
+        kind: Foo
+        metadata:
+          name: ${nr-sub:agent_id}
+        spec:
+          data: ${nr-var:data}
+

--- a/super-agent/tests/k8s/data/k8s_opamp_cr_subagent_installed_before_crd/local-data-super-agent.template
+++ b/super-agent/tests/k8s/data/k8s_opamp_cr_subagent_installed_before_crd/local-data-super-agent.template
@@ -1,0 +1,11 @@
+opamp:
+  endpoint: <opamp-endpoint>
+  headers:
+    api-key: test-api-key
+k8s:
+  namespace: <ns>
+  cluster_name: <cluster-name>
+  cr_type_meta:
+  - apiVersion: newrelic.com/v1
+    kind: Bar
+agents: {}

--- a/super-agent/tests/k8s/data/k8s_opamp_foo_cr_subagent/local-data-super-agent.template
+++ b/super-agent/tests/k8s/data/k8s_opamp_foo_cr_subagent/local-data-super-agent.template
@@ -1,0 +1,11 @@
+opamp:
+  endpoint: <opamp-endpoint>
+  headers:
+    api-key: test-api-key
+k8s:
+  namespace: <ns>
+  cluster_name: <cluster-name>
+  cr_type_meta:
+  - apiVersion: newrelic.com/v1
+    kind: Foo
+agents: {}

--- a/super-agent/tests/k8s/garbage_collector.rs
+++ b/super-agent/tests/k8s/garbage_collector.rs
@@ -1,8 +1,8 @@
 use crate::common::runtime::{block_on, tokio_runtime};
 
 use super::tools::{
-    foo_crd::{create_foo_cr, foo_type_meta, Foo},
     k8s_env::K8sEnv,
+    test_crd::{create_foo_cr, foo_type_meta, Foo},
 };
 use kube::{api::Api, core::TypeMeta};
 use mockall::{mock, Sequence};

--- a/super-agent/tests/k8s/scenarios.rs
+++ b/super-agent/tests/k8s/scenarios.rs
@@ -1,2 +1,3 @@
+mod cr_based_agents;
 mod no_opamp;
 mod opamp;

--- a/super-agent/tests/k8s/scenarios/cr_based_agents.rs
+++ b/super-agent/tests/k8s/scenarios/cr_based_agents.rs
@@ -1,0 +1,171 @@
+use crate::k8s::tools::k8s_api::check_config_map_exist;
+use crate::k8s::tools::super_agent::BAR_CR_AGENT_TYPE_PATH;
+use crate::k8s::tools::test_crd::{create_crd, delete_crd, Foo};
+use crate::k8s::tools::{
+    instance_id,
+    k8s_env::K8sEnv,
+    super_agent::{
+        start_super_agent_with_testdata_config, wait_until_super_agent_with_opamp_is_started,
+    },
+};
+use crate::{
+    common::{
+        opamp::{ConfigResponse, FakeServer},
+        retry::retry,
+        runtime::block_on,
+    },
+    k8s::tools::super_agent::FOO_CR_AGENT_TYPE_PATH,
+};
+use kube::{Api, CustomResource, CustomResourceExt};
+use newrelic_super_agent::super_agent::config::AgentID;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use std::time::Duration;
+use tempfile::tempdir;
+
+/// This scenario tests an Agent type which only create a CR when the CRD already exists.
+/// The sub-agent is added from remote config and then removed.
+#[test]
+#[ignore = "needs k8s cluster"]
+#[serial]
+fn k8s_opamp_foo_cr_subagent() {
+    let test_name = "k8s_opamp_foo_cr_subagent";
+
+    // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
+    let mut server = FakeServer::start_new();
+
+    // setup the k8s environment
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    let _sa = start_super_agent_with_testdata_config(
+        test_name,
+        FOO_CR_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        Some(&server.endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+    wait_until_super_agent_with_opamp_is_started(k8s.client.clone(), namespace.as_str());
+
+    let instance_id = instance_id::get_instance_id(&namespace, &AgentID::new_super_agent_id());
+
+    server.set_config_response(
+        instance_id.clone(),
+        ConfigResponse::from(
+            r#"
+agents:
+  foo-agent:
+    agent_type: "newrelic/com.newrelic.foo-cr-agent:0.0.1"
+            "#,
+        ),
+    );
+
+    let api: Api<Foo> = Api::namespaced(k8s.client.clone(), &namespace);
+
+    // Asserts the agent resources are created
+    retry(120, Duration::from_secs(1), || {
+        if block_on(api.get("foo-agent")).is_err() {
+            return Err("foo cr not found".into());
+        }
+        Ok(())
+    });
+
+    // Asserts the agent resources are garbage collected
+
+    // Due to an identified bug (NR-334506) in the GC, This waits for at least one execution (each 30s)
+    // of the GC to ensure that the sub-agent is added to the internal list of agents before it gets removed.
+    std::thread::sleep(Duration::from_secs(35));
+
+    server.set_config_response(
+        instance_id.clone(),
+        ConfigResponse::from(
+            r#"
+agents: {}
+            "#,
+        ),
+    );
+
+    retry(120, Duration::from_secs(1), || {
+        if block_on(api.get("foo-agent")).is_ok() {
+            return Err("foo found".into());
+        }
+        Ok(())
+    });
+}
+
+/// This scenario tests an Agent type which only create a CR before CRD exists.
+/// and asserts that the agent resources are created after the CRD is created.
+#[test]
+#[ignore = "needs k8s cluster"]
+#[serial]
+fn k8s_opamp_cr_subagent_installed_before_crd() {
+    let test_name = "k8s_opamp_cr_subagent_installed_before_crd";
+
+    // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
+    let mut server = FakeServer::start_new();
+
+    // setup the k8s environment
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+    // custom CRD defined for this test only.
+    #[derive(Default, CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
+    #[kube(group = "newrelic.com", version = "v1", kind = "Bar", namespaced)]
+    pub struct BarSpec {
+        pub data: String,
+    }
+    block_on(delete_crd(k8s.client.clone(), Bar::crd()))
+        .expect_err("CRD deleted, testing environment was not clean, re-run the test");
+
+    let _sa = start_super_agent_with_testdata_config(
+        test_name,
+        BAR_CR_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        Some(&server.endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+    wait_until_super_agent_with_opamp_is_started(k8s.client.clone(), namespace.as_str());
+
+    let instance_id = instance_id::get_instance_id(&namespace, &AgentID::new_super_agent_id());
+
+    server.set_config_response(
+        instance_id.clone(),
+        ConfigResponse::from(
+            r#"
+agents:
+  bar-agent:
+    agent_type: "newrelic/com.newrelic.bar-cr-agent:0.0.1"
+            "#,
+        ),
+    );
+
+    let api: Api<Bar> = Api::namespaced(k8s.client.clone(), &namespace);
+    // Asserts the agent has been initialized, the config built but the resources are missing.
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_exist(
+            k8s.client.clone(),
+            "opamp-data-bar-agent",
+            &namespace,
+        ))?;
+        Ok(())
+    });
+    block_on(api.get("bar-agent")).expect_err("there is no Bar CRD");
+
+    // Create the CRD
+    block_on(create_crd(k8s.client.clone(), Bar::crd())).expect("Error creating the Bar CRD");
+
+    // Asserts the agent resources are created without any intervention.
+    retry(120, Duration::from_secs(1), || {
+        block_on(api.get("bar-agent"))?;
+        Ok(())
+    });
+
+    // clean up the CRD
+    block_on(delete_crd(k8s.client.clone(), Bar::crd())).expect("Error deleting the Bar CRD");
+}

--- a/super-agent/tests/k8s/scenarios/no_opamp.rs
+++ b/super-agent/tests/k8s/scenarios/no_opamp.rs
@@ -1,4 +1,5 @@
 use crate::common::{retry::retry, runtime::block_on};
+use crate::k8s::tools::super_agent::CUSTOM_AGENT_TYPE_PATH;
 use crate::k8s::tools::{
     k8s_api::check_deployments_exist, k8s_env::K8sEnv,
     super_agent::start_super_agent_with_testdata_config,
@@ -21,6 +22,7 @@ fn k8s_sub_agent_started_with_no_opamp() {
 
     let _child = start_super_agent_with_testdata_config(
         test_name,
+        CUSTOM_AGENT_TYPE_PATH,
         k8s.client.clone(),
         &namespace,
         None,

--- a/super-agent/tests/k8s/scenarios/opamp.rs
+++ b/super-agent/tests/k8s/scenarios/opamp.rs
@@ -5,7 +5,7 @@ use crate::common::{
     retry::retry,
     runtime::block_on,
 };
-
+use crate::k8s::tools::super_agent::CUSTOM_AGENT_TYPE_PATH;
 use crate::k8s::tools::{
     instance_id,
     k8s_api::{check_deployments_exist, check_helmrelease_spec_values},
@@ -39,6 +39,7 @@ fn k8s_opamp_enabled_with_no_remote_configuration() {
     // start the super-agent
     let _sa = start_super_agent_with_testdata_config(
         test_name,
+        CUSTOM_AGENT_TYPE_PATH,
         k8s.client.clone(),
         &namespace,
         Some(&server.endpoint()),
@@ -97,6 +98,7 @@ fn k8s_opamp_subagent_configuration_change() {
     // start the super-agent
     let _sa = start_super_agent_with_testdata_config(
         test_name,
+        CUSTOM_AGENT_TYPE_PATH,
         k8s.client.clone(),
         &namespace,
         Some(&server.endpoint()),
@@ -201,6 +203,7 @@ fn k8s_opamp_add_subagent() {
     // start the super-agent
     let _sa = start_super_agent_with_testdata_config(
         test_name,
+        CUSTOM_AGENT_TYPE_PATH,
         k8s.client.clone(),
         &namespace,
         Some(&server.endpoint()),

--- a/super-agent/tests/k8s/tools/k8s_env.rs
+++ b/super-agent/tests/k8s/tools/k8s_env.rs
@@ -1,6 +1,6 @@
 use crate::common::runtime::tokio_runtime;
 
-use super::foo_crd::create_foo_crd;
+use super::test_crd::create_foo_crd;
 use k8s_openapi::api::core::v1::Namespace;
 use kube::{
     api::{DeleteParams, PostParams},

--- a/super-agent/tests/k8s/tools/mod.rs
+++ b/super-agent/tests/k8s/tools/mod.rs
@@ -1,5 +1,3 @@
-/// Defines the Foo CRD to be created and used in testing k8s clusters.
-pub mod foo_crd;
 pub mod instance_id;
 /// Provides tools to perform queries through the k8s API in order to perform assertions.
 pub mod k8s_api;
@@ -9,3 +7,5 @@ pub mod k8s_env;
 /// and specific initial configuration. Any helper receiving a `folder_name` assumes that the folder exists
 /// in the path `tests/k8s/data/`.
 pub mod super_agent;
+/// Defines the Foo CRD to be created and used in testing k8s clusters.
+pub mod test_crd;

--- a/super-agent/tests/k8s/tools/super_agent.rs
+++ b/super-agent/tests/k8s/tools/super_agent.rs
@@ -25,19 +25,23 @@ use std::time::Duration;
 use std::{fs::File, io::Write};
 
 pub const TEST_CLUSTER_NAME: &str = "minikube";
+pub const CUSTOM_AGENT_TYPE_PATH: &str = "tests/k8s/data/custom_agent_type.yml";
+pub const FOO_CR_AGENT_TYPE_PATH: &str = "tests/k8s/data/foo_cr_agent_type.yml";
+pub const BAR_CR_AGENT_TYPE_PATH: &str = "tests/k8s/data/bar_cr_agent_type.yml";
+
 /// Starts the super-agent through [start_super_agent] after setting up the corresponding configuration file
 /// and config map according to the provided `folder_name` and the provided `file_names`.
 pub fn start_super_agent_with_testdata_config(
     folder_name: &str,
+    dynamic_agent_type_path: &str,
     client: Client,
     ns: &str,
     opamp_endpoint: Option<&str>,
     subagent_file_names: Vec<&str>,
     local_dir: &Path,
 ) -> StartedSuperAgent {
-    // Move the custom agentType, for now there is only one for all the tests
     std::fs::copy(
-        "tests/k8s/data/custom_agent_type.yml",
+        dynamic_agent_type_path,
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
     )
     .unwrap();
@@ -51,7 +55,6 @@ pub fn start_super_agent_with_testdata_config(
             file_name,
         ))
     }
-
     start_super_agent_with_custom_config(BasePaths {
         local_dir: local_dir.to_path_buf(),
         remote_dir: local_dir.join("remote").to_path_buf(),


### PR DESCRIPTION
Adds an integration test for an agent type that deploys a CR . This would be the case of an sub-agent from the K8s Agent Operator

On top of #873 