### PR TITLE
fix: do not crash AC if the status server thread panicked

### DIFF
--- a/agent-control/src/agent_control/http_server/runner.rs
+++ b/agent-control/src/agent_control/http_server/runner.rs
@@ -129,9 +129,7 @@ impl Drop for Runner {
     fn drop(&mut self) {
         if let Some(join_handle) = self.join_handle.take() {
             info!("waiting for status server to stop gracefully...");
-            join_handle
-                .join()
-                .expect("error waiting for server join handle")
+            let _ = join_handle.join();
         }
     }
 }


### PR DESCRIPTION
## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
