### PR TITLE
fix: misleading typo in sub agent logs

### DIFF
--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -283,7 +283,7 @@ where
 {
     if let Some(s) = maybe_started_supervisor {
         let _ = s.stop().inspect_err(|err| {
-            error!(%err,"Error stopping k8s supervisor");
+            error!(%err,"error stopping supervisor");
         });
     }
 }


### PR DESCRIPTION
# What this PR does / why we need it
Cleaned a log that was showing `k8s` even in `on-host`