### PR TITLE
docs: revert enforcing documentation

### DIFF
--- a/agent-control/src/bin/main.rs
+++ b/agent-control/src/bin/main.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 #[cfg(all(unix, feature = "onhost", not(feature = "multiple-instances")))]
 use newrelic_agent_control::agent_control::pid_cache::PIDCache;
 use newrelic_agent_control::agent_control::run::AgentControlRunner;

--- a/agent-control/src/lib.rs
+++ b/agent-control/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 pub mod agent_control;
 pub mod agent_type;
 pub mod cli;

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 pub mod directory_manager;
 pub mod file_reader;
 pub mod file_renamer;

--- a/resource-detection/src/lib.rs
+++ b/resource-detection/src/lib.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Representations of entities.
 //!
 //! A [Resource] is an immutable representation of the entity producing
@@ -6,6 +5,8 @@
 //! running in a container on Kubernetes has a Pod name, it is in a namespace
 //! and possibly is part of a Deployment which also has a name. All three of
 //! these attributes can be included in the `Resource`.
+
+#![warn(missing_docs)]
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
# What this PR does / why we need it

This reverts commit 4395928fc7c1b3fae98d21b0c9751b72edb137f2.

As it adds too much noise for now. I still think this is valuable, so we should dedicate some time to document the code so this check can be enabled again.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
