### PR TITLE
feat!: apm agent type selector values

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
       type: string
       default: "latest"
       required: false
-    pod_label_selector:
+    podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
       required: false
-    namespace_label_selector:
+    namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
@@ -51,5 +51,5 @@ deployment:
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
-          podLabelSelector: ${nr-var:pod_label_selector}
-          namespaceLabelSelector: ${nr-var:namespace_label_selector}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
       type: string
       default: "latest"
       required: false
-    pod_label_selector:
+    podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
       required: false
-    namespace_label_selector:
+    namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
@@ -51,5 +51,5 @@ deployment:
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
-          podLabelSelector: ${nr-var:pod_label_selector}
-          namespaceLabelSelector: ${nr-var:namespace_label_selector}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
       type: string
       default: "latest"
       required: false
-    pod_label_selector:
+    podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
       required: false
-    namespace_label_selector:
+    namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
@@ -51,5 +51,5 @@ deployment:
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
-          podLabelSelector: ${nr-var:pod_label_selector}
-          namespaceLabelSelector: ${nr-var:namespace_label_selector}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
       type: string
       default: "latest"
       required: false
-    pod_label_selector:
+    podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
       required: false
-    namespace_label_selector:
+    namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
@@ -51,5 +51,5 @@ deployment:
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
-          podLabelSelector: ${nr-var:pod_label_selector}
-          namespaceLabelSelector: ${nr-var:namespace_label_selector}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
       type: string
       default: "latest"
       required: false
-    pod_label_selector:
+    podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
       required: false
-    namespace_label_selector:
+    namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
@@ -51,5 +51,5 @@ deployment:
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
-          podLabelSelector: ${nr-var:pod_label_selector}
-          namespaceLabelSelector: ${nr-var:namespace_label_selector}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -48,9 +48,9 @@ static AGENT_TYPE_APM_DOTNET: LazyLock<AgentTypeValuesTestCase> =
                     "check all value types are correct",
                     r#"
                 version: "some-string"
-                pod_label_selector:
+                podLabelSelector:
                     yaml: object
-                namespace_label_selector:
+                namespaceLabelSelector:
                     yaml: object
                 env:
                     - SOME_VAR: "some-value"
@@ -73,9 +73,9 @@ static AGENT_TYPE_APM_JAVA: LazyLock<AgentTypeValuesTestCase> =
                     "check all value types are correct",
                     r#"
                 version: "some-string"
-                pod_label_selector:
+                podLabelSelector:
                     yaml: object
-                namespace_label_selector:
+                namespaceLabelSelector:
                     yaml: object
                 env:
                     - SOME_VAR: "some-value"
@@ -98,9 +98,9 @@ static AGENT_TYPE_APM_NODE: LazyLock<AgentTypeValuesTestCase> =
                     "check all value types are correct",
                     r#"
                 version: "some-string"
-                pod_label_selector:
+                podLabelSelector:
                     yaml: object
-                namespace_label_selector:
+                namespaceLabelSelector:
                     yaml: object
                 env:
                     - SOME_VAR: "some-value"
@@ -123,9 +123,9 @@ static AGENT_TYPE_APM_PYTHON: LazyLock<AgentTypeValuesTestCase> =
                     "check all value types are correct",
                     r#"
                 version: "some-string"
-                pod_label_selector:
+                podLabelSelector:
                     yaml: object
-                namespace_label_selector:
+                namespaceLabelSelector:
                     yaml: object
                 env:
                     - SOME_VAR: "some-value"
@@ -148,9 +148,9 @@ static AGENT_TYPE_APM_RUBY: LazyLock<AgentTypeValuesTestCase> =
                     "check all value types are correct",
                     r#"
                 version: "some-string"
-                pod_label_selector:
+                podLabelSelector:
                     yaml: object
-                namespace_label_selector:
+                namespaceLabelSelector:
                     yaml: object
                 env:
                     - SOME_VAR: "some-value"

--- a/test/k8s-e2e/agent-control-apm.yml
+++ b/test/k8s-e2e/agent-control-apm.yml
@@ -17,7 +17,7 @@ agent-control-deployment:
       java-agent:
         type: newrelic/com.newrelic.apm_java:0.1.0
         content:
-          pod_label_selector:
+          podLabelSelector:
             matchExpressions:
               - key: "app"
                 operator: "In"
@@ -25,7 +25,7 @@ agent-control-deployment:
       python-agent:
         type: newrelic/com.newrelic.apm_python:0.1.0
         content:
-          pod_label_selector:
+          podLabelSelector:
             matchExpressions:
               - key: "app"
                 operator: "In"
@@ -33,7 +33,7 @@ agent-control-deployment:
       node-agent:
         type: newrelic/com.newrelic.apm_node:0.1.0
         content:
-          pod_label_selector:
+          podLabelSelector:
             matchExpressions:
               - key: "app"
                 operator: "In"
@@ -41,7 +41,7 @@ agent-control-deployment:
       ruby-agent:
         type: newrelic/com.newrelic.apm_ruby:0.1.0
         content:
-          pod_label_selector:
+          podLabelSelector:
             matchExpressions:
               - key: "app"
                 operator: "In"
@@ -49,7 +49,7 @@ agent-control-deployment:
       dotnet-agent:
         type: newrelic/com.newrelic.apm_dotnet:0.1.0
         content:
-          pod_label_selector:
+          podLabelSelector:
             matchExpressions:
               - key: "app"
                 operator: "In"


### PR DESCRIPTION
# What this PR does / why we need it
This PR changes the APM agent type values regarding k8s selectors to match conventional camel case fields.


## Special notes for your reviewer

## Checklist

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
