### PR TITLE
fix-repository-endpoint-for-onhost-e2e

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
         description: 'Repository endpoint to fetch packages from'
-        default: "https://download.newrelic.com/preview"
+        default: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
 
 env:
   UNIQUE_NAME: ${{ inputs.UNIQUE_NAME }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -108,6 +108,7 @@ jobs:
       UNIQUE_NAME: "onhost:e2e:${{ github.event.inputs.tag || github.event.release.tag_name }}"
       # We use single quotes so the double-quotes are passed to the sed command in the make target (see the test/provision target)
       EC2_FILTERS: '[\"ubuntu\",\"centos7\",\"centos8\",\"centos-stream\",\"sles-15.3\",\"sles-15.4\",\"sles-15.5\",\"redhat\",\"debian-bullseye\",\"debian-bookworm\",\"al\"]'
+      REPOSITORY_ENDPOINT: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}


### PR DESCRIPTION
Change the default endpoint for e2e onhost from "https://download.newrelic.com/preview" to "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"  and added to the vars of pre-release step