### PR TITLE
fix(test): fix nightlies e2e for k8s

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,7 +124,8 @@ jobs:
           ARCH: amd64
           BUILD_WITH: cargo
         with:
-          retry_attempts: 15
+          retry_attempts: 30
+          retry_seconds: 30
           agent_enabled: false
           spec_path: test/k8s-e2e/e2e-fleet-control.yml
           account_id: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
@@ -168,4 +169,3 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
         GITHUB_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-

--- a/test/k8s-e2e/agent-control-fleet-control.yml
+++ b/test/k8s-e2e/agent-control-fleet-control.yml
@@ -4,7 +4,8 @@ agent-control-deployment:
   config:
     fleet_control:
       enabled: true
-      fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTUzY2RkLTU1MWEtN2Y3NS1iZDhmLWI0YjA0Yzg5MmNhMQ
+      # Fleet with name 'ac-e2e-2'. The sub-agent reports data to the 'Agent Control Canaries' account.
+      fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTVjOGJkLTc3ZjYtN2Y2Ni05ZDQ4LTgxMzFlYTJlNWRkMw
       auth:
         secret:
           create: false

--- a/test/k8s-e2e/e2e-fleet-control.yml
+++ b/test/k8s-e2e/e2e-fleet-control.yml
@@ -22,3 +22,14 @@ scenarios:
       nrqls:
         # Check that newrelic-infrastructure data is reported, an extra where testKey=$SCENARIO_TAG is always added.
         - query: "FROM K8sClusterSample SELECT * WHERE `config_origin` = 'remote'"
+        # Expected remote config (already deployed in the corresponding fleet):
+        # chart_version: "*"
+        # chart_values:
+        #   global: # add 'cluster_name' (nri-kubernetes events have 'clusterName' attribute)
+        #     customAttributes:
+        #       cluster_name: ${nr-env:NR_CLUSTER_NAME}
+        #       config_origin: remote
+        #   nri-metadata-injection:
+        #     # TODO we are currently disabling the metadata injection since if enabled it breaks when installed
+        #     # together with the gateway
+        #     enabled: false


### PR DESCRIPTION
# What this PR does / why we need it

This PR updates the fleet-id used in the k8s e2e test executed in the nightlies, since the previous fleet was not working as expected because the deployment's configuration was removed.

The PR also increases the number of retry-attempts for the e2e and add some comments in order to easy future troubleshooting.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
