### PR TITLE
chore: refer license on Cargo manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["The New Relic Agent Control Team"]
 edition = "2021"
 publish = false
 rust-version = "1.85.0"
+license-file = "./LICENSE.md"
 
 [workspace.dependencies]
 serde_json = "1.0.138"
@@ -35,7 +36,12 @@ semver = "1.0.23"
 chrono = "0.4"
 jsonwebtoken = "9.3.0"
 # reqwest's default-features enables default-tls and we are not including it since we are using rustls only.
-reqwest = { version="0.12.11", default-features = false, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "socks"] }
+reqwest = { version = "0.12.11", default-features = false, features = [
+  "blocking",
+  "rustls-tls",
+  "rustls-tls-native-roots",
+  "socks",
+] }
 
 [profile.release]
 # remove debug symbols from the release binary

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
+license-file.workspace = true
 default-run = "newrelic-agent-control"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
+license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/license/Cargo.toml
+++ b/license/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
+license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/resource-detection/Cargo.toml
+++ b/resource-detection/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
+license-file.workspace = true
 
 [dependencies]
 nix = { workspace = true, features = ["hostname"] }


### PR DESCRIPTION
# What this PR does / why we need it

Just links the license file to the different `Cargo.toml` manifests we have in the repo.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
