### PR TITLE
ci: add cargo cache on GHA

### DIFF
--- a/.github/workflows/push_pr_check.yml
+++ b/.github/workflows/push_pr_check.yml
@@ -47,6 +47,15 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{ env.RUST_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
       - name: Check code formatting
         run: cargo fmt --check
 
@@ -84,6 +93,16 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
+          
       - name: cargo clippy (${{ matrix.flag }})
         run: cargo clippy --workspace ${{ matrix.flag }} --tests -- -D clippy::all
 
@@ -110,6 +129,17 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
+          
       - name: Create on-host documentation
         run: cargo doc --no-deps --features=onhost --package newrelic_agent_control
         env:
@@ -143,6 +173,17 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
+          
       - name: Check security and licensing
         run: cargo install --locked cargo-deny && cargo deny check
       - name: Ensure that third party notices is up to date

--- a/.github/workflows/push_pr_coverage.yml
+++ b/.github/workflows/push_pr_coverage.yml
@@ -45,6 +45,15 @@ jobs:
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
       - name: Generate coverage report
         run: COVERAGE_OUT_FORMAT=json COVERAGE_OUT_FILEPATH=jcov.info make coverage
       - name: Calculate and print total coverage

--- a/.github/workflows/push_pr_test.yml
+++ b/.github/workflows/push_pr_test.yml
@@ -40,6 +40,16 @@ jobs:
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release
+
       - name: Build k8s in release mode
         run: cargo build --release --package newrelic_agent_control --features k8s
       - name: Build onhost in release mode
@@ -76,6 +86,16 @@ jobs:
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
 
       - name: Run workspace tests excluding the agent control package
         run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
@@ -127,6 +147,16 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
 
       - name: Run onHost root-required lib tests only
         run: make -C agent-control test/onhost/root
@@ -185,6 +215,17 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
+
       - name: Run k8s integration tests
         run: make -C agent-control test/k8s/integration
 
@@ -227,6 +268,17 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug          
+
       - name: Run k8s e2e-test ${{ matrix.group }}
         uses: newrelic/newrelic-integration-e2e-action@v1
         env:


### PR DESCRIPTION
Adds cargo caches with keys based on cargo lock.

Cache miss:
![image](https://github.com/user-attachments/assets/00cb6806-85fe-40f0-be21-d8dba304cc5a)

Cache hit:
<img width="679" alt="image" src="https://github.com/user-attachments/assets/e925c81a-dcf9-4689-9ff2-cf02c2a6cdec" />
