### PR TITLE
fix: health should ignore max_unavailable [NR-365513]

### DIFF
--- a/agent-control/src/sub_agent/health/k8s/daemon_set.rs
+++ b/agent-control/src/sub_agent/health/k8s/daemon_set.rs
@@ -9,6 +9,8 @@ use crate::sub_agent::health::with_start_time::{HealthWithStartTime, StartTime};
 use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetStatus};
 use std::sync::Arc;
 
+const ROLLING_UPDATE_UPDATE_STRATEGY: &str = "RollingUpdate";
+
 pub struct K8sHealthDaemonSet {
     k8s_client: Arc<SyncK8sClient>,
     release_name: String,
@@ -112,7 +114,6 @@ impl K8sHealthDaemonSet {
     }
 }
 
-const ROLLING_UPDATE_UPDATE_STRATEGY: &str = "RollingUpdate";
 fn is_daemon_set_update_strategy_rolling_update(
     name: &str,
     daemon_set: &DaemonSet,


### PR DESCRIPTION
Before we were taking too many variables into account, but we took wrong assumptions:
 - we do not know if a rolling updated is ongoing
 - we do not have a timeout

Therefore, we were always taking into account max_unavailable, making very easy to report false negatives.

The implementation got simplified aiming to report unhealthy if not all the pods expected are ready:
> This implies that during a rollout an agent could appear as unHealthy if there are not all the ready pods expected. 

Moreover, please notice that following the APM case:
> We report as Healthy also if a replica is running an old version of the agent, since we can safely assume that it is in the process to be upgraded.