### PR TITLE
Moving to new account for Fargate

### DIFF
--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -51,10 +51,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision TF_VAR_inventory_output=/srv/runner/inventory/${{ env.TAG_OR_UNIQUE_NAME }}-inventory.ec2 TAG_OR_UNIQUE_NAME=${{ env.TAG_OR_UNIQUE_NAME }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"
@@ -72,10 +72,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/canaries ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.TAG_OR_UNIQUE_NAME }}-inventory.ec2' LIMIT=testing_hosts_linux NR_OTEL_COLLECTOR_MEMORY_LIMIT=100 NR_OTEL_COLLECTOR_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"

--- a/.github/workflows/component_canaries_prune.yaml
+++ b/.github/workflows/component_canaries_prune.yaml
@@ -48,10 +48,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=${{ env.TAG_OR_UNIQUE_NAME }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"

--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -63,10 +63,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision TF_VAR_inventory_output=/srv/runner/inventory/${{ env.UNIQUE_NAME }}-inventory.ec2 TAG_OR_UNIQUE_NAME=${{ env.UNIQUE_NAME }} EC2_FILTERS=${{ env.EC2_FILTERS }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"
@@ -84,10 +84,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/e2e REPOSITORY_ENDPOINT=${{ inputs.REPOSITORY_ENDPOINT }} ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.UNIQUE_NAME }}-inventory.ec2' PACKAGE_VERSION=${{ inputs.PACKAGE_VERSION }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"
@@ -99,10 +99,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=${{ env.UNIQUE_NAME }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"

--- a/.github/workflows/component_provision_packaging.yml
+++ b/.github/workflows/component_provision_packaging.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-2
-          
+
       - uses: actions/checkout@v4
 
       - name: Set branch name
@@ -48,10 +48,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision TF_VAR_inventory_output=/srv/runner/inventory/${{ env.TAG_OR_UNIQUE_NAME }}-inventory.ec2 TAG_OR_UNIQUE_NAME=${{ env.TAG_OR_UNIQUE_NAME }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"
@@ -68,11 +68,11 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/packaging ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.TAG_OR_UNIQUE_NAME }}-inventory.ec2' LIMIT=testing_hosts_linux NR_OTEL_COLLECTOR_MEMORY_LIMIT=100 NR_SUPER_AGENT_VERSION=${{ env.TAG_OR_UNIQUE_NAME }} NR_OTEL_COLLECTOR_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          container_make_target: "test/packaging ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.TAG_OR_UNIQUE_NAME }}-inventory.ec2' LIMIT=testing_hosts_linux NR_OTEL_COLLECTOR_MEMORY_LIMIT=100 NR_AGENT_CONTROL_VERSION=${{ env.TAG_OR_UNIQUE_NAME }} NR_OTEL_COLLECTOR_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317"
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"
@@ -83,10 +83,10 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=${{ env.TAG_OR_UNIQUE_NAME }}"
-          ecs_cluster_name: caos_super_agent_releases
-          task_definition_name: super_agent-releases
-          cloud_watch_logs_group_name: /ecs/test-prerelease-super_agent-releases
-          cloud_watch_logs_stream_name: ecs/test-super_agent-releases
+          ecs_cluster_name: agent_control
+          task_definition_name: agent_control
+          cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control
+          cloud_watch_logs_stream_name: ecs/test-agent_control
           aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
           repo_name: "newrelic/newrelic-super-agent"
           git_clone_url: "ssh://git@github.com/newrelic/newrelic-super-agent.git"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,8 +88,8 @@ jobs:
       REPOSITORY_ENDPOINT: "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/preview"
       PACKAGE_VERSION: 0.100.${{ github.run_id }}
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   notify-failure:
     if: ${{ always() && failure() }}

--- a/.github/workflows/on_demand_canaries.yml
+++ b/.github/workflows/on_demand_canaries.yml
@@ -17,5 +17,5 @@ jobs:
     with:
       TAG: ${{ inputs.tag }}
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }} 
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}

