### PR TITLE
chore(validator): unify remote config validators codebase

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -6,7 +6,6 @@ pub(super) mod event_handler;
 pub use agent_control::*;
 #[allow(clippy::module_inception)]
 mod agent_control;
-pub mod config_validator;
 pub mod http_server;
 pub mod pid_cache;
 pub mod run;

--- a/agent-control/src/agent_control/agent_control.rs
+++ b/agent-control/src/agent_control/agent_control.rs
@@ -3,13 +3,13 @@ use super::config_storer::loader_storer::{
     AgentControlDynamicConfigDeleter, AgentControlDynamicConfigLoader,
     AgentControlDynamicConfigStorer,
 };
-use crate::agent_control::config_validator::DynamicConfigValidator;
 use crate::agent_control::error::AgentError;
 use crate::event::{
     channel::{EventConsumer, EventPublisher},
     AgentControlEvent, ApplicationEvent, OpAMPEvent, SubAgentEvent,
 };
 use crate::opamp::remote_config::report::OpampRemoteConfigStatus;
+use crate::opamp::remote_config::validators::DynamicConfigValidator;
 use crate::opamp::{
     hash_repository::HashRepository,
     remote_config::hash::Hash,
@@ -411,8 +411,6 @@ mod tests {
         AgentControlDynamicConfig, AgentID, AgentTypeFQN, SubAgentConfig,
     };
     use crate::agent_control::config_storer::loader_storer::tests::MockAgentControlDynamicConfigStore;
-    use crate::agent_control::config_validator::tests::MockDynamicConfigValidatorMock;
-    use crate::agent_control::config_validator::DynamicConfigValidatorError;
     use crate::agent_control::AgentControl;
     use crate::agent_type::agent_type_registry::AgentRepositoryError;
     use crate::event::channel::pub_sub;
@@ -420,6 +418,8 @@ mod tests {
     use crate::opamp::client_builder::tests::MockStartedOpAMPClientMock;
     use crate::opamp::hash_repository::repository::tests::MockHashRepositoryMock;
     use crate::opamp::remote_config::hash::Hash;
+    use crate::opamp::remote_config::validators::tests::MockDynamicConfigValidatorMock;
+    use crate::opamp::remote_config::validators::DynamicConfigValidatorError;
     use crate::opamp::remote_config::{ConfigurationMap, RemoteConfig};
     use crate::sub_agent::collection::StartedSubAgents;
     use crate::sub_agent::health::health_checker::{Healthy, Unhealthy};

--- a/agent-control/src/agent_control/error.rs
+++ b/agent-control/src/agent_control/error.rs
@@ -1,5 +1,4 @@
 use super::config::AgentControlConfigError;
-use crate::agent_control::config_validator::DynamicConfigValidatorError;
 use crate::agent_type::agent_type_registry::AgentRepositoryError;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::render::persister::config_persister::PersistError;
@@ -7,6 +6,7 @@ use crate::event::channel::EventPublisherError;
 use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::repository::HashRepositoryError;
 use crate::opamp::instance_id;
+use crate::opamp::remote_config::validators::DynamicConfigValidatorError;
 use crate::opamp::remote_config::RemoteConfigError;
 use crate::sub_agent::effective_agents_assembler::EffectiveAgentsAssemblerError;
 use crate::sub_agent::error::{SubAgentBuilderError, SubAgentCollectionError, SubAgentError};

--- a/agent-control/src/agent_control/event_handler/opamp/remote_config.rs
+++ b/agent-control/src/agent_control/event_handler/opamp/remote_config.rs
@@ -5,8 +5,8 @@ use crate::agent_control::config_storer::loader_storer::{
     AgentControlDynamicConfigDeleter, AgentControlDynamicConfigLoader,
     AgentControlDynamicConfigStorer,
 };
-use crate::agent_control::config_validator::DynamicConfigValidator;
 use crate::opamp::remote_config::report::OpampRemoteConfigStatus;
+use crate::opamp::remote_config::validators::DynamicConfigValidator;
 use crate::sub_agent::health::health_checker::{Healthy, Unhealthy};
 use crate::{
     agent_control::{agent_control::AgentControl, error::AgentError},
@@ -68,12 +68,12 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use crate::opamp::remote_config::validators::tests::MockDynamicConfigValidatorMock;
     use crate::{
         agent_control::{
             agent_control::AgentControl,
             config::{AgentControlDynamicConfig, AgentID, SubAgentConfig},
             config_storer::loader_storer::tests::MockAgentControlDynamicConfigStore,
-            config_validator::tests::MockDynamicConfigValidatorMock,
         },
         event::channel::pub_sub,
         opamp::{

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -1,7 +1,6 @@
 use crate::agent_control::config::K8sConfig;
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
-use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, FLEET_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CHART_VERSION_ATTRIBUTE_KEY,
@@ -16,6 +15,7 @@ use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::Identifiers;
 use crate::opamp::operations::build_opamp_with_channel;
+use crate::opamp::remote_config::validators::dynamic_config::RegistryDynamicConfigValidator;
 use crate::opamp::remote_config::validators::regexes::ConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
 use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -1,6 +1,5 @@
 use crate::agent_control::config_storer::loader_storer::AgentControlConfigLoader;
 use crate::agent_control::config_storer::store::AgentControlConfigStore;
-use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, SUB_AGENT_DIR,
@@ -15,6 +14,7 @@ use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};
 use crate::opamp::operations::build_opamp_with_channel;
+use crate::opamp::remote_config::validators::dynamic_config::RegistryDynamicConfigValidator;
 use crate::opamp::remote_config::validators::regexes::ConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
 use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;

--- a/agent-control/src/opamp/remote_config/validators.rs
+++ b/agent-control/src/opamp/remote_config/validators.rs
@@ -1,6 +1,10 @@
 use super::RemoteConfig;
-use crate::agent_control::config::AgentTypeFQN;
+use crate::agent_control::config::{AgentControlDynamicConfig, AgentTypeFQN};
+use crate::agent_type::agent_type_registry::AgentRepositoryError;
 use std::fmt::Display;
+use thiserror::Error;
+
+pub mod dynamic_config;
 pub mod regexes;
 pub mod signature;
 
@@ -12,6 +16,20 @@ pub trait RemoteConfigValidator {
         agent_type_fqn: &AgentTypeFQN,
         remote_config: &RemoteConfig,
     ) -> Result<(), Self::Err>;
+}
+
+#[derive(Error, Debug)]
+pub enum DynamicConfigValidatorError {
+    #[error("validating dynamic config`{0}`")]
+    AgentRepositoryError(#[from] AgentRepositoryError),
+}
+
+/// Represents a validator for dynamic config
+pub trait DynamicConfigValidator {
+    fn validate(
+        &self,
+        dynamic_config: &AgentControlDynamicConfig,
+    ) -> Result<(), DynamicConfigValidatorError>;
 }
 
 #[cfg(test)]
@@ -30,6 +48,17 @@ pub mod tests {
                 agent_type_fqn: &AgentTypeFQN,
                 remote_config: &RemoteConfig,
             ) -> Result<(), <Self as RemoteConfigValidator>::Err>;
+        }
+    }
+
+    mock! {
+        pub DynamicConfigValidatorMock {}
+
+        impl DynamicConfigValidator for DynamicConfigValidatorMock {
+            fn validate(
+                &self,
+                dynamic_config: &AgentControlDynamicConfig,
+            ) -> Result<(), DynamicConfigValidatorError>;
         }
     }
 }

--- a/agent-control/src/opamp/remote_config/validators/dynamic_config.rs
+++ b/agent-control/src/opamp/remote_config/validators/dynamic_config.rs
@@ -1,22 +1,10 @@
 use crate::agent_control::config::AgentControlDynamicConfig;
-use crate::agent_type::agent_type_registry::{AgentRegistry, AgentRepositoryError};
+use crate::agent_type::agent_type_registry::AgentRegistry;
+use crate::opamp::remote_config::validators::{
+    DynamicConfigValidator, DynamicConfigValidatorError,
+};
 use std::ops::Deref;
 use std::sync::Arc;
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum DynamicConfigValidatorError {
-    #[error("`{0}`")]
-    AgentRepositoryError(#[from] AgentRepositoryError),
-}
-
-/// Represents a validator for dynamic config
-pub trait DynamicConfigValidator {
-    fn validate(
-        &self,
-        dynamic_config: &AgentControlDynamicConfig,
-    ) -> Result<(), DynamicConfigValidatorError>;
-}
 
 pub struct RegistryDynamicConfigValidator<R: AgentRegistry> {
     agent_type_registry: Arc<R>,
@@ -53,19 +41,7 @@ pub mod tests {
     use crate::agent_type::agent_metadata::AgentMetadata;
     use crate::agent_type::agent_type_registry::tests::MockAgentRegistryMock;
     use crate::agent_type::definition::AgentTypeDefinition;
-    use mockall::mock;
     use semver::Version;
-
-    mock! {
-        pub DynamicConfigValidatorMock {}
-
-        impl DynamicConfigValidator for DynamicConfigValidatorMock {
-            fn validate(
-                &self,
-                dynamic_config: &AgentControlDynamicConfig,
-            ) -> Result<(), DynamicConfigValidatorError>;
-        }
-    }
 
     #[test]
     fn test_existing_agent_type_validation() {


### PR DESCRIPTION
# What this PR does / why we need it
Validators are currently under the opamp package, the dynamic one was the only one left outside (in the agentControl crate)
<img width="280" alt="Screenshot 2025-02-27 at 17 33 19" src="https://github.com/user-attachments/assets/021880bc-5266-4d6e-b9c2-1ed91d0ee0ef" />



@alvarocabanas Can you take a look? I think you were the initial creator of this check 😄 

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
