### PR TITLE
fix(disableTakeOwnership): it does not exist for rollback

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -13,13 +13,13 @@ variables:
       description: "map of YAML configs for the OHIs"
       type: map[string]file
       required: false
-      default: {}
+      default: { }
       file_path: "integrations.d"
     config_logging:
       description: "map of YAML config for logging"
       type: map[string]file
       required: false
-      default: {}
+      default: { }
       file_path: "logging.d"
     backoff_delay:
       description: "seconds until next retry if agent fails to start"
@@ -42,27 +42,27 @@ variables:
         description: "newrelic-infrastructure chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       nri-metadata-injection:
         description: "nri-metadata-injection chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       kube-state-metrics:
         description: "kube-state-metrics chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       nri-kube-events:
         description: "nri-kube-events chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       global:
         description: "Global chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
     chart_version:
       description: "nri-bundle chart version"
       type: string
@@ -164,11 +164,10 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
-          - kind: Secret
-            name: default-values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+            - kind: Secret
+              name: default-values-${nr-sub:agent_id}
+              valuesKey: values.yaml
           values:
             newrelic-infrastructure: ${nr-var:chart_values.newrelic-infrastructure}
             nri-metadata-injection: ${nr-var:chart_values.nri-metadata-injection}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
         description: "Newrelic Kubernetes Agents Operator chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       global:
         description: "Global values for the chart"
         type: yaml
         required: false
-        default: {}
+        default: { }
     chart_version:
       description: "Newrelic Kubernetes Agents Operator chart version"
       type: string
@@ -94,13 +94,12 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
-          - kind: Secret
-            name: default-values-${nr-sub:agent_id}
-            valuesKey: values.yaml
-          - kind: Secret
-            name: values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+            - kind: Secret
+              name: default-values-${nr-sub:agent_id}
+              valuesKey: values.yaml
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: values.yaml
           values:
             global: ${nr-var:chart_values.global}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
         description: "Newrelic newrelic-prometheus-agent chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       global:
         description: "Global chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
     chart_version:
       description: "newrelic-prometheus chart version"
       type: string
@@ -94,13 +94,12 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
-          - kind: Secret
-            name: default-values-${nr-sub:agent_id}
-            valuesKey: values.yaml
-          - kind: Secret
-            name: values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+            - kind: Secret
+              name: default-values-${nr-sub:agent_id}
+              valuesKey: values.yaml
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: values.yaml
           values:
             ${nr-var:chart_values.global}

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -8,12 +8,12 @@ variables:
         description: "Newrelic newrelic-logging chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       global:
         description: "Global chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
     chart_version:
       description: "newrelic-logging chart version"
       type: string
@@ -94,13 +94,12 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
-          - kind: Secret
-            name: default-values-${nr-sub:agent_id}
-            valuesKey: values.yaml
-          - kind: Secret
-            name: values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+            - kind: Secret
+              name: default-values-${nr-sub:agent_id}
+              valuesKey: values.yaml
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: values.yaml
           values:
             global: ${nr-var:chart_values.global}

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -34,12 +34,12 @@ variables:
         description: "Newrelic otel collector chart values"
         type: yaml
         required: false
-        default: {}
+        default: { }
       global:
         description: "Global values for the chart"
         type: yaml
         required: false
-        default: {}
+        default: { }
     chart_version:
       description: "Newrelic otel collector chart version"
       type: string
@@ -65,7 +65,7 @@ deployment:
         backoff_strategy:
           type: fixed
           backoff_delay: ${nr-var:backoff_delay}
-        
+
   k8s:
     health:
       interval: 30s
@@ -142,13 +142,12 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
-          - kind: Secret
-            name: default-values-${nr-sub:agent_id}
-            valuesKey: values.yaml
-          - kind: Secret
-            name: values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+            - kind: Secret
+              name: default-values-${nr-sub:agent_id}
+              valuesKey: values.yaml
+            - kind: Secret
+              name: values-${nr-sub:agent_id}
+              valuesKey: values.yaml
           values:
             global: ${nr-var:chart_values.global}

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -95,7 +95,6 @@ deployment:
           rollback:
             disableWait: true
             disableWaitForJobs: true
-            disableTakeOwnership: true
           valuesFrom:
             - kind: Secret
               name: default-values-${nr-sub:agent_id}


### PR DESCRIPTION
# What this PR does 
 - Makes the indentation of the agentTypes more uniform
 - Removes disableTakeOwnership from the helmrelease.rollback 
```bash
 $ k explain helmrelease.spec.upgrade | grep disableTakeOwnership
  disableTakeOwnership  <boolean>
 $ k explain helmrelease.spec.install | grep disableTakeOwnership
  disableTakeOwnership  <boolean>
 $ k explain helmrelease.spec.rollback | grep disableTakeOwnership
```

## Which issue this PR fixes
This PR fixes the behaviour spotted by @rnoothi.
The AgentControl right now tries to reconcile the K8s object on a loop and it never succeeds since the object in the cluster discards `disableTakeOwnership` leading to the following behaviour:
```
DEBUG agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s object since it has changed [...]
DEBUG agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s object since it has changed [...]
DEBUG agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s object since it has changed [...]
DEBUG agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s object since it has changed [...]
DEBUG agent{id: nr-infra}:sub_thread{thread: "k8s objects supervisor"}: applying k8s object since it has changed [...]
```

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
