### PR TITLE
chore: avoid error-message field in logs [NR-383204]

### DIFF
--- a/agent-control/src/agent_control/http_server/runner.rs
+++ b/agent-control/src/agent_control/http_server/runner.rs
@@ -150,12 +150,7 @@ impl Drop for Runner {
         let _ = thread_context
             .stop()
             .inspect(|_| debug!("status server runner thread stopped"))
-            .inspect_err(|error_msg| {
-                error!(
-                    %error_msg,
-                    "Error stopping Status Server"
-                )
-            });
+            .inspect_err(|error_msg| error!("Error stopping Status Server: {error_msg}"));
     }
 }
 

--- a/agent-control/src/k8s/garbage_collector.rs
+++ b/agent-control/src/k8s/garbage_collector.rs
@@ -49,12 +49,7 @@ impl Drop for K8sGarbageCollectorStarted {
         let _ = thread_context
             .stop()
             .inspect(|_| info!("garbage collector thread stopped"))
-            .inspect_err(|error_msg| {
-                error!(
-                    %error_msg,
-                    "Error stopping {} thread", THREAD_NAME
-                )
-            });
+            .inspect_err(|error_msg| error!("Error stopping '{THREAD_NAME}' thread: {error_msg}"));
     }
 }
 

--- a/agent-control/src/sub_agent/event_handler/opamp/remote_config_handler.rs
+++ b/agent-control/src/sub_agent/event_handler/opamp/remote_config_handler.rs
@@ -142,7 +142,10 @@ where
         // The supervisor won't be recreated.
         for validator in &self.remote_config_validators {
             if let Err(error_msg) = validator.validate(&agent_identity, config) {
-                error!(%error_msg, hash = &config.hash.get(), "error validating remote config");
+                error!(
+                    hash = &config.hash.get(),
+                    "Error validating remote config: {error_msg}"
+                );
                 Self::report_error(opamp_client, config, error_msg.to_string())?;
                 return Err(RemoteConfigHandlerError::ConfigValidating(
                     error_msg.to_string(),

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -216,7 +216,7 @@ impl SupervisorStopper for StartedSupervisorK8s {
             match thread_context.stop_blocking() {
                 Ok(_) => info!(agent_id = %self.agent_id, "{} stopped", thread_name),
                 Err(error_msg) => {
-                    error!(agent_id = %self.agent_id, %error_msg);
+                    error!(agent_id = %self.agent_id, "Error stopping '{thread_name}': {error_msg}");
                     if stop_result.is_ok() {
                         stop_result = Err(error_msg);
                     }

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -87,7 +87,7 @@ impl SupervisorStopper for StartedSupervisorOnHost {
             match thread_context.stop_blocking() {
                 Ok(_) => info!("{} stopped", thread_name),
                 Err(error_msg) => {
-                    error!(%error_msg);
+                    error!("Error stopping '{thread_name}': {error_msg}");
                     if stop_result.is_ok() {
                         stop_result = Err(error_msg);
                     }

--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -164,7 +164,7 @@ where
 
                                 match self.remote_config_handler.handle(opamp_client,self.identity.clone(),&mut config) {
                                     Err(error) =>{
-                                        error!(%error,"error handling remote config")
+                                        error!("error handling remote config: {error}")
                                     },
                                     Ok(())  =>{
                                         info!("Applying remote config");

--- a/agent-control/src/sub_agent/version/version_checker.rs
+++ b/agent-control/src/sub_agent/version/version_checker.rs
@@ -68,7 +68,7 @@ where
                 );
             }
             Err(error) => {
-                warn!( %error, "failed to check agent version");
+                warn!("failed to check agent version: {error}");
                 version_retrieved = false;
             }
         }


### PR DESCRIPTION
# What this PR does / why we need it

This PR updates error log messages to stop including part of the error message as `error` or `error_msg` fields, as described in [NR-383204](https://new-relic.atlassian.net/browse/NR-383204)

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).


[NR-383204]: https://new-relic.atlassian.net/browse/NR-383204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