### PR TITLE
fix: adapt the otel-collector embedded binary and config download to the new repo format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ env:
   # Artifacts Versions
   # Currently the only way to update the sub-agent versions is rebuild the binary of the agent-control
   - NEWRELIC_INFRA_AGENT_VERSION=1.63.1
-  - NR_OTEL_COLLECTOR_VERSION=0.8.0
+  - NR_OTEL_COLLECTOR_VERSION=1.0.3
   #
 builds:
   - id: newrelic-agent-control
@@ -33,6 +33,8 @@ builds:
             - ARCH={{ .Arch }}
             - ARTIFACTS_VERSIONS={"newrelic-infra":"{{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}","nr-otel-collector":"{{ .Env.NR_OTEL_COLLECTOR_VERSION }}"}
         - cmd: sh ./build/scripts/download_collector_config.sh
+          env:
+            - NR_OTEL_COLLECTOR_VERSION={{ .Env.NR_OTEL_COLLECTOR_VERSION }}
   - id: newrelic-config-migrate
     main: ./build/dummy.go
     goos:
@@ -157,9 +159,9 @@ nfpms:
         type: dir
       - dst: /var/db/newrelic-infra/integrations.d
         type: dir
-      # NR Otel Collector
-      - src: build/embedded/artifacts/{{- .Arch }}/nr-otel-collector/nr-otel-collector
-        dst: /usr/bin/nr-otel-collector
+      # NR Otel Collector - Important to note the binary name is nrdot-collector-host matching nrdot binary
+      - src: build/embedded/artifacts/{{- .Arch }}/nr-otel-collector/nrdot-collector-host
+        dst: /usr/bin/nrdot-collector-host
       - src: build/examples/
         dst: /etc/newrelic-agent-control/examples
 

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -53,7 +53,8 @@ deployment:
         path: "${nr-var:health_check.path}"
         port: ${nr-var:health_check.port}
     executable:
-      path: /usr/bin/nr-otel-collector
+      # Important to note the binary name is nrdot-collector-host matching the new nrdot binary
+      path: /usr/bin/nrdot-collector-host
       args: >-
         --config=${nr-var:config}
         --feature-gates=-pkg.translator.prometheus.NormalizeName

--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -57,14 +57,9 @@ artifacts:
 
   - name: nr-otel-collector
     # Version now should be added in goreleaser.yaml global envs
-    url: https://github.com/newrelic/opentelemetry-collector-releases/releases/download/nr-otel-collector-{{.Version | trimv}}/nr-otel-collector_{{.Version | trimv}}_linux_{{.Arch}}.deb
+    url: https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.Version | trimv}}/nrdot-collector-host_{{.Version | trimv}}_linux_{{.Arch}}.deb
     files:
+     # Important to note the binary name is nrdot-collector-host matching the new nrdot binary
       - name: nt-otel-collector binary
-        src: usr/bin/nr-otel-collector
-        dest: artifacts/{{.Arch}}/nr-otel-collector
-      - name: nt-otel-collector conf
-        src: etc/nr-otel-collector/config.yaml
-        dest: artifacts/{{.Arch}}/nr-otel-collector
-      - name: nt-otel-collector conf service
-        src: etc/nr-otel-collector/nr-otel-collector.conf
+        src: usr/bin/nrdot-collector-host
         dest: artifacts/{{.Arch}}/nr-otel-collector

--- a/build/example_templates/values-nr-otel-collector-gateway.yaml
+++ b/build/example_templates/values-nr-otel-collector-gateway.yaml
@@ -1,2 +1,0 @@
-config: |
-  {{ OTEL_COLLECTOR_CONFIG }}

--- a/build/scripts/download_collector_config.sh
+++ b/build/scripts/download_collector_config.sh
@@ -1,35 +1,27 @@
 #!/usr/bin/env bash
 
 # This script will download the nr-otel-collector config and use it to create the values.yaml sample
-COLLECTOR_VERSION="0.8.0"
 BUILD_TMP_FOLDER=build-tmp
-URL="https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/nr-otel-collector-${COLLECTOR_VERSION}/configs"
-DEFAULT_CONFIG_FILENAME="nr-otel-collector-agent-linux.yaml"
-GATEWAY_CONFIG_FILENAME="nr-otel-collector-gateway.yaml"
+DEFAULT_CONFIG_FILENAME="config.yaml"
+URL="https://raw.githubusercontent.com/newrelic/nrdot-collector-releases/refs/tags/${NR_OTEL_COLLECTOR_VERSION}/distributions/nrdot-collector-host/${DEFAULT_CONFIG_FILENAME}"
 CONFIG_PLACEHOLDER="OTEL_COLLECTOR_CONFIG"
 TEMPLATE_DIR="build/example_templates"
 OUT_DIR="build/examples"
 TEMPLATE_DEFAULT="${TEMPLATE_DIR}/values-nr-otel-collector-agent-linux.yaml"
-TEMPLATE_GATEWAY="${TEMPLATE_DIR}/values-nr-otel-collector-gateway.yaml"
 FINAL_DEFAULT="${OUT_DIR}/values-nr-otel-collector-agent-linux.yaml"
-FINAL_GATEWAY="${OUT_DIR}/values-nr-otel-collector-gateway.yaml"
 
 # Copy templates into their final locations (ignored by git)
 cp ${TEMPLATE_DEFAULT} ${FINAL_DEFAULT}
-cp ${TEMPLATE_GATEWAY} ${FINAL_GATEWAY}
 
 mkdir -p ${BUILD_TMP_FOLDER}
 
 # Download nr-otel-collector config
 curl -s -o "${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}" "${URL}/${DEFAULT_CONFIG_FILENAME}"
-# Download nr-otel-collector config
-curl -s -o "${BUILD_TMP_FOLDER}/${GATEWAY_CONFIG_FILENAME}" "${URL}/${GATEWAY_CONFIG_FILENAME}"
+
 # Add spaces to be embedded in the values.yaml
 docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "sed -i 's/^/  /g' ${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}"
-docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "sed -i 's/^/  /g' ${BUILD_TMP_FOLDER}/${GATEWAY_CONFIG_FILENAME}"
 # Replace nr-otel-collector sample file placeholder with nr-otel-config
 docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "sed -i -e '/${CONFIG_PLACEHOLDER}/{r ${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}' -e 'd}' ${FINAL_DEFAULT}"
-docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "sed -i -e '/${CONFIG_PLACEHOLDER}/{r ${BUILD_TMP_FOLDER}/${GATEWAY_CONFIG_FILENAME}' -e 'd}' ${FINAL_GATEWAY}"
 
 
 


### PR DESCRIPTION
# What this PR does / why we need it

Adapts the otel-collector embedded binary and config download to the new repository.
It also bumps the otel collector to 1.0.3

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
