### PR TITLE
fix: add stop signal to status server (NR-376898)

### DIFF
--- a/agent-control/src/agent_control/http_server/config.rs
+++ b/agent-control/src/agent_control/http_server/config.rs
@@ -63,6 +63,12 @@ mod tests {
         server_config: ServerConfig,
     }
 
+    impl From<u16> for Port {
+        fn from(value: u16) -> Self {
+            Port(value)
+        }
+    }
+
     #[test]
     fn test_deserialize_default() {
         struct Test {

--- a/agent-control/src/agent_control/http_server/server.rs
+++ b/agent-control/src/agent_control/http_server/server.rs
@@ -70,6 +70,8 @@ pub async fn run_status_server(
     debug!("waiting for status server join handle");
     server_join_handle.await?;
 
+    debug!("status server gracefully stopped");
+
     Ok(())
 }
 


### PR DESCRIPTION
Deadlock cause by joining the thread handle contained by the Runner before closing the publisher channels. That made the Drop never finish so the channels were never closed (because the caller fn that had ownership never finished)

- Modify the runner to use ThreadContext (fixes the deadlock because introduces an external signal to close the threads even if the AC and Sub-agent consumers are still live)
- Change the Drop to use the retry stop from ThreadContext

on top of #1129 