### PR TITLE
feat(docker-image): attestations sbom

### DIFF
--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -61,6 +61,7 @@ jobs:
             --platform=$DOCKER_PLATFORMS \
             -t $DOCKER_IMAGE_NAME:${{ inputs.image-tag }} \
             --attest type=provenance,mode=max \
+            --attest type=sbom \
             .
 
       - name: Build image
@@ -70,4 +71,5 @@ jobs:
             --platform=$DOCKER_PLATFORMS \
             -t $DOCKER_IMAGE_NAME:${{ inputs.image-tag }} \
             --attest type=provenance,mode=max \
+            --attest type=sbom \
             .

--- a/.github/workflows/push_system_identity_registration_image.yml
+++ b/.github/workflows/push_system_identity_registration_image.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           docker buildx build \
             --attest type=provenance,mode=max \
+            --attest type=sbom \
             --platform=${DOCKER_PLATFORMS} \
             --tag ${DOCKER_IMAGE_NAME}:${{ inputs.tag || 'latest' }} \
             --file system_identity_registration/Dockerfile \
@@ -54,4 +55,5 @@ jobs:
             --file system_identity_registration/Dockerfile \
             --push \
             --attest type=provenance,mode=max \
+            --attest type=sbom \
             .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
             -t $DOCKER_IMAGE_NAME:${{ github.event.release.tag_name }} \
             -t $DOCKER_IMAGE_NAME:latest \
             --attest type=provenance,mode=max \
+            --attest type=sbom \
             $DOCKER_IMAGE_NAME:${{ github.event.release.tag_name }}-rc
 
 

--- a/system_identity_registration/Dockerfile
+++ b/system_identity_registration/Dockerfile
@@ -1,3 +1,4 @@
+# This image is leveraged in the Helm chart in order to create via script the L1 and the secret containing it.
 ARG base_image=alpine:3.21
 
 FROM $base_image


### PR DESCRIPTION
# What this PR does / why we need it
Adding as well SBOM to the image. This is going to be useful in the future when dockerhub will show to the public the scorecards

## Special notes for your reviewer
https://docs.docker.com/build/metadata/attestations/sbom/


[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
