### PR TITLE
docs: enforce documentation

### DIFF
--- a/agent-control/src/bin/main.rs
+++ b/agent-control/src/bin/main.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 #[cfg(all(unix, feature = "onhost", not(feature = "multiple-instances")))]
 use newrelic_agent_control::agent_control::pid_cache::PIDCache;
 use newrelic_agent_control::agent_control::run::AgentControlRunner;

--- a/agent-control/src/lib.rs
+++ b/agent-control/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 pub mod agent_control;
 pub mod agent_type;
 pub mod cli;

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 pub mod directory_manager;
 pub mod file_reader;
 pub mod file_renamer;

--- a/resource-detection/src/lib.rs
+++ b/resource-detection/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Representations of entities.
 //!
 //! A [Resource] is an immutable representation of the entity producing
@@ -5,8 +6,6 @@
 //! running in a container on Kubernetes has a Pod name, it is in a namespace
 //! and possibly is part of a Deployment which also has a name. All three of
 //! these attributes can be included in the `Resource`.
-
-#![warn(missing_docs)]
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
# What this PR does / why we need it

This is a PR to add comprehensive documentation for the project, in light of the possible public availability of the source code.

For now, it only adds a lint at the top of the modules, so we will all have warnings when adding a component without documentation. **This means the warning is triggered right now as not all modules are documented**. We can collaborate on this PR to add missing docs.

## Special notes for your reviewer

If you prefer, this can be turned into a feature branch with smaller PRs adding docs being merged here.

## Checklist

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
