### PR TITLE
Remove opamp client from supervisor

### DIFF
--- a/super-agent/src/sub_agent/on_host/builder.rs
+++ b/super-agent/src/sub_agent/on_host/builder.rs
@@ -93,7 +93,7 @@ where
     Y: YAMLConfigRepository,
 {
     type NotStartedSubAgent =
-        SubAgent<O::Client, SubAgentCallbacks<G>, A, SupervisortBuilderOnHost<O, G>, HR, Y>;
+        SubAgent<O::Client, SubAgentCallbacks<G>, A, SupervisortBuilderOnHost, HR, Y>;
 
     fn build(
         &self,
@@ -169,41 +169,18 @@ fn get_hostname() -> String {
     return unimplemented!();
 }
 
-pub struct SupervisortBuilderOnHost<O, G>
-where
-    G: EffectiveConfigLoader,
-    O: OpAMPClientBuilder<SubAgentCallbacks<G>>,
-{
+pub struct SupervisortBuilderOnHost {
     logging_path: PathBuf,
-
-    // This is needed to ensure the generic type parameters O and G are used.
-    // Else Rust will reject this, complaining that the type parameter is not used.
-    _opamp_client_builder: PhantomData<O>,
-    _effective_config_loader: PhantomData<G>,
 }
 
-impl<O, G> SupervisortBuilderOnHost<O, G>
-where
-    G: EffectiveConfigLoader,
-    O: OpAMPClientBuilder<SubAgentCallbacks<G>>,
-{
+impl SupervisortBuilderOnHost {
     pub fn new(logging_path: PathBuf) -> Self {
-        Self {
-            logging_path,
-            _opamp_client_builder: PhantomData,
-            _effective_config_loader: PhantomData,
-        }
+        Self { logging_path }
     }
 }
 
-impl<O, G> SupervisorBuilder for SupervisortBuilderOnHost<O, G>
-where
-    G: EffectiveConfigLoader,
-    O: OpAMPClientBuilder<SubAgentCallbacks<G>>,
-{
+impl SupervisorBuilder for SupervisortBuilderOnHost {
     type SupervisorStarter = NotStartedSupervisorOnHost;
-
-    type OpAMPClient = O::Client;
 
     fn build_supervisor(
         &self,

--- a/super-agent/src/sub_agent/sub_agent.rs
+++ b/super-agent/src/sub_agent/sub_agent.rs
@@ -77,7 +77,7 @@ where
     C: StartedClient<CB> + Send + Sync + 'static,
     CB: Callbacks + Send + Sync + 'static,
     A: EffectiveAgentsAssembler + Send + Sync + 'static,
-    B: SupervisorBuilder<OpAMPClient = C> + Send + Sync + 'static,
+    B: SupervisorBuilder + Send + Sync + 'static,
     HS: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository,
 {
@@ -101,7 +101,7 @@ where
     C: StartedClient<CB> + Send + Sync + 'static,
     CB: Callbacks + Send + Sync + 'static,
     A: EffectiveAgentsAssembler + Send + Sync + 'static,
-    B: SupervisorBuilder<OpAMPClient = C> + Send + Sync + 'static,
+    B: SupervisorBuilder + Send + Sync + 'static,
     HS: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository,
 {
@@ -302,7 +302,7 @@ where
     C: StartedClient<CB> + Send + Sync + 'static,
     CB: Callbacks + Send + Sync + 'static,
     A: EffectiveAgentsAssembler + Send + Sync + 'static,
-    B: SupervisorBuilder<OpAMPClient = C> + Send + Sync + 'static,
+    B: SupervisorBuilder + Send + Sync + 'static,
     HS: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository,
 {

--- a/super-agent/src/sub_agent/supervisor/builder.rs
+++ b/super-agent/src/sub_agent/supervisor/builder.rs
@@ -4,7 +4,6 @@ use crate::sub_agent::supervisor::starter::SupervisorStarter;
 
 pub trait SupervisorBuilder {
     type SupervisorStarter: SupervisorStarter;
-    type OpAMPClient;
 
     fn build_supervisor(
         &self,
@@ -14,9 +13,6 @@ pub trait SupervisorBuilder {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::opamp::callbacks::AgentCallbacks;
-    use crate::opamp::client_builder::tests::MockStartedOpAMPClientMock;
-    use crate::opamp::effective_config::loader::tests::MockEffectiveConfigLoaderMock;
     use crate::sub_agent::effective_agents_assembler::EffectiveAgent;
     use crate::sub_agent::error::SubAgentBuilderError;
     use crate::sub_agent::supervisor::builder::SupervisorBuilder;
@@ -28,7 +24,6 @@ pub(crate) mod tests {
 
         impl<A> SupervisorBuilder for SupervisorBuilder<A> where A: SupervisorStarter {
             type SupervisorStarter = A;
-            type OpAMPClient = MockStartedOpAMPClientMock<AgentCallbacks<MockEffectiveConfigLoaderMock>>;
 
             fn build_supervisor(
                 &self,


### PR DESCRIPTION
Supervisor builders had unnecessary and unused dependencies, probably leftovers from refactors.


```rust
    // This is needed to ensure the generic type parameters O and G are used.
    // Else Rust will reject this, complaining that the type parameter is not used.
    _opamp_client_builder: PhantomData<O>,
    _effective_config_loader: PhantomData<G>
```