### PR TITLE
style: remove unneeded `NEW_RELIC_AGENT_CONTROL_ENABLED` env vars for APM tests

### DIFF
--- a/test/k8s-e2e/agent-control-apm.yml
+++ b/test/k8s-e2e/agent-control-apm.yml
@@ -21,10 +21,7 @@ agent-control-deployment:
             matchExpressions:
               - key: "app"
                 operator: "In"
-                values: [ "javaapp" ]
-          env:
-            - name: NEW_RELIC_AGENT_CONTROL_ENABLED
-              value: "true"
+                values: ["javaapp"]
       python-agent:
         type: newrelic/com.newrelic.apm_python:0.1.0
         content:
@@ -32,10 +29,7 @@ agent-control-deployment:
             matchExpressions:
               - key: "app"
                 operator: "In"
-                values: [ "pythonapp" ]
-          env:
-            - name: NEW_RELIC_AGENT_CONTROL_ENABLED
-              value: "true"
+                values: ["pythonapp"]
       node-agent:
         type: newrelic/com.newrelic.apm_node:0.1.0
         content:
@@ -43,10 +37,7 @@ agent-control-deployment:
             matchExpressions:
               - key: "app"
                 operator: "In"
-                values: [ "nodeapp" ]
-          env:
-            - name: NEW_RELIC_AGENT_CONTROL_ENABLED
-              value: "true"
+                values: ["nodeapp"]
       ruby-agent:
         type: newrelic/com.newrelic.apm_ruby:0.1.0
         content:
@@ -54,10 +45,7 @@ agent-control-deployment:
             matchExpressions:
               - key: "app"
                 operator: "In"
-                values: [ "rubyapp" ]
-          env:
-            - name: NEW_RELIC_AGENT_CONTROL_ENABLED
-              value: "true"
+                values: ["rubyapp"]
       dotnet-agent:
         type: newrelic/com.newrelic.apm_dotnet:0.1.0
         content:
@@ -65,7 +53,4 @@ agent-control-deployment:
             matchExpressions:
               - key: "app"
                 operator: "In"
-                values: [ "dotneteapp" ]
-          env:
-            - name: NEW_RELIC_AGENT_CONTROL_ENABLED
-              value: "true"
+                values: ["dotneteapp"]


### PR DESCRIPTION
# What this PR does / why we need it

Removes env vars set up explicitly for APM agents given the K8s operator sets them already ([ref](https://github.com/newrelic/newrelic-agent-control/pull/1177/files#r2020947977)).

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
