### PR TITLE
NR-316157-Report-sub-agent-version-for-k8s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,8 +3211,8 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opamp-client"
-version = "0.0.22"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.22#495d743f9b2779d5c94a09b7fc63c78b11f900ed"
+version = "0.0.23"
+source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.23#186c1937c87685407acad370230b62c6fa2de174"
 dependencies = [
  "crossbeam",
  "http 1.1.0",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1449,7 +1449,7 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
-## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.22
+## opamp-client git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.23
 
 Distributed under the following license(s):
 * Apache-2.0

--- a/super-agent/Cargo.toml
+++ b/super-agent/Cargo.toml
@@ -37,7 +37,7 @@ chrono = { workspace = true }
 # New Relic dependencies (private external repos)
 # IMPORTANT: GitHub deployment keys are used to access these repos on the CI/CD pipelines
 nr-auth = { git = "ssh://git@github.com/newrelic/newrelic-oauth-client-rs.git", tag = "0.0.3" }
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.22", default-features = false }
+opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.23", default-features = false }
 # local dependencies
 fs = { path = "../fs" }
 

--- a/super-agent/src/agent_type.rs
+++ b/super-agent/src/agent_type.rs
@@ -13,3 +13,4 @@ pub mod runtime_config;
 pub mod runtime_config_templates;
 pub mod trivial_value;
 pub mod variable;
+pub mod version_config;

--- a/super-agent/src/agent_type/version_config.rs
+++ b/super-agent/src/agent_type/version_config.rs
@@ -1,0 +1,30 @@
+use duration_str::deserialize_duration;
+use serde::Deserialize;
+use std::time::Duration;
+
+const DEFAULT_VERSION_CHECKER_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct K8sVersionCheckerConfig {
+    pub(crate) interval: VersionCheckerInterval,
+}
+
+#[derive(Debug, Clone, Deserialize, Copy, PartialEq)]
+pub struct VersionCheckerInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+impl From<VersionCheckerInterval> for Duration {
+    fn from(value: VersionCheckerInterval) -> Self {
+        value.0
+    }
+}
+impl From<Duration> for VersionCheckerInterval {
+    fn from(value: Duration) -> Self {
+        Self(value)
+    }
+}
+
+impl Default for VersionCheckerInterval {
+    fn default() -> Self {
+        Self(DEFAULT_VERSION_CHECKER_INTERVAL)
+    }
+}

--- a/super-agent/src/event.rs
+++ b/super-agent/src/event.rs
@@ -5,6 +5,7 @@ pub mod channel;
 use crate::opamp::{LastErrorCode, LastErrorMessage};
 use crate::sub_agent::health::health_checker::{Healthy, Unhealthy};
 use crate::sub_agent::health::with_start_time::HealthWithStartTime;
+use crate::sub_agent::version::version_checker::AgentVersion;
 use crate::super_agent::config::AgentTypeFQN;
 use crate::{opamp::remote_config::RemoteConfig, super_agent::config::AgentID};
 
@@ -45,6 +46,7 @@ impl SubAgentEvent {
 pub enum SubAgentInternalEvent {
     StopRequested,
     AgentHealthInfo(HealthWithStartTime),
+    AgentVersionInfo(AgentVersion),
 }
 
 impl From<HealthWithStartTime> for SubAgentInternalEvent {

--- a/super-agent/src/opamp/client_builder.rs
+++ b/super-agent/src/opamp/client_builder.rs
@@ -128,6 +128,10 @@ pub(crate) mod tests {
         where
         C: Callbacks + Send + Sync + 'static {
 
+            fn get_agent_description(
+                &self,
+            ) -> ClientResult<AgentDescription>;
+
              fn set_agent_description(
                 &self,
                 description: AgentDescription,

--- a/super-agent/src/sub_agent.rs
+++ b/super-agent/src/sub_agent.rs
@@ -8,6 +8,7 @@ pub mod k8s;
 pub mod on_host;
 pub mod persister;
 pub mod supervisor;
+pub mod version;
 
 pub use sub_agent::*;
 mod config_validator;

--- a/super-agent/src/sub_agent/event_handler.rs
+++ b/super-agent/src/sub_agent/event_handler.rs
@@ -1,2 +1,3 @@
 pub mod on_health;
+pub mod on_version;
 pub mod opamp;

--- a/super-agent/src/sub_agent/event_handler/on_version.rs
+++ b/super-agent/src/sub_agent/event_handler/on_version.rs
@@ -1,0 +1,49 @@
+use crate::sub_agent::error::SubAgentError;
+use crate::sub_agent::version::version_checker::AgentVersion;
+use opamp_client::opamp::proto::{any_value, AgentDescription, AnyValue, KeyValue};
+use opamp_client::operation::callbacks::Callbacks;
+use opamp_client::StartedClient;
+
+/// This method request the AgentDescription from the current opamp client and, updates or add the
+/// field from agent version to be sent to opamp server
+pub fn on_version<C, CB>(
+    agent_data: AgentVersion,
+    maybe_opamp_client: Option<&C>,
+) -> Result<(), SubAgentError>
+where
+    C: StartedClient<CB>,
+    CB: Callbacks,
+{
+    if let Some(client) = maybe_opamp_client.as_ref() {
+        let agent_description = client.get_agent_description()?;
+        client.set_agent_description(add_or_change_chart_version_into_agent_description(
+            agent_description,
+            agent_data,
+        ))?;
+    }
+    Ok(())
+}
+
+fn add_or_change_chart_version_into_agent_description(
+    mut agent_description: AgentDescription,
+    agent_data: AgentVersion,
+) -> AgentDescription {
+    let version_info = Some(AnyValue {
+        value: Some(any_value::Value::StringValue(
+            agent_data.version().to_string(),
+        )),
+    });
+    if let Some(attribute) = agent_description
+        .identifying_attributes
+        .iter_mut()
+        .find(|attr| attr.key == agent_data.opamp_field())
+    {
+        attribute.value = version_info;
+    } else {
+        agent_description.identifying_attributes.push(KeyValue {
+            key: agent_data.opamp_field().to_string(),
+            value: version_info,
+        });
+    }
+    agent_description
+}

--- a/super-agent/src/sub_agent/on_host/supervisor.rs
+++ b/super-agent/src/sub_agent/on_host/supervisor.rs
@@ -368,6 +368,7 @@ pub mod tests {
     use crate::sub_agent::health::health_checker::Healthy;
     use crate::sub_agent::on_host::command::executable_data::ExecutableData;
     use crate::sub_agent::on_host::command::restart_policy::{Backoff, RestartPolicy};
+    use crate::sub_agent::version::version_checker::AgentVersion;
     use std::time::{Duration, Instant};
     use tracing_test::traced_test;
 
@@ -638,6 +639,12 @@ pub mod tests {
                     HealthWithStartTime::new(health.into(), start_time).into()
                 }
                 SubAgentInternalEvent::StopRequested => SubAgentInternalEvent::StopRequested,
+                SubAgentInternalEvent::AgentVersionInfo(agent_id) => {
+                    SubAgentInternalEvent::AgentVersionInfo(AgentVersion::new(
+                        agent_id.version().to_string(),
+                        agent_id.opamp_field().to_string(),
+                    ))
+                }
             })
             .collect::<Vec<_>>();
 

--- a/super-agent/src/sub_agent/sub_agent.rs
+++ b/super-agent/src/sub_agent/sub_agent.rs
@@ -10,6 +10,7 @@ use crate::sub_agent::health::health_checker::log_and_report_unhealthy;
 use crate::super_agent::config::{AgentID, SubAgentConfig};
 use crate::values::yaml_config_repository::YAMLConfigRepository;
 
+use crate::sub_agent::event_handler::on_version::on_version;
 use crate::sub_agent::event_handler::opamp::remote_config_handler::RemoteConfigHandler;
 use crate::sub_agent::supervisor::assembler::SupervisorAssembler;
 use crate::sub_agent::supervisor::builder::SupervisorBuilder;
@@ -212,6 +213,13 @@ where
                                     self.agent_cfg.agent_type.clone(),
                                 )
                                 .inspect_err(|e| error!(error = %e, select_arm = "sub_agent_internal_consumer", "processing health message"));
+                            }
+                            Ok(SubAgentInternalEvent::AgentVersionInfo(agenta_data)) => {
+                                 let _ = on_version(
+                                    agenta_data,
+                                    self.maybe_opamp_client.as_ref(),
+                                )
+                                .inspect_err(|e| error!(error = %e, select_arm = "sub_agent_internal_consumer", "processing version message"));
                             }
                         }
                     }

