### PR TITLE
Nr 320007 gc cleans from config list

### DIFF
--- a/super-agent/src/k8s/client.rs
+++ b/super-agent/src/k8s/client.rs
@@ -125,14 +125,6 @@ impl SyncK8sClient {
             .block_on(self.async_client.delete_configmap_key(configmap_name, key))
     }
 
-    pub fn supported_type_meta_collection(&self) -> Vec<TypeMeta> {
-        self.runtime.block_on(
-            self.async_client
-                .dynamic_object_managers()
-                .supported_dynamic_type_metas(),
-        )
-    }
-
     pub fn default_namespace(&self) -> &str {
         self.async_client.default_namespace()
     }

--- a/super-agent/src/k8s/dynamic_object.rs
+++ b/super-agent/src/k8s/dynamic_object.rs
@@ -237,8 +237,4 @@ impl DynamicObjectManagers {
 
         Ok(managers_guard)
     }
-
-    pub async fn supported_dynamic_type_metas(&self) -> Vec<TypeMeta> {
-        self.manager_by_type.lock().await.keys().cloned().collect()
-    }
 }

--- a/super-agent/src/super_agent/run/k8s.rs
+++ b/super-agent/src/super_agent/run/k8s.rs
@@ -110,7 +110,11 @@ impl SuperAgentRunner {
             .map(|(client, consumer)| (Some(client), Some(consumer)))
             .unwrap_or_default();
 
-        let gcc = NotStartedK8sGarbageCollector::new(config_storer.clone(), k8s_client);
+        let gcc = NotStartedK8sGarbageCollector::new(
+            config_storer.clone(),
+            k8s_client,
+            self.k8s_config.cr_type_meta,
+        );
         let _started_gcc = gcc.start();
 
         SuperAgent::new(


### PR DESCRIPTION
Modified GC behavior to look for CRs to collect from the list defined in the config, cr_type_meta.
```
k8s:
  namespace: default
  cluster_name: some-cluster
  cr_type_meta:
    - apiVersion: "custom.io/v1"
      kind: "CustomKind"
```
There is always the 2 default CR Type Meta on the list  that will be concatenated:
```
TypeMeta {
  api_version: "source.toolkit.fluxcd.io/v1".to_string(),
  kind: "HelmRepository".to_string(),
}

TypeMeta {
  api_version: "helm.toolkit.fluxcd.io/v2".to_string(),
  kind: "HelmRelease".to_string(),
}
```