### PR TITLE
feat: add github action to fix licenses file for renovate prs

### DIFF
--- a/.github/workflows/push_pr_check.yml
+++ b/.github/workflows/push_pr_check.yml
@@ -83,7 +83,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
-          
+
       - name: cargo clippy
         run: cargo clippy --workspace --tests -- -D clippy::all
 
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-  
+
       - name: Obtain Rust version from project
         run: |
           RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
@@ -114,7 +114,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
-          
+
       - name: Create documentation
         run: cargo doc --no-deps --package newrelic_agent_control
         env:
@@ -123,9 +123,13 @@ jobs:
   third-party-notices-check:
     runs-on: ubuntu-latest
     name: ⚖️ Check third party licenses
+    permissions:
+      # Allows github.token to push commit
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           submodules: true
 
       - name: Obtain Rust version from project
@@ -152,8 +156,28 @@ jobs:
         run: cargo fetch
 
       - uses: newrelic/rust-licenses-noticer@v1
+        if: ${{ ! contains(github.head_ref, 'renovate/') }}
         with:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
+
+      - uses: newrelic/rust-licenses-noticer@v1
+        if: ${{ contains(github.head_ref, 'renovate/') }}
+        id: license-verification
+        continue-on-error: true
+        with:
+          template-file: THIRD_PARTY_NOTICES.md.tmpl
+
+      - name: Correct and Update License Notices
+        if: ${{ steps.license-verification.outcome == 'failure' && contains(github.head_ref, 'renovate/') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make third-party-notices
+          git config user.name newrelic-coreint-bot
+          git config user.email coreint-dev@newrelic.com
+          git add THIRD_PARTY_NOTICES.md
+          git commit -m "Update THIRD PARTY NOTICES due to license check failure"
+          git push -u origin ${{ env.BRANCH }}
 
   unused-dependencies-check:
     name: Check unused dependencies


### PR DESCRIPTION
# What this PR does / why we need it

Add new github action: 

if the licenses check fails and the branch contains "renovate/" make thrid-party-dependecies command is executed and changes commited to the same branch.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