--- a/super-agent/src/sub_agent/version.rs
+++ b/super-agent/src/sub_agent/version.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "k8s")]
+pub mod k8s;
+pub mod version_checker;

--- a/super-agent/src/sub_agent/version/k8s.rs
+++ b/super-agent/src/sub_agent/version/k8s.rs
@@ -1,0 +1,1 @@
+pub mod k8s_version_checker;

--- a/super-agent/src/sub_agent/version/k8s/k8s_version_checker.rs
+++ b/super-agent/src/sub_agent/version/k8s/k8s_version_checker.rs
@@ -1,0 +1,257 @@
+#[cfg_attr(test, mockall_double::double)]
+use crate::k8s::client::SyncK8sClient;
+use crate::sub_agent::version::version_checker::{AgentVersion, VersionCheckError, VersionChecker};
+use crate::super_agent::defaults::OPAMP_CHART_VERSION_ATTRIBUTE_KEY;
+use chrono::NaiveDateTime;
+use serde_json::Value;
+use std::sync::Arc;
+
+const LAST_ATTEMPTED_REVISION: &str = "lastAttemptedRevision";
+const LAST_REVISION: &str = "*";
+pub struct K8sVersionChecker {
+    k8s_client: Arc<SyncK8sClient>,
+    agent_id: String,
+}
+
+impl K8sVersionChecker {
+    pub fn new(k8s_client: Arc<SyncK8sClient>, agent_id: String) -> Self {
+        Self {
+            k8s_client,
+            agent_id,
+        }
+    }
+    fn extract_version(
+        &self,
+        data: &serde_json::Map<String, Value>,
+    ) -> Result<AgentVersion, VersionCheckError> {
+        let extractors = [
+            extract_revision,
+            extract_last_deployed_revision,
+            extract_revision_from_history,
+        ];
+
+        for extractor in &extractors {
+            if let Some(version) = extractor(data) {
+                if !version.is_empty() {
+                    return Ok(AgentVersion::new(
+                        version,
+                        OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                    ));
+                }
+            }
+        }
+
+        Err(VersionCheckError::Generic(
+            "No valid version found in HelmRelease".to_string(),
+        ))
+    }
+}
+
+impl VersionChecker for K8sVersionChecker {
+    fn check_agent_version(&self) -> Result<AgentVersion, VersionCheckError> {
+        // Attempt to get the HelmRelease from Kubernetes
+        let helm_release = self
+            .k8s_client
+            .get_helm_release(&self.agent_id)
+            .map_err(|e| {
+                VersionCheckError::Generic(format!(
+                    "Error fetching HelmRelease '{}': {}",
+                    &self.agent_id, e
+                ))
+            })?
+            .ok_or_else(|| {
+                VersionCheckError::Generic(format!("HelmRelease '{}' not found", &self.agent_id))
+            })?;
+
+        let helm_release_data = helm_release.data.as_object().ok_or_else(|| {
+            VersionCheckError::Generic("HelmRelease data is not an object".to_string())
+        })?;
+
+        self.extract_version(helm_release_data)
+    }
+}
+//Attempt to get version from chart
+fn extract_revision(helm_data: &serde_json::map::Map<String, Value>) -> Option<String> {
+    helm_data
+        .get("spec")
+        .and_then(|spec| spec.get("chart"))
+        .and_then(|chart| chart.get("spec"))
+        .and_then(|spec| spec.get("version"))
+        .and_then(|version| version.as_str())
+        .filter(|&version| version != LAST_REVISION)
+        .map(|version| version.to_string())
+}
+//Attempt to get version from last attempted deployed revision
+fn extract_last_deployed_revision(
+    helm_data: &serde_json::map::Map<String, Value>,
+) -> Option<String> {
+    helm_data
+        .get(LAST_ATTEMPTED_REVISION)
+        .and_then(|last_attempt_revision| last_attempt_revision.as_str())
+        .filter(|version| !version.is_empty())
+        .map(|version| version.to_string())
+}
+//Attempt to get version from the history looking for status deployed and sort by date
+fn extract_revision_from_history(
+    helm_data: &serde_json::map::Map<String, Value>,
+) -> Option<String> {
+    let helm_history = helm_data.get("history")?.as_array()?;
+
+    let latest_entry = helm_history
+        .iter()
+        .filter_map(|history_item| {
+            let item = history_item.as_object()?;
+            let status = item.get("status")?.as_str()?;
+            let deployment_date = item.get("firstDeployed")?.as_str()?;
+            let chart_version = item.get("chartVersion")?.as_str()?;
+
+            if status == "deployed" {
+                let parsed_date =
+                    NaiveDateTime::parse_from_str(deployment_date, "%Y-%m-%dT%H:%M:%SZ").ok()?;
+                Some((parsed_date, chart_version.to_string()))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|entry| entry.0);
+
+    match latest_entry {
+        Some((_, version)) => Some(version),
+        _ => None,
+    }
+}
+#[cfg(test)]
+pub mod test {
+    use crate::k8s::client::MockSyncK8sClient;
+    use crate::sub_agent::version::k8s::k8s_version_checker::K8sVersionChecker;
+    use crate::sub_agent::version::version_checker::{
+        AgentVersion, VersionCheckError, VersionChecker,
+    };
+    use crate::super_agent::config::helm_release_type_meta;
+    use crate::super_agent::defaults::OPAMP_CHART_VERSION_ATTRIBUTE_KEY;
+    use kube::api::DynamicObject;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_k8s_check_agent_version() {
+        struct TestCase {
+            name: &'static str,
+            expected: Result<AgentVersion, VersionCheckError>,
+            mock_return: String,
+        }
+        impl TestCase {
+            fn run(self) {
+                let mut k8s_client = MockSyncK8sClient::new();
+                setup_default_mock(&mut k8s_client, self.mock_return);
+                let check =
+                    K8sVersionChecker::new(Arc::new(k8s_client), String::from("default-test"));
+                let result = check.check_agent_version();
+                match self.expected {
+                    Ok(expected_agent_version) => {
+                        let agent_version_result = result.unwrap_or_else(|e| {
+                            panic!("Failed to check agent version {}: {}", self.name, e)
+                        });
+                        assert_eq!(expected_agent_version, agent_version_result);
+                    }
+                    Err(expected_err) => {
+                        assert_eq!(
+                            expected_err.to_string(),
+                            format!("{}", result.unwrap_err()),
+                            "{}",
+                            self.name
+                        );
+                    }
+                }
+            }
+        }
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                name: "Helm version is obtained from the chart version",
+                expected: Ok(AgentVersion::new(
+                    String::from("1.12.12"),
+                    OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                )),
+                mock_return: build_json_data("1.12.12", "1.15.1"),
+            },
+            TestCase {
+                name: "Helm version is obtained from the last attempted revision",
+                expected: Ok(AgentVersion::new(
+                    String::from("1.15.1"),
+                    OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                )),
+                mock_return: build_json_data("*", "1.15.1"),
+            },
+            TestCase {
+                name: "Helm version is obtained from the history",
+                expected: Ok(AgentVersion::new(
+                    String::from("1.43.6"),
+                    OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                )),
+                mock_return: build_json_data("*", ""),
+            },
+            TestCase {
+                name: "Helm version couldn't be obtained from the helm data",
+                expected: Err(VersionCheckError::Generic(
+                    "No valid version found in HelmRelease".to_string(),
+                )),
+                mock_return: "{}".to_string(),
+            },
+        ];
+
+        for test_case in test_cases {
+            test_case.run();
+        }
+    }
+    fn build_json_data(chart_version: &str, last_attempted_version: &str) -> String {
+        format!(
+            r#"{{
+        "lastAttemptedRevision": "{}",
+        "spec": {{
+            "chart": {{
+                "spec": {{
+                    "chart": "default-test",
+                    "version": "{}"
+                }}
+            }}
+        }},
+        "history": [
+            {{
+                "chartName": "default-test",
+                "chartVersion": "1.45.6",
+                "firstDeployed": "2024-11-13T14:28:33Z",
+                "status": "deployed"
+            }},
+            {{
+                "chartName": "default-test",
+                "chartVersion": "1.43.6",
+                "firstDeployed": "2024-11-16T14:28:33Z",
+                "status": "deployed"
+            }},
+            {{
+                "chartName": "default-test",
+                "chartVersion": "1.45.9",
+                "firstDeployed": "2024-11-14T14:28:33Z",
+                "status": "fail"
+            }}
+        ]
+    }}"#,
+            last_attempted_version, chart_version
+        )
+    }
+    fn get_dynamic_object(json_data: String) -> DynamicObject {
+        let parsed_data: Value = serde_json::from_str(&json_data).expect("Error parsing JSON");
+        DynamicObject {
+            types: Some(helm_release_type_meta()),
+            metadata: Default::default(),
+            data: json!(parsed_data),
+        }
+    }
+
+    fn setup_default_mock(mock: &mut MockSyncK8sClient, json_data: String) {
+        mock.expect_get_helm_release()
+            .withf(|name| name == "default-test")
+            .times(1)
+            .returning(move |_| Ok(Some(Arc::new(get_dynamic_object(json_data.clone())))));
+    }
+}

