### PR TITLE
fix: add proxy configration to cert fetcher (NR-352330)

### DIFF
--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -109,7 +109,7 @@ impl AgentControlRunner {
 
                 let http_builder = OpAMPHttpClientBuilder::new(
                     opamp_config.clone(),
-                    config.proxy,
+                    config.proxy.clone(),
                     token_retriever,
                 );
 
@@ -141,7 +141,9 @@ impl AgentControlRunner {
 
         let signature_validator = config
             .opamp
-            .map(|fleet_config| build_signature_validator(fleet_config.signature_validation))
+            .map(|fleet_config| {
+                build_signature_validator(fleet_config.signature_validation, config.proxy)
+            })
             .transpose()?
             .unwrap_or(SignatureValidator::Noop);
 

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -35,8 +35,11 @@ pub enum SignatureValidatorError {
 
 /// Returns a SignatureValidator wrapping a CertificateSignatureValidator if fleet_control and signature validation are
 /// enabled and a no-op validator otherwise.
+///
+/// Proxies configuration that intercept TLS traffic are not supported since the fetcher expects to connect directly to the server.
 pub fn build_signature_validator(
     config: SignatureValidatorConfig,
+    proxy_config: ProxyConfig,
 ) -> Result<SignatureValidator, SignatureValidatorError> {
     if !config.enabled {
         warn!("Remote config signature validation is disabled");
@@ -55,10 +58,11 @@ pub fn build_signature_validator(
             "Remote config signature validation is enabled, fetching certificate from: {}",
             config.certificate_server_url
         );
+
         let http_config = HttpConfig::new(
             DEFAULT_HTTPS_CLIENT_TIMEOUT,
             DEFAULT_HTTPS_CLIENT_TIMEOUT,
-            ProxyConfig::default(), // Proxy is not supported for fetching certificate
+            proxy_config,
         )
         .with_tls_info();
 


### PR DESCRIPTION
Adds missing proxy configuration for the certificate fetcher connection. 
Even if fetching the certificate from `newrelic.com` will not work with a proxy that acts as a MITM regarding TLS, it will allow users to set up bypass exception for `newrelic.com` on the proxy to make it work.

Important Note: 
There is an [issue](https://github.com/seanmonstar/reqwest/issues/2589) with reqwest create that is not honouring the `tls_info` flag whenever a proxy is used. So this change doesn't have effect until that issues is fixed. 