--- a/.github/workflows/on_demand_canaries_prune.yaml
+++ b/.github/workflows/on_demand_canaries_prune.yaml
@@ -17,5 +17,5 @@ jobs:
     with:
       TAG: ${{ inputs.tag }}
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}

--- a/.github/workflows/on_demand_onhost_e2e.yml
+++ b/.github/workflows/on_demand_onhost_e2e.yml
@@ -28,6 +28,6 @@ jobs:
       EC2_FILTERS: ${{ inputs.EC2_FILTERS || '[\"ubuntu22.04\"]' }}
       REPOSITORY_ENDPOINT: ${{ inputs.REPOSITORY_ENDPOINT || 'https://nr-downloads-ohai-staging.s3.amazonaws.com/'}}
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 

--- a/.github/workflows/on_demand_packaging_tests.yml
+++ b/.github/workflows/on_demand_packaging_tests.yml
@@ -17,5 +17,5 @@ jobs:
     with:
       TAG_OR_UNIQUE_NAME: ${{ inputs.tag }}
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }} 
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}

--- a/.github/workflows/on_demand_release.yml
+++ b/.github/workflows/on_demand_release.yml
@@ -44,7 +44,7 @@ jobs:
           gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
           disable_lock: false
           dest_prefix: "preview/"
-          local_packages_path:  "/srv/dist/"
+          local_packages_path: "/srv/dist/"
           apt_skip_mirror: false
 
       - name: Publish rpm to S3 action
@@ -69,12 +69,12 @@ jobs:
           gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
           disable_lock: false
           dest_prefix: "preview/"
-          local_packages_path:  "/srv/dist/"
+          local_packages_path: "/srv/dist/"
           apt_skip_mirror: false
 
   molecule-packaging-tests:
     uses: ./.github/workflows/component_molecule_packaging.yml
-    needs: [upload]
+    needs: [ upload ]
     with:
       TAG: ${{ github.event.inputs.tag }}
       PACKAGE_NAME: "newrelic-agent-control"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -100,18 +100,17 @@ jobs:
           local_packages_path: "/srv/dist/"
           apt_skip_mirror: false
 
-  # e2e test were not actually testing the new packages! This will be addressed in https://new-relic.atlassian.net/browse/NR-346876
-  # onhost-e2e:
-  #   uses: ./.github/workflows/component_onhost_e2e.yaml
-  #   needs: [ upload ]
-  #   with:
-  #     TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
-  #     UNIQUE_NAME: "onhost:e2e:${{ github.event.inputs.tag || github.event.release.tag_name }}"
-  #     # We use single quotes so the double-quotes are passed to the sed command in the make target (see the test/provision target)
-  #     EC2_FILTERS: '[\"ubuntu\",\"centos7\",\"centos8\",\"centos-stream\",\"sles-15.3\",\"sles-15.4\",\"sles-15.5\",\"redhat\",\"debian-bullseye\",\"debian-bookworm\",\"al\"]'
-  #   secrets:
-  #     AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-  #     AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+  onhost-e2e:
+    uses: ./.github/workflows/component_onhost_e2e.yaml
+    needs: [ upload ]
+    with:
+      PACKAGE_VERSION: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      UNIQUE_NAME: "onhost:e2e:${{ github.event.inputs.tag || github.event.release.tag_name }}"
+      # We use single quotes so the double-quotes are passed to the sed command in the make target (see the test/provision target)
+      EC2_FILTERS: '[\"ubuntu\",\"centos7\",\"centos8\",\"centos-stream\",\"sles-15.3\",\"sles-15.4\",\"sles-15.5\",\"redhat\",\"debian-bullseye\",\"debian-bookworm\",\"al\"]'
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   molecule-packaging-tests:
     uses: ./.github/workflows/component_molecule_packaging.yml
@@ -128,8 +127,8 @@ jobs:
   #    with:
   #      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
   #    secrets:
-  #      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-  #      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+  #      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+  #      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   get_previous_tag:
     runs-on: ubuntu-latest
