### PR TITLE
Increase k8s opamp integration tests number of retries

### DIFF
--- a/super-agent/tests/k8s/scenarios/opamp.rs
+++ b/super-agent/tests/k8s/scenarios/opamp.rs
@@ -55,7 +55,7 @@ licenseKey: test
 
     let instance_id = instance_id::get_instance_id(&namespace, &AgentID::new_super_agent_id());
 
-    retry(30, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(5), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -125,7 +125,7 @@ fn k8s_opamp_subagent_configuration_change() {
 valid: true
     "#;
 
-    retry(30, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(5), || {
         block_on(check_helmrelease_spec_values(
             k8s.client.clone(),
             namespace.as_str(),
@@ -223,7 +223,7 @@ agents:
     );
 
     // check that the expected deployments exist
-    retry(30, Duration::from_secs(5), || {
+    retry(60, Duration::from_secs(5), || {
         block_on(check_deployments_exist(
             k8s.client.clone(),
             &["hello-world"],


### PR DESCRIPTION
We detected a flaky test, specifically `k8s_opamp_add_subagent` that failed with the number of retries to find a specific Deployment that should be created by Flux.

We reproduced the error locally by reducing the time for the retries, and we could also see that even looking for k8s objects not created  by flux also fail because take too long to be created.

So the only solution for this flaky test is to increment the time so Flux is capable to apply the helm chart and k8s to create the objects. We may think about not testing Flux applying charts but that is left to discussion and left outside of this PR.