### PR TITLE
test: Increase GC period on integration tests

### DIFF
--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -11,6 +11,8 @@ use newrelic_agent_control::values::file::YAMLConfigRepositoryFile;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub const K8S_GC_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Starts the agent-control in a separate thread. The agent-control will be stopped when the `StartedAgentControl` is dropped.
 /// Take into account that some of the logic from main is not present here.
 pub fn start_agent_control_with_custom_config(base_paths: BasePaths) -> StartedAgentControl {
@@ -30,8 +32,8 @@ pub fn start_agent_control_with_custom_config(base_paths: BasePaths) -> StartedA
 
         let agent_control_config = config_storer.load().unwrap();
 
-        let opamp_poll_interval = Duration::from_secs(2);
-        let garbage_collector_interval = Duration::from_secs(1);
+        let opamp_poll_interval = Duration::from_secs(10);
+        let garbage_collector_interval = K8S_GC_INTERVAL;
         // TODO - Temporal solution until https://new-relic.atlassian.net/browse/NR-343594 is done.
         // There is a current issue with the diff computation the GC does in order to collect agents. If a new agent is added and removed
         // before the GC process it, the resources will never be collected.

--- a/agent-control/tests/k8s/scenarios/cr_based_agents.rs
+++ b/agent-control/tests/k8s/scenarios/cr_based_agents.rs
@@ -1,3 +1,4 @@
+use crate::common::agent_control::K8S_GC_INTERVAL;
 use crate::k8s::tools::agent_control::BAR_CR_AGENT_TYPE_PATH;
 use crate::k8s::tools::k8s_api::check_config_map_exist;
 use crate::k8s::tools::test_crd::{create_crd, delete_crd, Foo};
@@ -20,6 +21,7 @@ use kube::{Api, CustomResource, CustomResourceExt};
 use newrelic_agent_control::agent_control::config::AgentID;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ops::Add;
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -77,8 +79,12 @@ agents:
         Ok(())
     });
 
-    // Asserts the agent resources are garbage collected
+    // This function is used to wait for the k8s garbage collector to run.
+    // It is used in tests to ensure that the garbage collector has run before checking the state of the system.
+    // This is a HACK until we address the GC refactor.
+    std::thread::sleep(K8S_GC_INTERVAL.add(Duration::from_millis(100)));
 
+    // Asserts the agent resources are garbage collected
     server.set_config_response(
         instance_id.clone(),
         ConfigResponse::from(


### PR DESCRIPTION
Noticed that some of the K8s flaky integration test are due to the GC removing the sub-agent CM before the whole flow is finished. 

The real fix of this is the GC refactor which is selected for dev after Feb launch

Some examples:
https://github.com/newrelic/newrelic-agent-control/actions/runs/13283362157/job/37086449320#step:8:1384
https://github.com/newrelic/newrelic-agent-control/actions/runs/13284844619/job/37091137208#step:8:1680
``` logs
2025-02-12T12:11:39  INFO Applying remote config, agent_id: agent-control
2025-02-12T12:11:39 DEBUG ConfigMap fleet-data-agent-control missing key remote_config
2025-02-12T12:11:39  INFO Creating SubAgent bar-agent
2025-02-12T12:11:39 DEBUG building subAgent, agent_id: "bar-agent"
2025-02-12T12:11:39 DEBUG retrieving instance id, agent_id: agent-control
2025-02-12T12:11:39 DEBUG storer: getting Instance ID of agent_id: agent-control
2025-02-12T12:11:39 DEBUG retrieving instance id, agent_id: bar-agent
2025-02-12T12:11:39 DEBUG storer: getting Instance ID of agent_id: bar-agent
2025-02-12T12:11:39 DEBUG ConfigMap fleet-data-bar-agent not found
2025-02-12T12:11:39 DEBUG storer returned no data, agent_id: bar-agent
2025-02-12T12:11:39 DEBUG persisting instance id 0194FA126D3C7682A6FFCC2B6915FC2B, agent_id: bar-agent
2025-02-12T12:11:39 DEBUG storer: setting Instance ID of agent_id: bar-agent
2025-02-12T12:11:39 DEBUG ConfigMap fleet-data-agent-control missing key remote_config
2025-02-12T12:11:39 DEBUG collecting config_maps: `app.kubernetes.io/managed-by==newrelic-agent-control,newrelic.io/agent-id notin (agent-control)`
2025-02-12T12:11:39 DEBUG Deleting collection: "ConfigMapList"/Some("fleet-data-bar-agent")
2025-02-12T12:11:39 DEBUG Initializing dynamic object manager for type: TypeMeta { api_version: "newrelic.com/v1", kind: "Bar" }
2025-02-12T12:11:39 DEBUG GC skipping collect for TypeMeta, error: apiVersion: newrelic.com/v1 kind: Bar
2025-02-12T12:11:40  INFO OpAMP client started, agent_id: bar-agent
```