### PR TITLE
fix: lint pr title

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -21,4 +21,4 @@ jobs:
           npm i @commitlint/config-conventional
 
       - name: Validate PR title
-        run: echo ${{ github.event.pull_request.title }} | npx commitlint --extends @commitlint/config-conventional
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --extends @commitlint/config-conventional


### PR DESCRIPTION
@sigilioso detected that my workflow was flawed. This PR fixes the problem. We now add quotes to the pr title so that the whole string is correctly linted.