### PR TITLE
fix: validate and fail if agent control config has non-existent agent-types (NR-369601)

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -6,6 +6,7 @@ pub(super) mod event_handler;
 pub use agent_control::*;
 #[allow(clippy::module_inception)]
 mod agent_control;
+pub mod config_validator;
 pub mod http_server;
 pub mod pid_cache;
 pub mod run;

--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -1,0 +1,114 @@
+use crate::agent_control::config::AgentControlDynamicConfig;
+use crate::agent_type::agent_type_registry::{AgentRegistry, AgentRepositoryError};
+use std::ops::Deref;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DynamicConfigValidatorError {
+    #[error("`{0}`")]
+    AgentRepositoryError(#[from] AgentRepositoryError),
+}
+
+/// Represents a validator for dynamic config
+pub trait DynamicConfigValidator {
+    fn validate(
+        &self,
+        dynamic_config: &AgentControlDynamicConfig,
+    ) -> Result<(), DynamicConfigValidatorError>;
+}
+
+pub struct RegistryDynamicConfigValidator<R: AgentRegistry> {
+    agent_type_registry: Arc<R>,
+}
+
+impl<R: AgentRegistry> RegistryDynamicConfigValidator<R> {
+    pub fn new(agent_type_registry: Arc<R>) -> Self {
+        Self {
+            agent_type_registry,
+        }
+    }
+}
+
+impl<R: AgentRegistry> DynamicConfigValidator for RegistryDynamicConfigValidator<R> {
+    fn validate(
+        &self,
+        dynamic_config: &AgentControlDynamicConfig,
+    ) -> Result<(), DynamicConfigValidatorError> {
+        dynamic_config
+            .agents
+            .values()
+            .try_for_each(|sub_agent_cfg| {
+                let _ = self
+                    .agent_type_registry
+                    .get(sub_agent_cfg.agent_type.deref())?;
+                Ok(())
+            })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::agent_type::agent_metadata::AgentMetadata;
+    use crate::agent_type::agent_type_registry::tests::MockAgentRegistryMock;
+    use crate::agent_type::definition::AgentTypeDefinition;
+    use mockall::mock;
+    use semver::Version;
+
+    mock! {
+        pub DynamicConfigValidatorMock {}
+
+        impl DynamicConfigValidator for DynamicConfigValidatorMock {
+            fn validate(
+                &self,
+                dynamic_config: &AgentControlDynamicConfig,
+            ) -> Result<(), DynamicConfigValidatorError>;
+        }
+    }
+
+    #[test]
+    fn test_existing_agent_type_validation() {
+        let mut registry = MockAgentRegistryMock::new();
+
+        let agent_type_definition = AgentTypeDefinition::empty_with_metadata(AgentMetadata {
+            name: "some_fqn".into(),
+            version: Version::parse("0.0.1").unwrap(),
+            namespace: "ns".into(),
+        });
+
+        //Expectations
+        registry.should_get("ns/some_fqn:0.0.1".to_string(), &agent_type_definition);
+
+        let dynamic_config = serde_yaml::from_str::<AgentControlDynamicConfig>(
+            r#"
+agents:
+  some-agent:
+    agent_type: ns/some_fqn:0.0.1
+"#,
+        )
+        .unwrap();
+
+        let dynamic_config_validator = RegistryDynamicConfigValidator::new(Arc::new(registry));
+
+        assert!(dynamic_config_validator.validate(&dynamic_config).is_ok());
+    }
+    #[test]
+    fn test_non_existing_agent_type_validation() {
+        let mut registry = MockAgentRegistryMock::new();
+        registry.should_not_get("ns/another:0.0.1".to_string());
+
+        let dynamic_config = serde_yaml::from_str::<AgentControlDynamicConfig>(
+            r#"
+agents:
+  some-agent:
+    agent_type: ns/another:0.0.1
+"#,
+        )
+        .unwrap();
+
+        let dynamic_config_validator = RegistryDynamicConfigValidator::new(Arc::new(registry));
+
+        assert!(dynamic_config_validator.validate(&dynamic_config).is_err());
+    }
+}

--- a/agent-control/src/agent_control/error.rs
+++ b/agent-control/src/agent_control/error.rs
@@ -1,4 +1,5 @@
 use super::config::AgentControlConfigError;
+use crate::agent_control::config_validator::DynamicConfigValidatorError;
 use crate::agent_type::agent_type_registry::AgentRepositoryError;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::render::persister::config_persister::PersistError;
@@ -103,4 +104,7 @@ pub enum AgentError {
     #[cfg(feature = "onhost")]
     #[error("failed to initialize the identifiers provider: `{0}`")]
     InitializeIdentifiersProvider(#[from] instance_id::IdentifiersProviderError),
+
+    #[error("agent control remote config validation error: `{0}`")]
+    RemoteConfigValidatorError(#[from] DynamicConfigValidatorError),
 }

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -66,7 +66,7 @@ pub struct AgentControlRunConfig {
 /// Fields are public just for testing. The object is destroyed right after is deleted,
 /// Therefore, we should be worried of any tampering after its creation.
 pub struct AgentControlRunner {
-    agent_type_registry: EmbeddedRegistry,
+    agent_type_registry: Arc<EmbeddedRegistry>,
     application_event_consumer: EventConsumer<ApplicationEvent>,
     opamp_http_builder: Option<OpAMPHttpClientBuilder<TokenRetrieverImpl>>,
     opamp_poll_interval: Duration,
@@ -132,12 +132,12 @@ impl AgentControlRunner {
             config.opamp.clone(),
         );
 
-        let agent_type_registry = EmbeddedRegistry::new(
+        let agent_type_registry = Arc::new(EmbeddedRegistry::new(
             config
                 .base_paths
                 .local_dir
                 .join(DYNAMIC_AGENT_TYPE_FILENAME),
-        );
+        ));
 
         let signature_validator = config
             .opamp

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -1,6 +1,7 @@
 use crate::agent_control::config::{AgentID, AgentTypeFQN, K8sConfig};
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
+use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, FLEET_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CHART_VERSION_ATTRIBUTE_KEY,
@@ -92,7 +93,7 @@ impl AgentControlRunner {
 
         let agents_assembler = Arc::new(LocalEffectiveAgentsAssembler::new(
             yaml_config_repository.clone(),
-            self.agent_type_registry,
+            self.agent_type_registry.clone(),
             template_renderer,
         ));
 
@@ -152,6 +153,9 @@ impl AgentControlRunner {
         );
         let _started_gcc = gcc.start();
 
+        let dynamic_config_validator =
+            RegistryDynamicConfigValidator::new(self.agent_type_registry);
+
         AgentControl::new(
             maybe_client,
             hash_repository,
@@ -161,6 +165,7 @@ impl AgentControlRunner {
             self.sub_agent_publisher,
             self.application_event_consumer,
             maybe_opamp_consumer,
+            dynamic_config_validator,
         )
         .run()
     }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -1,6 +1,7 @@
 use crate::agent_control::config::{AgentID, AgentTypeFQN};
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
+use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, SUB_AGENT_DIR,
@@ -105,7 +106,7 @@ impl AgentControlRunner {
 
         let agents_assembler = Arc::new(LocalEffectiveAgentsAssembler::new(
             yaml_config_repository.clone(),
-            self.agent_type_registry,
+            self.agent_type_registry.clone(),
             template_renderer,
         ));
 
@@ -150,6 +151,9 @@ impl AgentControlRunner {
             .map(|(client, consumer)| (Some(client), Some(consumer)))
             .unwrap_or_default();
 
+        let dynamic_config_validator =
+            RegistryDynamicConfigValidator::new(self.agent_type_registry);
+
         AgentControl::new(
             maybe_client,
             agent_control_hash_repository,
@@ -159,6 +163,7 @@ impl AgentControlRunner {
             self.sub_agent_publisher,
             self.application_event_consumer,
             maybe_sa_opamp_consumer,
+            dynamic_config_validator,
         )
         .run()
     }

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -105,7 +105,7 @@ where
     D: YAMLConfigRepository,
     Y: Renderer,
 {
-    registry: R,
+    registry: Arc<R>,
     yaml_config_repository: Arc<D>,
     renderer: Y,
 }
@@ -117,7 +117,7 @@ where
 {
     pub fn new(
         yaml_config_repository: Arc<Y>,
-        registry: EmbeddedRegistry,
+        registry: Arc<EmbeddedRegistry>,
         renderer: TemplateRenderer<ConfigurationPersisterFile>,
     ) -> Self {
         LocalEffectiveAgentsAssembler {
@@ -279,7 +279,7 @@ pub(crate) mod tests {
     {
         pub fn new_for_testing(registry: R, remote_values_repo: D, renderer: N) -> Self {
             Self {
-                registry,
+                registry: Arc::new(registry),
                 yaml_config_repository: Arc::new(remote_values_repo),
                 renderer,
             }


### PR DESCRIPTION
fix: validate and fail if agent control config has non-existent agent-types (NR-369601)