### PR TITLE
feat: change how renovate cargo dependecies are group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,25 +57,6 @@
   "packageRules": [
     {
       "managers": [
-        "cargo"
-      ],
-      "updateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "cargo minor and patch updates"
-    },
-    {
-      "managers": [
-        "cargo"
-      ],
-      "updateTypes": [
-        "major",
-      ],
-      "groupName": "cargo major updates"
-    },
-    {
-      "managers": [
         "gomod"
       ],
       "updateTypes": [


### PR DESCRIPTION
# What this PR does / why we need it

Change the group of renovate cargo updates, now are going to be indiviual.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
