### PR TITLE
chore: avoid creating instance id from tests helpers

### DIFF
--- a/super-agent/tests/k8s/tools/instance_id.rs
+++ b/super-agent/tests/k8s/tools/instance_id.rs
@@ -1,21 +1,26 @@
-use super::super_agent::TEST_CLUSTER_NAME;
+use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
 use newrelic_super_agent::k8s::client::SyncK8sClient;
-use newrelic_super_agent::k8s::store::K8sStore;
-use newrelic_super_agent::opamp::instance_id;
-use newrelic_super_agent::opamp::instance_id::getter::{
-    InstanceIDGetter, InstanceIDWithIdentifiersGetter,
-};
+use newrelic_super_agent::k8s::store::{K8sStore, STORE_KEY_INSTANCE_ID};
+use newrelic_super_agent::opamp::instance_id::getter::DataStored;
 use newrelic_super_agent::opamp::instance_id::InstanceID;
 use newrelic_super_agent::super_agent::config::AgentID;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub fn get_instance_id(namespace: &str, agent_id: &AgentID) -> InstanceID {
     let k8s_client =
         Arc::new(SyncK8sClient::try_new(tokio_runtime(), namespace.to_string()).unwrap());
-    let instance_id_getter = InstanceIDWithIdentifiersGetter::new_k8s_instance_id_getter(
-        Arc::new(K8sStore::new(k8s_client)),
-        instance_id::get_identifiers(TEST_CLUSTER_NAME.to_string(), "".to_string()),
-    );
-    instance_id_getter.get(agent_id).unwrap()
+    let store = K8sStore::new(k8s_client);
+
+    let mut id = InstanceID::create();
+
+    retry(60, Duration::from_secs(1), || {
+        let data: Option<DataStored> = store.get_opamp_data(agent_id, STORE_KEY_INSTANCE_ID)?;
+        id = data
+            .ok_or(format!("agent_id={} Instance ID not found", agent_id))?
+            .instance_id;
+        Ok(())
+    });
+    id
 }


### PR DESCRIPTION
replace the instanceid getter, which creates instance ids in case they don't exists. This might be the reason we [still](https://github.com/newrelic/newrelic-super-agent/actions/runs/12274906679/job/34248819360?pr=939#step:8:1083) see k8s integration flaky tests