### PR TITLE
Add new steps to the workflows to update the helm release on the canaries

### DIFF
--- a/.github/workflows/component_k8s_canaries.yml
+++ b/.github/workflows/component_k8s_canaries.yml
@@ -1,0 +1,60 @@
+name: 📞 k8s canaries helm update
+
+on:
+  workflow_call:
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      AWS_VPC_SUBNET:
+        required: true
+
+    inputs:
+      image-tag:
+        required: true
+        type: string
+      cluster_name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  infra:
+    name: Prepare infra
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Set branch name
+        run: |
+          # Short name for current branch. For PRs, use target branch (base ref)
+          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          # Is the ref a tag? If so, remove refs/tags/ prefix
+          GIT_BRANCH=${GIT_BRANCH#refs/tags/}
+          echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Upgrade helm release
+        uses: newrelic/fargate-runner-action@main
+        with:
+          aws_region: us-east-2
+          container_make_target: "IMAGE_TAG=${{ inputs.image-tag }} CLUSTER_NAME=${{ inputs.cluster_name }} HELM_DIR=test/k8s-canaries/helm test/k8s-canaries/helm-upgrade"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: ${{ github.repository }}
+          git_clone_url: "ssh://git@github.com/${{ github.repository }}.git"
+          ref: "${{ env.GIT_BRANCH }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,6 +91,16 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
+  k8s_canaries:
+    uses: ./.github/workflows/component_k8s_canaries.yml
+    needs: [ build-image ]
+    with:
+      image-tag: nightly
+      cluster_name: Agent_Control_Canaries_Staging-Cluster
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
+
   notify-failure:
     if: ${{ always() && failure() }}
     needs: [ build-image ]

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -130,6 +130,16 @@ jobs:
   #      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
   #      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
+  k8s_canaries:
+    uses: ./.github/workflows/component_k8s_canaries.yml
+    needs: [ build-image ]
+    with:
+      image-tag: ${{ github.event.release.tag_name }}-rc
+      cluster_name: Agent_Control_Canaries_Production-Cluster
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
+
   get_previous_tag:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/push_pr_canaries_apply.yml
+++ b/.github/workflows/push_pr_canaries_apply.yml
@@ -1,0 +1,62 @@
+permissions:
+  id-token: write
+  contents: read
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - test/k8s-canaries/terraform/**
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"
+  cancel-in-progress: false
+name: terraform apply k8s canaries
+
+jobs:
+  infra:
+    name: Prepare infra
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        run: |
+          # Short name for current branch. For PRs, use target branch (base ref)
+          GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          # Is the ref a tag? If so, remove refs/tags/ prefix
+          GIT_BRANCH="${GIT_BRANCH#refs/tags/}"
+          echo "GIT_BRANCH=$GIT_BRANCH" >> "$GITHUB_ENV"
+
+      - name: Sync k8s staging canary
+        uses: newrelic/fargate-runner-action@main
+        with:
+          aws_region: us-east-2
+          container_make_target: "TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=staging test/k8s-canaries/terraform-apply"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: ${{ github.repository }}
+          git_clone_url: "ssh://git@github.com/${{ github.repository }}.git"
+          ref: "${{ env.GIT_BRANCH }}"
+
+      - name: Sync k8s production canary
+        uses: newrelic/fargate-runner-action@main
+        with:
+          aws_region: us-east-2
+          container_make_target: "TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=production test/k8s-canaries/terraform-apply"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: ${{ github.repository }}
+          git_clone_url: "ssh://git@github.com/${{ github.repository }}.git"
+          ref: "${{ env.GIT_BRANCH }}"

--- a/.github/workflows/push_pr_canaries_plan.yml
+++ b/.github/workflows/push_pr_canaries_plan.yml
@@ -1,0 +1,60 @@
+permissions:
+  id-token: write
+  contents: read
+on:
+  pull_request:
+    paths:
+      - test/k8s-canaries/terraform/**
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"
+  cancel-in-progress: false
+name: plan k8s canaries changes
+
+jobs:
+  infra:
+    name: Prepare infra
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        run: |
+          # Short name for current branch. For PRs, use target branch (base ref)
+          GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          # Is the ref a tag? If so, remove refs/tags/ prefix
+          GIT_BRANCH="${GIT_BRANCH#refs/tags/}"
+          echo "GIT_BRANCH=$GIT_BRANCH" >> "$GITHUB_ENV"
+
+      - name: Plan k8s staging canary changes
+        uses: newrelic/fargate-runner-action@main
+        with:
+          aws_region: us-east-2
+          container_make_target: "TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=staging test/k8s-canaries/terraform-plan"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: ${{ github.repository }}
+          git_clone_url: "ssh://git@github.com/${{ github.repository }}.git"
+          ref: "${{ env.GIT_BRANCH }}"
+
+      - name: Plan k8s production canary changes
+        uses: newrelic/fargate-runner-action@main
+        with:
+          aws_region: us-east-2
+          container_make_target: "TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=production test/k8s-canaries/terraform-plan"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: ${{ github.repository }}
+          git_clone_url: "ssh://git@github.com/${{ github.repository }}.git"
+          ref: "${{ env.GIT_BRANCH }}"

--- a/test/k8s-canaries/Makefile
+++ b/test/k8s-canaries/Makefile
@@ -1,5 +1,6 @@
 TERRAFORM_DIR := ./terraform
 HELM_DIR := ./helm
+AWS_REGION := us-east-2
 .DEFAULT_GOAL := all
 
 # Generate a random key to add to the helm deployment annotation
@@ -10,27 +11,45 @@ DEPLOYMENT_KEY := $(shell openssl rand -base64 32 | tr -dc A-Za-z0-9 | head -c 1
 all:
 	@echo "No default target"
 
-.PHONY: test/k8s-canaries/sync
-test/k8s-canaries/sync:
+.PHONY: test/k8s-canaries/terraform-plan
+test/k8s-canaries/terraform-plan:
 ifndef CANARY_DIR
-	@echo "CANARY_DIR variable must be provided to know which canary to sync"
+	@echo "CANARY_DIR variable must be provided to know which canary to terraform-plan"
+	exit 1
+endif
+	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) init && \
+	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) plan
+
+.PHONY: test/k8s-canaries/terraform-apply
+test/k8s-canaries/terraform-apply:
+ifndef CANARY_DIR
+	@echo "CANARY_DIR variable must be provided to know which canary to terraform-apply"
 	exit 1
 endif
 	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) init && \
 	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) apply -auto-approve
 
-.PHONY: test/k8s-canaries/helm
-test/k8s-canaries/helm:
+
+.PHONY: test/k8s-canaries/update-kubeconfig-from-aws
+test/k8s-canaries/update-kubeconfig-from-aws:
+ifndef CLUSTER_NAME
+	@echo "CLUSTER_NAME variable must be provided for test/k8s-canaries/aws-eks"
+	exit 1
+endif
+	@aws eks update-kubeconfig --region=$(AWS_REGION) --name $(CLUSTER_NAME)
+
+.PHONY: test/k8s-canaries/helm-upgrade
+test/k8s-canaries/helm-upgrade: test/k8s-canaries/update-kubeconfig-from-aws
 ifndef NR_LICENSE_KEY
-	@echo "NR_LICENSE_KEY variable must be provided for k8s-canaries/helm"
+	@echo "NR_LICENSE_KEY variable must be provided for test/k8s-canaries/helm-upgrade"
 	exit 1
 endif
 ifndef CLUSTER_NAME
-	@echo "CLUSTER_NAME variable must be provided for k8s-canaries/helm"
+	@echo "CLUSTER_NAME variable must be provided for test/k8s-canaries/helm-upgrade"
 	exit 1
 endif
 ifndef IMAGE_TAG
-	@echo "IMAGE_TAG variable must be provided for k8s-canaries/helm"
+	@echo "IMAGE_TAG variable must be provided for test/k8s-canaries/helm-upgrade"
 	exit 1
 endif
 	@helm repo add newrelic https://helm-charts.newrelic.com
@@ -40,3 +59,4 @@ endif
     --set global.cluster=$(CLUSTER_NAME) \
     --set agent-control-deployment.image.tag=$(IMAGE_TAG) \
     --set agent-control-deployment.podAnnotations.deploymentKey="${DEPLOYMENT_KEY}"
+

--- a/test/k8s-canaries/README.md
+++ b/test/k8s-canaries/README.md
@@ -22,12 +22,12 @@ The default terraform dir for where the terraform modules are taken from is:
 `TERRAFORM_DIR := ./terraform`
 
 ```bash
-$ make CANARY_DIR=staging test/k8s-canaries/sync
+$ make CANARY_DIR=staging test/k8s-canaries/terraform-apply
 ```
 
 If this target is called from the root of this repository, the TERRAFORM_DIR should be overwritten to point to the relative path:
 ```bash
-$ make TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=staging test/k8s-canaries/sync
+$ make TERRAFORM_DIR=test/k8s-canaries/terraform CANARY_DIR=staging test/k8s-canaries/terraform-apply
 ```
 
 ### Helm Upgrade for nightlies and prereleases
@@ -39,10 +39,10 @@ The default helm dir where there is the default values file to apply is:
 `HELM_DIR := ./helm`
 
 ```bash
-$ make NR_LICENSE_KEY=xxx CLUSTER_NAME=my-cluster IMAGE_TAG=nightly test/k8s-canaries/helm
+$ make NR_LICENSE_KEY=xxx CLUSTER_NAME=my-cluster IMAGE_TAG=nightly test/k8s-canaries/helm-upgrade
 ```
 
 If this target is called from the root of this repository, the HELM_DIR should be overwritten to point to the relative path:
 ```bash
-$ make HELM_DIR=test/k8s-canaries/helm NR_LICENSE_KEY=xxx CLUSTER_NAME=my-cluster IMAGE_TAG=nightly test/k8s-canaries/helm
+$ make HELM_DIR=test/k8s-canaries/helm NR_LICENSE_KEY=xxx CLUSTER_NAME=my-cluster IMAGE_TAG=nightly test/k8s-canaries/helm-upgrade
 ```

--- a/test/k8s-canaries/terraform/modules/eks_cluster/main.tf
+++ b/test/k8s-canaries/terraform/modules/eks_cluster/main.tf
@@ -107,7 +107,7 @@ resource "aws_eks_node_group" "eks-nodegroup" {
 
   launch_template {
     id      = aws_launch_template.eks_node.id
-    version = "$Latest"
+    version = "1"
   }
 
   ami_type       = var.nodes_ami_type

--- a/test/k8s-canaries/terraform/modules/eks_cluster/outputs.tf
+++ b/test/k8s-canaries/terraform/modules/eks_cluster/outputs.tf
@@ -1,10 +1,6 @@
-output "ekscluster" {
+output "cluster" {
   value = {
-    aws_eks_cluster = {
-      ekscluster = {
-        name     = aws_eks_cluster.ekscluster.name
-        endpoint = aws_eks_cluster.ekscluster.endpoint
-      }
-    }
+     name     = aws_eks_cluster.ekscluster.name
+     endpoint = aws_eks_cluster.ekscluster.endpoint
   }
 }

--- a/test/k8s-canaries/terraform/modules/eks_cluster/rbac.tf
+++ b/test/k8s-canaries/terraform/modules/eks_cluster/rbac.tf
@@ -1,0 +1,116 @@
+
+data "aws_eks_cluster" "ekscluster" {
+  name = aws_eks_cluster.ekscluster.name
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}
+
+data "aws_eks_cluster_auth" "ekscluster" {
+  name = aws_eks_cluster.ekscluster.name
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}
+provider "kubernetes" {
+  # When a modification on the terraform requires deleting the cluster TF is not capable of retrieving the endpoint
+  # and defaults to localhost (failing), in that case the provider needs to use the kube config that must be having
+  # the current context pointing to the cluster. If config_path is used, the other attributes must be commented.
+  # config_path = "~/.kube/config"
+  host                   = data.aws_eks_cluster.ekscluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.ekscluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.ekscluster.token
+}
+
+# Retrieves the aws_auth configmap created by the EKS Fargate module that has the RBAC for the role used by terraform
+data "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}
+
+locals {
+  new_role_mapping = <<EOF
+- rolearn: ${var.fargate_iam_role_arn}
+  username: ${var.fargate_iam_role_user}
+  groups:
+    - system:masters
+EOF
+
+  # Check if the role mapping already exists in the current mapRoles
+  role_exists = can(regex("${var.fargate_iam_role_arn}", data.kubernetes_config_map.aws_auth.data["mapRoles"]))
+
+  # Construct the updated mapRoles by only adding the new role if it's not already present
+  updated_map_roles = local.role_exists ? data.kubernetes_config_map.aws_auth.data["mapRoles"] : "${data.kubernetes_config_map.aws_auth.data["mapRoles"]}\n${local.new_role_mapping}"
+}
+
+# The aws-auth RBAC configmap is updated with the new user keeping also the old one.
+resource "kubernetes_config_map_v1_data" "aws_auth" {
+  force = true
+
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = local.updated_map_roles
+  }
+
+  lifecycle {
+    ignore_changes = [
+      data["mapUsers"],
+      data["mapAccounts"]
+    ]
+    create_before_destroy = true
+  }
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}
+
+resource "kubernetes_cluster_role" "fargate_role" {
+  metadata {
+    name = "fargate-role"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "services", "deployments"]
+    verbs      = ["get", "list", "watch", "create", "update", "delete"]
+  }
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}
+
+resource "kubernetes_cluster_role_binding" "fargate_role" {
+  metadata {
+    name = "fargate-role-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.fargate_role.metadata[0].name
+  }
+
+  subject {
+    kind      = "User"
+    name      = var.fargate_iam_role_user
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  depends_on = [
+    aws_eks_cluster.ekscluster
+  ]
+}

--- a/test/k8s-canaries/terraform/modules/eks_cluster/variables.tf
+++ b/test/k8s-canaries/terraform/modules/eks_cluster/variables.tf
@@ -50,3 +50,16 @@ variable "cluster_min_size" {
   type        = number
   default     = 2
 }
+
+# This ARN may change if the Fargate Runner TF is modified
+variable "fargate_iam_role_arn" {
+  description = "The ARN of the Fargate runner IAM role to be mapped in the aws-auth ConfigMap"
+  type        = string
+  default     = "arn:aws:iam::288761741714:role/test_prerelease_fargate-zke"
+}
+
+variable "fargate_iam_role_user" {
+  description = "The RBAC user created for the IAM role to be mapped in the aws-auth ConfigMap"
+  type        = string
+  default     = "fargate-user"
+}

--- a/test/k8s-canaries/terraform/modules/state_backend/variables.tf
+++ b/test/k8s-canaries/terraform/modules/state_backend/variables.tf
@@ -1,11 +1,11 @@
 variable "bucket_name" {
   description = "The name of the S3 bucket to store Terraform state"
   type        = string
-  default     = "agent-control-canary-states"
+  default     = "agent-control-terraform-states"
 }
 
 variable "dynamodb_table_name" {
   description = "The name of the DynamoDB table used for state locking"
   type        = string
-  default     = "agent-control-canary-states"
+  default     = "agent-control-terraform-states"
 }

--- a/test/k8s-canaries/terraform/production/.terraform.lock.hcl
+++ b/test/k8s-canaries/terraform/production/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.35.1"
+  hashes = [
+    "h1:zgXeWvp4//Ry+4glwNrLMpPFOU8QBQlARNmR9WCNe9o=",
+    "zh:12212ca5ae47823ce14bfafb909eeb6861faf1e2435fb2fc4a8b334b3544b5f5",
+    "zh:3f49b3d77182df06b225ab266667de69681c2e75d296867eb2cf06a8f8db768c",
+    "zh:40832494d19f8a2b3cd0c18b80294d0b23ef6b82f6f6897b5fe00248a9997460",
+    "zh:739a5ddea61a77925ee7006a29c8717377a2e9d0a79a0bbd98738d92eec12c0d",
+    "zh:a02b472021753627c5c39447a56d125a32214c29ff9108fc499f2dcdf4f1cc4f",
+    "zh:b78865b3867065aa266d6758c9601a2756741478f5735a838c20d633d65e085b",
+    "zh:d362e87464683f5632790e66920ea803adb54c2bc0cb24b6fd9a314d2b1efffd",
+    "zh:d98206fe88c2c9a52b8d2d0cb2c877c812a4a51d19f9d8428e63cbd5fd8a304d",
+    "zh:dfa320946b1ce3f3615c42b3447a28dc9f604c06d8b9a6fe289855ab2ade4d11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1debd2e695b5222d2ccc8b24dab65baba4ee2418ecce944e64d42e79474cb5",
+    "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
+  ]
+}

--- a/test/k8s-canaries/terraform/production/backend.tf
+++ b/test/k8s-canaries/terraform/production/backend.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "agent-control-canary-states"
-    dynamodb_table = "agent-control-canary-states"
+    bucket         = "agent-control-terraform-states"
+    dynamodb_table = "agent-control-terraform-states"
     key            = "k8s_production/terraform-states-backend.tfstate"
     region         = "us-east-2"
   }

--- a/test/k8s-canaries/terraform/staging/.terraform.lock.hcl
+++ b/test/k8s-canaries/terraform/staging/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.35.1"
+  hashes = [
+    "h1:zgXeWvp4//Ry+4glwNrLMpPFOU8QBQlARNmR9WCNe9o=",
+    "zh:12212ca5ae47823ce14bfafb909eeb6861faf1e2435fb2fc4a8b334b3544b5f5",
+    "zh:3f49b3d77182df06b225ab266667de69681c2e75d296867eb2cf06a8f8db768c",
+    "zh:40832494d19f8a2b3cd0c18b80294d0b23ef6b82f6f6897b5fe00248a9997460",
+    "zh:739a5ddea61a77925ee7006a29c8717377a2e9d0a79a0bbd98738d92eec12c0d",
+    "zh:a02b472021753627c5c39447a56d125a32214c29ff9108fc499f2dcdf4f1cc4f",
+    "zh:b78865b3867065aa266d6758c9601a2756741478f5735a838c20d633d65e085b",
+    "zh:d362e87464683f5632790e66920ea803adb54c2bc0cb24b6fd9a314d2b1efffd",
+    "zh:d98206fe88c2c9a52b8d2d0cb2c877c812a4a51d19f9d8428e63cbd5fd8a304d",
+    "zh:dfa320946b1ce3f3615c42b3447a28dc9f604c06d8b9a6fe289855ab2ade4d11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1debd2e695b5222d2ccc8b24dab65baba4ee2418ecce944e64d42e79474cb5",
+    "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
+  ]
+}

--- a/test/k8s-canaries/terraform/staging/backend.tf
+++ b/test/k8s-canaries/terraform/staging/backend.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "agent-control-canary-states"
-    dynamodb_table = "agent-control-canary-states"
+    bucket         = "agent-control-terraform-states"
+    dynamodb_table = "agent-control-terraform-states"
     key            = "foundations/terraform-states-backend.tfstate"
     region         = "us-east-2"
   }

--- a/test/k8s-canaries/terraform/states_setup/main.tf
+++ b/test/k8s-canaries/terraform/states_setup/main.tf
@@ -10,8 +10,8 @@ terraform {
   # On first execution it should be commented to allow creation of the bucket,
   # because this will fail to save the state on a bucket that was still not created.
   backend s3 {
-    bucket         = "agent-control-canary-states"
-    dynamodb_table = "agent-control-canary-states"
+    bucket         = "agent-control-terraform-states"
+    dynamodb_table = "agent-control-terraform-states"
     key            = "foundations/state_framework.tfstate"
     region         = "us-east-2"
   }
@@ -31,6 +31,6 @@ data "aws_region" "current" {}
 
 module "state_backend" {
   source              = "../modules/state_backend"
-  bucket_name         = "agent-control-canary-states"
-  dynamodb_table_name = "agent-control-canary-states"
+  bucket_name         = "agent-control-terraform-states"
+  dynamodb_table_name = "agent-control-terraform-states"
 }


### PR DESCRIPTION
- Added plan workflows to trigger tf plan on a PR whenever there are changes in the canaries terraform files.
- Added sync workflow to trigger tf apply when there is a merge to main with canaries terraform files.
- Added new k8s canaries helm update for nightly and prerelease.