### PR TITLE
faet(agents): add dotnet and ruby

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -96,5 +96,5 @@ helm_resource(
   resource_deps=['build-binary']+extra_resource_deps
 )
 
-# We had flaky e2e test faling due to timeout applying the chart on 30s
+# We had flaky e2e test failing due to timeout applying the chart on 30s
 update_settings(k8s_upsert_timeout_secs=150)

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -1,0 +1,42 @@
+namespace: newrelic
+name: com.newrelic.apm_dotnet
+version: 0.1.0
+variables:
+  k8s:
+    version:
+      description: "Dotnet Agent init container version"
+      type: string
+      default: "latest"
+      required: false
+    pod_label_selector:
+      description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    namespace_label_selector:
+      description: "Namespace label selector"
+      type: yaml
+      default: { }
+      required: false
+    env:
+      description: "environment variables to pass to Dotnet agent"
+      type: yaml
+      default: [ ]
+      required: false
+deployment:
+  k8s:
+    health:
+      interval: 30s
+    objects:
+      instrumentation:
+        apiVersion: newrelic.com/v1alpha2
+        kind: Instrumentation
+        metadata:
+          name: ${nr-sub:agent_id}
+        spec:
+          agent:
+            language: dotnet
+            image: newrelic/newrelic-dotnet-init:${nr-var:version}
+            env: ${nr-var:env}
+          podLabelSelector: ${nr-var:pod_label_selector}
+          namespaceLabelSelector: ${nr-var:namespace_label_selector}

--- a/super-agent/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/super-agent/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -1,0 +1,42 @@
+namespace: newrelic
+name: com.newrelic.apm_ruby
+version: 0.1.0
+variables:
+  k8s:
+    version:
+      description: "Ruby Agent init container version"
+      type: string
+      default: "latest"
+      required: false
+    pod_label_selector:
+      description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    namespace_label_selector:
+      description: "Namespace label selector"
+      type: yaml
+      default: { }
+      required: false
+    env:
+      description: "environment variables to pass to Ruby agent"
+      type: yaml
+      default: [ ]
+      required: false
+deployment:
+  k8s:
+    health:
+      interval: 30s
+    objects:
+      instrumentation:
+        apiVersion: newrelic.com/v1alpha2
+        kind: Instrumentation
+        metadata:
+          name: ${nr-sub:agent_id}
+        spec:
+          agent:
+            language: ruby
+            image: newrelic/newrelic-ruby-init:${nr-var:version}
+            env: ${nr-var:env}
+          podLabelSelector: ${nr-var:pod_label_selector}
+          namespaceLabelSelector: ${nr-var:namespace_label_selector}

--- a/test/k8s-e2e/e2e-apm.yml
+++ b/test/k8s-e2e/e2e-apm.yml
@@ -6,16 +6,23 @@ scenarios:
   - description: Deploy SA with APM operator and Java, Python and Node.js agents
     before:
       - cd ../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/super-agent-apm.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      # we need wait and retry since the resource might me not created yet
+      - timeout 600s bash -c "until kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 deploy/operator-k8s-agents-operator; do sleep 5; echo waiting on operator ; done"
       - sleep 60
-      - kubectl run ${SCENARIO_TAG}-java --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main -o yaml | kubectl label app=javaapp -f - --local -o yaml | kubectl create -f -
       - kubectl run ${SCENARIO_TAG}-python --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python:main -o yaml | kubectl label app=pythonapp -f - --local -o yaml | kubectl create -f -
+      - kubectl run ${SCENARIO_TAG}-java --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main -o yaml | kubectl label app=javaapp -f - --local -o yaml | kubectl create -f -
+      - kubectl run ${SCENARIO_TAG}-dotnet --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-dotnet:main -o yaml | kubectl label app=dotneteapp -f - --local -o yaml | kubectl create -f -
       - kubectl run ${SCENARIO_TAG}-node --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-nodejs:main -o yaml --command -- sh -c "yarn add express && node index.js" | kubectl label app=nodeapp -f - --local -o yaml | kubectl create -f -
