### PR TITLE
feat(builder): build subAgents in one way only

### DIFF
--- a/agent-control/src/http/client.rs
+++ b/agent-control/src/http/client.rs
@@ -8,7 +8,7 @@ use nr_auth::http_client::HttpClientError as OauthHttpClientError;
 use opamp_client::http::HttpClientError as OpampHttpClientError;
 use reqwest::tls::TlsInfo;
 use reqwest::{
-    blocking::{Client, ClientBuilder, Response as BlockingResponse},
+    blocking::{Client, Response as BlockingResponse},
     Certificate, Proxy,
 };
 use std::{
@@ -16,7 +16,6 @@ use std::{
     fs::File,
     io::Read,
     path::{Path, PathBuf},
-    time::Duration,
 };
 use tracing::warn;
 

--- a/agent-control/src/opamp/effective_config/sub_agent.rs
+++ b/agent-control/src/opamp/effective_config/sub_agent.rs
@@ -1,16 +1,11 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::defaults::default_capabilities;
-use crate::agent_type::agent_type_id::AgentTypeID;
-use crate::agent_type::definition::{AgentType, VariableTree};
-use crate::agent_type::runtime_config::{Deployment, Runtime};
-use crate::opamp::remote_config::ConfigurationMap;
-use crate::values::yaml_config_repository::{load_remote_fallback_local, YAMLConfigRepository};
-
 use super::error::LoaderError;
 use super::loader::EffectiveConfigLoader;
+use crate::agent_control::agent_id::AgentID;
+use crate::agent_control::defaults::default_capabilities;
+use crate::opamp::remote_config::ConfigurationMap;
+use crate::values::yaml_config_repository::{load_remote_fallback_local, YAMLConfigRepository};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Loader for effective configuration of a sub-agent.
 #[derive(Debug)]
@@ -39,15 +34,6 @@ where
     Y: YAMLConfigRepository,
 {
     fn load(&self) -> Result<ConfigurationMap, LoaderError> {
-        // TODO this gets removed after refactor PR. Is only used for capabilities has_remote.
-        let fake_agent_type = AgentType::new(
-            AgentTypeID::try_from("namespace/name:0.0.1").unwrap(),
-            VariableTree::default(),
-            Runtime {
-                deployment: Deployment::default(),
-            },
-        );
-
         let values = load_remote_fallback_local(
             self.yaml_config_repository.as_ref(),
             &self.agent_id,


### PR DESCRIPTION
# What this PR does / why we need it
This PR removes NotStartedSubAgents collection. It was created and destroyed the step after.
After removing it the creation of the agent is unified when creating the first time and when re-creating them.

The only difference is that before we were building all and then starting all. Now we are building and starting one by one

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
