### PR TITLE
fix: ansible common to always calculate current_dir

### DIFF
--- a/.github/workflows/component_onhost_canaries.yml
+++ b/.github/workflows/component_onhost_canaries.yml
@@ -11,12 +11,10 @@ on:
     inputs:
       environment:
         required: true
-        type: enum
-        enum: [staging, production]
+        type: string
       operation:
         required: true
-        type: enum
-        enum: [plan, apply] 
+        type: string
 
 permissions:
   id-token: write

--- a/test/Ansible.common
+++ b/test/Ansible.common
@@ -1,9 +1,10 @@
-ANSIBLE_FOLDER ?= $(CURDIR)
+ANSIBLE_FOLDER := $(CURDIR)
 
-export REQUIREMENTS_FILE ?= $(ANSIBLE_FOLDER)/requirements.yml
-export ROLES_PATH:=$(ANSIBLE_FOLDER)/roles
-export COLLECTIONS_PATH:=$(ANSIBLE_FOLDER)/collections
+export REQUIREMENTS_FILE := $(ANSIBLE_FOLDER)/requirements.yml
+export ROLES_PATH := $(ANSIBLE_FOLDER)/roles
+export COLLECTIONS_PATH := $(ANSIBLE_FOLDER)/collections
 export CROWDSTRIKE_ROLE_PULL_KEY := $(HOME)/.ssh/crowdstrike_ansible_role_key
+
 
 $(ROLES_PATH) $(COLLECTIONS_PATH):
 	@mkdir -p $@


### PR DESCRIPTION
# What this PR does / why we need it

## Which issue this PR fixes

- fixes error on pipelines that was calculating wrong the current folder to generate the ansible requirements.
- fixes wrong github actions input type enum

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
