### PR TITLE
refactor: remove dependencies from remote config handler

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -140,11 +140,7 @@ impl AgentControlRunner {
             )),
         ];
 
-        let remote_config_handler = AgentRemoteConfigHandler::new(
-            remote_config_validators,
-            hash_repository.clone(),
-            yaml_config_repository.clone(),
-        );
+        let remote_config_handler = AgentRemoteConfigHandler::new(remote_config_validators);
 
         info!("Creating the k8s sub_agent builder");
         let sub_agent_builder = K8sSubAgentBuilder::new(
@@ -153,6 +149,8 @@ impl AgentControlRunner {
             self.k8s_config.clone(),
             Arc::new(supervisor_assembler),
             Arc::new(remote_config_handler),
+            hash_repository.clone(),
+            yaml_config_repository.clone(),
         );
 
         let gcc = NotStartedK8sGarbageCollector::new(

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -170,17 +170,15 @@ impl AgentControlRunner {
                 Environment::OnHost,
             )),
         ];
-        let remote_config_handler = AgentRemoteConfigHandler::new(
-            remote_config_validators,
-            sub_agent_hash_repository,
-            yaml_config_repository.clone(),
-        );
+        let remote_config_handler = AgentRemoteConfigHandler::new(remote_config_validators);
 
         let sub_agent_builder = OnHostSubAgentBuilder::new(
             opamp_client_builder.as_ref(),
             &instance_id_getter,
             Arc::new(supervisor_assembler),
             Arc::new(remote_config_handler),
+            sub_agent_hash_repository,
+            yaml_config_repository,
         );
 
         let dynamic_config_validator =

--- a/agent-control/src/opamp/remote_config/validators.rs
+++ b/agent-control/src/opamp/remote_config/validators.rs
@@ -60,7 +60,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use mockall::mock;
+    use mockall::{mock, predicate};
 
     mock! {
         pub RemoteConfigValidatorMock {}
@@ -73,6 +73,23 @@ pub mod tests {
                 agent_identity: &AgentIdentity,
                 remote_config: &RemoteConfig,
             ) -> Result<(), <Self as RemoteConfigValidator>::Err>;
+        }
+    }
+
+    impl MockRemoteConfigValidatorMock {
+        pub fn should_validate(
+            &mut self,
+            agent_identity: &AgentIdentity,
+            remote_config: &RemoteConfig,
+            result: Result<(), <Self as RemoteConfigValidator>::Err>,
+        ) {
+            self.expect_validate()
+                .once()
+                .with(
+                    predicate::eq(agent_identity.clone()),
+                    predicate::eq(remote_config.clone()),
+                )
+                .return_once(move |_, _| result);
         }
     }
 }

--- a/agent-control/src/sub_agent/error.rs
+++ b/agent-control/src/sub_agent/error.rs
@@ -2,9 +2,6 @@ use super::effective_agents_assembler::EffectiveAgentsAssemblerError;
 use crate::event::channel::EventPublisherError;
 use crate::opamp::client_builder::OpAMPClientBuilderError;
 use crate::opamp::hash_repository::repository::HashRepositoryError;
-use crate::opamp::remote_config::validators::SupportedRemoteConfigValidatorError;
-use crate::opamp::remote_config::RemoteConfigError;
-use crate::values::yaml_config::YAMLConfigError;
 use crate::values::yaml_config_repository::YAMLConfigRepositoryError;
 use opamp_client::StartedClientError;
 use opamp_client::{ClientError, NotStartedClientError};
@@ -25,19 +22,12 @@ pub enum SubAgentError {
     NotStartedOpampClientError(#[from] NotStartedClientError),
     #[error("remote config hash error: `{0}`")]
     RemoteConfigHashError(#[from] HashRepositoryError),
-
     #[error("config assembler error: `{0}`")]
     ConfigAssemblerError(#[from] EffectiveAgentsAssemblerError),
     #[error("sub agent yaml config repository error: `{0}`")]
     YAMLConfigRepositoryError(#[from] YAMLConfigRepositoryError),
-    #[error("sub agent values error: `{0}`")]
-    ValuesUnserializeError(#[from] YAMLConfigError),
-    #[error("remote config error: `{0}`")]
-    RemoteConfigError(#[from] RemoteConfigError),
     #[error("Error publishing event: `{0}`")]
     EventPublisherError(#[from] EventPublisherError),
-    #[error("ConfigValidator error: `{0}`")]
-    ConfigValidatorError(#[from] SupportedRemoteConfigValidatorError),
 }
 
 #[derive(Error, Debug)]

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -245,6 +245,7 @@ pub mod tests {
     use crate::sub_agent::k8s::builder::tests::k8s_sample_runtime_config;
     use crate::sub_agent::supervisor::assembler::tests::MockSupervisorAssemblerMock;
     use crate::sub_agent::{NotStartedSubAgent, SubAgent};
+    use crate::values::yaml_config_repository::tests::MockYAMLConfigRepositoryMock;
     use assert_matches::assert_matches;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
     use k8s_openapi::serde_json;
@@ -504,6 +505,7 @@ pub mod tests {
             .with(predicate::eq(agent_identity.id.clone()))
             .return_const(Ok(None));
 
+        let yaml_config_repository = MockYAMLConfigRepositoryMock::new();
         let remote_config_handler = MockRemoteConfigHandlerMock::new();
 
         let agent_identity_clone = agent_identity.clone();
@@ -530,6 +532,8 @@ pub mod tests {
                 sub_agent_internal_consumer,
             ),
             Arc::new(remote_config_handler),
+            Arc::new(sub_agent_remote_config_hash_repository),
+            Arc::new(yaml_config_repository),
         )
         .run();
 

--- a/agent-control/src/values/yaml_config_repository.rs
+++ b/agent-control/src/values/yaml_config_repository.rs
@@ -107,5 +107,15 @@ pub mod tests {
                     ))
                 });
         }
+
+        pub fn should_store_remote(&mut self, agent_id: &AgentID, yaml_config: &YAMLConfig) {
+            self.expect_store_remote()
+                .once()
+                .with(
+                    predicate::eq(agent_id.clone()),
+                    predicate::eq(yaml_config.clone()),
+                )
+                .returning(|_, _| Ok(()));
+        }
     }
 }


### PR DESCRIPTION
# What this PR does / why we need it

This PR remove the dependencies to the OpAMP Client and to the persistence repositories (hash and yaml) from the RemoteConfigHandler.

The remote config handler used to have many responsibilities:
- Load the remote config values and hash
- Check if there where previous errors stored in the remote-config hash
- Perform validations
- Store the configuration or report and store any failure

Now the RemoteConfigHandler:
- Loads the configuration
- Perform validations (including previous errors stored in the hash)
- Returns a YamlConfiguration or an error

Therefore, the sub-agent stores the returned configuration or stores and report the error if the configuration wasn't valid.

## Which issue this PR fixes

[NR-402698](https://new-relic.atlassian.net/browse/NR-402698) (internal link)

## Special notes for your reviewer

- The sub-agent has more dependencies because it needs to be aware of the hash and yaml repositories.
  - As a result, the sub-agent "unit" tests have two additional mocks back.
- The current sub-agent code is a bit more convoluted, but this should get better when we simplify (or remove) the supervisor-assembler.
- The RemoteConfigHandler implementation now have unit-tests of its own.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../docs/style/logs.md)


[NR-402698]: https://new-relic.atlassian.net/browse/NR-402698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