### PR TITLE
feat: optional health instrumentation fields

### DIFF
--- a/agent-control/src/sub_agent/health/k8s/instrumentation.rs
+++ b/agent-control/src/sub_agent/health/k8s/instrumentation.rs
@@ -79,6 +79,7 @@ impl InstrumentationStatus {
         }
     }
 
+    // If this changes please align the docs here: <https://newrelic.atlassian.net/wiki/spaces/INST/pages/3945988387/K8s+Retrieving+health+from+Instrumentation+CR+s+status#Agent-Control-logic>
     fn is_healthy(&self) -> bool {
         // All pods must be ready
         self.pods_not_ready <= 0


### PR DESCRIPTION
The `InstrumentationStatus` structure that is deserialized from the homonymous K8s CR can now generate values if not all fields are present in the CR. Previously, all fields were required to be present with the exception of `unhealthyPodsErrors`.

Besides, the logic for determining **healthy** or **unhealthy** result from the deserialized `InstrumentationStatus` has been modified. See the `InstrumentationStatus::is_healthy` method for details.

Please see the tests in this module for getting a clear idea on what values are permitted to deserialize from, and for examples of values evaluating to a healthy or unhealthy result.