### PR TITLE
refactor: move all values from helmrelease to secrets (NR-399798)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -107,13 +107,13 @@ deployment:
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
-      default-values:
+      values:
         apiVersion: v1
         kind: Secret
         metadata:
-          name: default-values-${nr-sub:agent_id}
+          name: values-${nr-sub:agent_id}
         stringData:
-          values.yaml: |
+          default.yaml: |
             newrelic-infrastructure:
               enabled: true
             nri-metadata-injection:
@@ -128,6 +128,37 @@ deployment:
               nrStaging: ${nr-env:NR_STAGING}
               lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
               verboseLog: ${nr-env:NR_VERBOSE_LOG}
+          values.yaml: |
+            newrelic-infrastructure: 
+              ${nr-var:chart_values.newrelic-infrastructure | indent 2}
+            nri-metadata-injection: 
+              ${nr-var:chart_values.nri-metadata-injection | indent 2}
+            kube-state-metrics: 
+              ${nr-var:chart_values.kube-state-metrics | indent 2}
+            nri-kube-events: 
+              ${nr-var:chart_values.nri-kube-events | indent 2}
+            global: 
+              ${nr-var:chart_values.global | indent 2}
+          # The rest of nri-bundle charts are explicitly disabled below.
+          # Note: this needs to be in sync with nri-bundle's supported charts. If a new version of
+          # nri-bundle included a new chart enabled by default, it needs to be disabled here.
+          fixed.yaml: |
+            nri-prometheus:
+              enabled: false
+            newrelic-logging:
+              enabled: false
+            newrelic-pixie:
+              enabled: false
+            k8s-agents-operator:
+              enabled: false
+            pixie-chart:
+              enabled: false
+            newrelic-infra-operator:
+              enabled: false
+            newrelic-prometheus-agent:
+              enabled: false
+            newrelic-k8s-metrics-adapter:
+              enabled: false 
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -166,31 +197,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            newrelic-infrastructure: ${nr-var:chart_values.newrelic-infrastructure}
-            nri-metadata-injection: ${nr-var:chart_values.nri-metadata-injection}
-            kube-state-metrics: ${nr-var:chart_values.kube-state-metrics}
-            nri-kube-events: ${nr-var:chart_values.nri-kube-events}
-            global: ${nr-var:chart_values.global}
-
-            # The rest of nri-bundle charts are explicitly disabled below.
-            # Note: this needs to be in sync with nri-bundle's supported charts. If a new version of
-            # nri-bundle included a new chart enabled by default, it needs to be disabled here.
-            nri-prometheus:
-              enabled: false
-            newrelic-logging:
-              enabled: false
-            newrelic-pixie:
-              enabled: false
-            k8s-agents-operator:
-              enabled: false
-            pixie-chart:
-              enabled: false
-            newrelic-infra-operator:
-              enabled: false
-            newrelic-prometheus-agent:
-              enabled: false
-            newrelic-k8s-metrics-adapter:
-              enabled: false
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: fixed.yaml

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -36,28 +36,25 @@ deployment:
           interval: 30m
           provider: generic
           url: https://newrelic.github.io/k8s-agents-operator
-      default-values:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: default-values-${nr-sub:agent_id}
-        stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
-          # ${nr-env:NR_STAGING}, ${nr-env:NR_LOW_DATA_MODE} and ${nr-env:NR_VERBOSE_LOG} are not set because they are
-          # not supported by the chart.
-          values.yaml: |
-            global:
-              licenseKey: ${nr-env:NR_LICENSE_KEY}
-              cluster: ${nr-env:NR_CLUSTER_NAME}
       values:
         apiVersion: v1
         kind: Secret
         metadata:
           name: values-${nr-sub:agent_id}
         stringData:
-          # global values defined inside here will have less precedence than the ones defined in `chart_values.global`
+          # These env variables are attached to the AC pod on the Helm Chart.
+          # ${nr-env:NR_STAGING}, ${nr-env:NR_LOW_DATA_MODE} and ${nr-env:NR_VERBOSE_LOG} are not set because they are
+          # not supported by the chart.
+          default.yaml: |
+            global:
+              licenseKey: ${nr-env:NR_LICENSE_KEY}
+              cluster: ${nr-env:NR_CLUSTER_NAME}
           values.yaml: |
             ${nr-var:chart_values.k8s-agents-operator}
+          # chart_values.global will have precedence over chart_values.k8s-agents-operator.global
+          global.yaml: |
+            global:
+              ${nr-var:chart_values.global | indent 2}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -96,10 +93,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
-              valuesKey: values.yaml
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
             - kind: Secret
               name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            global: ${nr-var:chart_values.global}
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: global.yaml

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -36,28 +36,26 @@ deployment:
           interval: 30m
           provider: generic
           url: https://newrelic.github.io/newrelic-prometheus-configurator
-      default-values:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: default-values-${nr-sub:agent_id}
-        stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
-          values.yaml: |
-            global:
-              licenseKey: ${nr-env:NR_LICENSE_KEY}
-              cluster: ${nr-env:NR_CLUSTER_NAME}
-              nrStaging: ${nr-env:NR_STAGING}
-              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
-              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret
         metadata:
           name: values-${nr-sub:agent_id}
         stringData:
