### PR TITLE
[NR-343813] test: avoid ignoring underlying panics for builder test

### DIFF
--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -359,6 +359,8 @@ mod tests {
             status: Failed as i32,
             last_remote_config_hash: "a-hash".as_bytes().to_vec(),
         });
+        started_client.should_update_effective_config(1);
+        started_client.should_stop(1);
 
         opamp_builder.should_build_and_start(
             sub_agent_id.clone(),


### PR DESCRIPTION
Same as #977 but for a different test

```
cargo test --features=onhost --package newrelic_agent_control --lib sub_agent::on_host::builder::tests::test_subagent_should_report_failed_config -- --exact --nocapture
```