@@ -141,14 +140,15 @@ jobs:
       - id: previous_tag_step
         run: ./.github/workflows/scripts/previous_version.sh ${{ inputs.TAG }} >> "$GITHUB_OUTPUT"
 
-  prune-previous-canaries:
-    needs: get_previous_tag
-    uses: ./.github/workflows/component_canaries_prune.yaml
-    with:
-      TAG: ${{ needs.get_previous_tag.outputs.previous_tag }}
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.TMP_AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.TMP_AWS_VPC_SUBNET }}
+  # TODO The creation of the canaries is commented out right now
+  #  prune-previous-canaries:
+  #    needs: get_previous_tag
+  #    uses: ./.github/workflows/component_canaries_prune.yaml
+  #    with:
+  #      TAG: ${{ needs.get_previous_tag.outputs.previous_tag }}
+  #    secrets:
+  #      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+  #      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   notify-failure:
     if: ${{ always() && failure() }}

--- a/test/provision/terraform/main.tf
+++ b/test/provision/terraform/main.tf
@@ -1,6 +1,26 @@
 variable "ec2_prefix" {
   default = ""
 }
+
+variable "ec2_otels" {
+  type = map(any)
+  default = {
+    "amd64:ubuntu22.04" = {
+      ami           = "ami-0884d2865dbe9de4b"
+      subnet        = "subnet-00aa02e6d991b478e"
+      security_groups = ["sg-04ae18f8c34a11d38"]
+      key_name      = "caos-dev-arm"
+      instance_type = "t3a.small"
+      username      = "ubuntu"
+      python        = "/usr/bin/python3"
+      platform      = "linux"
+      tags = {
+        "otel_role" = "agent"
+      }
+    }
+  }
+}
+
 variable "ec2_filters" {
   default = ""
 }
@@ -32,7 +52,7 @@ variable "inventory_output" {
   default = "./inventory.ec2"
 }
 
