### PR TITLE
feat: use the OS’ trust store in ureq client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4913,6 +4913,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "socks",
  "url",

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { version = "1.8.0", features = ["serde", "v7"] }
 duration-str = "0.11.2"
 konst = { workspace = true }
 http = { workspace = true }
-ureq = { workspace = true, features = ["http-crate", "socks-proxy"] }
+ureq = { workspace = true, features = ["http-crate", "socks-proxy", "native-certs"] }
 url = { version = "2.5.4", features = ["serde"] }
 actix-web = "4"
 serde_json = { workspace = true }

--- a/resource-detection/Cargo.toml
+++ b/resource-detection/Cargo.toml
@@ -15,7 +15,7 @@ tracing = { workspace = true }
 serde_json = { workspace = true }
 http = { workspace = true }
 bytes = "1.6.0"
-ureq = { workspace = true, features = ["http-crate"] }
+ureq = { workspace = true, features = ["http-crate", "native-certs"] }
 fs = { path = "../fs" }
 konst = { workspace = true }
 url = { version = "2.5.0" }


### PR DESCRIPTION
Currently the Agent Control uses https://docs.rs/webpki-roots/latest/webpki_roots/ for root certificates, but

> This library is suitable for use in applications that can always be recompiled and instantly deployed.

So we are moving to OS certificates with `native-certs` feature

> native-certs makes the default TLS implementation use the OS’ trust store (see TLS doc below).

https://docs.rs/ureq/latest/ureq/#features