### PR TITLE
refactor: simplify dynamic object manager

### DIFF
--- a/super-agent/src/k8s/error.rs
+++ b/super-agent/src/k8s/error.rs
@@ -43,9 +43,6 @@ pub enum K8sError {
     #[error("reflector timeout: {0}")]
     ReflectorTimeout(String),
 
-    #[error("initialized dynamic object manager is missing for type: {0}")]
-    MissingInitializedManager(String),
-
     #[error("api resource kind not present in the cluster: {0}")]
     MissingAPIResource(String),
 }


### PR DESCRIPTION
This PR simplifies the `DynamicObjectManager` implementation by allowing sharing references to DynamicObjectManagers (through `Arc`).

The function in charge of 'getting or creating' the reflectors returns the reference to the target `DynamicObjectManager` instead of returning the whole HashMap. The HashMap read and and writes are still protected by the mutex but, since we are using an `Arc` now, the reference can live longer than the mutex's lock.

We avoid a bit of repetition and also get rid of an unreachable error which was causing confusion.