-module "super_agent-env-provisioner" {
+module "agent_control-env-provisioner" {
   source             = "git::https://github.com/newrelic-experimental/env-provisioner//terraform/otel-ec2"
   ec2_prefix         = var.ec2_prefix
   ec2_filters        = var.ec2_filters
@@ -43,6 +63,7 @@ module "super_agent-env-provisioner" {
   inventory_template = "${path.module}/inventory.tmpl"
   inventory_output   = var.inventory_output
   ansible_playbook   = var.ansible_playbook
+  ec2_otels          = var.ec2_otels
 }
 
 output "check_vars" {

--- a/test/provision/terraform/terraform.backend.tf.dist
+++ b/test/provision/terraform/terraform.backend.tf.dist
@@ -3,8 +3,9 @@
 #########################################
 terraform {
   backend "s3" {
-    bucket = "automation-pipeline-terraform-state"
-    key    = "super_agent-pipeline/TAG_OR_UNIQUE_NAME"
+    bucket         = "agent-control-terraform-states"
+    dynamodb_table = "agent-control-terraform-states"
+    key    = "agent_control-pipeline/TAG_OR_UNIQUE_NAME"
     region = "us-east-2"
   }
 }

--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -7,115 +7,100 @@ provider "aws" {
 #########################################
 terraform {
   backend "s3" {
-    bucket = "automation-pipeline-terraform-state"
-    key    = "super_agent_releases"
-    region = "us-east-2"
+    bucket         = "agent-control-terraform-states"
+    dynamodb_table = "agent-control-terraform-states"
+    key            = "fargate_cluster/terraform-states-backend.tfstate"
+    region         = "us-east-2"
   }
 }
 
 
-module "super_agent_infra" {
-    source = "github.com/newrelic/fargate-runner-action//terraform/modules/infra-ecs-fargate?ref=main"
-    region = var.region
-    vpc_id = var.vpc_id
-    vpc_subnet_id = var.vpc_subnet
-    account_id = var.accountId
+module "agent_control_infra" {
+  source                  = "github.com/newrelic/fargate-runner-action//terraform/modules/infra-ecs-fargate?ref=main"
+  region                  = var.region
+  vpc_id                  = var.vpc_id
+  vpc_subnet_id           = var.vpc_subnet
+  account_id              = var.accountId
+  s3_terraform_bucket_arn = var.s3_bucket
+  cluster_name            = var.cluster_name
+  cloudwatch_log_group    = var.task_logs_group
+  task_container_image    = var.task_container_image
+  task_container_name     = var.task_container_name
+  task_name_prefix        = var.task_name_prefix
+  task_secrets = [
+    # All canaries, e2e and packaging tests points to the same account.
+    {
+      "name" : "NR_LICENSE_KEY",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}"
+    },
+    {
+      "name" : "NEW_RELIC_ACCOUNT_ID",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}"
+    },
+    {
+      "name" : "NEW_RELIC_API_KEY",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}"
+    },
+    {
+      "name" : "NR_ORGANIZATION_ID",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}"
+    },
+    ####
+    {
+      "name" : "SSH_KEY",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}"
+    },
+    {
+      "name" : "CROWDSTRIKE_CLIENT_ID",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}"
+    },
+    {
+      "name" : "CROWDSTRIKE_CLIENT_SECRET",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_secret}"
+    },
+    {
+      "name" : "CROWDSTRIKE_CUSTOMER_ID",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_customer_id}"
+    },
+    {
+      "name" : "CROWDSTRIKE_ANSIBLE_ROLE_KEY",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_ansible_role_key}"
+    }
+  ]
+  task_custom_policies = [
+    jsonencode(
+      {
+        "Version" : "2012-10-17",
+        "Statement" : [
 
-    s3_terraform_bucket_arn = var.s3_bucket
-
-
-
-    cluster_name           = var.cluster_name
-
-    cloudwatch_log_group = var.task_logs_group
-
-    task_container_image = var.task_container_image
-    task_container_name = var.task_container_name
-    task_name_prefix = var.task_name_prefix
-    task_secrets = [
-        # All canaries, e2e and packaging tests points to the same account.
-        {
-          "name" : "NR_LICENSE_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}"
-        },
-        {
-          "name" : "NEW_RELIC_ACCOUNT_ID",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}"
-        },
-        {
-          "name" : "NEW_RELIC_API_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}"
-        },
-        {
-          "name" : "NR_ORGANIZATION_ID",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}"
-        },
-        ####
-        {
-          "name" : "SSH_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}"
-        },
-        {
-          "name" : "DOCKER_USERNAME",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_username}"
-        },
-        {
-          "name" : "DOCKER_PASSWORD",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_password}"
-        },
-        {
-          "name" : "CROWDSTRIKE_CLIENT_ID",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}" 
-        },
-        {
-          "name" : "CROWDSTRIKE_CLIENT_SECRET",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_secret}" 
-        },
-        {
-          "name" : "CROWDSTRIKE_CUSTOMER_ID",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_customer_id}" 
-        },
-        {
-          "name" : "CROWDSTRIKE_ANSIBLE_ROLE_KEY",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_ansible_role_key}"
-        }
-      ]
-    task_custom_policies = [
-        jsonencode(
           {
-            "Version" : "2012-10-17",
-            "Statement" : [
-
-              {
-                "Effect" : "Allow",
-                "Action" : [
-                  "secretsmanager:GetSecretValue"
-                ],
-                "Resource" : [
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_username}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_docker_password}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_secret}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_customer_id}",
-                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_ansible_role_key}"
-                ]
-              }
+            "Effect" : "Allow",
+            "Action" : [
+              "secretsmanager:GetSecretValue"
+            ],
+            "Resource" : [
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_organization_id}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_id}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_client_secret}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_customer_id}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_crowdstrike_ansible_role_key}"
             ]
           }
-        )
-      ]
+        ]
+      }
+    )
+  ]
 
