### PR TITLE
feat(trait): introduce new trait

### DIFF
--- a/super-agent/src/sub_agent/health/health_checker.rs
+++ b/super-agent/src/sub_agent/health/health_checker.rs
@@ -6,6 +6,7 @@ use crate::event::SubAgentInternalEvent;
 #[cfg(feature = "k8s")]
 use crate::k8s;
 use crate::sub_agent::health::with_start_time::HealthWithStartTime;
+use crate::sub_agent::supervisor::SupervisorError;
 use crate::super_agent::config::AgentID;
 use std::thread;
 use std::time::{SystemTime, SystemTimeError};
@@ -249,6 +250,24 @@ pub(crate) fn publish_health_event(
             "could not publish sub agent event"
         )
     });
+}
+
+/// Logs the provided error and publishes the corresponding unhealthy event.
+pub fn log_and_report_unhealthy(
+    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
+    err: &SupervisorError,
+    msg: &str,
+    start_time: SystemTime,
+) {
+    let last_error = format!("{msg}: {err}");
+
+    let event = SubAgentInternalEvent::AgentHealthInfo(HealthWithStartTime::new(
+        Unhealthy::new(String::default(), last_error).into(),
+        start_time,
+    ));
+
+    error!(%err, msg);
+    publish_health_event(sub_agent_internal_publisher, event);
 }
 
 #[cfg(test)]

--- a/super-agent/src/sub_agent/k8s.rs
+++ b/super-agent/src/sub_agent/k8s.rs
@@ -1,6 +1,3 @@
 pub mod builder;
 pub mod sub_agent;
-mod supervisor;
-
-pub use supervisor::NotStartedSupervisorK8s;
-pub use supervisor::SupervisorError;
+pub mod supervisor;

--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -243,7 +243,7 @@ where
     O: OpAMPClientBuilder<SubAgentCallbacks<G>>,
     HR: HashRepository,
 {
-    type Supervisor = NotStartedSupervisorK8s;
+    type SupervisorStarter = NotStartedSupervisorK8s;
 
     type OpAMPClient = O::Client;
 
@@ -251,7 +251,7 @@ where
         &self,
         effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
         maybe_opamp_client: &Option<Self::OpAMPClient>,
-    ) -> Result<Option<Self::Supervisor>, SubAgentBuilderError> {
+    ) -> Result<Option<Self::SupervisorStarter>, SubAgentBuilderError> {
         build_supervisor_or_default::<HR, O, _, _, _>(
             &self.agent_id,
             &self.hash_repository,

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -249,7 +249,7 @@ where
     O: OpAMPClientBuilder<SubAgentCallbacks<G>>,
     HR: HashRepository,
 {
-    type Supervisor = SupervisorOnHost<command_supervisor::NotStarted>;
+    type SupervisorStarter = SupervisorOnHost<command_supervisor::NotStarted>;
 
     type OpAMPClient = O::Client;
 
@@ -257,7 +257,7 @@ where
         &self,
         effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
         maybe_opamp_client: &Option<Self::OpAMPClient>,
-    ) -> Result<Option<Self::Supervisor>, SubAgentBuilderError> {
+    ) -> Result<Option<Self::SupervisorStarter>, SubAgentBuilderError> {
         build_supervisor_or_default::<HR, O, _, _, _>(
             &self.agent_id,
             &self.hash_repository,

--- a/super-agent/src/sub_agent/supervisor.rs
+++ b/super-agent/src/sub_agent/supervisor.rs
@@ -2,14 +2,46 @@ use super::{
     effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssemblerError},
     error::SubAgentBuilderError,
 };
+use crate::event::channel::{EventPublisher, EventPublisherError};
+use crate::event::SubAgentInternalEvent;
+use std::thread::JoinHandle;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SupervisorError {
+    #[cfg(feature = "k8s")]
+    #[error("the kube client returned an error: `{0}`")]
+    Generic(#[from] crate::k8s::error::K8sError),
+
+    #[cfg(feature = "k8s")]
+    #[error("building k8s resources: `{0}`")]
+    ConfigError(String),
+
+    #[cfg(feature = "k8s")]
+    #[error("building health checkers: `{0}`")]
+    HealthError(#[from] crate::sub_agent::health::health_checker::HealthCheckerError),
+}
 
 pub trait SupervisorBuilder {
-    type Supervisor;
+    type SupervisorStarter: SupervisorStarter;
     type OpAMPClient;
 
     fn build_supervisor(
         &self,
         effective_agent_result: Result<EffectiveAgent, EffectiveAgentsAssemblerError>,
         maybe_opamp_client: &Option<Self::OpAMPClient>,
-    ) -> Result<Option<Self::Supervisor>, SubAgentBuilderError>;
+    ) -> Result<Option<Self::SupervisorStarter>, SubAgentBuilderError>;
+}
+
+pub trait SupervisorStarter {
+    type SupervisorStopper: SupervisorStopper;
+
+    fn start(
+        self,
+        sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
+    ) -> Result<Self::SupervisorStopper, SupervisorError>;
+}
+
+pub trait SupervisorStopper {
+    fn stop(self) -> Result<JoinHandle<()>, EventPublisherError>;
 }

--- a/super-agent/src/super_agent/config.rs
+++ b/super-agent/src/super_agent/config.rs
@@ -485,6 +485,7 @@ fleet_id: 123
 agents: {}
 "#;
 
+    #[cfg(feature = "k8s")]
     const EXAMPLE_K8S_EXTRA_CR_CONFIG: &str = r#"
 agents:
   agent-1:

--- a/super-agent/src/values/yaml_config_repository.rs
+++ b/super-agent/src/values/yaml_config_repository.rs
@@ -118,6 +118,7 @@ pub mod test {
                 });
         }
 
+        #[cfg(feature = "onhost")]
         pub fn should_store_remote(&mut self, agent_id: &AgentID, yaml_config: &YAMLConfig) {
             self.expect_store_remote()
                 .once()

--- a/super-agent/tests/k8s/garbage_collector.rs
+++ b/super-agent/tests/k8s/garbage_collector.rs
@@ -8,7 +8,7 @@ use kube::{api::Api, core::TypeMeta};
 use mockall::{mock, Sequence};
 use newrelic_super_agent::agent_type::runtime_config;
 use newrelic_super_agent::k8s::annotations::Annotations;
-use newrelic_super_agent::sub_agent::k8s::NotStartedSupervisorK8s;
+use newrelic_super_agent::sub_agent::k8s::supervisor::NotStartedSupervisorK8s;
 use newrelic_super_agent::super_agent::config::{default_group_version_kinds, AgentTypeFQN};
 use newrelic_super_agent::{
     agent_type::runtime_config::K8sObject,


### PR DESCRIPTION
This PR:
 - introducing `SupervisorStarter` and `SupervisorStopper`.
 - changes slightly the code of the supervisors to make them lerage these traits
 - moves the computation of the timestamp inside of the k8s supervisor (as onhost was doing it already)


Notice that the starter and stopper onHost cannot return an error, but to share the trait they simply return already Ok(...)
 