### PR TITLE
test: fix flaky tests with SubAgent client builder

### DIFF
--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -240,6 +240,7 @@ mod tests {
         AgentDescription, DescriptionValueType, StartSettings,
     };
     use std::collections::HashMap;
+    use std::time::Duration;
     use tracing_test::traced_test;
 
     // TODO: tests below are testing not only the builder but also the sub-agent start/stop behavior.
@@ -277,10 +278,13 @@ mod tests {
         started_client.should_stop(1);
 
         // Infra Agent OpAMP no final stop nor health, just after stopping on reload
-        opamp_builder.should_build_and_start(
+        // TODO: We should discuss if this is a valid approach once we refactor the unit tests
+        // Build an OpAMP Client and let it run so the publisher is not dropped
+        opamp_builder.should_build_and_start_and_run(
             sub_agent_id.clone(),
             start_settings_infra,
             started_client,
+            Duration::from_millis(10),
         );
 
         let mut instance_id_getter = MockInstanceIDGetterMock::new();
@@ -375,10 +379,13 @@ mod tests {
         started_client.should_update_effective_config(1);
         started_client.should_stop(1);
 
-        opamp_builder.should_build_and_start(
+        // TODO: We should discuss if this is a valid approach once we refactor the unit tests
+        // Build an OpAMP Client and let it run so the publisher is not dropped
+        opamp_builder.should_build_and_start_and_run(
             sub_agent_id.clone(),
             start_settings_infra,
             started_client,
+            Duration::from_millis(10),
         );
 
         effective_agent_assembler.should_assemble_agent(


### PR DESCRIPTION
This PR fixes flaky tests that randomly fail with:
```
2025-01-14T08:30:25.438571Z DEBUG newrelic_agent_control::sub_agent::sub_agent: 
channel closed 
error=receiving on an empty and disconnected channel 
select_arm="sub_agent_opamp_consumer"
```

The reason is that the Mock OpAMP Client Builder owns the OpAMP Event Publisher, and this gets eventually dropped (after expectations are asserted, probably). This triggers an error and the Sub Agent loop exits, which make the Stop call fail.

Temporary (maybe not) fix: Run a thread in the Mock which will maintain alive the publisher, mimicking the expected behavior.

**Note that these tests do not belong here and that we should do a refactor of unit tests and only tests what we should (i.e. do not run the Sub Agent in the Sub Agent builder). But the scope of this task is just to fix them.**