### PR TITLE
chore(logs): error message was misleading

### DIFF
--- a/agent-control/src/agent_control/agent_id.rs
+++ b/agent-control/src/agent_control/agent_id.rs
@@ -17,7 +17,7 @@ pub struct AgentID(String);
 
 #[derive(Error, Debug)]
 pub enum AgentIDError {
-    #[error("AgentID must contain 32 characters at most, contain alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric")]
+    #[error("AgentID must contain 32 characters at most, contain lowercase alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric")]
     InvalidFormat,
     #[error("AgentID '{0}' is reserved")]
     Reserved(String),

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -408,7 +408,7 @@ agents: {}
         assert!(actual
             .unwrap_err()
             .to_string()
-            .contains("AgentID must contain 32 characters at most, contain alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric"))
+            .contains("AgentID must contain 32 characters at most, contain lowercase alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric"))
     }
 
     #[test]


### PR DESCRIPTION
# What this PR does / why we need it
fix log test



[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
