### PR TITLE
fix(k8s): make Opamp interval greater than GC 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,8 +3211,8 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opamp-client"
-version = "0.0.21"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.21#2897728f043d08f5a5be92a9df1ad65227853761"
+version = "0.0.22"
+source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.22#495d743f9b2779d5c94a09b7fc63c78b11f900ed"
 dependencies = [
  "crossbeam",
  "http 1.1.0",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1449,7 +1449,7 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.21
+## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.22
 
 Distributed under the following license(s):
 * Apache-2.0

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -28,7 +28,7 @@ duration-str = "0.11.2"
 konst = { workspace = true }
 http = { workspace = true }
 ureq = { workspace = true, features = ["http-crate", "socks-proxy"] }
-url = { version = "2.5.2", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
 actix-web = "4"
 serde_json = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 # New Relic dependencies (private external repos)
 # IMPORTANT: GitHub deployment keys are used to access these repos on the CI/CD pipelines
 nr-auth = { git = "ssh://git@github.com/newrelic/newrelic-oauth-client-rs.git", tag = "0.0.3" }
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.21", default-features = false }
+opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.22", default-features = false }
 # local dependencies
 fs = { path = "../fs" }
 

--- a/super-agent/src/k8s/dynamic_object.rs
+++ b/super-agent/src/k8s/dynamic_object.rs
@@ -110,8 +110,8 @@ impl DynamicObjectManager {
             return Ok(());
         }
         debug!(
-            "applying k8s object since it has changed: '{:?}'",
-            obj.metadata
+            "applying k8s object since it has changed: '{:?}' '{:?}'",
+            obj.types, obj.metadata,
         );
         self.apply(obj).await
     }

--- a/super-agent/src/opamp/http/builder.rs
+++ b/super-agent/src/opamp/http/builder.rs
@@ -98,7 +98,9 @@ pub(crate) mod test {
     use crate::{
         event::channel::pub_sub,
         opamp::{
-            client_builder::{DefaultOpAMPClientBuilder, OpAMPClientBuilder},
+            client_builder::{
+                DefaultOpAMPClientBuilder, OpAMPClientBuilder, DEFAULT_POLL_INTERVAL,
+            },
             effective_config::loader::tests::{
                 MockEffectiveConfigLoaderBuilderMock, MockEffectiveConfigLoaderMock,
             },
@@ -149,7 +151,11 @@ pub(crate) mod test {
             .times(1)
             .return_once(|| Ok(http_client));
 
-        let builder = DefaultOpAMPClientBuilder::new(http_builder, effective_config_loader_builder);
+        let builder = DefaultOpAMPClientBuilder::new(
+            http_builder,
+            effective_config_loader_builder,
+            DEFAULT_POLL_INTERVAL,
+        );
         let actual_client = builder.build_and_start(tx, agent_id, start_settings);
 
         assert!(actual_client.is_ok());
@@ -172,7 +178,11 @@ pub(crate) mod test {
             )))
         });
 
-        let builder = DefaultOpAMPClientBuilder::new(http_builder, effective_config_loader_builder);
+        let builder = DefaultOpAMPClientBuilder::new(
+            http_builder,
+            effective_config_loader_builder,
+            DEFAULT_POLL_INTERVAL,
+        );
         let actual_client = builder.build_and_start(tx, agent_id, start_settings);
 
         assert!(actual_client.is_err());

--- a/super-agent/src/super_agent/run.rs
+++ b/super-agent/src/super_agent/run.rs
@@ -17,6 +17,7 @@ use crate::super_agent::http_server::runner::Runner;
 use std::error::Error;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::runtime::Runtime;
 use tracing::{debug, error};
 
@@ -47,11 +48,14 @@ impl Default for BasePaths {
 /// Structures for running the super-agent provided by CLI inputs
 pub struct SuperAgentRunConfig {
     pub opamp: Option<OpAMPClientConfig>,
+    pub opamp_poll_interval: Duration,
     pub http_server: ServerConfig,
     pub base_paths: BasePaths,
     pub proxy: ProxyConfig,
     #[cfg(feature = "k8s")]
     pub k8s_config: super::config::K8sConfig,
+    #[cfg(feature = "k8s")]
+    pub garbage_collector_interval: Duration,
 }
 
 /// Structure with all the data required to run the super agent.
@@ -62,11 +66,14 @@ pub struct SuperAgentRunner {
     agent_type_registry: EmbeddedRegistry,
     application_event_consumer: EventConsumer<ApplicationEvent>,
     opamp_http_builder: Option<UreqHttpClientBuilder<TokenRetrieverImpl>>,
+    opamp_poll_interval: Duration,
     super_agent_publisher: EventPublisher<SuperAgentEvent>,
     sub_agent_publisher: EventPublisher<SubAgentEvent>,
     base_paths: BasePaths,
     #[cfg(feature = "k8s")]
     k8s_config: super::config::K8sConfig,
+    #[cfg(feature = "k8s")]
+    garbage_collector_interval: Duration,
 
     #[allow(dead_code)]
     runtime: Arc<Runtime>,
@@ -130,9 +137,12 @@ impl SuperAgentRunner {
             runtime,
             #[cfg(feature = "k8s")]
             k8s_config: config.k8s_config,
+            #[cfg(feature = "k8s")]
+            garbage_collector_interval: config.garbage_collector_interval,
             agent_type_registry,
             application_event_consumer,
             opamp_http_builder,
+            opamp_poll_interval: config.opamp_poll_interval,
             super_agent_publisher,
             sub_agent_publisher,
             base_paths: config.base_paths,

--- a/super-agent/src/super_agent/run/k8s.rs
+++ b/super-agent/src/super_agent/run/k8s.rs
@@ -73,6 +73,7 @@ impl SuperAgentRunner {
             DefaultOpAMPClientBuilder::new(
                 http_builder,
                 DefaultEffectiveConfigLoaderBuilder::new(yaml_config_repository.clone()),
+                self.opamp_poll_interval,
             )
         });
 
@@ -121,6 +122,7 @@ impl SuperAgentRunner {
             config_storer.clone(),
             k8s_client,
             self.k8s_config.cr_type_meta,
+            self.garbage_collector_interval,
         );
         let _started_gcc = gcc.start();
 

--- a/super-agent/src/super_agent/run/on_host.rs
+++ b/super-agent/src/super_agent/run/on_host.rs
@@ -84,6 +84,7 @@ impl SuperAgentRunner {
             DefaultOpAMPClientBuilder::new(
                 http_builder,
                 DefaultEffectiveConfigLoaderBuilder::new(yaml_config_repository.clone()),
+                self.opamp_poll_interval,
             )
         });
 

--- a/super-agent/tests/common/global_logger.rs
+++ b/super-agent/tests/common/global_logger.rs
@@ -8,7 +8,14 @@ static INIT_LOGGER: Once = Once::new();
 
 pub fn init_logger() {
     INIT_LOGGER.call_once(|| {
-        LoggingConfig::default()
+        let logging_config: LoggingConfig = serde_yaml::from_str(
+            r#"
+level: debug        
+        "#,
+        )
+        .unwrap();
+
+        logging_config
             .try_init(PathBuf::from(SUPER_AGENT_LOG_DIR))
             .unwrap();
     });

--- a/super-agent/tests/common/opamp.rs
+++ b/super-agent/tests/common/opamp.rs
@@ -137,7 +137,6 @@ impl FakeServer {
         identifier: &InstanceID,
     ) -> Option<opamp::proto::ComponentHealth> {
         let state = self.state.lock().unwrap();
-        print!("{:?}", state.attributes);
         state.health_statuses.get(identifier).cloned()
     }
     pub fn get_attributes(

--- a/super-agent/tests/common/super_agent.rs
+++ b/super-agent/tests/common/super_agent.rs
@@ -7,6 +7,7 @@ use newrelic_super_agent::super_agent::config_storer::store::SuperAgentConfigSto
 use newrelic_super_agent::super_agent::run::{BasePaths, SuperAgentRunConfig, SuperAgentRunner};
 use newrelic_super_agent::values::file::YAMLConfigRepositoryFile;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Starts the super-agent in a separate thread. The super-agent will be stopped when the `StartedSuperAgent` is dropped.
 /// Take into account that some of the logic from main is not present here.
@@ -27,13 +28,23 @@ pub fn start_super_agent_with_custom_config(base_paths: BasePaths) -> StartedSup
 
         let super_agent_config = config_storer.load().unwrap();
 
+        let opamp_poll_interval = Duration::from_secs(2);
+        let garbage_collector_interval = Duration::from_secs(1);
+        // TODO - Temporal solution until https://new-relic.atlassian.net/browse/NR-343594 is done.
+        // There is a current issue with the diff computation the GC does in order to collect agents. If a new agent is added and removed
+        // before the GC process it, the resources will never be collected.
+        assert!(opamp_poll_interval > garbage_collector_interval);
+
         let run_config = SuperAgentRunConfig {
             opamp: super_agent_config.opamp,
+            opamp_poll_interval,
             http_server: super_agent_config.server,
             base_paths,
             proxy: super_agent_config.proxy,
             #[cfg(feature = "k8s")]
             k8s_config: super_agent_config.k8s.unwrap(),
+            #[cfg(feature = "k8s")]
+            garbage_collector_interval,
         };
 
         // Create the actual super agent runner with the rest of required configs and the application_event_consumer

--- a/super-agent/tests/k8s/Makefile
+++ b/super-agent/tests/k8s/Makefile
@@ -5,4 +5,5 @@ all: test-integration-minikube
 test-integration-minikube:
 	KUBECONFIG='./.kubeconfig-dev' minikube update-context
 	tilt ci
-	LOG_LEVEL=newrelic_super_agent=debug cargo test --features k8s k8s_ -- --nocapture --ignored
+	# reducing the number of threads to 1 forces the tests to run sequentially
+	LOG_LEVEL=newrelic_super_agent=debug cargo test --features k8s k8s_ -- --nocapture --ignored  --test-threads=1

--- a/super-agent/tests/k8s/client.rs
+++ b/super-agent/tests/k8s/client.rs
@@ -24,7 +24,7 @@ const TEST_LABEL_VALUE: &str = "value";
 // tokio test runs with 1 thread by default causing deadlock when executing `block_on` code during test helper drop.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs k8s cluster"]
-async fn k8s_client_creation_fail() {
+async fn k8s_missing_namespace_creation_fail() {
     let test_ns = "test-not-existing-namespace";
     assert!(AsyncK8sClient::try_new(test_ns.to_string()).await.is_err());
 }

--- a/super-agent/tests/k8s/data/bar_cr_agent_type.yml
+++ b/super-agent/tests/k8s/data/bar_cr_agent_type.yml
@@ -11,7 +11,7 @@ variables:
 deployment:
   k8s:
     health:
-      interval: 30s
+      interval: 5s
     objects:
       bar_cr:
         # This CRD is created in the cluster when initializing the test environment.

--- a/super-agent/tests/k8s/data/custom_agent_type.yml
+++ b/super-agent/tests/k8s/data/custom_agent_type.yml
@@ -10,7 +10,7 @@ variables:
 deployment:
   k8s:
     health:
-      interval: 30s
+      interval: 5s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/super-agent/tests/k8s/data/custom_agent_type_secret.yml
+++ b/super-agent/tests/k8s/data/custom_agent_type_secret.yml
@@ -11,7 +11,7 @@ variables:
 deployment:
   k8s:
     health:
-      interval: 30s
+      interval: 5s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/super-agent/tests/k8s/data/foo_cr_agent_type.yml
+++ b/super-agent/tests/k8s/data/foo_cr_agent_type.yml
@@ -11,7 +11,7 @@ variables:
 deployment:
   k8s:
     health:
-      interval: 30s
+      interval: 5s
     objects:
       foo_cr:
         # This CRD is created in the cluster when initializing the test environment.

--- a/super-agent/tests/k8s/scenarios/ac_restarts.rs
+++ b/super-agent/tests/k8s/scenarios/ac_restarts.rs
@@ -66,7 +66,7 @@ fn k8s_opamp_subagent_configuration_change_after_ac_restarts() {
 valid: true
     "#;
 
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -102,7 +102,7 @@ chart_values:
 valid: super-true
     "#;
 
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -139,7 +139,7 @@ valid: super-true
     wait_until_super_agent_with_opamp_is_started(k8s.client.clone(), namespace.as_str());
 
     // Check if the HelmRelease is still with the correct config
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -175,7 +175,7 @@ chart_values:
 valid: super-super-true
     "#;
 
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),

--- a/super-agent/tests/k8s/scenarios/cr_based_agents.rs
+++ b/super-agent/tests/k8s/scenarios/cr_based_agents.rs
@@ -76,10 +76,6 @@ agents:
 
     // Asserts the agent resources are garbage collected
 
-    // Due to an identified bug (NR-334506) in the GC, This waits for at least one execution (each 30s)
-    // of the GC to ensure that the sub-agent is added to the internal list of agents before it gets removed.
-    std::thread::sleep(Duration::from_secs(35));
-
     server.set_config_response(
         instance_id.clone(),
         ConfigResponse::from(

--- a/super-agent/tests/k8s/scenarios/no_opamp.rs
+++ b/super-agent/tests/k8s/scenarios/no_opamp.rs
@@ -33,7 +33,7 @@ fn k8s_sub_agent_started_with_no_opamp() {
     // Check deployment for first Agent is created with retry, the name has the key
     // 'override-by-secret' concatenated to the name because the secret created adds that
     // NameOverride to the values.
-    retry(30, Duration::from_secs(5), || {
+    retry(30, Duration::from_secs(1), || {
         block_on(check_deployments_exist(
             k8s.client.clone(),
             &["hello-world-override-by-secret"],

--- a/super-agent/tests/k8s/scenarios/opamp.rs
+++ b/super-agent/tests/k8s/scenarios/opamp.rs
@@ -62,7 +62,7 @@ licenseKey: test
     let sub_agent_instance_id =
         instance_id::get_instance_id(&namespace, &AgentID::new("hello-world").unwrap());
 
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -83,9 +83,8 @@ licenseKey: test
 
         check_latest_health_status_was_healthy(&server, &instance_id.clone())
     });
-
     // Delete the helm release to check if super agent recreate it correctly
-    retry(30, Duration::from_secs(5), || {
+    retry(30, Duration::from_secs(1), || {
         block_on(delete_helm_release(
             k8s.client.clone(),
             namespace.as_str(),
@@ -94,7 +93,14 @@ licenseKey: test
         Ok(())
     });
 
-    retry(60, Duration::from_secs(5), || {
+    // Wait for the helm release to be recreated
+    retry(60, Duration::from_secs(1), || {
+        block_on(check_helmrelease_spec_values(
+            k8s.client.clone(),
+            namespace.as_str(),
+            "hello-world",
+            expected_spec_values,
+        ))?;
         check_latest_health_status_was_healthy(&server, &sub_agent_instance_id.clone())
     });
 }
@@ -147,7 +153,7 @@ fn k8s_opamp_subagent_configuration_change() {
 valid: true
     "#;
 
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -183,7 +189,7 @@ chart_values:
 valid: super-true
     "#;
 
-    retry(30, Duration::from_secs(5), || {
+    retry(30, Duration::from_secs(1), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -246,7 +252,7 @@ agents:
     );
 
     // check that the expected deployments exist
-    retry(60, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(1), || {
         block_on(check_deployments_exist(
             k8s.client.clone(),
             &["hello-world"],

--- a/super-agent/tests/k8s/tools/super_agent.rs
+++ b/super-agent/tests/k8s/tools/super_agent.rs
@@ -135,7 +135,7 @@ pub fn create_local_super_agent_config(
 /// If it is present we assume that the SuperAgent was started and was able to connect to the cluster.
 pub fn wait_until_super_agent_with_opamp_is_started(k8s_client: Client, namespace: &str) {
     // check that the expected cm exist, meaning that the SA started
-    retry(30, Duration::from_secs(5), || {
+    retry(30, Duration::from_secs(1), || {
         block_on(check_config_map_exist(
             k8s_client.clone(),
             "opamp-data-super-agent",


### PR DESCRIPTION
Fix:
- Makes OpAMP poll interval greater than GC to fix [NR-334506](https://new-relic.atlassian.net/browse/NR-334506). Thi is a quick fix since the root cause should be solved here [NR-343594](https://new-relic.atlassian.net/browse/NR-343594)
- Sending health event to disconnect channel whenever the status server is disabled

Changes related to flaky tests detection
- Makes OpAMP poll, and GC, intervals configurable for testing. 
- Added extra time after delete when `deleting` is received
- reduce retry intervals
- Make test runs in 1 thread so `serial` is honour. Now logs make sense and they are activated in debug mode


[NR-334506]: https://new-relic.atlassian.net/browse/NR-334506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NR-343594]: https://new-relic.atlassian.net/browse/NR-343594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