### PR TITLE
fix(logs): disable ansi-colors for logs by default

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -446,7 +446,8 @@ agents: {}
             LoggingConfig {
                 format: LoggingFormat {
                     target: true,
-                    timestamp: TimestampFormat("%Y".to_string())
+                    timestamp: TimestampFormat("%Y".to_string()),
+                    ansi_colors: false,
                 },
                 ..Default::default()
             }

--- a/agent-control/src/instrumentation/config/logs/format.rs
+++ b/agent-control/src/instrumentation/config/logs/format.rs
@@ -20,10 +20,13 @@ impl Default for TimestampFormat {
 /// # Fields:
 /// - `target`: A bool that indicates whether or not the target of the trace event will be included in the formatted output.
 /// - `timestamp`: Specifies a `TimestampFormat` the application will use for logging timestamps.
+/// - `ansi_colors`: Specifies if ansi colors should be used in stdout logs.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
 pub struct LoggingFormat {
     #[serde(default)]
     pub(crate) target: bool,
     #[serde(default)]
     pub(crate) timestamp: TimestampFormat,
+    #[serde(default)]
+    pub(crate) ansi_colors: bool,
 }

--- a/agent-control/src/instrumentation/tracing_layers/stdout.rs
+++ b/agent-control/src/instrumentation/tracing_layers/stdout.rs
@@ -11,6 +11,7 @@ pub fn stdout(config: &LoggingConfig) -> Result<LayerBox, LoggingConfigError> {
 
     let layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stdout)
+        .with_ansi(config.format.ansi_colors)
         .with_target(target)
         .with_timer(ChronoLocal::new(timestamp_fmt))
         .fmt_fields(PrettyFields::new())

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,6 +33,7 @@ logs:
   format:
     target: true # Defaults to false, includes extra information for debugging purposes
     timestamp: "%Y-%m-%dT%H:%M%S" # Defaults to "%Y-%m-%dT%H:%M%S", details in <https://docs.rs/chrono/0.4.40/chrono/format/strftime/index.html#fn7>
+    ansi_colors: true # Defaults to false, set up ansi-colors in the stdout logs output.
   level: debug # Defines the log level, defaults to "info".
   insecure_fine_grained_level: debug # Enables logs for external dependencies and sets its level. This cannot be considered secure since external dependencies may leek secrets. If this is set the 'level' field does not apply.
   file:


### PR DESCRIPTION
# What this PR does / why we need it

Disables ansi colors by default in stdout logs since it can cause issues in particular environments. Eg:

```
[2m2025-04-09T05:47:43[0m [34mDEBUG[0m [1mopamp[0m[1m{[0m[1minstance_uid[0m: 01960EB97BD4775298B83F775B84B052[1m}[0m[2m:[0m sending first AgentToServer message
[2m2025-04-09T05:47:44[0m [34mDEBUG[0m [1mopamp[0m[1m{[0m[1minstance_uid[0m: 01960EB97BD4775298B83F775B84B052[1m}[0m[2m:[0m[1mprocess_message[0m[2m:[0m OpAMP get effective config, [1magent_id[0m: agent-control
[2m2025-04-09T05:47:44[0m [34mDEBUG[0m [1mopamp[0m[1m{[0m[1minstance_uid[0m: 01960EB97BD4775298B83F775B84B052[1m}[0m[2m:[0m[1mprocess_message[0m[2m:[0m loading config
```

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
