### PR TITLE
fix: add disableTakeOwnership to our agent_types when enabling flux 2.5

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -148,12 +148,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -162,6 +164,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
           - kind: Secret
             name: default-values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -78,12 +78,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -92,6 +94,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
           - kind: Secret
             name: default-values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -78,12 +78,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -92,6 +94,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
           - kind: Secret
             name: default-values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -78,12 +78,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -92,6 +94,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
           - kind: Secret
             name: default-values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -125,12 +125,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -139,6 +141,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
           - kind: Secret
             name: default-values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -81,12 +81,14 @@ deployment:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             remediation:
               retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
             cleanupOnFail: true
             force: true
             remediation:
@@ -95,6 +97,7 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
+            disableTakeOwnership: true
           valuesFrom:
             - kind: Secret
               name: default-values-${nr-sub:agent_id}

--- a/agent-control/tests/common/opamp.rs
+++ b/agent-control/tests/common/opamp.rs
@@ -237,7 +237,7 @@ impl Drop for FakeServer {
 }
 
 async fn opamp_handler(state: web::Data<Arc<Mutex<State>>>, req: web::Bytes) -> HttpResponse {
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
     let message = opamp::proto::AgentToServer::decode(req).unwrap();
     let instance_id: InstanceID = InstanceUid::try_from(message.clone().instance_uid)
         .unwrap()


### PR DESCRIPTION
# What this PR does / why we need it

## Which issue this PR fixes

- fixes the ownership take-off by our helm releases in flux 2.5 that is going to be bumped in [#helm-chart-1653](https://github.com/newrelic/helm-charts/pull/1653/files).
- This PR can be merged before because Flux 2.4 ignores this attributes if present.

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
