### PR TITLE
[NR-337659] add k8s infra e2e

### DIFF
--- a/.github/workflows/push_pr_test.yml
+++ b/.github/workflows/push_pr_test.yml
@@ -170,8 +170,11 @@ jobs:
   # In case a breaking change is introduced by the PR, a feature branch can be used as explained
   # in the test/k8s-e2e/Readme.md
   k8s-e2-tests:
-    name: K8s e2e tests
+    name: K8s e2e tests ${{ matrix.group }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        group: [ collector, apm, infra ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,7 +198,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - name: Run e2e-test collector
+      - name: Run k8s e2e-test ${{ matrix.group }}
         uses: newrelic/newrelic-integration-e2e-action@v1
         env:
           # Tilt configs
@@ -204,20 +207,7 @@ jobs:
         with:
           retry_attempts: 10
           agent_enabled: false
-          spec_path: test/k8s-e2e/e2e-collector.yml
-          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
-          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
-      - name: Run e2e-test apm
-        uses: newrelic/newrelic-integration-e2e-action@v1
-        env:
-          # Tilt configs
-          ARCH: amd64
-          BUILD_WITH: cargo
-        with:
-          retry_attempts: 10
-          agent_enabled: false
-          spec_path: test/k8s-e2e/e2e-apm.yml
+          spec_path: test/k8s-e2e/e2e-${{ matrix.group }}.yml
           account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.COREINT_E2E_API_KEY }}
           license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -43,9 +43,10 @@ docker_build(
 
 ######## Feature Branch Workaround ########
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-chart_source = 'helm-repo' # local|branch|helm-repo
-feature_branch = ''
-local_chart_repo = ''
+chart_source = os.getenv('CHART_SOURCE', 'branch') # local|branch|helm-repo
+feature_branch = 'gsanchez/feat/normalize-nrdot-agent-type'
+# relative path to the NR Helm Charts repo on your local machine
+local_chart_repo = os.getenv('LOCAL_CHARTS_PATH','')
 
 #### Set-up charts
 load('ext://helm_resource', 'helm_repo','helm_resource')
@@ -58,7 +59,7 @@ extra_resource_deps=[]
 if chart_source == 'local':
   chart = local_chart_repo
   update_dependencies = True
-  deps=[chart+'super-agent-deployment/templates']
+  deps=[chart+'super-agent/charts/super-agent-deployment/templates']
 elif chart_source == 'branch':
   git_checkout('https://github.com/newrelic/helm-charts#'+feature_branch, checkout_dir='local/helm-charts', unsafe_mode=False)
   chart = 'local/helm-charts/charts/'

--- a/super-agent/src/super_agent/config.rs
+++ b/super-agent/src/super_agent/config.rs
@@ -349,6 +349,14 @@ pub fn instrumentation_type_meta() -> TypeMeta {
 }
 
 #[cfg(feature = "k8s")]
+pub fn secret_type_meta() -> TypeMeta {
+    TypeMeta {
+        api_version: "v1".to_string(),
+        kind: "Secret".to_string(),
+    }
+}
+
+#[cfg(feature = "k8s")]
 pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // In flux health check we are currently supporting just a single helm_release_type_meta
     // Each time we support a new version we should decide if and how to support retrieving its health
@@ -356,6 +364,7 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
         instrumentation_type_meta(),
         helm_repository_type_meta(),
         helm_release_type_meta(),
+        secret_type_meta(),
     ]
 }
 

--- a/test/k8s-e2e/e2e-infra.yml
+++ b/test/k8s-e2e/e2e-infra.yml
@@ -1,0 +1,24 @@
+description: E2E Test
+
+custom_test_key: cluster_name
+
+scenarios:
+  - description: Deploy all infra agents
+    before:
+      - cd ../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/super-agent-infra.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - sleep 60
+    after:
+      - kubectl logs -l app.kubernetes.io/name=super-agent-deployment --all-containers --prefix=true
+      - kubectl logs -l app.kubernetes.io/instance=infra --all-containers --prefix=true
+      - kubectl logs -l app.kubernetes.io/instance=prometheus --all-containers --prefix=true
+      - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true
+      - kubectl get all -o wide
+      - cd ../../ && tilt down
+    tests:
+      nrqls:
+        # Check that prometheus-agent is collecting metrics, an extra where testKey=$SCENARIO_TAG is always added.
+        - query: "FROM Metric SELECT * WHERE collector.name = 'prometheus-agent'"
+        # Check Logs data is reported, an extra where testKey=$SCENARIO_TAG is always added.
+        - query: "From Log SELECT *"
+        # Check that newrelic-infrastructure data is reported, an extra where testKey=$SCENARIO_TAG is always added.
+        - query: "FROM K8sClusterSample SELECT *"

--- a/test/k8s-e2e/super-agent-infra.yml
+++ b/test/k8s-e2e/super-agent-infra.yml
@@ -1,0 +1,27 @@
+# Cluster and License info is set with "--set" in the e2e-spec file
+
+super-agent-deployment:
+  config:
+    opamp:
+      enabled: false
+    superAgent:
+      content:
+        log:
+          level: debug
+    subAgents:
+      infra:
+        type: newrelic/com.newrelic.infrastructure_agent:0.1.3
+        content:
+          chart_version: 5.0.102
+          chart_values:
+            global: # add 'cluster_name' (nri-kubernetes events have 'clusterName')
+              customAttributes:
+                cluster_name: ${nr-env:NR_CLUSTER_NAME}
+      prometheus:
+        type: newrelic/com.newrelic.prometheus:0.1.0
+        content:
+          chart_version: 1.15.2
+      logs:
+        type: newrelic/com.newrelic.logs:0.1.0
+        content:
+          chart_version: 1.23.5


### PR DESCRIPTION
Add k8s e2e tests for infra agent-types.

It updates the current k8s e2e job in the workflow to use matrix.