### PR TITLE
refactor: do not read env vars on the renderer

### DIFF
--- a/agent-control/src/agent_type/environment_variable.rs
+++ b/agent-control/src/agent_type/environment_variable.rs
@@ -5,10 +5,10 @@ use std::env;
 
 pub fn retrieve_env_var_variables() -> HashMap<String, VariableDefinition> {
     let mut vars: HashMap<String, VariableDefinition> = HashMap::new();
-    env::vars().for_each(|(k, v)| {
+    env::vars_os().for_each(|(k, v)| {
         vars.insert(
-            Namespace::EnvironmentVariable.namespaced_name(k.as_str()),
-            VariableDefinition::new_final_string_variable(v),
+            Namespace::EnvironmentVariable.namespaced_name(k.to_string_lossy().as_ref()),
+            VariableDefinition::new_final_string_variable(v.to_string_lossy().to_string()),
         );
     });
 

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -4,6 +4,7 @@ use crate::agent_type::agent_type_registry::{AgentRegistry, AgentRepositoryError
 use crate::agent_type::definition::{AgentType, AgentTypeDefinition};
 use crate::agent_type::embedded_registry::EmbeddedRegistry;
 use crate::agent_type::environment::Environment;
+use crate::agent_type::environment_variable::retrieve_env_var_variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::renderer::{Renderer, TemplateRenderer};
 #[cfg(feature = "k8s")]
@@ -158,9 +159,17 @@ where
             agent_id: agent_id.get(),
         };
 
-        let runtime_config = self
-            .renderer
-            .render(agent_id, agent_type, values, attributes)?;
+        // Values are expanded substituting all ${nr-env...} with environment variables.
+        // Notice that only environment variables are taken into consideration (no other vars for example)
+        let environment_variables = retrieve_env_var_variables();
+
+        let runtime_config = self.renderer.render(
+            agent_id,
+            agent_type,
+            values,
+            attributes,
+            environment_variables,
+        )?;
 
         Ok(EffectiveAgent::new(
             agent_id.clone(),


### PR DESCRIPTION
I noticed that with the (only) current implementation of `Renderer`, `TemplateRenderer`, if its `persister` is set to `None` then no I/O seems to happen **except** reading all the environment variables via `env::vars` (an operation that may also `panic`).

When testing with `TemplateRenderer` to render agent types, given the default value has the `persister` set to `None`, it is easy to achieve pure computations if we pass the env vars explicitly from outside or via a closure.

So, this PR:

- Modifies `retrieve_env_var_variables` so it does not panic.
- Changes `render`'s signature to accept the environment variables as a `HashMap<String, VariableDefinition>` parameter. This removes the need for setting env vars in unit tests and thus stop being `serial`.
  - Let me know if you would prefer the method to accept a `FnOnce() -> HashMap<String, VariableDefinition>` instead. I tried this but gave up because `mockall` does not play well with it and didn't want to remove the mock without checking with you first.

A next step for the renderer implementation to be completely pure could be modifying the `render` function return type to describe the effect we want to perform with the persister, if any, along the original return value, but given this impacts the behavior of the function in a major way I leave it for a future refactor.