### PR TITLE
feat(unifyCode): merge functions

### DIFF
--- a/super-agent/src/sub_agent/k8s/builder.rs
+++ b/super-agent/src/sub_agent/k8s/builder.rs
@@ -1,3 +1,4 @@
+use crate::agent_type::environment::Environment;
 use crate::agent_type::runtime_config::K8sObject;
 use crate::event::channel::{pub_sub, EventPublisher};
 use crate::event::SubAgentEvent;
@@ -148,6 +149,7 @@ where
             Arc::new(
                 ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
             ),
+            Environment::K8s,
         ))
     }
 }

--- a/super-agent/src/sub_agent/k8s/sub_agent.rs
+++ b/super-agent/src/sub_agent/k8s/sub_agent.rs
@@ -343,6 +343,7 @@ pub mod test {
             Arc::new(
                 ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
             ),
+            Environment::K8s,
         )
     }
 

--- a/super-agent/src/sub_agent/k8s/supervisor.rs
+++ b/super-agent/src/sub_agent/k8s/supervisor.rs
@@ -184,6 +184,8 @@ pub struct StartedSupervisorK8s {
 
 impl SupervisorStopper for StartedSupervisorK8s {
     fn stop(self) -> Result<JoinHandle<()>, EventPublisherError> {
+        // OnK8s this does not delete directly the CR. It will be the garbage collector doing so if needed.
+
         if let Some(stop_health) = self.maybe_stop_health {
             stop_health.publish(())?; // TODO: should we also return the health-check join handle?
         }

--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -2,6 +2,7 @@ use super::supervisor::command_supervisor_config::ExecutableData;
 use super::supervisor::{
     command_supervisor::SupervisorOnHost, command_supervisor_config::SupervisorConfigOnHost,
 };
+use crate::agent_type::environment::Environment;
 use crate::agent_type::runtime_config::Executable;
 use crate::event::channel::{pub_sub, EventPublisher};
 use crate::event::SubAgentEvent;
@@ -153,6 +154,7 @@ where
             Arc::new(
                 ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
             ),
+            Environment::OnHost,
         ))
     }
 }

--- a/super-agent/src/sub_agent/on_host/sub_agent.rs
+++ b/super-agent/src/sub_agent/on_host/sub_agent.rs
@@ -271,6 +271,7 @@ pub(crate) mod test {
             Arc::new(
                 ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
             ),
+            Environment::OnHost,
         );
 
         //start the runtime
@@ -366,6 +367,7 @@ pub(crate) mod test {
             Arc::new(
                 ConfigValidator::try_new().expect("Failed to compile config validation regexes"),
             ),
+            Environment::OnHost,
         );
 
         //start the runtime


### PR DESCRIPTION
This PR on top of https://github.com/newrelic/newrelic-super-agent/pull/897 aims to merge the two subAgents that are 100% identical in some parts of the code.

Main change -> It removes SubAgentK8s and SubAgentOnHost in favour of SubAgent

A follow up PR will take care of merging the last part in common `.runtime()` and change some names