--- a/super-agent/src/sub_agent/version/version_checker.rs
+++ b/super-agent/src/sub_agent/version/version_checker.rs
@@ -1,0 +1,155 @@
+use crate::agent_type::version_config::VersionCheckerInterval;
+use crate::event::cancellation::CancellationMessage;
+use crate::event::channel::{EventConsumer, EventPublisher};
+use crate::event::SubAgentInternalEvent;
+use crate::super_agent::config::AgentID;
+use std::thread;
+use tracing::{debug, error};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentVersion {
+    version: String,
+    opamp_field: String,
+}
+
+impl AgentVersion {
+    pub fn new(version: String, opamp_field: String) -> Self {
+        Self {
+            version,
+            opamp_field,
+        }
+    }
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+    pub fn opamp_field(&self) -> &str {
+        &self.opamp_field
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum VersionCheckError {
+    #[error("Generic error: {0}")]
+    Generic(String),
+}
+pub trait VersionChecker {
+    /// Use it to report the agent version for the opamp client
+    /// Uses a thread to check the version of and agent and report it
+    /// with internal events. The reported AgentVersion should
+    /// contain "version" and the field for opamp that is going to contain the version
+    fn check_agent_version(&self) -> Result<AgentVersion, VersionCheckError>;
+}
+
+pub(crate) fn spawn_version_checker<V>(
+    agent_id: AgentID,
+    version_checker: V,
+    cancel_signal: EventConsumer<CancellationMessage>,
+    sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
+    interval: VersionCheckerInterval,
+) where
+    V: VersionChecker + Send + Sync + 'static,
+{
+    thread::spawn(move || loop {
+        if cancel_signal.is_cancelled(interval.into()) {
+            break;
+        }
+        debug!(%agent_id, "starting to check version with the configured checker");
+
+        match version_checker.check_agent_version() {
+            Ok(agent_data) => {
+                publish_version_event(
+                    &sub_agent_internal_publisher,
+                    SubAgentInternalEvent::AgentVersionInfo(agent_data),
+                );
+            }
+            Err(error) => {
+                error!(%agent_id, %error, "failed to check agent version");
+            }
+        }
+    });
+}
+
+pub(crate) fn publish_version_event(
+    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
+    event: SubAgentInternalEvent,
+) {
+    let event_type_str = format!("{:?}", event);
+    _ = sub_agent_internal_publisher
+        .publish(event)
+        .inspect_err(|e| {
+            error!(
+                err = e.to_string(),
+                event_type = event_type_str,
+                "could not publish sub agent event"
+            )
+        });
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::event::channel::pub_sub;
+    use crate::event::SubAgentInternalEvent;
+    use crate::event::SubAgentInternalEvent::AgentVersionInfo;
+    use crate::sub_agent::version::version_checker::{
+        spawn_version_checker, AgentVersion, VersionCheckError, VersionChecker,
+    };
+    use crate::super_agent::config::AgentID;
+    use crate::super_agent::defaults::OPAMP_CHART_VERSION_ATTRIBUTE_KEY;
+    use mockall::{mock, Sequence};
+    use std::time::Duration;
+
+    mock! {
+        pub VersionCheckerMock {}
+        impl VersionChecker for VersionCheckerMock {
+            fn check_agent_version(&self) -> Result<AgentVersion, VersionCheckError>;
+        }
+    }
+
+    #[test]
+    fn test_spawn_version_checker() {
+        let (cancel_publisher, cancel_signal) = pub_sub();
+        let (version_publisher, version_consumer) = pub_sub();
+
+        let mut version_checker = MockVersionCheckerMock::new();
+        let mut seq = Sequence::new();
+        version_checker
+            .expect_check_agent_version()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Ok(AgentVersion::new(
+                    "1.0.0".to_string(),
+                    OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                ))
+            });
+
+        version_checker
+            .expect_check_agent_version()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                cancel_publisher.publish(()).unwrap();
+                Err(VersionCheckError::Generic(
+                    "mocked version check error!".to_string(),
+                ))
+            });
+
+        let agent_id = AgentID::new("test-agent").unwrap();
+        spawn_version_checker(
+            agent_id,
+            version_checker,
+            cancel_signal,
+            version_publisher,
+            Duration::default().into(),
+        );
+
+        let expected_version_events: Vec<SubAgentInternalEvent> = {
+            vec![AgentVersionInfo(AgentVersion {
+                version: "1.0.0".to_string(),
+                opamp_field: OPAMP_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+            })]
+        };
+        let actual_version_events = version_consumer.as_ref().iter().collect::<Vec<_>>();
+        assert_eq!(expected_version_events, actual_version_events);
+    }
+}

