### PR TITLE
NR-356855-Update-instrumentation-cr-structure-health

### DIFF
--- a/.github/workflows/push_pr_test.yml
+++ b/.github/workflows/push_pr_test.yml
@@ -170,7 +170,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.10.0
         with:
           minikube version: v1.32.0
-          kubernetes version: "v1.28.1" # Should we support a specific range of versions?
+          kubernetes version: "v1.30.9" # Should we support a specific range of versions?
           driver: docker
       - name: Install Tilt
         run: |
@@ -212,7 +212,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.10.0
         with:
           minikube version: v1.32.0
-          kubernetes version: "v1.28.1"
+          kubernetes version: "v1.30.9"
           driver: docker
       - name: Install Tilt
         run: |

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -21,7 +21,7 @@ variables:
     env:
       description: "environment variables to pass to Dotnet agent"
       type: yaml
-      default: [ ]
+      default: []
       required: false
 deployment:
   k8s:
@@ -29,7 +29,7 @@ deployment:
       interval: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1alpha2
+        apiVersion: newrelic.com/v1beta1
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -21,7 +21,17 @@ variables:
     env:
       description: "environment variables to pass to java agent"
       type: yaml
-      default: [ ]
+      default: []
+      required: false
+    health_env:
+      description: "environment variables to pass to health sidecar"
+      type: yaml
+      default: []
+      required: false
+    health_version:
+      description: "health sidecar image version"
+      type: string
+      default: "latest"
       required: false
 deployment:
   k8s:
@@ -29,7 +39,7 @@ deployment:
       interval: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1alpha2
+        apiVersion: newrelic.com/v1beta1
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -38,5 +48,8 @@ deployment:
             language: java
             image: newrelic/newrelic-java-init:${nr-var:version}
             env: ${nr-var:env}
