### PR TITLE
[NR-346622] update agent-type definitions to set new global values from env variables

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -125,6 +125,9 @@ deployment:
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
               cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -43,6 +43,8 @@ deployment:
           name: default-values-${nr-sub:agent_id}
         stringData:
           # These env variables are attached to the AC pod on the Helm Chart.
+          # ${nr-env:NR_STAGING}, ${nr-env:NR_LOW_DATA_MODE} and ${nr-env:NR_VERBOSE_LOG} are not set because they are
+          # not supported by the chart.
           values.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -42,10 +42,14 @@ deployment:
         metadata:
           name: default-values-${nr-sub:agent_id}
         stringData:
+          # These env variables are attached to the AC pod on the Helm Chart.
           values.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
               cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -42,10 +42,14 @@ deployment:
         metadata:
           name: default-values-${nr-sub:agent_id}
         stringData:
+          # These env variables are attached to the AC pod on the Helm Chart.
+          # ${nr-env:NR_VERBOSE_LOG} is not set, since it is not used in the chart.
           values.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
               cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
       values:
         apiVersion: v1
         kind: Secret

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.2.0.yaml
@@ -93,6 +93,9 @@ deployment:
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
               cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -49,6 +49,9 @@ deployment:
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
               cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret


### PR DESCRIPTION
This PR updates the agent-type definitions to use the new environment variables introduced in the helm-chart: https://github.com/newrelic/helm-charts/pull/1565 (the chart PR needs to be merged before)