### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<a href="https://opensource.newrelic.com/oss-category/#community-plus"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Community_Plus.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"><img alt="New Relic Open Source community plus project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"></picture></a>
-
 | ⚠️ | New Relic agent control is in preview and licensed under the New Relic Pre-Release Software Notice. |
 |---------------|:------------------------|
 


### PR DESCRIPTION
Removed open source banner since the agent is licensed under a proprietary license.  Banner should be added back in if agent control is licensed under an open source license.