### PR TITLE
fix: stop finished thread (NR-382675)

### DIFF
--- a/agent-control/src/event/channel.rs
+++ b/agent-control/src/event/channel.rs
@@ -33,6 +33,11 @@ impl<E> EventPublisher<E> {
             .send(event)
             .map_err(|err| EventPublisherError::SendError(err.to_string()))
     }
+    pub fn try_publish(&self, event: E) -> Result<(), EventPublisherError> {
+        self.0
+            .try_send(event)
+            .map_err(|err| EventPublisherError::SendError(err.to_string()))
+    }
 }
 
 impl<E> Clone for EventPublisher<E> {


### PR DESCRIPTION
We noticed a [flaky test](https://github.com/newrelic/newrelic-agent-control/actions/runs/14054296724/job/39350289161) caused by a race condition on the thread context stop for threads that are finished by external signals.

This Pr makes the stops fn to try for sending the stop signal but keep joining if that fails.  

Extra: 
- Removes flaky asserts on `test_thread_context_start_stop_blocking_on_finished_thread` test