### PR TITLE
chore: use public repos of opamp-rs and nr-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,7 +3127,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 [[package]]
 name = "nr-auth"
 version = "0.0.4"
-source = "git+ssh://git@github.com/newrelic/newrelic-oauth-client-rs.git?tag=0.0.4#e9f1c8aa962e276c8ce85e8e2305475b0676acee"
+source = "git+ssh://git@github.com/newrelic/newrelic-auth-rs.git?tag=0.0.4#0c9be0ff7378324fc46d3f7a42966ee0cddeaa33"
 dependencies = [
  "chrono",
  "http 1.2.0",
@@ -3136,7 +3136,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
- "ureq",
  "url",
  "uuid",
 ]
@@ -3212,7 +3211,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 [[package]]
 name = "opamp-client"
 version = "0.0.31"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.31#f9935e657474f9fb89f8e18403b2151533b80344"
+source = "git+ssh://git@github.com/newrelic/newrelic-opamp-rs.git?tag=0.0.31#08bd5c60e58a6adf65cce82a76bae10ca9efc487"
 dependencies = [
  "crossbeam",
  "http 1.2.0",
@@ -3596,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "proto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/newrelic/opamp-rs.git?tag=0.0.31#f9935e657474f9fb89f8e18403b2151533b80344"
+source = "git+ssh://git@github.com/newrelic/newrelic-opamp-rs.git?tag=0.0.31#08bd5c60e58a6adf65cce82a76bae10ca9efc487"
 dependencies = [
  "prost",
  "prost-build",
@@ -5034,22 +5033,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1996,12 +1996,6 @@ Distributed under the following license(s):
 Distributed under the following license(s):
 
 * ISC
-## ureq <https://crates.io/crates/ureq>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
 ## url <https://crates.io/crates/url>
 
 Distributed under the following license(s):

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -36,8 +36,8 @@ chrono = { workspace = true }
 base64 = { version = "0.22.1" }
 # New Relic dependencies (private external repos)
 # IMPORTANT: GitHub deployment keys are used to access these repos on the CI/CD pipelines
-nr-auth = { git = "ssh://git@github.com/newrelic/newrelic-oauth-client-rs.git", tag = "0.0.4"}
-opamp-client = { git = "ssh://git@github.com/newrelic/opamp-rs.git", tag = "0.0.31", default-features = false }
+nr-auth = { git = "ssh://git@github.com/newrelic/newrelic-auth-rs.git", tag = "0.0.4" }
+opamp-client = { git = "ssh://git@github.com/newrelic/newrelic-opamp-rs.git", tag = "0.0.31", default-features = false }
 # local dependencies
 fs = { path = "../fs" }
 
@@ -57,7 +57,9 @@ tracing-appender = "0.2.3"
 cfg-if = "1.0.0"
 # HOST_ID and HOST_NAME attributes are experimental fields and after 0.26.0 are not included by default.
 # Check <https://github.com/open-telemetry/opentelemetry-rust/pull/2098> for details.
-opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }
+opentelemetry-semantic-conventions = { version = "0.28.0", features = [
+  "semconv_experimental",
+] }
 http-serde = "2.1.1"
 paste = "1.0"
 config = { version = "0.15.9", features = ["yaml"] }
@@ -105,12 +107,7 @@ path = "src/bin/config_migrate.rs"
 
 [features]
 onhost = []
-k8s = [
-  "dep:kube",
-  "dep:k8s-openapi",
-  "dep:either",
-  "dep:futures",
-]
+k8s = ["dep:kube", "dep:k8s-openapi", "dep:either", "dep:futures"]
 # feature ci allows calling --all-features (needed on the test pipelines) and not failing to compile
 ci = []
 # feature tokio-console allows debugging tokio tasks using tokio-console


### PR DESCRIPTION
# What this PR does / why we need it

Our dependency repos are finally public! This PR "switches" the implementations to pull from the public mirrors.

After this is done, the upstream repos will be archived.

## Which issue this PR fixes

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
