### PR TITLE
docs: document the purpose of `Instrumentation.status` fields

### DIFF
--- a/agent-control/src/sub_agent/health/k8s/instrumentation.rs
+++ b/agent-control/src/sub_agent/health/k8s/instrumentation.rs
@@ -11,33 +11,55 @@ use std::sync::Arc;
 
 /// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1alpha2.
 ///
-/// To be deserialized correctly, the JSON should have the following fields:
-/// - `podsMatching` (int): The number of pods that match the Instrumentation.
-/// - `podsHealthy` (int): The number of healthy pods.
-/// - `podsInjected` (int): The number of pods that have been injected.
-/// - `podsNotReady` (int): The number of pods that are not ready.
-/// - `podsOutdated` (int): The number of outdated pods.
-/// - `podsUnhealthy` (int): The number of unhealthy pods.
-///
-/// The following fields are optional:
-/// - `unhealthyPodsErrors` (array): An array of objects with the following fields:
-///   - `pod` (string): The name of the pod.
-///   - `lastError` (string): The last error message.
+/// The `Instrumentation` CR structure which contains this `status` field in K8s also contains a
+/// field `Instrumentation.status.lastUpdated`, this represents when the statuses were written
+/// because a status changed.
+/// It does not represent when the health was last checked or anything from a health response, so we
+/// do not use it here
 #[derive(Debug, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct InstrumentationStatus {
+    /// [`pods_matching`] is the number of pods which match the
+    /// `Instrumentation.spec.podLabelSelectors` and `Instrumentation.spec.NamespaceLabelSelectors`
+    /// (when empty defaults to matching everything, and both must match to "select" a pod).
     #[serde(default)]
     pods_matching: i64,
+
+    /// [`pods_healthy`] is the number of pods which match based on [`pods_matching`] and
+    /// [`pods_injected`] and the operator was able to get:
+    /// - The correct pod IP/port.
+    /// - A health response which had a healthy status reported via the yaml field healthy.
+    /// - An http status code of 200.
     #[serde(default)]
     pods_healthy: i64,
+
+    /// [`pods_injected`] is the number of pods which matched the Instrumentation based on
+    /// [`pods_matching`] which had the the health sidecar injected.
     #[serde(default)]
     pods_injected: i64,
+
+    /// [`pods_not_ready`] is the number of pods which are not in a ready state
+    /// (`Pod.status.phase` != `"Running"`) which matched both [`pods_matching`]
+    /// and [`pods_injected`].
     #[serde(default)]
     pods_not_ready: i64,
+
+    /// [`pods_outdated`] is the number of pods which match based on [`pods_matching`] and
+    /// [`pods_injected`] but there's a mismatch between the `Instrumentation.generation` and
+    /// the injected pods annotation (to identify changes to the spec).
     #[serde(default)]
     pods_outdated: i64,
+
+    /// [`pods_unhealthy`] is the number of pods which failed a health check, either because
+    /// the operator couldn't get the pod ip, pod port, communication issues, timeout,
+    /// non-200 http status, failure to decode the http response, and lastly
+    /// the `last_error` field in the response.
     #[serde(default)]
     pods_unhealthy: i64,
+
+    /// [`unhealthy_pod_errors`] is a list of pods (namespace.name/pod.name) and either
+    /// the last error from the response
+    /// or the error from the operator while trying to collect health.
     #[serde(default)]
     unhealthy_pods_errors: Vec<UnhealthyPodError>,
 }


### PR DESCRIPTION
This was discussed originally at https://newrelic.slack.com/archives/C07DBUPJRQE/p1736974385724689