-    efs_volume_mount_point = var.efs_volume_mount_point
-    efs_volume_name = var.efs_volume_name
-    additional_efs_security_group_rules = var.additional_efs_security_group_rules
-    canaries_security_group = var.canaries_security_group
-
-    oidc_repository = var.oidc_repository
-    oidc_role_name = var.oidc_role_name
-
+  efs_volume_mount_point              = var.efs_volume_mount_point
+  efs_volume_name                     = var.efs_volume_name
+  additional_efs_security_group_rules = var.additional_efs_security_group_rules
+  canaries_security_group             = var.canaries_security_group
+  oidc_repository                     = var.oidc_repository
+  oidc_role_name                      = var.oidc_role_name
+  task_runtime_custom_policies        = var.task_runtime_custom_policies
+  tags                                = var.tags
 }

--- a/test/terraform/fargate/vars.tf
+++ b/test/terraform/fargate/vars.tf
@@ -7,77 +7,71 @@ variable "region" {
 }
 
 variable "accountId" {
-  default = "018789649883"
+  default = "288761741714"
 }
 
 variable "vpc_id" {
-  default = "vpc-0a3c00f5dc8645fe0"
+  default = "vpc-0f62d8a55c8d9ad61"
 }
 
 variable "vpc_subnet" {
-  default = "subnet-09b64de757828cdd4"
+  default = "subnet-00aa02e6d991b478e"
 }
 
 variable "cluster_name" {
-  default = "caos_super_agent_releases"
+  default = "agent_control"
 }
 
 #######################################
 # Task definition
 #######################################
 
