### PR TITLE
docs: update steps for running kubernetes locally

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -363,19 +363,20 @@ We use [Minikube](https://minikube.sigs.k8s.io/docs/) and [Tilt](https://tilt.de
 #### Prerequisites
 - Install Minikube for local Kubernetes cluster emulation.
 - Install [ctlptl](https://github.com/tilt-dev/ctlptl)
-- Pull docker image `ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5`
 - Ensure you have Tilt installed for managing local development environments.
 - Add a agent-control-deployment values file in `local/agent-control-tilt.yml`
+
+> Be aware that cross 0.2.5 [broke cross-compilation](https://github.com/cross-rs/cross/issues/1214). If you are using it, run the following command.
+>
+> ```
+> docker pull ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5 --platform linux/x86_64
+> ```
 
 Note: Adding the `'chart_repo'` setting, pointing to the [newrelic charts](https://github.com/newrelic/helm-charts/tree/master/charts) on a local path, allows to use local helm charts.
 #### Steps
 ```shell
 ctlptl create registry ctlptl-registry --port=5005
 ctlptl create cluster minikube --registry=ctlptl-registry
-# Linux
-docker pull ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5
-# Mac
-docker pull ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5 --platform linux/x86_64
 make tilt-up
 ```
 


### PR DESCRIPTION
Tilt requires downloading a docker image. This PR updates the docs. Let me know if it makes sense.

### Context

The first time I tried to use `tilt` I had a couple of problems. One of them was not having `ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5` on my system. I had to manually install it, otherwise the `build-binary` step fails. I tried to do it from scratch again and had the same problem.