### PR TITLE
test: add notification for canary alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ ci/terraform/caos.auto.tfvars
 *.tfstate.*
 *.auto.tfvars
 **/.terraform.lock.hcl
+*.tfvars
 
 # Inventories for pkg testing, canaries...
 test/**/inventory.*

--- a/test/k8s-canaries/Makefile
+++ b/test/k8s-canaries/Makefile
@@ -14,38 +14,46 @@ all:
 .PHONY: test/k8s-canaries/terraform-plan
 test/k8s-canaries/terraform-plan:
 ifndef CANARY_DIR
-	@echo "CANARY_DIR variable must be provided to know which canary to terraform-plan"
+	@echo "CANARY_DIR missing"
 	exit 1
 endif
 ifndef NEW_RELIC_ACCOUNT_ID
-	@echo "NEW_RELIC_ACCOUNT_ID variable must be provided for test/k8s-canaries/terraform-plan"
+	@echo "NEW_RELIC_ACCOUNT_ID missing"
 	exit 1
 endif
 ifndef NEW_RELIC_API_KEY
-	@echo "NEW_RELIC_API_KEY variable must be provided for test/k8s-canaries/terraform-plan"
+	@echo "NEW_RELIC_API_KEY missing"
+	exit 1
+endif
+ifndef SLACK_WEBHOOK_URL
+	@echo SLACK_WEBHOOK_URL missing"
 	exit 1
 endif
 	@terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) init && \
 	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) plan \
-	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)"
+	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)"
 
 .PHONY: test/k8s-canaries/terraform-apply
 test/k8s-canaries/terraform-apply:
 ifndef CANARY_DIR
-	@echo "CANARY_DIR variable must be provided to know which canary to terraform-apply"
+	@echo "CANARY_DIR missing"
 	exit 1
 endif
 ifndef NEW_RELIC_ACCOUNT_ID
-	@echo "NEW_RELIC_ACCOUNT_ID variable must be provided for test/k8s-canaries/terraform-plan"
+	@echo "NEW_RELIC_ACCOUNT_ID missing"
 	exit 1
 endif
 ifndef NEW_RELIC_API_KEY
-	@echo "NEW_RELIC_API_KEY variable must be provided for test/k8s-canaries/terraform-plan"
+	@echo "NEW_RELIC_API_KEY missing"
+	exit 1
+endif
+ifndef SLACK_WEBHOOK_URL
+	@echo SLACK_WEBHOOK_URL missing"
 	exit 1
 endif
 	@terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) init && \
 	terraform -chdir=$(TERRAFORM_DIR)/$(CANARY_DIR) apply -auto-approve \
-	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)"
+	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)"
 
 .PHONY: test/k8s-canaries/update-kubeconfig-from-aws
 test/k8s-canaries/update-kubeconfig-from-aws:
@@ -58,11 +66,11 @@ endif
 .PHONY: test/k8s-canaries/set-persistent-system-identity
 test/k8s-canaries/set-persistent-system-identity:
 ifndef NR_SYSTEM_IDENTITY_CLIENT_ID
-	@echo "NR_SYSTEM_IDENTITY_CLIENT_ID variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "NR_SYSTEM_IDENTITY_CLIENT_ID missing"
 	exit 1
 endif
 ifndef NR_SYSTEM_IDENTITY_PRIVATE_KEY
-	@echo "NR_SYSTEM_IDENTITY_PRIVATE_KEY variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "NR_SYSTEM_IDENTITY_PRIVATE_KEY missing"
 	exit 1
 endif
 	@kubectl create namespace newrelic --dry-run=client -o yaml | kubectl apply -f -
@@ -76,24 +84,24 @@ endif
 .PHONY: test/k8s-canaries/helm-upgrade
 test/k8s-canaries/helm-upgrade: test/k8s-canaries/update-kubeconfig-from-aws test/k8s-canaries/set-persistent-system-identity
 ifndef NR_LICENSE_KEY
-	@echo "NR_LICENSE_KEY variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "NR_LICENSE_KEY missing"
 	exit 1
 endif
 ifndef CLUSTER_NAME
-	@echo "CLUSTER_NAME variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "CLUSTER_NAME missing"
 	exit 1
 endif
 ifndef IMAGE_TAG
-	@echo "IMAGE_TAG variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "IMAGE_TAG missing"
 	exit 1
 endif
 ifndef FLEET_ID
-	@echo "FLEET_ID variable must be provided for test/k8s-canaries/helm-upgrade"
+	@echo "FLEET_ID missing"
 	exit 1
 endif
 ifneq ($(IS_STAGING),true)
 ifneq ($(IS_STAGING),false)
-	@echo "IS_STAGING variable must be either 'true' or 'false' for test/k8s-canaries/helm-upgrade. Got '$(IS_STAGING)'"
+	@echo "IS_STAGING variable must be either 'true' or 'false'. Got '$(IS_STAGING)'"
 	exit 1
 endif
 endif

