### PR TITLE
feat: update onhost canaries after build packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,7 +155,7 @@ jobs:
 
   onhost_canaries:
     uses: ./.github/workflows/component_onhost_canaries.yml
-    needs: [ build-image ]
+    needs: [ build-packages ]
     with:
       environment: staging
       operation: apply

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -182,7 +182,7 @@ jobs:
 
   onhost_canaries:
     uses: ./.github/workflows/component_onhost_canaries.yml
-    needs: [ build-image ]
+    needs: [ build-packages ]
     with:
       environment: production
       operation: apply


### PR DESCRIPTION
# What this PR does / why we need it

Updates onhost canaries after building the packages instead of the images.