--- a/super-agent/src/super_agent/defaults.rs
+++ b/super-agent/src/super_agent/defaults.rs
@@ -13,6 +13,7 @@ pub const NR_OTEL_COLLECTOR_VERSION: &str =
     konst::option::unwrap_or!(option_env!("NR_OTEL_COLLECTOR_VERSION"), "0.0.0");
 
 // Keys identifying attributes
+pub const OPAMP_CHART_VERSION_ATTRIBUTE_KEY: &str = "chart.version";
 pub const OPAMP_SERVICE_NAME: &str = "service.name";
 pub const OPAMP_SERVICE_VERSION: &str = "service.version";
 pub const OPAMP_SERVICE_NAMESPACE: &str = "service.namespace";

--- a/super-agent/tests/common/attributes.rs
+++ b/super-agent/tests/common/attributes.rs
@@ -1,13 +1,9 @@
 use crate::common::opamp::FakeServer;
 use newrelic_super_agent::opamp::instance_id::InstanceID;
-use newrelic_super_agent::super_agent::defaults::{
-    HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_NAME,
-    OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, PARENT_AGENT_ID_ATTRIBUTE_KEY,
-};
-use nix::unistd::gethostname;
+
 use opamp_client::opamp::proto::any_value::Value;
-use opamp_client::opamp::proto::any_value::Value::BytesValue;
 use opamp_client::opamp::proto::{AnyValue, KeyValue};