-      # Give time to the apps to start, query python and node apps to trigger instrumentation
-      - until kubectl exec ${SCENARIO_TAG}-python -c ${SCENARIO_TAG}-python -- wget -qO- 127.0.0.1:8080; do sleep 5; done
-      - until kubectl exec ${SCENARIO_TAG}-node -c ${SCENARIO_TAG}-node -- wget -qO- 127.0.0.1:3000; do sleep 5; done
-      # Repeat the same queries a couple times more just in case, to ensure metrics are generated
-      - seq 4 | xargs -I{} kubectl exec ${SCENARIO_TAG}-python -c ${SCENARIO_TAG}-python -- wget -qO- 127.0.0.1:8080
-      - seq 4 | xargs -I{} kubectl exec ${SCENARIO_TAG}-node -c ${SCENARIO_TAG}-node -- wget -qO- 127.0.0.1:3000
+      - kubectl create -f ./rubyapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-ruby/ | kubectl create -f -
+
+      # Generate some traffic
+      - kubectl wait --for=condition=Ready --all pods --timeout 5m
+      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-python -c ${SCENARIO_TAG}-python -- wget -qO /dev/null 127.0.0.1:8080
+      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-node -c ${SCENARIO_TAG}-node -- wget -qO /dev/null 127.0.0.1:3000
+      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null 127.0.0.1:9292
+      # dotnet image does not have wget available, we use one from a different pod
+      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`
+
     after:
       - kubectl logs -l app.kubernetes.io/name=super-agent-deployment --all-containers --prefix=true
       - kubectl logs -l app.kubernetes.io/instance=operator --all-containers --prefix=true
@@ -28,7 +35,5 @@ scenarios:
         - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-java' -- comment disabling the appended testKey: "
         - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-python' -- comment disabling the appended testKey: "
         - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-node' -- comment disabling the appended testKey: "
-
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.errorRate' AND appName = '${SCENARIO_TAG}-java' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.errorRate' AND appName = '${SCENARIO_TAG}-python' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.errorRate' AND appName = '${SCENARIO_TAG}-node' -- comment disabling the appended testKey: "
+        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-ruby' -- comment disabling the appended testKey: "
+        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-dotnet' -- comment disabling the appended testKey: "

--- a/test/k8s-e2e/rubyapp.yaml
+++ b/test/k8s-e2e/rubyapp.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder
+data:
+  Gemfile: |
+    # frozen_string_literal: true
+    source 'https://rubygems.org'
+    gem 'sinatra'
+    gem 'rackup', '~> 2.2'
+    gem 'webrick'
+  main.rb: |
+    # frozen_string_literal: true
+    require 'sinatra'
+    get '/' do
+      "Hello, World!"
+    end
+  config.ru: |
+    require 'bundler'
+    Bundler.require
+    require './main.rb'
+    run Sinatra::Application
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  labels:
+    app: rubyapp
+spec:
+  containers:
+    - name: placeholder
+      image: ruby:3.3-alpine
+      workingDir: /app
+      command:
+        - sh
+        - -c
+        - "bundle install ; bundle exec rackup --host 0.0.0.0 --port 9292"
+      ports:
+        - containerPort: 9292
+      volumeMounts:
+        - mountPath: /app/Gemfile
+          name: code
+          subPath: Gemfile
+        - mountPath: /app/config.ru
+          name: code
+          subPath: config.ru
+        - mountPath: /app/main.rb
+          name: code
+          subPath: main.rb
+  volumes:
+    - name: code
+      configMap:
+        name: placeholder

--- a/test/k8s-e2e/super-agent-apm.yml
+++ b/test/k8s-e2e/super-agent-apm.yml
@@ -38,3 +38,19 @@ super-agent-deployment:
               - key: "app"
                 operator: "In"
                 values: [ "nodeapp" ]
+      ruby-agent:
+        type: newrelic/com.newrelic.apm_ruby:0.1.0
+        content:
+          pod_label_selector:
+            matchExpressions:
+              - key: "app"
+                operator: "In"
+                values: [ "rubyapp" ]
+      dotnet-agent:
+        type: newrelic/com.newrelic.apm_dotnet:0.1.0
+        content:
+          pod_label_selector:
+            matchExpressions:
+              - key: "app"
+                operator: "In"
+                values: [ "dotneteapp" ]


### PR DESCRIPTION
This PR:
 - adds the support for ruby and dotnet
 - adds e2e tests for the 2 new agentTypes
 - improves the stability of the tests