### PR TITLE
NR-342834-Move-to-k8s-rust-labels-selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2642,9 +2653,9 @@ checksum = "00af7901ba50898c9e545c24d5c580c96a982298134e8037d8978b6594782c07"
 
 [[package]]
 name = "kube"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fd2596428f922f784ca43907c449f104d69055c811135684474143736c67ae"
+checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2655,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d539b6493d162ae5ab691762be972b6a1c20f6d8ddafaae305c0e2111b589d99"
+checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2693,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a87cc0046cf6b62cbb63ae1fbc366ee8ba29269f575289679473754ff5d7a7"
+checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2711,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65576922713e6154a89b5a8d2747adca15725b90fa64fc2b828774bf96d6acd8"
+checksum = "37745d8a4076b77e0b1952e94e358726866c8e14ec94baaca677d47dcdb98658"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2724,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f348cc3e6c9be0ae17f300594bde541b667d10ab8934a119edd61ab5123c43e"
+checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -2736,6 +2747,7 @@ dependencies = [
  "educe",
  "futures",
  "hashbrown 0.15.2",
+ "hostname",
  "json-patch",
  "jsonptr",
  "k8s-openapi",
@@ -5148,6 +5160,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-core"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -909,6 +909,12 @@ Distributed under the following license(s):
 * Apache-2.0
 
 
+## hostname https://crates.io/crates/hostname
+
+Distributed under the following license(s):
+* MIT
+
+
 ## http https://crates.io/crates/http
 
 Distributed under the following license(s):
@@ -2469,6 +2475,13 @@ Distributed under the following license(s):
 
 
 ## winapi-x86_64-pc-windows-gnu https://crates.io/crates/winapi-x86_64-pc-windows-gnu
+
+Distributed under the following license(s):
+* MIT
+* Apache-2.0
+
+
+## windows https://crates.io/crates/windows
 
 Distributed under the following license(s):
 * MIT

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -47,8 +47,8 @@ resource-detection = { path = "../resource-detection" }
 
 # K8S subagent dependencies
 # IMPORTANT: All k8s only deps needs to be `optional = true` so they won't be compiled by default
-kube = { version = "0.97.0", features = ["runtime", "derive"], optional = true }
-k8s-openapi = { version = "0.23.0", features = ["v1_30"], optional = true }
+kube = { version = "0.98.0", features = ["runtime", "derive"], optional = true }
+k8s-openapi = { version = "0.24.0", features = ["v1_30"], optional = true }
 either = { version = "1.12.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 

--- a/agent-control/src/k8s/utils.rs
+++ b/agent-control/src/k8s/utils.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use k8s_openapi::{
     apimachinery::pkg::util::intstr::IntOrString, Metadata, NamespaceResourceScope, Resource,
 };
@@ -117,18 +115,6 @@ impl std::fmt::Display for IntOrPercentage {
             }
         }
     }
-}
-
-/// This function returns true if there are labels and they contain the provided key, value.
-pub fn contains_label_with_value(
-    labels: &Option<BTreeMap<String, String>>,
-    key: &str,
-    value: &str,
-) -> bool {
-    labels
-        .as_ref()
-        .and_then(|labels| labels.get(key))
-        .is_some_and(|v| v == value)
 }
 
 /// Return the value of `.metadata.name` of the object that is passed.
@@ -270,68 +256,6 @@ pub mod tests {
             TestCase {
                 name: "int_or_percentage should not parse: broken percentage",
                 int_or_string: IntOrString::String("%100".into()),
-            },
-        ];
-
-        test_cases.into_iter().for_each(|tc| tc.run());
-    }
-
-    #[test]
-    fn test_contains_label_with_value() {
-        struct TestCase {
-            name: &'static str,
-            labels: Option<BTreeMap<String, String>>,
-            key: &'static str,
-            value: &'static str,
-            expected: bool,
-        }
-
-        impl TestCase {
-            fn run(self) {
-                assert_eq!(
-                    self.expected,
-                    contains_label_with_value(&self.labels, self.key, self.value),
-                    "{}",
-                    self.name
-                )
-            }
-        }
-
-        let test_cases = [
-            TestCase {
-                name: "No labels",
-                labels: None,
-                key: "key",
-                value: "value",
-                expected: false,
-            },
-            TestCase {
-                name: "Empty labels",
-                labels: Some(BTreeMap::default()),
-                key: "key",
-                value: "value",
-                expected: false,
-            },
-            TestCase {
-                name: "No matching label",
-                labels: Some([("a".to_string(), "b".to_string())].into()),
-                key: "key",
-                value: "value",
-                expected: false,
-            },
-            TestCase {
-                name: "Matching label with different value",
-                labels: Some([("key".to_string(), "other".to_string())].into()),
-                key: "key",
-                value: "value",
-                expected: false,
-            },
-            TestCase {
-                name: "Matching label and value",
-                labels: Some([("key".to_string(), "value".to_string())].into()),
-                key: "key",
-                value: "value",
-                expected: true,
             },
         ];
 


### PR DESCRIPTION
Fn **flux_release_filter** now is using the internal label selector from k8s library instead of our internal code.