### PR TITLE
feat(instrumentation): add spans and agent_id context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "regex",
  "tempfile",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/agent-control/src/agent_control/agent_control.rs
+++ b/agent-control/src/agent_control/agent_control.rs
@@ -27,7 +27,7 @@ use crossbeam::select;
 use opamp_client::StartedClient;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 pub struct AgentControl<S, O, HR, SL, DV>
 where
@@ -141,6 +141,7 @@ where
     //  * Recreate the Final Agent using the Agent Type and the latest persisted config
     //  * Build a Stopped Sub Agent
     //  * Run the Sub Agent and add it to the Running Sub Agents
+    #[instrument(skip_all)]
     pub(super) fn recreate_sub_agent(
         &self,
         agent_identity: &AgentIdentity,
@@ -149,12 +150,10 @@ where
         >,
     ) -> Result<(), AgentError> {
         running_sub_agents.stop_and_remove(&agent_identity.id)?;
-
         self.build_and_run_sub_agent(agent_identity, running_sub_agents)
     }
 
-    // build_sub_agents returns a collection of started sub agents given the corresponding
-    // EffectiveAgents
+    // build_sub_agents returns a collection of started sub agents
     fn build_and_run_sub_agents(
         &self,
         sub_agents: &SubAgentsMap,
@@ -250,6 +249,7 @@ where
         }
     }
 
