### PR TITLE
fix: remove `Serialize` impls

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use url::Url;
 
 /// AgentControlConfig represents the configuration for the agent control.
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
 pub struct AgentControlConfig {
     #[serde(default)]
     pub log: LoggingConfig,
@@ -120,16 +120,14 @@ pub struct SubAgentConfig {
     pub agent_type: AgentTypeID,
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct OpAMPClientConfig {
     pub endpoint: Url,
-    #[serde(with = "http_serde::header_map")]
     pub headers: HeaderMap,
     pub auth_config: Option<AuthConfig>,
     /// Unique identifier for the fleet in which the super agent will join upon initialization.
     pub fleet_id: String,
     /// Contains the signature_validation configuration
-    #[serde(default)]
     pub signature_validation: SignatureValidatorConfig,
 }
 

--- a/agent-control/src/agent_control/http_server/config.rs
+++ b/agent-control/src/agent_control/http_server/config.rs
@@ -1,16 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 
 const DEFAULT_PORT: u16 = 51200;
 pub(super) const DEFAULT_WORKERS: usize = 1;
 const DEFAULT_HOST: &str = "127.0.0.1";
 
-#[derive(PartialEq, Deserialize, Serialize, Debug, Clone)]
+#[derive(PartialEq, Deserialize, Debug, Clone)]
 pub struct Port(u16);
-#[derive(PartialEq, Deserialize, Serialize, Debug, Clone)]
+#[derive(PartialEq, Deserialize, Debug, Clone)]
 pub struct Host(String);
 
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(PartialEq, Deserialize, Clone, Debug, Default)]
 pub struct ServerConfig {
     #[serde(default)]
     pub port: Port,

--- a/agent-control/src/agent_control/uptime_report.rs
+++ b/agent-control/src/agent_control/uptime_report.rs
@@ -25,7 +25,7 @@
 
 use crossbeam::channel::{never, tick, Receiver};
 use duration_str::deserialize_duration;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::time::{Duration, Instant, SystemTime, SystemTimeError};
 use tracing::trace;
 use wrapper_with_default::WrapperWithDefault;
@@ -34,7 +34,7 @@ use wrapper_with_default::WrapperWithDefault;
 const DEFAULT_UPTIME_REPORT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Default configuration for uptime reporting. Enabled by default.
-#[derive(Debug, Default, Serialize, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 pub struct UptimeReportConfig {
     /// Whether uptime reporting is enabled or not.
     #[serde(default)]
@@ -59,7 +59,7 @@ impl UptimeReportConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 struct EnabledByDefault(bool);
 impl Default for EnabledByDefault {
     fn default() -> Self {
@@ -75,7 +75,7 @@ impl From<bool> for EnabledByDefault {
 
 /// Wrapper for the uptime report interval. This is a duration in seconds that is fixed to
 /// 60 seconds via [`DEFAULT_UPTIME_REPORT_INTERVAL`].
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_UPTIME_REPORT_INTERVAL)]
 pub struct UptimeReportInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 

--- a/agent-control/src/http/config.rs
+++ b/agent-control/src/http/config.rs
@@ -112,7 +112,7 @@ impl ProxyUrl {
 /// // The url will contain the value corresponding to the standard environment variables.
 /// let proxy_config = ProxyConfig::default().try_with_url_from_env().unwrap();
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
 pub struct ProxyConfig {
     /// Proxy URL proxy:
     /// <protocol>://<user>:<password>@<host>:<port>

--- a/agent-control/src/instrumentation/config.rs
+++ b/agent-control/src/instrumentation/config.rs
@@ -8,7 +8,7 @@
 //! ```
 
 use crate::http::config::ProxyConfig;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub mod logs;
 pub mod otel;
@@ -16,7 +16,7 @@ pub mod otel;
 /// Represents the the configuration for instrumenting the application.
 /// It does not include _regular logs_ configuration, which are directly configured through the [logs]
 /// module, but it can also report logs with a different set of filtering and exporters.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
 pub struct InstrumentationConfig {
     pub(crate) opentelemetry: Option<otel::OtelConfig>,
 }

--- a/agent-control/src/instrumentation/config/logs/config.rs
+++ b/agent-control/src/instrumentation/config/logs/config.rs
@@ -29,7 +29,7 @@ pub enum LoggingConfigError {
 }
 
 /// Defines the logging configuration Agent control.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
 pub struct LoggingConfig {
     /// Allows setting up custom formatting options.
     #[serde(default)]

--- a/agent-control/src/instrumentation/config/logs/file_logging.rs
+++ b/agent-control/src/instrumentation/config/logs/file_logging.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
 pub(crate) struct FileLoggingConfig {
     pub(crate) enabled: bool,
     // Default value is being set by `ConfigPatcher` right after deserialization.

--- a/agent-control/src/instrumentation/config/logs/format.rs
+++ b/agent-control/src/instrumentation/config/logs/format.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// Represents a custom time stamp format for logging.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub(crate) struct TimestampFormat(pub(crate) String);
 
 /// Provides a default `TimestampFormat`. The default format is based on
@@ -21,7 +21,7 @@ impl Default for TimestampFormat {
 /// - `target`: A bool that indicates whether or not the target of the trace event will be included in the formatted output.
 /// - `timestamp`: Specifies a `TimestampFormat` the application will use for logging timestamps.
 /// - `ansi_colors`: Specifies if ansi colors should be used in stdout logs.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
 pub struct LoggingFormat {
     #[serde(default)]
     pub(crate) target: bool,

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -27,7 +27,7 @@ const METRICS_SUFFIX: &str = "/v1/metrics";
 const LOGS_SUFFIX: &str = "/v1/logs";
 
 /// Represents the OpenTelemetry configuration
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct OtelConfig {
     /// Metrics configuration
     #[serde(default)]

--- a/agent-control/src/opamp/auth/config.rs
+++ b/agent-control/src/opamp/auth/config.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use nr_auth::ClientID;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use url::Url;
 
 use crate::agent_control::defaults::AUTH_PRIVATE_KEY_FILE_NAME;
 
 /// Authorization configuration used by the OpAmp connection to NewRelic.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct AuthConfig {
     /// Endpoint to obtain the access token presenting the client id and secret.
     pub token_url: Url,
@@ -25,7 +25,7 @@ pub struct AuthConfig {
 }
 
 /// Supported access token request signers methods
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(tag = "provider")]
 pub enum ProviderConfig {
     #[serde(rename = "local")]
@@ -33,7 +33,7 @@ pub enum ProviderConfig {
 }
 
 /// Uses a local private key to sign the access token request.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct LocalConfig {
     /// Private key absolute path.
     pub private_key_path: PathBuf,

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -7,7 +7,7 @@ use crate::opamp::remote_config::validators::RemoteConfigValidator;
 use crate::opamp::remote_config::RemoteConfig;
 use crate::sub_agent::identity::AgentIdentity;
 use nix::NixPath;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::path::PathBuf;
 use std::time::Duration;
 use thiserror::Error;
@@ -80,7 +80,7 @@ pub fn build_signature_validator(
     ))
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct SignatureValidatorConfig {
     #[serde(default = "default_signature_validator_url")]
     pub certificate_server_url: Url,
@@ -102,7 +102,7 @@ impl Default for SignatureValidatorConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct SignatureCertificateServerUrl(Url);
 
 impl From<SignatureCertificateServerUrl> for Url {


### PR DESCRIPTION
# What this PR does / why we need it

Noticed that the AC config structures implemented `Serialize` without a reason. Perhaps it was needed in the past but not anymore, maybe for persisting?

The thing is this is not used anymore and I don't think this will work on "serde round-trips" when **durations** are present, so if we assume things carelessly about it we might find program crashes:

1. Deserialize a YAML config string or file with `Duration` in it into an `AgentControlConfig`.
2. Serialize the `AgentControlConfig` into a YAML string or file.
3. Deserialize this new YAML string or file again.

When we deserialize a `Duration` we treat the input as a string (`"1m"`, `"30s"`) and convert it using helper functions, but the serialization of the `Duration` will have this format:

```yaml
some_duration:
  secs: 30
  nanos: 0
```

So this is no longer the `"30s"` we expect, any attempts at deserializing this back into an `AgentControlConfig` will fail.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
