### PR TITLE
refactor: adds RemoteConfigValidators (NR-381670)

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -16,7 +16,8 @@ use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::Identifiers;
 use crate::opamp::operations::build_opamp_with_channel;
-use crate::opamp::remote_config::validators::regexes::ConfigValidator;
+use crate::opamp::remote_config::validators::regexes::RegexValidator;
+use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
 use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
@@ -132,11 +133,15 @@ impl AgentControlRunner {
             Environment::K8s,
         );
 
+        let remote_config_validators = vec![
+            SupportedRemoteConfigValidator::Signature(self.signature_validator),
+            SupportedRemoteConfigValidator::Regex(RegexValidator::default()),
+        ];
+
         let remote_config_handler = AgentRemoteConfigHandler::new(
-            Arc::new(ConfigValidator::default()),
+            remote_config_validators,
             hash_repository.clone(),
             yaml_config_repository.clone(),
-            Arc::new(self.signature_validator),
         );
 
         info!("Creating the k8s sub_agent builder");

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -17,7 +17,8 @@ use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
 use crate::opamp::instance_id::getter::InstanceIDWithIdentifiersGetter;
 use crate::opamp::instance_id::{Identifiers, Storer};
 use crate::opamp::operations::build_opamp_with_channel;
-use crate::opamp::remote_config::validators::regexes::ConfigValidator;
+use crate::opamp::remote_config::validators::regexes::RegexValidator;
+use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
 use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
@@ -153,11 +154,14 @@ impl AgentControlRunner {
             Environment::OnHost,
         );
 
+        let remote_config_validators = vec![
+            SupportedRemoteConfigValidator::Signature(self.signature_validator),
+            SupportedRemoteConfigValidator::Regex(RegexValidator::default()),
+        ];
         let remote_config_handler = AgentRemoteConfigHandler::new(
-            Arc::new(ConfigValidator::default()),
+            remote_config_validators,
             sub_agent_hash_repository,
             yaml_config_repository.clone(),
-            Arc::new(self.signature_validator),
         );
 
         let sub_agent_builder = OnHostSubAgentBuilder::new(

--- a/agent-control/src/opamp/remote_config/validators.rs
+++ b/agent-control/src/opamp/remote_config/validators.rs
@@ -1,17 +1,50 @@
-use super::RemoteConfig;
-use crate::agent_type::agent_type_id::AgentTypeID;
-use std::fmt::Display;
 pub mod regexes;
 pub mod signature;
+
+use super::RemoteConfig;
+use crate::agent_type::agent_type_id::AgentTypeID;
+use regexes::RegexValidator;
+use signature::validator::SignatureValidator;
+use std::fmt::Display;
+use thiserror::Error;
 
 /// Represents a validator for config remote
 pub trait RemoteConfigValidator {
     type Err: Display;
+
     fn validate(
         &self,
         agent_type_id: &AgentTypeID,
         remote_config: &RemoteConfig,
     ) -> Result<(), Self::Err>;
+}
+
+#[derive(Error, Debug)]
+#[error("{0}")]
+/// Represents an error for RemoteConfigValidatorImpl
+pub struct SupportedRemoteConfigValidatorError(String);
+/// Variants of Implementations of [RemoteConfigValidator] to facilitate Static Dispatch.
+pub enum SupportedRemoteConfigValidator {
+    Signature(SignatureValidator),
+    Regex(RegexValidator),
+}
+
+impl RemoteConfigValidator for SupportedRemoteConfigValidator {
+    type Err = SupportedRemoteConfigValidatorError;
+    fn validate(
+        &self,
+        agent_type_id: &AgentTypeID,
+        remote_config: &RemoteConfig,
+    ) -> Result<(), SupportedRemoteConfigValidatorError> {
+        match self {
+            Self::Signature(s) => s
+                .validate(agent_type_id, remote_config)
+                .map_err(|e| SupportedRemoteConfigValidatorError(e.to_string())),
+            Self::Regex(r) => r
+                .validate(agent_type_id, remote_config)
+                .map_err(|e| SupportedRemoteConfigValidatorError(e.to_string())),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/agent-control/src/sub_agent/error.rs
+++ b/agent-control/src/sub_agent/error.rs
@@ -2,8 +2,7 @@ use super::effective_agents_assembler::EffectiveAgentsAssemblerError;
 use crate::event::channel::EventPublisherError;
 use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::repository::HashRepositoryError;
-use crate::opamp::remote_config::validators::regexes::ConfigValidatorError;
-use crate::opamp::remote_config::validators::signature::validator::SignatureValidatorError;
+use crate::opamp::remote_config::validators::SupportedRemoteConfigValidatorError;
 use crate::opamp::remote_config::RemoteConfigError;
 use crate::values::yaml_config::YAMLConfigError;
 use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
@@ -38,9 +37,7 @@ pub enum SubAgentError {
     #[error("Error publishing event: `{0}`")]
     EventPublisherError(#[from] EventPublisherError),
     #[error("ConfigValidator error: `{0}`")]
-    ConfigValidatorError(#[from] ConfigValidatorError),
-    #[error("SignatureValidator error: `{0}`")]
-    SignatureValidatorError(#[from] SignatureValidatorError),
+    ConfigValidatorError(#[from] SupportedRemoteConfigValidatorError),
 }
 
 #[derive(Error, Debug)]

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -442,7 +442,10 @@ pub mod tests {
                 let max_duration = Duration::from_millis(100);
                 let start = Instant::now();
 
-                started_supervisor.expect("no error").stop().unwrap();
+                started_supervisor
+                    .expect("no error")
+                    .stop()
+                    .unwrap_or_else(|_| panic!("test case: {}", self.name));
 
                 let duration = start.elapsed();
 


### PR DESCRIPTION
- Renames the Regex validator
- Implement RemoteConfigValidator for the Regex one
- Adds a composite validator
- Iterate over validators in remote config handler

