### PR TITLE
feat(logs): k8s pass context of error when creating an object NR-373122

### DIFF
--- a/agent-control/src/k8s/error.rs
+++ b/agent-control/src/k8s/error.rs
@@ -16,7 +16,8 @@ pub enum K8sError {
     #[error("cannot start a k8s reader `{0}`")]
     ReflectorWriterDropped(#[from] kube::runtime::reflector::store::WriterDropped),
 
-    #[error("cannot post object `{0}`")]
+    // We need to add the debug info since the string representation of CommitError hide the source of the error
+    #[error("cannot post object `{0:?}`")]
     CommitError(#[from] api::entry::CommitError),
 
     #[error("the kind of the cr is missing")]


### PR DESCRIPTION
# What this PR does / why we need it
This PR makes sure that the errors from the K8s client are exposed.

Due to the structure of the commitError:
```
pub enum CommitError {
    /// Pre-commit validation failed
    #[error("failed to validate object for saving")]
    Validate(#[from] CommitValidationError),
    /// Failed to submit the new object to the Kubernetes API
    #[error("failed to save object")]
    Save(#[source] Error),
}
```
the context of the error was not propagated making troubleshooting the issues complex

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