+
 pub fn check_latest_identifying_attributes_match_expected(
     opamp_server: &FakeServer,
     instance_id: &InstanceID,
@@ -52,57 +48,12 @@ fn check_opamp_attributes(
     }
     Ok(())
 }
-pub fn get_expected_identifying_attributes(
-    namespace: String,
-    service_name: String,
-    service_version: String,
-    agent_version: Option<String>,
-) -> Vec<KeyValue> {
-    let mut y: Vec<KeyValue> = Vec::from([
-        (KeyValue {
-            key: OPAMP_SERVICE_NAMESPACE.to_string(),
-            value: Some(AnyValue {
-                value: Some(Value::StringValue(namespace)),
-            }),
-        }),
-        (KeyValue {
-            key: OPAMP_SERVICE_NAME.to_string(),
-            value: Some(AnyValue {
-                value: Some(Value::StringValue(service_name)),
-            }),
-        }),
-        (KeyValue {
-            key: OPAMP_SERVICE_VERSION.to_string(),
-            value: Some(AnyValue {
-                value: Some(Value::StringValue(service_version)),
-            }),
-        }),
-    ]);
-    if let Some(agent_version) = agent_version {
-        y.push(KeyValue {
-            key: OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
-            value: Some(AnyValue {
-                value: Some(Value::StringValue(agent_version)),
-            }),
+
+pub fn convert_to_vec_key_value(data: Vec<(&str, Value)>) -> Vec<KeyValue> {
+    data.into_iter()
+        .map(|(k, v)| KeyValue {
+            key: k.to_string(),
+            value: Some(AnyValue { value: Some(v) }),
         })
-    }
-    y
-}
-pub fn get_expected_non_identifying_attributes(instace_id: InstanceID) -> Vec<KeyValue> {
-    Vec::from([
-        (KeyValue {
-            key: HOST_NAME_ATTRIBUTE_KEY.to_string(),
-            value: Some(AnyValue {
-                value: Some(Value::StringValue(
-                    gethostname().unwrap_or_default().into_string().unwrap(),
-                )),
-            }),
-        }),
-        (KeyValue {
-            key: PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
-            value: Some(AnyValue {
-                value: Some(BytesValue(instace_id.into())),
-            }),
-        }),
-    ])
+        .collect()
 }

--- a/super-agent/tests/k8s/scenarios.rs
+++ b/super-agent/tests/k8s/scenarios.rs
@@ -1,4 +1,5 @@
 mod ac_restarts;
+mod attributes;
 mod cr_based_agents;
 mod no_opamp;
 mod opamp;

--- a/super-agent/tests/k8s/scenarios/attributes.rs
+++ b/super-agent/tests/k8s/scenarios/attributes.rs
@@ -1,0 +1,158 @@
+use crate::common::attributes::{
+    check_latest_identifying_attributes_match_expected,
+    check_latest_non_identifying_attributes_match_expected, convert_to_vec_key_value,
+};
+use crate::common::opamp::ConfigResponse;
+use crate::common::retry::retry;
+use crate::common::{opamp::FakeServer, runtime::block_on};
+use crate::k8s::tools::super_agent::{
+    wait_until_super_agent_with_opamp_is_started, CUSTOM_AGENT_TYPE_PATH,
+};
+use crate::k8s::tools::{
+    instance_id, k8s_env::K8sEnv, super_agent::start_super_agent_with_testdata_config,
+};
+use newrelic_super_agent::super_agent::config::AgentID;
+use newrelic_super_agent::super_agent::defaults::{
+    CLUSTER_NAME_ATTRIBUTE_KEY, FLEET_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CHART_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_NAME,
+    OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, PARENT_AGENT_ID_ATTRIBUTE_KEY,
+};
+use nix::unistd::gethostname;
+use opamp_client::opamp::proto::any_value::Value;
+use opamp_client::opamp::proto::any_value::Value::BytesValue;
+use serial_test::serial;
+use std::time::Duration;
+use tempfile::tempdir;
+
+/// This scenario tests an Agent type which only create a CR when the CRD already exists.
+/// The sub-agent is added from remote config and them we check if the agent description is what we expect.
+#[test]
+#[ignore = "needs a k8s cluster"]
+#[serial]
+fn test_attributes_from_existing_agent_type() {
+    let test_name = "k8s_opamp_add_sub_agent";
+
+    // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
+    let mut server = FakeServer::start_new();
+
+    // setup the k8s environment
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    // start the super-agent
+    let _sa = start_super_agent_with_testdata_config(
+        test_name,
+        CUSTOM_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        Some(&server.endpoint()),
+        vec!["local-data-hello-world"],
+        tmp_dir.path(),
+    );
+    wait_until_super_agent_with_opamp_is_started(k8s.client.clone(), namespace.as_str());
+
+    let instance_id = instance_id::get_instance_id(&namespace, &AgentID::new_super_agent_id());
+    server.set_config_response(
+        instance_id.clone(),
+        ConfigResponse::from(
+            r#"
+agents:
+  hello-world:
+    agent_type: "newrelic/com.newrelic.custom_agent:0.0.1"
+            "#,
+        ),
+    );
+
+    let expected_identifying_attributes = convert_to_vec_key_value(Vec::from([
+        (
+            OPAMP_SERVICE_NAMESPACE,
+            Value::StringValue("newrelic".to_string()),
+        ),
+        (
+            OPAMP_SERVICE_NAME,
+            Value::StringValue("com.newrelic.super_agent".to_string()),
+        ),
+        (
+            OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+            Value::StringValue("0.26.0".to_string()),
+        ),
+    ]));
+
+    let expected_non_identifying_attributes = convert_to_vec_key_value(Vec::from([
+        (
+            HOST_NAME_ATTRIBUTE_KEY,
+            Value::StringValue(gethostname().unwrap_or_default().into_string().unwrap()),
+        ),
+        (
+            FLEET_ID_ATTRIBUTE_KEY,
+            Value::StringValue(String::default()),
+        ),
+        (
+            CLUSTER_NAME_ATTRIBUTE_KEY,
+            Value::StringValue("minikube".to_string()),
+        ),
+    ]));
+
+    // Check attributes of Agent Control
+    retry(60, Duration::from_secs(5), || {
+        check_latest_identifying_attributes_match_expected(
+            &server,
+            &instance_id,
+            expected_identifying_attributes.clone(),
+        )?;
+        check_latest_non_identifying_attributes_match_expected(
+            &server,
+            &instance_id,
+            expected_non_identifying_attributes.clone(),
+        )?;
+        Ok(())
+    });
+
+    let expected_identifying_attributes_sub_agent = convert_to_vec_key_value(Vec::from([
+        (
+            OPAMP_SERVICE_NAMESPACE,
+            Value::StringValue("newrelic".to_string()),
+        ),
+        (
+            OPAMP_SERVICE_NAME,
+            Value::StringValue("com.newrelic.custom_agent".to_string()),
+        ),
+        (
+            OPAMP_SERVICE_VERSION,
+            Value::StringValue("0.0.1".to_string()),
+        ),
+        (
+            OPAMP_CHART_VERSION_ATTRIBUTE_KEY,
+            Value::StringValue("0.1.0".to_string()),
+        ),
+    ]));
+
+    let expected_non_identifying_attributes_sub_agent = convert_to_vec_key_value(Vec::from([
+        (
+            CLUSTER_NAME_ATTRIBUTE_KEY,
+            Value::StringValue("minikube".to_string()),
+        ),
+        (
+            PARENT_AGENT_ID_ATTRIBUTE_KEY,
+            BytesValue(instance_id.clone().into()),
+        ),
+    ]));
+
+    // Check attributes of sub agent
+    retry(90, Duration::from_secs(5), || {
+        let instance_id_sub_agent =
+            instance_id::get_instance_id(&namespace, &AgentID::new("hello-world").unwrap());
+        check_latest_identifying_attributes_match_expected(
+            &server,
+            &instance_id_sub_agent,
+            expected_identifying_attributes_sub_agent.clone(),
+        )?;
+        check_latest_non_identifying_attributes_match_expected(
+            &server,
+            &instance_id_sub_agent,
+            expected_non_identifying_attributes_sub_agent.clone(),
+        )?;
+        Ok(())
+    })
+}


### PR DESCRIPTION
Add new thread spawn in the same way than health check to check the version of the charts of the sub agents.

The order is : 
1 - look for the version of the spec -> chart .. etc to version.
2 - LastAttemptedRevision field.
3 - Look into the history of deployments to get the once with deployed status and newer in time status "FirstDeployed"

This thread publish a events to be consumed internally and the message handler execute the action to get all the attributes from opamp client "synced state" and if the chart.version is there should be updated and if not is added.