### PR TITLE
style: remove `Default` impl for unit structs

### DIFF
--- a/agent-control/src/agent_control/pid_cache.rs
+++ b/agent-control/src/agent_control/pid_cache.rs
@@ -61,7 +61,7 @@ impl Default for PIDCache<LocalFile, DirectoryManagerFs> {
     fn default() -> Self {
         PIDCache {
             file_rw: LocalFile,
-            directory_manager: DirectoryManagerFs::default(),
+            directory_manager: DirectoryManagerFs,
             file_path: PID_FILE_PATH.into(),
             proc_path: PROC_PATH.into(),
         }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -73,7 +73,7 @@ impl AgentControlRunner {
 
         let instance_id_storer = Storer::new(
             LocalFile,
-            DirectoryManagerFs::default(),
+            DirectoryManagerFs,
             self.base_paths.remote_dir.clone(),
             self.base_paths.remote_dir.join(SUB_AGENT_DIR),
         );

--- a/agent-control/src/config_migrate/migration/persister/values_persister_file.rs
+++ b/agent-control/src/config_migrate/migration/persister/values_persister_file.rs
@@ -38,7 +38,7 @@ impl ValuesPersisterFile<DirectoryManagerFs> {
     pub fn new(data_dir: PathBuf) -> Self {
         ValuesPersisterFile {
             file_writer: LocalFile,
-            directory_manager: DirectoryManagerFs::default(),
+            directory_manager: DirectoryManagerFs,
             local_agent_data_dir: data_dir,
         }
     }

--- a/agent-control/src/opamp/hash_repository/on_host.rs
+++ b/agent-control/src/opamp/hash_repository/on_host.rs
@@ -54,7 +54,7 @@ impl HashRepositoryFile<LocalFile, DirectoryManagerFs> {
         HashRepositoryFile {
             file_rw: LocalFile,
             conf_path,
-            directory_manager: DirectoryManagerFs::default(),
+            directory_manager: DirectoryManagerFs,
         }
     }
 }

--- a/agent-control/src/sub_agent/persister/config_persister_file.rs
+++ b/agent-control/src/sub_agent/persister/config_persister_file.rs
@@ -38,7 +38,7 @@ impl ConfigurationPersisterFile<LocalFile, DirectoryManagerFs> {
 
         ConfigurationPersisterFile {
             file_writer: LocalFile,
-            directory_manager: DirectoryManagerFs::default(),
+            directory_manager: DirectoryManagerFs,
             generated_conf_path: generated_conf_dir,
         }
     }

--- a/agent-control/tests/on_host/config_persister.rs
+++ b/agent-control/tests/on_host/config_persister.rs
@@ -20,7 +20,7 @@ fn test_configuration_persister_single_file() {
     let mut temp_path = PathBuf::from(&tempdir.path());
     temp_path.push("test_configuration_persister_single_file");
 
-    let dir_manager = DirectoryManagerFs::default();
+    let dir_manager = DirectoryManagerFs;
     let res = dir_manager.create(temp_path.as_path(), Permissions::from_mode(0o700));
 
     assert!(res.is_ok());

--- a/agent-control/tests/on_host/tools/instance_id.rs
+++ b/agent-control/tests/on_host/tools/instance_id.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 pub fn get_instance_id(agent_id: &AgentID, base_paths: BasePaths) -> InstanceID {
     let instance_id_storer = Storer::new(
         LocalFile,
-        DirectoryManagerFs::default(),
+        DirectoryManagerFs,
         base_paths.remote_dir.clone(),
         base_paths.remote_dir.join(SUB_AGENT_DIR),
     );

--- a/agent-control/tests/on_host/yaml_config_repository.rs
+++ b/agent-control/tests/on_host/yaml_config_repository.rs
@@ -22,7 +22,7 @@ fn test_store_remote_no_mocks() {
     let mut remote_dir = PathBuf::from(&tempdir.path());
     remote_dir.push("remote_dir");
 
-    let dir_manager = DirectoryManagerFs::default();
+    let dir_manager = DirectoryManagerFs;
 
     // Ensure dir exists
     let res = dir_manager.create(remote_dir.as_path(), Permissions::from_mode(0o700));

--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -30,8 +30,7 @@ pub trait DirectoryManager {
     fn delete(&self, path: &Path) -> Result<(), DirectoryManagementError>;
 }
 
-#[derive(Default)]
-pub struct DirectoryManagerFs {}
+pub struct DirectoryManagerFs;
 
 impl DirectoryManager for DirectoryManagerFs {
     #[cfg(target_family = "unix")]
@@ -159,19 +158,18 @@ pub mod mock {
 pub mod tests {
     use std::fs;
     use std::fs::Permissions;
-    #[cfg(target_family = "unix")]
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
 
-    use super::{DirectoryManager, DirectoryManagerFs};
+    use super::DirectoryManagerFs;
+    use crate::directory_manager::DirectoryManager;
 
-    #[cfg(target_family = "unix")]
     #[test]
     fn test_path_to_create_cannot_contain_dots() {
         // Prepare temp path and folder name
         let folder_name = "some/path/../with/../dots";
         let path = PathBuf::from(folder_name);
-        let directory_manager = DirectoryManagerFs::default();
+        let directory_manager = DirectoryManagerFs;
 
         let result = directory_manager.create(&path, Permissions::from_mode(0o645));
 
@@ -182,13 +180,12 @@ pub mod tests {
         );
     }
 
-    #[cfg(target_family = "unix")]
     #[test]
     fn test_path_to_delete_cannot_contain_dots() {
         // Prepare temp path and folder name
         let folder_name = "some/path/../with/../dots";
         let path = PathBuf::from(folder_name);
-        let directory_manager = DirectoryManagerFs::default();
+        let directory_manager = DirectoryManagerFs;
 
         let result = directory_manager.delete(&path);
 
@@ -199,7 +196,6 @@ pub mod tests {
         );
     }
 
-    #[cfg(target_family = "unix")]
     #[test]
     fn test_folder_creation_and_permissions() {
         // Prepare temp path and folder name
@@ -211,7 +207,7 @@ pub mod tests {
 
         // Create directory manager and create directory with some permissions
         let some_permissions = Permissions::from_mode(0o645);
-        let directory_manager = DirectoryManagerFs::default();
+        let directory_manager = DirectoryManagerFs;
         let create_result = directory_manager.create(path.as_path(), some_permissions.clone());
         assert!(create_result.is_ok());
 
@@ -239,7 +235,6 @@ pub mod tests {
         );
     }
 
-    #[cfg(target_family = "unix")]
     #[test]
     fn test_folder_creation_should_not_fail_if_exists() {
         // Prepare temp path and folder name
@@ -251,14 +246,13 @@ pub mod tests {
 
         // Create directory manager and create directory with some permissions
         let some_permissions = Permissions::from_mode(0o645);
-        let directory_manager = DirectoryManagerFs::default();
+        let directory_manager = DirectoryManagerFs;
         let create_result = directory_manager.create(path.as_path(), some_permissions.clone());
         assert!(create_result.is_ok());
         let create_result = directory_manager.create(path.as_path(), some_permissions.clone());
         assert!(create_result.is_ok());
     }
 
-    #[cfg(target_family = "unix")]
     #[test]
     fn test_folder_deletion() {
         // Prepare temp path and folder name
@@ -270,7 +264,7 @@ pub mod tests {
 
         // Create directory manager and create directory with some permissions
         let some_permissions = Permissions::from_mode(0o645);
-        let directory_manager = DirectoryManagerFs::default();
+        let directory_manager = DirectoryManagerFs;
         let create_result = directory_manager.create(path.as_path(), some_permissions.clone());
         assert!(create_result.is_ok());
         let delete_result = directory_manager.delete(path.as_path());

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -4,7 +4,7 @@ pub mod file_renamer;
 pub mod utils;
 pub mod writer_file;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LocalFile;
 
 #[cfg(feature = "mocks")]


### PR DESCRIPTION
You can only construct one possible value of a struct without fields, so an `impl Default` is redundant.