### PR TITLE
chore(test): show unexpected error when the test fails

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
@@ -178,7 +178,7 @@ mod tests {
                     Duration::from_secs(10),
                 )
                 .fetch()
-                .unwrap_or_else(|_| panic!("fetching cert, case: {}", self.name));
+                .unwrap_or_else(|err| panic!("fetching cert err '{}', case: '{}'", err, self.name));
             }
         }
         let test_cases = vec![


### PR DESCRIPTION
Show the error when the certificate test fails: it will help us to understand what is causing it.