+          healthAgent:
+            image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
+            env: ${nr-var:health_env}
           podLabelSelector: ${nr-var:pod_label_selector}
           namespaceLabelSelector: ${nr-var:namespace_label_selector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -21,7 +21,7 @@ variables:
     env:
       description: "environment variables to pass to nodejs agent"
       type: yaml
-      default: [ ]
+      default: []
       required: false
 deployment:
   k8s:
@@ -29,7 +29,7 @@ deployment:
       interval: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1alpha2
+        apiVersion: newrelic.com/v1beta1
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -23,13 +23,23 @@ variables:
       type: yaml
       default: []
       required: false
+    health_env:
+      description: "environment variables to pass to health sidecar"
+      type: yaml
+      default: []
+      required: false
+    health_version:
+      description: "health sidecar image version"
+      type: string
+      default: "latest"
+      required: false
 deployment:
   k8s:
     health:
       interval: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1alpha2
+        apiVersion: newrelic.com/v1beta1
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -38,5 +48,8 @@ deployment:
             language: python
             image: newrelic/newrelic-python-init:${nr-var:version}
             env: ${nr-var:env}
+          healthAgent:
+            image: newrelic/k8s-apm-agent-health-sidecar:latest
+            env: ${nr-var:health_env}
           podLabelSelector: ${nr-var:pod_label_selector}
           namespaceLabelSelector: ${nr-var:namespace_label_selector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -21,7 +21,7 @@ variables:
     env:
       description: "environment variables to pass to Ruby agent"
       type: yaml
-      default: [ ]
+      default: []
       required: false
 deployment:
   k8s:
@@ -29,7 +29,7 @@ deployment:
       interval: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1alpha2
+        apiVersion: newrelic.com/v1beta1
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -356,13 +356,12 @@ pub fn helmrelease_v2_type_meta() -> TypeMeta {
 }
 
 #[cfg(feature = "k8s")]
-pub fn instrumentation_v1alpha2_type_meta() -> TypeMeta {
+pub fn instrumentation_v1beta1_type_meta() -> TypeMeta {
     TypeMeta {
-        api_version: "newrelic.com/v1alpha2".to_string(),
+        api_version: "newrelic.com/v1beta1".to_string(),
         kind: "Instrumentation".to_string(),
     }
 }
-
 #[cfg(feature = "k8s")]
 pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // In flux health check we are currently supporting just a single helm_release_type_meta
@@ -370,7 +369,7 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // A dynamic object reflector will be created for each of these types, since the GC lists them.
     vec![
         // Agent Operator CRD
-        instrumentation_v1alpha2_type_meta(),
+        instrumentation_v1beta1_type_meta(),
         // This allows Secrets created as dynamic objects to be cleaned up by the GC
         // This should not be needed anymore whenever the GC detection logic doesn't rely on this list.
         TypeMeta {

--- a/agent-control/src/sub_agent/health/k8s/health_checker/resource_type.rs
+++ b/agent-control/src/sub_agent/health/k8s/health_checker/resource_type.rs
@@ -1,6 +1,6 @@
 use kube::api::TypeMeta;
 
-use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1alpha2_type_meta};
+use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta};
 
 pub enum ResourceType {
     HelmRelease,
@@ -15,7 +15,7 @@ impl TryFrom<&TypeMeta> for ResourceType {
     fn try_from(value: &TypeMeta) -> Result<Self, Self::Error> {
         if value == &helmrelease_v2_type_meta() {
             Ok(ResourceType::HelmRelease)
-        } else if value == &instrumentation_v1alpha2_type_meta() {
+        } else if value == &instrumentation_v1beta1_type_meta() {
             Ok(ResourceType::InstrumentationCRD)
         } else {
             Err(UnsupportedResourceType)

--- a/agent-control/src/sub_agent/health/k8s/instrumentation.rs
+++ b/agent-control/src/sub_agent/health/k8s/instrumentation.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use std::fmt::Display;
 use std::sync::Arc;
 
-/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1alpha2.
+/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1beta1.
 ///
 /// The `Instrumentation` CR structure which contains this `status` field in K8s also contains a
 /// field `Instrumentation.status.lastUpdated`, this represents when the statuses were written

--- a/agent-control/src/sub_agent/version/k8s/checkers.rs
+++ b/agent-control/src/sub_agent/version/k8s/checkers.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::config::{
-    helmrelease_v2_type_meta, instrumentation_v1alpha2_type_meta, AgentID,
+    helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta, AgentID,
 };
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
@@ -26,7 +26,7 @@ impl TryFrom<&TypeMeta> for SupportedResourceType {
         if type_meta == &helmrelease_v2_type_meta() {
             return Ok(Self::HelmRelease);
         }
-        if type_meta == &instrumentation_v1alpha2_type_meta() {
+        if type_meta == &instrumentation_v1beta1_type_meta() {
             return Ok(Self::Instrumentation);
         }
         Err(UnsupportedResourceType)
@@ -85,7 +85,7 @@ impl K8sAgentVersionChecker {
 mod tests {
     use super::*;
     use crate::{
-        agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1alpha2_type_meta},
+        agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta},
         k8s::client::MockSyncK8sClient,
     };
     use assert_matches::assert_matches;
@@ -214,7 +214,7 @@ mod tests {
     }
 
     fn instrumentation_dyn_obj() -> DynamicObject {
-        empty_dynamic_object(instrumentation_v1alpha2_type_meta())
+        empty_dynamic_object(instrumentation_v1beta1_type_meta())
     }
 
     fn secret_dyn_obj() -> DynamicObject {

--- a/agent-control/src/sub_agent/version/k8s/instrumentation.rs
+++ b/agent-control/src/sub_agent/version/k8s/instrumentation.rs
@@ -65,7 +65,7 @@ impl VersionChecker for NewrelicInstrumentationVersionChecker {
     }
 }
 
-/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1alpha2, Instrumentation) object.
+/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1beta1, Instrumentation) object.
 /// Specifically it gets it from `spec.agent.image`, where the image's tag is considered the version.
 fn version_from_newrelic_instrumentation_image(
     data: &serde_json::Map<String, serde_json::Value>,

--- a/test/k8s-e2e/Readme.md
+++ b/test/k8s-e2e/Readme.md
@@ -7,6 +7,14 @@ this Sub-Agent have reached NR.
 
 # Run locally
 
+To be able to run the tests these dependencies should be installed
+```bash
+brew install coreutils
+brew install jq
+```
+
+# Run locally
+
 The test leverages the Tilt environment so all requirements to launch Tilt must be followed.
 Notice that the local execution expect to use Testing account.
 


### PR DESCRIPTION
Changes Added:
 - move all agents from v1alpha2 to v1beta1
 - Change of metadata from k8s to use the v1beta1
 - Add health feature to java and python agent
 - Add some vars to be able to pass the e2e and update our k8s version in pipes from 1.28.1 to 1.30.0