### PR TITLE
fix: fleet_id inside fleet_control in config

### DIFF
--- a/build/examples/agent-control-config-all-agents.yaml
+++ b/build/examples/agent-control-config-all-agents.yaml
@@ -2,13 +2,14 @@
 #   endpoint: https://opamp.service.newrelic.com/v1/opamp
 #   headers:
 #     api-key: API_KEY_HERE
+#   fleet_id: FLEET_ID_HERE
 #   auth_config:
 #     token_url: PLACEHOLDER
 #     client_id: PLACEHOLDER
 #     provider: PLACEHOLDER
 #     private_key_path: PLACEHOLDER
 
-# fleet_id: FLEET_ID_HERE
+
 
 server:
   enabled: true

--- a/build/examples/agent-control-config-no-agents.yaml
+++ b/build/examples/agent-control-config-no-agents.yaml
@@ -2,13 +2,12 @@
 #   endpoint: https://opamp.service.newrelic.com/v1/opamp
 #   headers:
 #     api-key: API_KEY_HERE
+#   fleet_id: FLEET_ID_HERE
 #   auth_config:
 #     token_url: PLACEHOLDER
 #     client_id: PLACEHOLDER
 #     provider: PLACEHOLDER
 #     private_key_path: PLACEHOLDER
-
-# fleet_id: FLEET_ID_HERE
 
 server:
   enabled: true

--- a/build/examples/agent-control-config-nr-infra-agent.yaml
+++ b/build/examples/agent-control-config-nr-infra-agent.yaml
@@ -2,13 +2,12 @@
 #   endpoint: https://opamp.service.newrelic.com/v1/opamp
 #   headers:
 #     api-key: API_KEY_HERE
+#   fleet_id: FLEET_ID_HERE
 #   auth_config:
 #     token_url: PLACEHOLDER
 #     client_id: PLACEHOLDER
 #     provider: PLACEHOLDER
 #     private_key_path: PLACEHOLDER
-
-# fleet_id: FLEET_ID_HERE
 
 server:
   enabled: true

--- a/build/examples/agent-control-config-nr-otel-collector.yaml
+++ b/build/examples/agent-control-config-nr-otel-collector.yaml
@@ -2,13 +2,12 @@
 #   endpoint: https://opamp.service.newrelic.com/v1/opamp
 #   headers:
 #     api-key: API_KEY_HERE
+#   fleet_id: FLEET_ID_HERE
 #   auth_config:
 #     token_url: PLACEHOLDER
 #     client_id: PLACEHOLDER
 #     provider: PLACEHOLDER
 #     private_key_path: PLACEHOLDER
-
-# fleet_id: FLEET_ID_HERE
 
 server:
   enabled: true


### PR DESCRIPTION
This PR fixes the config examples, moving `fleet_id` under `fleet_control`