### PR TITLE
chore: remove redundant match

### DIFF
--- a/super-agent/src/k8s/garbage_collector.rs
+++ b/super-agent/src/k8s/garbage_collector.rs
@@ -153,13 +153,11 @@ where
                     }
                     Ok::<(), GarbageCollectorK8sError>(())
                 }),
-                Err(e) => match e {
-                    K8sError::MissingAPIResource(_) => {
-                        debug!(error = %e, "GC skipping collect for TypeMeta");
-                        Ok(())
-                    }
-                    _ => Err(e.into()),
-                },
+                Err(K8sError::MissingAPIResource(e)) => {
+                    debug!(error = %e, "GC skipping collect for TypeMeta");
+                    Ok(())
+                }
+                Err(e) => Err(e.into()),
             }
         })?;
 


### PR DESCRIPTION
The first one can pattern match on the error types directly as well