### PR TITLE
test: Fix k8s attributes test

### DIFF
--- a/agent-control/tests/k8s/data/k8s_opamp_attributes_existing_agent_type/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_attributes_existing_agent_type/local-data-agent-control.template
@@ -1,4 +1,4 @@
-opamp:
+fleet_control:
   endpoint: <opamp-endpoint>
   headers:
     api-key: test-api-key

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -25,12 +25,10 @@ use serial_test::serial;
 use std::time::Duration;
 use tempfile::tempdir;
 
-/// This scenario tests an Agent type which only create a CR when the CRD already exists.
-/// The sub-agent is added from remote config and them we check if the agent description is what we expect.
 #[test]
 #[ignore = "needs a k8s cluster"]
 #[serial]
-fn test_attributes_from_existing_agent_type() {
+fn k8s_test_attributes_from_existing_agent_type() {
     let test_name = "k8s_opamp_attributes_existing_agent_type";
 
     // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.


### PR DESCRIPTION
This test was not being executed since didn't have the `k8s_` prefix used to filter them by the one who need the cluster running. There was also an issue on the config