### PR TITLE
feat: lint pr title [NR-367066]

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,0 +1,24 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install commitlint with default config
+        run: |
+          npm i @commitlint/cli
+          npm i @commitlint/config-conventional
+
+      - name: Validate PR title
+        run: echo ${{ github.event.pull_request.title }} | npx commitlint --extends @commitlint/config-conventional


### PR DESCRIPTION
This PR solves https://new-relic.atlassian.net/browse/NR-367066. We added a new github workflow that checks the PR title follows conventional commits using Angular guidelines. The title is checked when a PR is created or when it's edited. This avoids running the check on unnecessary situations like when the code changes.

* We use https://commitlint.js.org/ as the UI projects
* Check https://newrelic.atlassian.net/wiki/spaces/INST/pages/4105732222/DACI+Enforce+commit+message+structure+in+main+branch+automatically for additional information