### PR TITLE
chore(style): align new_agent_control_fqn and new_agent_control_id

### DIFF
--- a/agent-control/src/agent_control/agent_control.rs
+++ b/agent-control/src/agent_control/agent_control.rs
@@ -1,14 +1,9 @@
-use super::config::{
-    AgentControlDynamicConfig, AgentID, AgentTypeFQN, SubAgentConfig, SubAgentsMap,
-};
+use super::config::{AgentControlDynamicConfig, AgentID, SubAgentConfig, SubAgentsMap};
 use super::config_storer::loader_storer::{
     AgentControlDynamicConfigDeleter, AgentControlDynamicConfigLoader,
     AgentControlDynamicConfigStorer,
 };
-use crate::agent_control::{
-    defaults::{AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION},
-    error::AgentError,
-};
+use crate::agent_control::error::AgentError;
 use crate::event::{
     channel::{EventConsumer, EventPublisher},
     AgentControlEvent, ApplicationEvent, OpAMPEvent, SubAgentEvent,
@@ -407,17 +402,6 @@ where
         }
         Ok(())
     }
-}
-
-pub fn agent_control_fqn() -> AgentTypeFQN {
-    AgentTypeFQN::try_from(
-        format!(
-            "{}/{}:{}",
-            AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION
-        )
-        .as_str(),
-    )
-    .unwrap()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -1,7 +1,7 @@
 use super::http_server::config::ServerConfig;
-use crate::agent_control::agent_control_fqn;
 use crate::agent_control::defaults::{
     default_capabilities, default_sub_agent_custom_capabilities, AGENT_CONTROL_ID,
+    AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
 };
 use crate::http::proxy::ProxyConfig;
 use crate::logging::config::LoggingConfig;
@@ -221,6 +221,13 @@ impl AgentTypeFQN {
     pub fn version(&self) -> String {
         self.0.chars().skip_while(|&i| i != ':').skip(1).collect()
     }
+
+    pub fn new_agent_control_fqn() -> Self {
+        AgentTypeFQN(format!(
+            "{}/{}:{}",
+            AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION
+        ))
+    }
 }
 
 impl Display for AgentTypeFQN {
@@ -379,7 +386,7 @@ impl AgentTypeFQN {
 
     pub(crate) fn get_custom_capabilities(&self) -> Option<CustomCapabilities> {
         //TODO: We should move this to EffectiveAgent
-        if self.eq(&agent_control_fqn()) {
+        if self.eq(&AgentTypeFQN::new_agent_control_fqn()) {
             // Agent_Control does not have custom capabilities for now
             return None;
         }

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -1,4 +1,4 @@
-use crate::agent_control::config::{AgentID, K8sConfig};
+use crate::agent_control::config::{AgentID, AgentTypeFQN, K8sConfig};
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
 use crate::agent_control::defaults::{
@@ -6,7 +6,7 @@ use crate::agent_control::defaults::{
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CHART_VERSION_ATTRIBUTE_KEY,
 };
 use crate::agent_control::run::AgentControlRunner;
-use crate::agent_control::{agent_control_fqn, AgentControl};
+use crate::agent_control::AgentControl;
 use crate::agent_type::renderer::TemplateRenderer;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
@@ -119,7 +119,7 @@ impl AgentControlRunner {
                     builder,
                     &instance_id_getter,
                     AgentID::new_agent_control_id(),
-                    &agent_control_fqn(),
+                    &AgentTypeFQN::new_agent_control_fqn(),
                     additional_identifying_attributes,
                     non_identifying_attributes,
                 )

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -1,4 +1,4 @@
-use crate::agent_control::config::AgentID;
+use crate::agent_control::config::{AgentID, AgentTypeFQN};
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
 use crate::agent_control::defaults::{
@@ -6,7 +6,7 @@ use crate::agent_control::defaults::{
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, SUB_AGENT_DIR,
 };
 use crate::agent_control::run::AgentControlRunner;
-use crate::agent_control::{agent_control_fqn, AgentControl};
+use crate::agent_control::AgentControl;
 use crate::agent_type::variable::definition::VariableDefinition;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
@@ -127,7 +127,7 @@ impl AgentControlRunner {
                     builder,
                     &instance_id_getter,
                     AgentID::new_agent_control_id(),
-                    &agent_control_fqn(),
+                    &AgentTypeFQN::new_agent_control_fqn(),
                     HashMap::from([(
                         OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
                         DescriptionValueType::String(AGENT_CONTROL_VERSION.to_string()),

--- a/agent-control/src/opamp/remote_config/validators/certificate_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/certificate_fetcher.rs
@@ -1,6 +1,5 @@
 use crate::opamp::remote_config::validators::signature::Certificate;
 use std::sync::Mutex;
-use std::time::SystemTime;
 use thiserror::Error;
 use tracing::debug;
 use tracing::log::error;

--- a/agent-control/src/opamp/remote_config/validators/signature.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature.rs
@@ -61,7 +61,6 @@ impl SignatureValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_control::agent_control_fqn;
     use crate::agent_control::config::AgentID;
     use crate::opamp::remote_config::hash::Hash;
     use crate::opamp::remote_config::signature::Signature;
@@ -105,7 +104,7 @@ mod tests {
             Hash::new("test".to_string()),
             None,
         );
-        let agent_type = agent_control_fqn();
+        let agent_type = AgentTypeFQN::new_agent_control_fqn();
 
         assert!(signature_validator.validate(&agent_type, &rc).unwrap());
     }


### PR DESCRIPTION
We had already AgentID::new_agent_control_id(), we had no reason to follow a different approach