### PR TITLE
chore: fix pr template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,5 @@
 - [ ] Provided a meaningful title following conventional commit style.
 - [ ] Included a detailed description for the Pull Request.
 - [ ] Documentation under `docs` is aligned with the change.
-- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
-- [ ] Follows [`log level guidelines`](../docs/style/logs.md)
+- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
+- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).


### PR DESCRIPTION
# What this PR does / why we need it

Fix PR template links to the documentation. 

Relative links don't seem to work. Check this [stackoverflow](https://stackoverflow.com/questions/49242645/github-relative-internal-repository-links-in-pull-request-template-md). I couldn't manage to make it work, so I decided to point to the documentation in the main branch.

```
- [ ] Some [`link`](../blob/main/doc.md)
```

I modified the links on this PR so that you can see how it works. You can also see the wrong behaviour by clicking the links on any other PR.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).