+          # These env variables are attached to the AC pod on the Helm Chart.
+          default.yaml: |
+            global:
+              licenseKey: ${nr-env:NR_LICENSE_KEY}
+              cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
           values.yaml: |
             ${nr-var:chart_values.newrelic-prometheus-agent}
+          # chart_values.global will have precedence over chart_values.newrelic-prometheus-agent.global
+          global.yaml: |
+            global:
+              ${nr-var:chart_values.global | indent 2}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -96,10 +94,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
-              valuesKey: values.yaml
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
             - kind: Secret
               name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            ${nr-var:chart_values.global}
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: global.yaml

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -36,28 +36,26 @@ deployment:
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
-      default-values:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: default-values-${nr-sub:agent_id}
-        stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
-          # ${nr-env:NR_VERBOSE_LOG} is not set, since it is not used in the chart.
-          values.yaml: |
-            global:
-              licenseKey: ${nr-env:NR_LICENSE_KEY}
-              cluster: ${nr-env:NR_CLUSTER_NAME}
-              nrStaging: ${nr-env:NR_STAGING}
-              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
       values:
         apiVersion: v1
         kind: Secret
         metadata:
           name: values-${nr-sub:agent_id}
         stringData:
+          # These env variables are attached to the AC pod on the Helm Chart.
+          # ${nr-env:NR_VERBOSE_LOG} is not set, since it is not used in the chart.
+          default.yaml: |
+            global:
+              licenseKey: ${nr-env:NR_LICENSE_KEY}
+              cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
           values.yaml: |
             ${nr-var:chart_values.newrelic-logging}
+          # chart_values.global will have precedence over chart_values.newrelic-logging.global
+          global.yaml: |
+            global:
+              ${nr-var:chart_values.global | indent 2}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -96,10 +94,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
-              valuesKey: values.yaml
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
             - kind: Secret
               name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            global: ${nr-var:chart_values.global}
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: global.yaml

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -83,29 +83,26 @@ deployment:
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
-      default-values:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: default-values-${nr-sub:agent_id}
-        stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
-          values.yaml: |
-            global:
-              licenseKey: ${nr-env:NR_LICENSE_KEY}
-              cluster: ${nr-env:NR_CLUSTER_NAME}
-              nrStaging: ${nr-env:NR_STAGING}
-              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
-              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret
         metadata:
           name: values-${nr-sub:agent_id}
         stringData:
-          # global values defined inside here will have less precedence than the ones defined in `chart_values.global`
+          # These env variables are attached to the AC pod on the Helm Chart.
+          default.yaml: |
+            global:
+              licenseKey: ${nr-env:NR_LICENSE_KEY}
+              cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
           values.yaml: |
             ${nr-var:chart_values.nr-k8s-otel-collector}
+          # chart_values.global will have precedence over chart_values.nr-k8s-otel-collector.global
+          global.yaml: |
+            global:
+              ${nr-var:chart_values.global | indent 2}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -144,10 +141,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
-              valuesKey: values.yaml
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
             - kind: Secret
               name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            global: ${nr-var:chart_values.global}
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: global.yaml

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -36,29 +36,26 @@ deployment:
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
-      default-values:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: default-values-${nr-sub:agent_id}
-        stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
-          values.yaml: |
-            global:
-              licenseKey: ${nr-env:NR_LICENSE_KEY}
-              cluster: ${nr-env:NR_CLUSTER_NAME}
-              nrStaging: ${nr-env:NR_STAGING}
-              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
-              verboseLog: ${nr-env:NR_VERBOSE_LOG}
       values:
         apiVersion: v1
         kind: Secret
         metadata:
           name: values-${nr-sub:agent_id}
         stringData:
-          # global values defined inside here will have less precedence than the ones defined in `chart_values.global`
+          # These env variables are attached to the AC pod on the Helm Chart.
+          default.yaml: |
+            global:
+              licenseKey: ${nr-env:NR_LICENSE_KEY}
+              cluster: ${nr-env:NR_CLUSTER_NAME}
+              nrStaging: ${nr-env:NR_STAGING}
+              lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
+              verboseLog: ${nr-env:NR_VERBOSE_LOG}
           values.yaml: |
             ${nr-var:chart_values.gateway}
+          # chart_values.global will have precedence over chart_values.gateway.global
+          global.yaml: |
+            global:
+              ${nr-var:chart_values.global | indent 2}
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -97,10 +94,11 @@ deployment:
             disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
-              name: default-values-${nr-sub:agent_id}
-              valuesKey: values.yaml
+              name: values-${nr-sub:agent_id}
+              valuesKey: default.yaml
             - kind: Secret
               name: values-${nr-sub:agent_id}
               valuesKey: values.yaml
-          values:
-            global: ${nr-var:chart_values.global}
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: global.yaml


### PR DESCRIPTION
Some of the current user defined values were being rendered inside the `values:` section of the `HelmRelease` which could print in plain text any secret expanded from envars using the `${nr-env:<SECRET>}` 

The goal of the PR is to move those values to Secrets that are referenced from the HelmRelease, the merging order keeps the same as it was. It also moves all values to a single secret with different entries.