### PR TITLE
chore(deps): bump opentelemetry dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,9 +2981,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
+checksum = "e716f864eb23007bdd9dc4aec381e188a1cee28eecf22066772b5fd822b9727d"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -3008,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3022,11 +3022,10 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http 1.3.1",
  "opentelemetry",
@@ -3041,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3059,18 +3058,17 @@ checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
@@ -4678,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -65,12 +65,12 @@ webpki = { version = "0.22.4", features = ["alloc"] }
 x509-parser = "0.17.0"
 ring = "0.17.13"
 bytes = "1.10.1"
-opentelemetry = { version = "0.28.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.28.0", features = ["trace"] }
-tracing-opentelemetry = "0.29.0"
-opentelemetry-otlp = { version = "0.28.0", features = ["reqwest-rustls"] }
-opentelemetry-http = { version = "0.28.0" }
-opentelemetry-appender-tracing = { version = "0.28.1", features = [
+opentelemetry = { version = "0.29.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.29.0", features = ["trace"] }
+tracing-opentelemetry = "0.30.0"
+opentelemetry-otlp = { version = "0.29.0", features = ["reqwest-rustls"] }
+opentelemetry-http = { version = "0.29.0" }
+opentelemetry-appender-tracing = { version = "0.29.0", features = [
   "experimental_use_tracing_span_context",
 ] }
 async-trait = "0.1.86"

--- a/agent-control/src/instrumentation/tracing_layers/otel.rs
+++ b/agent-control/src/instrumentation/tracing_layers/otel.rs
@@ -2,12 +2,12 @@ use crate::http::client::{HttpBuildError, HttpClient};
 use crate::http::config::HttpConfig;
 use crate::instrumentation::config::otel::OtelConfig;
 use crate::instrumentation::tracing::LayerBox;
-use opentelemetry::trace::{TraceError, TracerProvider};
+use opentelemetry::trace::TracerProvider;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_http::HttpClient as OtelHttpClient;
-use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-use opentelemetry_sdk::logs::{BatchLogProcessor, LogError, SdkLoggerProvider};
-use opentelemetry_sdk::metrics::{MetricError, PeriodicReader, SdkMeterProvider};
+use opentelemetry_otlp::{ExporterBuildError, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use std::sync::LazyLock;
@@ -25,12 +25,8 @@ static RESOURCE: LazyLock<Resource> =
 pub enum OtelBuildError {
     #[error("could not build the otel http client: {0}")]
     HttpClient(#[from] HttpBuildError),
-    #[error("could not build traces exporter: {0}")]
-    Traces(#[from] TraceError),
-    #[error("could not build metrics exporter: {0}")]
-    Metrics(#[from] MetricError),
-    #[error("could not build logs exporter: {0}")]
-    Logs(#[from] LogError),
+    #[error("could not build the exporter: {0}")]
+    ExporterBuild(#[from] ExporterBuildError),
     #[error("invalid filtering directive `{directive}`: {err}")]
     FilteringDirective { directive: String, err: String },
 }


### PR DESCRIPTION
# What this PR does / why we need it

It bumps OpenTelemetry dependencies and takes care of the corresponding breaking changes. Once it is merged #1205 and #1208 can be closed.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.