--- a/test/k8s-canaries/terraform/modules/nr_alerts/variables.tf
+++ b/test/k8s-canaries/terraform/modules/nr_alerts/variables.tf
@@ -26,6 +26,10 @@ variable "policies_prefix" {
   default = "[Staging] Agent Control canaries metric monitoring"
 }
 
+variable "slack_webhook_url" {
+  description = "Slack webhook where New Relic will send alerts"
+}
+
 # conditions should follow next structure:
 #[
 # {

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -9,11 +9,13 @@ module "eks_cluster" {
 
 variable "account_id" {}
 variable "api_key" {}
+variable "slack_webhook_url" {}
 module "alerts" {
   source = "../modules/nr_alerts"
 
   api_key         = var.api_key
   account_id      = var.account_id
+  slack_webhook_url = var.slack_webhook_url
   policies_prefix = "Agent Control canaries metric monitoring"
   conditions = [
     {

--- a/test/k8s-canaries/terraform/staging/.terraform.lock.hcl
+++ b/test/k8s-canaries/terraform/staging/.terraform.lock.hcl
@@ -42,3 +42,28 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
     "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
   ]
 }
+
+provider "registry.terraform.io/newrelic/newrelic" {
+  version = "3.57.0"
+  hashes = [
+    "h1:tkGat2AhylI5euYORLYAju7SZG/1SVqGZcR/0RCJEsA=",
+    "zh:0b5180e0b0ed2b0d7a7b2340ae465121a1fa10313a7783bdbc904b3596f7c725",
+    "zh:1ee6458b5e9ec51b24789ce28c68e006f0e365c558073e634a3e545357501fa7",
+    "zh:20ea548ea31ee761c9a936c6648c62c506d76bcf1ebf937ff5cdca8034fd8cdb",
+    "zh:2c78d070f3c5eea171c1ad1520ce3de08cf6405dcda1b3ebd74603039a3406cb",
+    "zh:2f5ce3ac9708ffa1077d4b3de527d598be16aaeb562108c9cbeadbc5af025fc2",
+    "zh:54d8f25402bd95e0efd6e10fab4fea17c6e3915e5b9ca0b6139b93a3aec21def",
+    "zh:6ca0f572602415bda07749c205160c1ac0bd9d764e76b44cbc1323b80932a08c",
+    "zh:8cbe877f0a7378b162dea8ca0512ecd7860e7d9b97837011ca9685e4dea1d27e",
+    "zh:a37430b41e8d72cfdcec6255046e2a1b7359b541a7e2f4ddac24969002cdc653",
+    "zh:c8501d4ef9e7fd6cc02576e4a141fef4ac3ef7ec7876008ccf0c17160104657f",
+    "zh:db15cb9efd59f0f7e984f1c067a0c38f6324c528f33817ddb0b30aa7467673a6",
+    "zh:f30c2d2606cb57ee615cc725b1b18791c8faf73be3beaca1472dba9602ef226c",
+    "zh:f57ef3f4840557c996e0493ad0d373e87c457d434b0801b98b1cb462e56eb502",
+    "zh:f68f4f94e4a634af3d505171fb4ca63a657e97ac1e4dd1097e4683c7e5d5e40d",
+    "zh:f74440e5c479b4f8b3e0c9cfed5ee4c9a71b8d5a075724fadc82f05d8c86880e",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fc9aa2d568d606d0d2f95001e2a9d66febe391991cb654970a2cf8bf7fac72c4",
+    "zh:fefd31ef8ec63d722b5af6f629ac45ea6e23ad3e58f620b328022082e5b40ffd",
+  ]
+}

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -10,11 +10,14 @@ module "eks_cluster" {
 
 variable "account_id" {}
 variable "api_key" {}
+variable "slack_webhook_url" {}
+
 module "alerts" {
   source = "../modules/nr_alerts"
 
   api_key         = var.api_key
   account_id      = var.account_id
+  slack_webhook_url = var.slack_webhook_url
   policies_prefix = "Agent Control canaries metric monitoring"
   conditions = [
     {

--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -55,6 +55,10 @@ module "agent_control_infra" {
     },
     ####
     {
+      "name" : "SLACK_WEBHOOK_URL",
+      "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_super-secret-agent-slack-webhook}"
+    },
+    {
       "name" : "SSH_KEY",
       "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}"
     },
@@ -88,6 +92,7 @@ module "agent_control_infra" {
             ],
             "Resource" : [
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_ssh}",
+              "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_super-secret-agent-slack-webhook}",
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license}",
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account_id}",
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api_key}",

--- a/test/terraform/fargate/vars.tf
+++ b/test/terraform/fargate/vars.tf
@@ -58,6 +58,10 @@ variable "secret_name_system_identity_private_key" {
   default = "canaries/system_identity_private_key-G5vwsz"
 }
 
+variable "secret_name_super-secret-agent-slack-webhook" {
+  default = "super-secret-agent-slack-webhook-WsH2yK"
+}
+
 ####
 
 variable "secret_name_ssh" {


### PR DESCRIPTION
- Adds a slack notification whenever any of the canaries Alerts is triggered. To keep things simple this is just a notification with the canary name so the hero investigate further from the alerts UI.
