### PR TITLE
fix: handle channel disconnection in status updater

### DIFF
--- a/agent-control/src/agent_control/http_server.rs
+++ b/agent-control/src/agent_control/http_server.rs
@@ -21,7 +21,3 @@ pub enum StatusServerError {
     #[error("error waiting for async join handle `{0}`")]
     JoinHandleError(#[from] JoinError),
 }
-
-pub trait StatusServer {
-    fn run(self) -> Result<(), StatusServerError>;
-}

--- a/agent-control/src/opamp/client_builder.rs
+++ b/agent-control/src/opamp/client_builder.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Error, Debug)]
 pub enum OpAMPClientBuilderError {
-    #[error("`{0}`")]
+    #[error("OpAMP client: `{0}`")]
     NotStartedClientError(#[from] NotStartedClientError),
     #[error("error getting agent instance id: `{0}`")]
     GetInstanceIDError(#[from] instance_id::GetterError),


### PR DESCRIPTION
This PR fixes the case where status server channels are disconnected. 

i.e. when the OpAMP first request fails, the channels publishers are dropped and this code panicked. Now it both channels are disconnected, the loop will just end.