### PR TITLE
feat: log supervisor start

### DIFF
--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -130,6 +130,7 @@ impl NotStartedSupervisorK8s {
         let agent_id = self.agent_id.clone();
         let k8s_client = self.k8s_client.clone();
 
+        info!(%agent_id, "k8s objects supervisor started");
         let join_handle = thread::spawn(move || loop {
             // Check and apply k8s objects
             if let Err(err) = Self::apply_resources(&agent_id, resources.iter(), k8s_client.clone())


### PR DESCRIPTION
This PR solves issue 1 on https://new-relic.atlassian.net/browse/NR-347938. We log when the supervisor starts working.

**Example updating config from fleet management:**
![Captura de pantalla 2025-01-28 a las 11 29 59](https://github.com/user-attachments/assets/bbee4ca5-0747-40ae-836b-f972349c19c8)

**Example when starting the agent control:**
![Captura de pantalla 2025-01-28 a las 11 31 10](https://github.com/user-attachments/assets/114801d1-b6e1-4592-9fd8-76d519c4b61c)