+    #[instrument(skip_all)]
     // apply an agent control remote config
     pub(super) fn apply_remote_agent_control_config(
         &self,

--- a/agent-control/src/agent_control/error.rs
+++ b/agent-control/src/agent_control/error.rs
@@ -10,7 +10,6 @@ use crate::opamp::instance_id;
 use crate::opamp::remote_config::RemoteConfigError;
 use crate::sub_agent::effective_agents_assembler::EffectiveAgentsAssemblerError;
 use crate::sub_agent::error::{SubAgentBuilderError, SubAgentCollectionError, SubAgentError};
-use crate::utils::thread_context::ThreadContextStopperError;
 use crate::values::yaml_config::YAMLConfigError;
 use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
 use fs::file_reader::FileReaderError;

--- a/agent-control/src/agent_control/event_handler/opamp/remote_config.rs
+++ b/agent-control/src/agent_control/event_handler/opamp/remote_config.rs
@@ -1,6 +1,3 @@
-use opamp_client::StartedClient;
-use tracing::{error, info};
-
 use crate::agent_control::config_storer::loader_storer::{
     AgentControlDynamicConfigDeleter, AgentControlDynamicConfigLoader,
     AgentControlDynamicConfigStorer,
@@ -13,6 +10,8 @@ use crate::{
     opamp::{hash_repository::HashRepository, remote_config::RemoteConfig},
     sub_agent::{collection::StartedSubAgents, NotStartedSubAgent, SubAgentBuilder},
 };
+use opamp_client::StartedClient;
+use tracing::{error, info};
 
 impl<S, O, HR, SL, DV> AgentControl<S, O, HR, SL, DV>
 where
@@ -38,7 +37,7 @@ where
             unreachable!("got remote config without OpAMP being enabled");
         };
 
-        info!(agent_id=%remote_config.agent_id, "Applying remote config");
+        info!("Applying remote config");
         OpampRemoteConfigStatus::Applying.report(opamp_client, &remote_config.hash)?;
 
         match self.apply_remote_agent_control_config(&remote_config, sub_agents) {

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -19,8 +19,6 @@ const DEFAULT_BATCH_SCHEDULED_DELAY: Duration = Duration::from_secs(30);
 const TRACES_SUFFIX: &str = "/v1/traces";
 /// Metrics suffix for the OpenTelemetry endpoint
 const METRICS_SUFFIX: &str = "/v1/metrics";
-/// Logs suffix for the OpenTelemetry endpoint
-const LOGS_SUFFIX: &str = "/v1/logs";
 
 /// Represents the OpenTelemetry configuration
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]

--- a/agent-control/src/k8s/garbage_collector.rs
+++ b/agent-control/src/k8s/garbage_collector.rs
@@ -18,7 +18,7 @@ use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::TypeMeta;
 use std::{sync::Arc, time::Duration};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 const THREAD_NAME: &str = "Garbage collector";
 
@@ -106,6 +106,7 @@ where
     /// Garbage collect all resources managed by the SA associated to removed sub-agents.
     /// Collection is stateful, only happens when the list of active agents has changed from
     /// the previous execution.
+    #[instrument(skip_all, name = "garbage_collector_collect")]
     pub fn collect(&mut self) -> Result<(), GarbageCollectorK8sError> {
         // check if current active agents differs from previous execution.
         if !self.update_active_config()? {

--- a/agent-control/src/opamp/client_builder.rs
+++ b/agent-control/src/opamp/client_builder.rs
@@ -92,14 +92,13 @@ where
     ) -> Result<Self::Client, OpAMPClientBuilderError> {
         let http_client = self.http_client_builder.build()?;
         let effective_config_loader = self.effective_config_loader_builder.build(agent_id.clone());
-        let callbacks =
-            AgentCallbacks::new(agent_id.clone(), opamp_publisher, effective_config_loader);
+        let callbacks = AgentCallbacks::new(agent_id, opamp_publisher, effective_config_loader);
         let not_started_client = NotStartedHttpClient::new(http_client, callbacks, start_settings)?;
         let mut not_started_client = not_started_client.with_interval(self.poll_interval);
         if self.disable_startup_check {
             not_started_client = not_started_client.with_startup_check_disabled();
         }
-        info!(%agent_id,"OpAMP client started");
+        info!("OpAMP client started");
         Ok(not_started_client.start()?)
     }
 }

--- a/agent-control/src/opamp/instance_id/getter.rs
+++ b/agent-control/src/opamp/instance_id/getter.rs
@@ -42,16 +42,15 @@ where
 {
     fn get(&self, agent_id: &AgentID) -> Result<InstanceID, GetterError> {
         let storer = self.storer.lock().expect("failed to acquire the lock");
-        debug!(%agent_id, "retrieving instance id");
+        debug!("retrieving instance id");
         let data = storer.get(agent_id)?;
 
         match data {
             None => {
-                debug!(%agent_id, "storer returned no data");
+                debug!("storer returned no data");
             }
             Some(d) if d.identifiers == self.identifiers => return Ok(d.instance_id),
             Some(d) => debug!(
-                %agent_id,
                 "stored data had different identifiers {:?}!={:?}",
                 d.identifiers, self.identifiers
             ),
@@ -62,7 +61,7 @@ where
             identifiers: self.identifiers.clone(),
         };
 
-        debug!(%agent_id, "persisting instance id {}", new_data.instance_id);
+        debug!("persisting instance id {}", new_data.instance_id);
         storer.set(agent_id, &new_data)?;
 
         Ok(new_data.instance_id)

--- a/agent-control/src/opamp/instance_id/on_host/getter.rs
+++ b/agent-control/src/opamp/instance_id/on_host/getter.rs
@@ -3,7 +3,6 @@ use crate::opamp::instance_id::on_host::storer::StorerError;
 use resource_detection::cloud::aws::detector::{
     AWSDetector, AWS_IPV4_METADATA_ENDPOINT, AWS_IPV4_METADATA_TOKEN_ENDPOINT,
 };
-use resource_detection::cloud::aws::http_client::AWSHttpClient;
 use resource_detection::cloud::azure::detector::{AzureDetector, AZURE_IPV4_METADATA_ENDPOINT};
 use resource_detection::cloud::cloud_id::detector::CloudIdDetector;
 use resource_detection::cloud::gcp::detector::{GCPDetector, GCP_IPV4_METADATA_ENDPOINT};

--- a/agent-control/src/sub_agent/event_handler/opamp/remote_config_handler.rs
+++ b/agent-control/src/sub_agent/event_handler/opamp/remote_config_handler.rs
@@ -137,7 +137,6 @@ where
         C: StartedClient + Send + Sync + 'static,
     {
         debug!(
-            agent_id = agent_identity.id.to_string(),
             select_arm = "sub_agent_opamp_consumer",
             "remote config received"
         );
@@ -149,7 +148,7 @@ where
             .config_validator
             .validate(&agent_identity.agent_type_id, config)
         {
-            error!(error = %e, agent_id = %agent_identity.id, hash = &config.hash.get(), "error validating remote config with regexes");
+            error!(error = %e, hash = &config.hash.get(), "error validating remote config with regexes");
             Self::report_error(opamp_client, config, e.to_string())?;
             return Err(RemoteConfigHandlerError::ConfigValidating(e.to_string()));
         }
@@ -158,7 +157,7 @@ where
             .signature_validator
             .validate(&agent_identity.agent_type_id, config)
         {
-            error!(error = %e, agent_id = %agent_identity.id, hash = &config.hash.get(), "error validating signature of remote config");
+            error!(error = %e,  hash = &config.hash.get(), "error validating signature of remote config");
             Self::report_error(opamp_client, config, e.to_string())?;
             return Err(RemoteConfigHandlerError::ConfigValidating(e.to_string()));
         }
@@ -175,7 +174,7 @@ where
 
         if let Err(e) = self.store_remote_config_hash_and_values(config) {
             // log the error as it might be that we return a different error
-            error!(error = %e, agent_id = %agent_identity.id, hash = &config.hash.get(), "error storing remote config");
+            error!(error = %e, hash = &config.hash.get(), "error storing remote config");
             Self::report_error(opamp_client, config, e.to_string())?;
             return Err(RemoteConfigHandlerError::HashAndValuesStore(e.to_string()));
         }

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -20,7 +20,7 @@ use crate::{
 use opamp_client::operation::settings::DescriptionValueType;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub struct K8sSubAgentBuilder<'a, O, I, SA, R>
 where
@@ -71,15 +71,13 @@ where
 {
     type NotStartedSubAgent = SubAgent<O::Client, SA, R>;
 
+    #[instrument(skip_all, fields(%agent_identity),name = "build_sub_agent")]
     fn build(
         &self,
         agent_identity: &AgentIdentity,
         sub_agent_publisher: EventPublisher<SubAgentEvent>,
     ) -> Result<Self::NotStartedSubAgent, SubAgentBuilderError> {
-        debug!(
-            agent_id = agent_identity.id.to_string(),
-            "building subAgent"
-        );
+        debug!("building subAgent");
 
         let (maybe_opamp_client, sub_agent_opamp_consumer) = self
             .opamp_builder

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -21,7 +21,7 @@ use nix::unistd::gethostname;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub struct OnHostSubAgentBuilder<'a, O, I, SA, R>
 where
@@ -67,15 +67,13 @@ where
 {
     type NotStartedSubAgent = SubAgent<O::Client, SA, R>;
 
+    #[instrument(skip_all, fields(%agent_identity),name = "build_sub_agent")]
     fn build(
         &self,
         agent_identity: &AgentIdentity,
         sub_agent_publisher: EventPublisher<SubAgentEvent>,
     ) -> Result<Self::NotStartedSubAgent, SubAgentBuilderError> {
-        debug!(
-            agent_id = agent_identity.id.to_string(),
-            "building subAgent"
-        );
+        debug!("building subAgent");
 
         let (maybe_opamp_client, sub_agent_opamp_consumer) = self
             .opamp_builder

--- a/agent-control/src/sub_agent/on_host/command/logging/thread.rs
+++ b/agent-control/src/sub_agent/on_host/command/logging/thread.rs
@@ -150,11 +150,11 @@ mod tests {
 
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_agent_control::sub_agent::on_host::command::logging::logger",
-            "logging test 1 agent_id=agent-control",
+            "logging test 1",
         ));
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_agent_control::sub_agent::on_host::command::logging::logger",
-            "logging test 2 agent_id=agent-control",
+            "logging test 2",
         ));
     }
 
@@ -193,11 +193,11 @@ mod tests {
 
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_agent_control::sub_agent::on_host::command::logging::logger",
-            "err logging test 1 agent_id=agent-control",
+            "err logging test 1",
         ));
         assert!(logs_with_scope_contain(
             "DEBUG newrelic_agent_control::sub_agent::on_host::command::logging::logger",
-            "err logging test 2 agent_id=agent-control",
+            "err logging test 2",
         ));
     }
 

--- a/agent-control/src/sub_agent/version/k8s/checkers.rs
+++ b/agent-control/src/sub_agent/version/k8s/checkers.rs
@@ -59,7 +59,7 @@ impl K8sAgentVersionChecker {
         // It returns the first version-checker matching an object.
         for object in k8s_objects.iter() {
             let Some(type_meta) = object.types.clone() else {
-                warn!(%agent_id, "Skipping k8s object with unknown type {:?}", object);
+                warn!("Skipping k8s object with unknown type {:?}", object);
                 continue;
             };
             let Ok(resource_type) = (&type_meta).try_into() else {
@@ -75,7 +75,7 @@ impl K8sAgentVersionChecker {
             };
             return Some(health_checker);
         }
-        warn!(%agent_id, "Version cannot be fetched from any of the agent underlying resources, it won't be reported");
+        warn!("Version cannot be fetched from any of the agent underlying resources, it won't be reported");
         None
     }
 }

--- a/agent-control/src/values/file.rs
+++ b/agent-control/src/values/file.rs
@@ -135,6 +135,7 @@ where
     S: DirectoryManager + Send + Sync + 'static,
     F: FileWriter + FileReader + Send + Sync + 'static,
 {
+    #[tracing::instrument(skip_all, err)]
     fn load_local(
         &self,
         agent_id: &AgentID,
@@ -146,6 +147,7 @@ where
             .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
+    #[tracing::instrument(skip_all, err)]
     fn load_remote(
         &self,
         agent_id: &AgentID,
@@ -160,6 +162,7 @@ where
             .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
+    #[tracing::instrument(skip_all, err)]
     fn store_remote(
         &self,
         agent_id: &AgentID,
@@ -190,6 +193,7 @@ where
     // TODO Currently we are not deleting the whole folder, therefore multiple files are not supported
     // Moreover, we are also loading one file only, therefore we should review this once support is added
     // Notice that in that case we will likely need to move AgentControlConfig file to a folder
+    #[tracing::instrument(skip_all err)]
     fn delete_remote(&self, agent_id: &AgentID) -> Result<(), YAMLConfigRepositoryError> {
         #[allow(clippy::readonly_write_lock)]
         let _write_guard = self.rw_lock.write().unwrap();

--- a/agent-control/src/values/k8s.rs
+++ b/agent-control/src/values/k8s.rs
@@ -37,6 +37,7 @@ impl YAMLConfigRepositoryConfigMap {
 }
 
 impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
+    #[tracing::instrument(skip_all)]
     fn load_local(
         &self,
         agent_id: &AgentID,
@@ -46,6 +47,7 @@ impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
             .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
+    #[tracing::instrument(skip_all)]
     fn load_remote(
         &self,
         agent_id: &AgentID,
@@ -60,6 +62,7 @@ impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
             .map_err(|err| YAMLConfigRepositoryError::LoadError(err.to_string()))
     }
 
+    #[tracing::instrument(skip_all)]
     fn store_remote(
         &self,
         agent_id: &AgentID,
@@ -73,6 +76,7 @@ impl YAMLConfigRepository for YAMLConfigRepositoryConfigMap {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, err)]
     fn delete_remote(&self, agent_id: &AgentID) -> Result<(), YAMLConfigRepositoryError> {
         debug!(agent_id = agent_id.to_string(), "deleting remote config");
 

--- a/agent-control/src/values/yaml_config_repository.rs
+++ b/agent-control/src/values/yaml_config_repository.rs
@@ -41,23 +41,17 @@ pub fn load_remote_fallback_local<R: YAMLConfigRepository>(
     agent_id: &AgentID,
     capabilities: &Capabilities,
 ) -> Result<YAMLConfig, YAMLConfigRepositoryError> {
-    debug!(agent_id = agent_id.to_string(), "loading config");
+    debug!("loading config");
 
     if let Some(values_result) = config_repository.load_remote(agent_id, capabilities)? {
         return Ok(values_result);
     }
-    debug!(
-        agent_id = agent_id.to_string(),
-        "remote config not found, loading local"
-    );
+    debug!("remote config not found, loading local");
 
     if let Some(values_result) = config_repository.load_local(agent_id)? {
         return Ok(values_result);
     }
-    debug!(
-        agent_id = agent_id.to_string(),
-        "local config not found, falling back to defaults"
-    );
+    debug!("local config not found, falling back to defaults");
     Ok(YAMLConfig::default())
 }
 #[cfg(test)]

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -13,6 +13,7 @@ license-file.workspace = true
 mockall = { workspace = true, optional = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
+tracing = "0.1.41"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -6,6 +6,7 @@ use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use thiserror::Error;
+use tracing::instrument;
 
 #[derive(Error, Debug)]
 pub enum DirectoryManagementError {
@@ -54,6 +55,7 @@ impl DirectoryManager for DirectoryManagerFs {
         }
     }
 
+    #[instrument(skip_all, fields(path = %path.display()))]
     fn delete(&self, path: &Path) -> Result<(), DirectoryManagementError> {
         validate_path(path)?;
 

--- a/fs/src/writer_file.rs
+++ b/fs/src/writer_file.rs
@@ -1,17 +1,15 @@
+use super::directory_manager::DirectoryManagementError;
+use super::utils::{validate_path, FsError};
+use super::LocalFile;
 use std::fs::Permissions;
 use std::io::Write;
-use std::path::Path;
-use std::{fs, io};
-
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
-
-use super::directory_manager::DirectoryManagementError;
-use super::utils::{validate_path, FsError};
+use std::path::Path;
+use std::{fs, io};
 use thiserror::Error;
-
-use super::LocalFile;
+use tracing::instrument;
 
 #[derive(Error, Debug)]
 pub enum WriteError {
@@ -37,6 +35,7 @@ impl FileWriter for LocalFile {
 
 impl LocalFile {
     #[cfg(target_family = "unix")]
+    #[instrument(skip_all, fields(path = %path.display()))]
     pub fn write(
         &self,
         path: &Path,

--- a/resource-detection/src/cloud/aws/detector.rs
+++ b/resource-detection/src/cloud/aws/detector.rs
@@ -7,6 +7,7 @@ use crate::{cloud::AWS_INSTANCE_ID, DetectError, Detector, Key, Resource, Value}
 use core::str;
 use std::time::Duration;
 use thiserror::Error;
+use tracing::instrument;
 
 /// The default AWS instance metadata endpoint.
 pub const AWS_IPV4_METADATA_ENDPOINT: &str =
@@ -45,6 +46,7 @@ impl<C> Detector for AWSDetector<C>
 where
     C: HttpClient,
 {
+    #[instrument(skip_all, name = "detect_aws")]
     fn detect(&self) -> Result<Resource, DetectError> {
         let response = self
             .aws_http_client

--- a/resource-detection/src/cloud/azure/detector.rs
+++ b/resource-detection/src/cloud/azure/detector.rs
@@ -4,6 +4,7 @@ use crate::cloud::http_client::{HttpClient, HttpClientError};
 use crate::{cloud::AZURE_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
 use http::HeaderMap;
 use thiserror::Error;
+use tracing::instrument;
 
 /// The default Azure instance metadata endpoint.
 pub const AZURE_IPV4_METADATA_ENDPOINT: &str =
@@ -54,6 +55,7 @@ impl<C> Detector for AzureDetector<C>
 where
     C: HttpClient,
 {
+    #[instrument(skip_all, name = "detect_azure")]
     fn detect(&self) -> Result<Resource, DetectError> {
         let response = self
             .http_client

--- a/resource-detection/src/cloud/cloud_id/detector.rs
+++ b/resource-detection/src/cloud/cloud_id/detector.rs
@@ -1,17 +1,16 @@
 //! Aggregation cloud instance id detector implementation
-use thiserror::Error;
-use tracing::warn;
-
 use crate::cloud::aws::detector::{AWSDetector, TTL_TOKEN_DEFAULT};
 use crate::cloud::aws::http_client::AWSHttpClient;
 use crate::cloud::azure::detector::AzureDetector;
 use crate::cloud::gcp::detector::GCPDetector;
-use crate::cloud::http_client::{HttpClient, HttpClientError};
+use crate::cloud::http_client::HttpClient;
 use crate::cloud::{
     AZURE_INSTANCE_ID, CLOUD_INSTANCE_ID, CLOUD_TYPE, CLOUD_TYPE_AWS, CLOUD_TYPE_AZURE,
     CLOUD_TYPE_GCP, CLOUD_TYPE_NO, GCP_INSTANCE_ID,
 };
 use crate::{cloud::AWS_INSTANCE_ID, DetectError, Detector, Key, Resource, Value};
+use thiserror::Error;
+use tracing::warn;
 
 /// The `AWSDetector` struct encapsulates an HTTP client used to retrieve the instance metadata.
 pub struct CloudIdDetector<AWS: Detector, AZURE: Detector, GCP: Detector> {
@@ -125,6 +124,7 @@ mod tests {
     use crate::cloud::aws::detector::AWSDetectorError;
     use crate::cloud::azure::detector::AzureDetectorError;
     use crate::cloud::gcp::detector::GCPDetectorError;
+    use crate::cloud::http_client::HttpClientError;
     use crate::cloud::CLOUD_TYPE_GCP;
     use mockall::mock;
 

--- a/resource-detection/src/cloud/gcp/detector.rs
+++ b/resource-detection/src/cloud/gcp/detector.rs
@@ -5,6 +5,7 @@ use crate::cloud::GCP_INSTANCE_ID;
 use crate::{DetectError, Detector, Key, Resource, Value};
 use http::HeaderMap;
 use thiserror::Error;
+use tracing::instrument;
 
 /// Default GCP instance metadata endpoint.
 pub const GCP_IPV4_METADATA_ENDPOINT: &str =
@@ -55,6 +56,7 @@ impl<C> Detector for GCPDetector<C>
 where
     C: HttpClient,
 {
+    #[instrument(skip_all, name = "detect_gcp")]
     fn detect(&self) -> Result<Resource, DetectError> {
         let response = self
             .http_client

--- a/resource-detection/src/system/detector.rs
+++ b/resource-detection/src/system/detector.rs
@@ -1,6 +1,6 @@
 //! System resource detector implementation
 use fs::LocalFile;
-use tracing::error;
+use tracing::{error, instrument};
 
 use crate::{DetectError, Detector, Key, Resource, Value};
 
@@ -42,6 +42,7 @@ impl Default for SystemDetector {
 
 /// Implementing the `Detect` trait for the `SystemDetector` struct.
 impl Detector for SystemDetector {
+    #[instrument(skip_all, name = "detect_system")]
     fn detect(&self) -> Result<Resource, DetectError> {
         let mut collected_resources: Vec<(Key, Value)> = vec![];
 


### PR DESCRIPTION
# What this PR does / why we need it

This PR adds several spans all level "info". 
Notice that since the run_subagent span is adding agent_identity as context, all following logs are getting that for free

```
2025-03-20T15:35:18  INFO agent{id: fluentbit}: Stopping OpAMP client for supervised agent type: fluentbit
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: ConfigMap fleet-data-nr-infra missing key remote_config_hash
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: no previous remote config found
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: loading config
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:load_remote: ConfigMap fleet-data-nr-infra missing key remote_config
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: remote config not found, loading local
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:load_local{agent_id: AgentID("nr-infra")}: ConfigMap local-data-nr-infra not found
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: local config not found, falling back to defaults
2025-03-20T15:35:18 ERROR apply_remote_agent_control_config:agent{id: nr-infra}: cannot assemble supervisor, error: error assembling agent: `error assembling agents: `Not all values for this agent type have been populated: ["chart_version"]``
2025-03-20T15:35:18 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: runtime started
[...]
2025-03-20T15:37:19 DEBUG status_http_server event_processor sub_agent_became_healthy, agent_id: nr-infra, agent_type: newrelic/com.newrelic.infrastructure:0.1.0
2025-03-20T15:37:19 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s objects if changed
2025-03-20T15:37:19 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:19 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:19 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:19 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: K8s objects applied
2025-03-20T15:37:24 DEBUG sending scheduled status report AgentToServer message, instance_uid: "0195B431CCFF7C62B5DC7D19B8BFF142"
2025-03-20T15:37:29 DEBUG sending scheduled status report AgentToServer message, instance_uid: "0195B335A89B7AD1B9003C2238487A80"
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "health checker"}: starting to check health with the configured checker
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}: AgentHealthInfo, select_arm: "sub_agent_internal_consumer", health: HealthWithStartTime { start_time: SystemTime { tv_sec: 1742484918, tv_nsec: 996747637 }, health: Healthy(Healthy { status_time: SystemTime { tv_sec: 1742485069, tv_nsec: 7772637 }, status: "" }) }
2025-03-20T15:37:49 DEBUG status_http_server event_processor sub_agent_became_healthy, agent_id: nr-infra, agent_type: newrelic/com.newrelic.infrastructure:0.1.0
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s objects if changed
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: not applying k8s resource since it has not changed
2025-03-20T15:37:49 DEBUG apply_remote_agent_control_config:agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: K8s objects applied
2025-03-20T15:37:54 DEBUG sending scheduled status report AgentToServer message, instance_uid: "0195B431CCFF7C62B5DC7D19B8BFF142"
2025-03-20T15:37:59 DEBUG sending scheduled status report AgentToServer message, instance_uid: "0195B335A89B7AD1B9003C2238487A80"

```

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