-variable "task_command" {
-  default = [
-    "test/automated-run"
-  ]
+variable "tags" {
+  type = map
+  default = {
+    owning_team = "agent_control"
+  }
 }
+
 # Account secrets
 variable "secret_name_license" {
-  default = "agent_control/canaries/license_key-33qwzE"
+  default = "canaries/license_key-5wRtkT"
 }
 
 variable "secret_name_account_id" {
-  default = "agent_control/canaries/account_id-fCpTng"
+  default = "canaries/account_id-a25041"
 }
 
 variable "secret_name_api_key" {
-  default = "agent_control/canaries/nr_api_key-62y4Xp"
+  default = "canaries/nr_api_key-zHyTVS"
 }
 
 variable "secret_name_organization_id" {
-  default = "agent_control/canaries/organization_id-EPEqrL"
+  default = "canaries/organization_id-a0w4NX"
 }
 
 ####
 
 variable "secret_name_ssh" {
-  default = "caos/canaries/ssh_key-UBSKNA"
-}
-
-variable "secret_name_docker_username" {
-  default = "caos/canaries/docker-username-iksa0V"
-}
-
-variable "secret_name_docker_password" {
-  default = "caos/canaries/docker-password-jAtw3v"
+  default = "canaries/ssh_key-yhthNk"
 }
 
 # CrowdStrike Falcon secrets
 
 variable "secret_name_crowdstrike_client_id" {
-  default = "caos/canaries/crowdstrike_falcon_client_id-N7nGXx"
+  default = "canaries/crowdstrike_falcon_client_id-OnAVWJ"
 }
 
 variable "secret_name_crowdstrike_client_secret" {
-  default = "caos/canaries/crowdstrike_falcon_client_secret-l9EIhi"
+  default = "canaries/crowdstrike_falcon_client_secret-PfSOHH"
 }
 
 variable "secret_name_crowdstrike_customer_id" {
-  default = "caos/canaries/crowdstrike_falcon_customer_id-f7n7rI"
+  default = "canaries/crowdstrike_falcon_customer_id-2NbNLJ"
 }
 
 variable "secret_name_crowdstrike_ansible_role_key" {
-  default = "caos/crowdstrike/ansible-role-key-DPyrW4"
+  default = "crowdstrike/ansible-role-key-jJrGNu"
 }
 
 ####
@@ -87,23 +81,19 @@ variable "task_container_image" {
 }
 
 variable "task_logs_group" {
-  default = "/ecs/test-prerelease-super_agent-releases"
+  default = "/ecs/test-prerelease-agent_control"
 }
 
 variable "task_container_name" {
-  default = "test-super_agent-releases"
+  default = "test-agent_control"
 }
 
 variable "task_name_prefix" {
-  default = "super_agent-releases"
-}
-
-variable "task_logs_prefix" {
-  default = "ecs-super_agent-releases"
+  default = "agent_control"
 }
 
 variable "s3_bucket" {
-  default = "arn:aws:s3:::automation-pipeline-terraform-state"
+  default = "arn:aws:s3:::agent-control-terraform-states"
 }
 
 #######################################
@@ -115,22 +105,22 @@ variable "efs_volume_mount_point" {
 }
 
 variable "efs_volume_name" {
-  default = "shared-super_agent-releases"
+  default = "shared-agent_control"
 }
 
 variable "canaries_security_group" {
-  default = "sg-044ef7bc34691164a"
+  default = "sg-04ae18f8c34a11d38"
 }
 
 variable "additional_efs_security_group_rules" {
-    default = [
+  default = [
     {
-      type                     = "ingress"
-      from_port                = 0
-      to_port                  = 65535
-      protocol                 = "tcp"
-      cidr_blocks              = ["10.10.0.0/24"]
-      description              = "Allow ingress traffic to EFS from trusted subnet"
+      type        = "ingress"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "tcp"
+      cidr_blocks = ["10.10.0.0/24"]
+      description = "Allow ingress traffic to EFS from trusted subnet"
     }
   ]
 }
@@ -139,10 +129,22 @@ variable "additional_efs_security_group_rules" {
 # OIDC permissions
 #######################################
 
+// These permissions are the ones that the Fargate task can assume and execute.
+variable "task_runtime_custom_policies" {
+  type = list(string)
+  description = "Custom policies for task runtime as JSON strings."
+  default = [
+    "{ \"Statement\": [{ \"Effect\": \"Allow\", \"Action\": \"eks:*\", \"Resource\": \"*\" }] }",
+    "{ \"Statement\": [{ \"Effect\": \"Allow\", \"Action\": \"ec2:*\", \"Resource\": \"*\" }] }",
+    "{ \"Statement\": [{ \"Effect\": \"Allow\", \"Action\": \"dynamodb:*\", \"Resource\": \"*\" }]}",
+    "{ \"Statement\": [{ \"Effect\": \"Allow\", \"Action\": [\"iam:GetGroup\", \"iam:GetGroupPolicy\", \"iam:GetPolicy\", \"iam:GetPolicyVersion\", \"iam:GetRole\", \"iam:GetRolePolicy\", \"iam:GetUser\", \"iam:GetUserPolicy\", \"iam:ListAttachedGroupPolicies\", \"iam:ListAttachedRolePolicies\", \"iam:ListAttachedUserPolicies\", \"iam:ListGroups\", \"iam:ListGroupPolicies\", \"iam:ListGroupsForUser\", \"iam:ListRolePolicies\", \"iam:ListRoles\", \"iam:ListUserPolicies\", \"iam:ListUsers\"], \"Resource\": \"*\"}]}"
+  ]
+}
+
 variable "oidc_repository" {
   default = "repo:newrelic/newrelic-super-agent:*"
 }
 
 variable "oidc_role_name" {
-  default = "caos-pipeline-oidc-super_agent-releases"
+  default = "caos-pipeline-oidc-agent_control"
 }


### PR DESCRIPTION
This PR:
 - moves the Fargate cluster to the new account updating the naming super_agent -> agent_control and all resource references
 
Small Extras:
 - moves credentials to new variables TMP_AWS_ROLE_ARN -> AWS_ROLE_ARN
 - Comments out `prune-previous-canaries` since the creation was already disabled
 - re-enable some e2e tests for the pre-release (they are already running for the nightly)
 
The ECS Fargate cluster is already running.
Notice that after the PR is merged I'll update the OIDC rule to point to the new repository and I'll change its name