### PR TITLE
chore: rename remote-config-handler to remote-config-parser

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -19,9 +19,9 @@ use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::opamp::remote_config::validators::values::ValuesValidator;
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
-use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::k8s::builder::SupervisorBuilderK8s;
+use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
 use crate::sub_agent::supervisor::assembler::AgentSupervisorAssembler;
 use crate::{
     agent_control::error::AgentError,
@@ -140,7 +140,7 @@ impl AgentControlRunner {
             )),
         ];
 
-        let remote_config_handler = AgentRemoteConfigHandler::new(remote_config_validators);
+        let remote_config_parser = AgentRemoteConfigParser::new(remote_config_validators);
 
         info!("Creating the k8s sub_agent builder");
         let sub_agent_builder = K8sSubAgentBuilder::new(
@@ -148,7 +148,7 @@ impl AgentControlRunner {
             &instance_id_getter,
             self.k8s_config.clone(),
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             hash_repository.clone(),
             yaml_config_repository.clone(),
         );

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -21,9 +21,9 @@ use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::opamp::remote_config::validators::values::ValuesValidator;
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
-use crate::sub_agent::event_handler::opamp::remote_config_handler::AgentRemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::builder::SupervisortBuilderOnHost;
+use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
 use crate::sub_agent::supervisor::assembler::AgentSupervisorAssembler;
 use crate::{agent_control::error::AgentError, opamp::client_builder::DefaultOpAMPClientBuilder};
 use crate::{
@@ -170,13 +170,13 @@ impl AgentControlRunner {
                 Environment::OnHost,
             )),
         ];
-        let remote_config_handler = AgentRemoteConfigHandler::new(remote_config_validators);
+        let remote_config_parser = AgentRemoteConfigParser::new(remote_config_validators);
 
         let sub_agent_builder = OnHostSubAgentBuilder::new(
             opamp_client_builder.as_ref(),
             &instance_id_getter,
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             sub_agent_hash_repository,
             yaml_config_repository,
         );

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -2,6 +2,7 @@ pub mod collection;
 pub mod effective_agents_assembler;
 pub mod error;
 pub mod health;
+pub mod remote_config_parser;
 
 pub mod k8s;
 

--- a/agent-control/src/sub_agent/event_handler.rs
+++ b/agent-control/src/sub_agent/event_handler.rs
@@ -1,3 +1,2 @@
 pub mod on_health;
 pub mod on_version;
-pub mod opamp;

--- a/agent-control/src/sub_agent/event_handler/opamp.rs
+++ b/agent-control/src/sub_agent/event_handler/opamp.rs
@@ -1,1 +1,0 @@
-pub mod remote_config_handler;

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -8,8 +8,8 @@ use crate::opamp::hash_repository::HashRepository;
 use crate::opamp::instance_id::getter::InstanceIDGetter;
 use crate::opamp::operations::build_sub_agent_opamp;
 use crate::sub_agent::effective_agents_assembler::EffectiveAgent;
-use crate::sub_agent::event_handler::opamp::remote_config_handler::RemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
+use crate::sub_agent::remote_config_parser::RemoteConfigParser;
 use crate::sub_agent::supervisor::assembler::SupervisorAssembler;
 use crate::sub_agent::supervisor::builder::SupervisorBuilder;
 use crate::sub_agent::SubAgent;
@@ -29,7 +29,7 @@ where
     O: OpAMPClientBuilder,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
@@ -37,7 +37,7 @@ where
     instance_id_getter: &'a I,
     k8s_config: K8sConfig,
     supervisor_assembler: Arc<SA>,
-    remote_config_handler: Arc<R>,
+    remote_config_parser: Arc<R>,
     hash_repository: Arc<H>,
     yaml_config_repository: Arc<Y>,
 }
@@ -47,7 +47,7 @@ where
     O: OpAMPClientBuilder,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
@@ -58,7 +58,7 @@ where
         instance_id_getter: &'a I,
         k8s_config: K8sConfig,
         supervisor_assembler: Arc<SA>,
-        remote_config_handler: Arc<R>,
+        remote_config_parser: Arc<R>,
         hash_repository: Arc<H>,
         yaml_config_repository: Arc<Y>,
     ) -> Self {
@@ -67,7 +67,7 @@ where
             instance_id_getter,
             k8s_config,
             supervisor_assembler,
-            remote_config_handler,
+            remote_config_parser,
             hash_repository,
             yaml_config_repository,
         }
@@ -79,7 +79,7 @@ where
     O: OpAMPClientBuilder + Send + Sync + 'static,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
@@ -122,7 +122,7 @@ where
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             pub_sub(),
-            self.remote_config_handler.clone(),
+            self.remote_config_parser.clone(),
             self.hash_repository.clone(),
             self.yaml_config_repository.clone(),
         ))
@@ -199,7 +199,7 @@ pub mod tests {
     use crate::opamp::instance_id::getter::tests::MockInstanceIDGetterMock;
     use crate::opamp::instance_id::InstanceID;
     use crate::opamp::operations::start_settings;
-    use crate::sub_agent::event_handler::opamp::remote_config_handler::tests::MockRemoteConfigHandlerMock;
+    use crate::sub_agent::remote_config_parser::tests::MockRemoteConfigParserMock;
     use crate::sub_agent::supervisor::assembler::tests::MockSupervisorAssemblerMock;
     use crate::sub_agent::supervisor::starter::tests::MockSupervisorStarter;
     use crate::values::yaml_config_repository::tests::MockYAMLConfigRepositoryMock;
@@ -233,14 +233,14 @@ pub mod tests {
         };
 
         let supervisor_assembler = MockSupervisorAssemblerMock::<MockSupervisorStarter>::new();
-        let remote_config_handler = MockRemoteConfigHandlerMock::new();
+        let remote_config_parser = MockRemoteConfigParserMock::new();
 
         let builder = K8sSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
             k8s_config,
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             Arc::new(MockHashRepositoryMock::new()),
             Arc::new(MockYAMLConfigRepositoryMock::new()),
         );
@@ -269,14 +269,14 @@ pub mod tests {
         };
 
         let supervisor_assembler = MockSupervisorAssemblerMock::<MockSupervisorStarter>::new();
-        let remote_config_handler = MockRemoteConfigHandlerMock::new();
+        let remote_config_parser = MockRemoteConfigParserMock::new();
 
         let builder = K8sSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
             k8s_config,
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             Arc::new(MockHashRepositoryMock::new()),
             Arc::new(MockYAMLConfigRepositoryMock::new()),
         );

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -241,8 +241,8 @@ pub mod tests {
     use crate::k8s::labels::AGENT_ID_LABEL_KEY;
     use crate::opamp::client_builder::tests::MockStartedOpAMPClientMock;
     use crate::opamp::hash_repository::repository::tests::MockHashRepositoryMock;
-    use crate::sub_agent::event_handler::opamp::remote_config_handler::tests::MockRemoteConfigHandlerMock;
     use crate::sub_agent::k8s::builder::tests::k8s_sample_runtime_config;
+    use crate::sub_agent::remote_config_parser::tests::MockRemoteConfigParserMock;
     use crate::sub_agent::supervisor::assembler::tests::MockSupervisorAssemblerMock;
     use crate::sub_agent::{NotStartedSubAgent, SubAgent};
     use crate::values::yaml_config_repository::tests::MockYAMLConfigRepositoryMock;
@@ -506,7 +506,7 @@ pub mod tests {
             .return_const(Ok(None));
 
         let yaml_config_repository = MockYAMLConfigRepositoryMock::new();
-        let remote_config_handler = MockRemoteConfigHandlerMock::new();
+        let remote_config_parser = MockRemoteConfigParserMock::new();
 
         let agent_identity_clone = agent_identity.clone();
         let mut supervisor_assembler = MockSupervisorAssemblerMock::new();
@@ -531,7 +531,7 @@ pub mod tests {
                 sub_agent_internal_publisher.clone(),
                 sub_agent_internal_consumer,
             ),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             Arc::new(sub_agent_remote_config_hash_repository),
             Arc::new(yaml_config_repository),
         )

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -6,10 +6,10 @@ use crate::opamp::hash_repository::HashRepository;
 use crate::opamp::instance_id::getter::InstanceIDGetter;
 use crate::opamp::operations::build_sub_agent_opamp;
 use crate::sub_agent::effective_agents_assembler::EffectiveAgent;
-use crate::sub_agent::event_handler::opamp::remote_config_handler::RemoteConfigHandler;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
 use crate::sub_agent::on_host::supervisor::NotStartedSupervisorOnHost;
+use crate::sub_agent::remote_config_parser::RemoteConfigParser;
 use crate::sub_agent::supervisor::assembler::SupervisorAssembler;
 use crate::sub_agent::supervisor::builder::SupervisorBuilder;
 use crate::sub_agent::SubAgent;
@@ -30,14 +30,14 @@ where
     O: OpAMPClientBuilder,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
     opamp_builder: Option<&'a O>,
     instance_id_getter: &'a I,
     supervisor_assembler: Arc<SA>,
-    remote_config_handler: Arc<R>,
+    remote_config_parser: Arc<R>,
     hash_repository: Arc<H>,
     yaml_config_repository: Arc<Y>,
 }
@@ -47,7 +47,7 @@ where
     O: OpAMPClientBuilder,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
@@ -55,7 +55,7 @@ where
         opamp_builder: Option<&'a O>,
         instance_id_getter: &'a I,
         supervisor_assembler: Arc<SA>,
-        remote_config_handler: Arc<R>,
+        remote_config_parser: Arc<R>,
         hash_repository: Arc<H>,
         yaml_config_repository: Arc<Y>,
     ) -> Self {
@@ -63,7 +63,7 @@ where
             opamp_builder,
             instance_id_getter,
             supervisor_assembler,
-            remote_config_handler,
+            remote_config_parser,
             hash_repository,
             yaml_config_repository,
         }
@@ -75,7 +75,7 @@ where
     O: OpAMPClientBuilder + Send + Sync + 'static,
     I: InstanceIDGetter,
     SA: SupervisorAssembler + Send + Sync + 'static,
-    R: RemoteConfigHandler + Send + Sync + 'static,
+    R: RemoteConfigParser + Send + Sync + 'static,
     H: HashRepository + Send + Sync + 'static,
     Y: YAMLConfigRepository + Send + Sync + 'static,
 {
@@ -115,7 +115,7 @@ where
             sub_agent_publisher,
             sub_agent_opamp_consumer,
             pub_sub(),
-            self.remote_config_handler.clone(),
+            self.remote_config_parser.clone(),
             self.hash_repository.clone(),
             self.yaml_config_repository.clone(),
         ))
@@ -191,7 +191,7 @@ mod tests {
     use crate::opamp::hash_repository::repository::tests::MockHashRepositoryMock;
     use crate::opamp::instance_id::getter::tests::MockInstanceIDGetterMock;
     use crate::opamp::instance_id::InstanceID;
-    use crate::sub_agent::event_handler::opamp::remote_config_handler::tests::MockRemoteConfigHandlerMock;
+    use crate::sub_agent::remote_config_parser::tests::MockRemoteConfigParserMock;
     use crate::sub_agent::supervisor::assembler::tests::MockSupervisorAssemblerMock;
     use crate::sub_agent::supervisor::starter::tests::MockSupervisorStarter;
     use crate::sub_agent::supervisor::stopper::tests::MockSupervisorStopper;
@@ -259,13 +259,13 @@ mod tests {
             agent_identity.clone(),
         );
 
-        let remote_config_handler = MockRemoteConfigHandlerMock::new();
+        let remote_config_parser = MockRemoteConfigParserMock::new();
 
         let on_host_builder = OnHostSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             Arc::new(MockHashRepositoryMock::new()),
             Arc::new(MockYAMLConfigRepositoryMock::new()),
         );
@@ -335,14 +335,14 @@ mod tests {
             agent_identity.clone(),
         );
 
-        let remote_config_handler = MockRemoteConfigHandlerMock::new();
+        let remote_config_parser = MockRemoteConfigParserMock::new();
 
         // Sub Agent Builder
         let on_host_builder = OnHostSubAgentBuilder::new(
             Some(&opamp_builder),
             &instance_id_getter,
             Arc::new(supervisor_assembler),
-            Arc::new(remote_config_handler),
+            Arc::new(remote_config_parser),
             Arc::new(MockHashRepositoryMock::new()),
             Arc::new(MockYAMLConfigRepositoryMock::new()),
         );

--- a/agent-control/src/sub_agent/remote_config_parser.rs
+++ b/agent-control/src/sub_agent/remote_config_parser.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error};
 type ErrorMessage = String;
 
 #[derive(Debug, Error)]
-pub enum RemoteConfigHandlerError {
+pub enum RemoteConfigParserError {
     #[error("remote configuration with validation errors: {0}")]
     Validation(ErrorMessage),
     #[error("remote configuration cannot be loaded: {0}")]
@@ -17,45 +17,45 @@ pub enum RemoteConfigHandlerError {
     InvalidValues(String),
 }
 
-/// Defines how to validate and process a remote configuration and obtain the corresponding yaml configuration.
-pub trait RemoteConfigHandler {
-    fn handle(
+/// Defines how to parse the remote configuration in order to validate it and extract the corresponding values as [YAMLConfig].
+pub trait RemoteConfigParser {
+    fn parse(
         &self,
         agent_identity: AgentIdentity,
         config: &RemoteConfig,
-    ) -> Result<Option<YAMLConfig>, RemoteConfigHandlerError>;
+    ) -> Result<Option<YAMLConfig>, RemoteConfigParserError>;
 }
 
-pub struct AgentRemoteConfigHandler<V> {
+pub struct AgentRemoteConfigParser<V> {
     remote_config_validators: Vec<V>,
 }
 
-impl<V> AgentRemoteConfigHandler<V>
+impl<V> AgentRemoteConfigParser<V>
 where
     V: RemoteConfigValidator,
 {
     pub fn new(remote_config_validators: Vec<V>) -> Self {
-        AgentRemoteConfigHandler {
+        AgentRemoteConfigParser {
             remote_config_validators,
         }
     }
 }
 
-impl<V> RemoteConfigHandler for AgentRemoteConfigHandler<V>
+impl<V> RemoteConfigParser for AgentRemoteConfigParser<V>
 where
     V: RemoteConfigValidator,
 {
     /// Handles the remote configuration received by the OpAMP client and returns the corresponding yaml configuration
     /// or an error if the configuration is invalid according to the configured validators.
-    fn handle(
+    fn parse(
         &self,
         agent_identity: AgentIdentity,
         config: &RemoteConfig,
-    ) -> Result<Option<YAMLConfig>, RemoteConfigHandlerError> {
+    ) -> Result<Option<YAMLConfig>, RemoteConfigParserError> {
         // Errors here will cause the sub-agent to continue running with the previous configuration.
         // The supervisor won't be recreated.
         if let Some(err_msg) = config.hash.error_message() {
-            return Err(RemoteConfigHandlerError::RemoteConfigLoad(err_msg));
+            return Err(RemoteConfigParserError::RemoteConfigLoad(err_msg));
         }
         for validator in &self.remote_config_validators {
             if let Err(error_msg) = validator.validate(&agent_identity, config) {
@@ -63,7 +63,7 @@ where
                     hash = &config.hash.get(),
                     "Invalid remote configuration: {error_msg}"
                 );
-                return Err(RemoteConfigHandlerError::Validation(error_msg.to_string()));
+                return Err(RemoteConfigParserError::Validation(error_msg.to_string()));
             }
         }
         extract_remote_config_values(config)
@@ -73,9 +73,9 @@ where
 /// Extracts the remote configuration values and parses them to [YAMLConfig], if the values are empty it returns None.
 fn extract_remote_config_values(
     remote_config: &RemoteConfig,
-) -> Result<Option<YAMLConfig>, RemoteConfigHandlerError> {
+) -> Result<Option<YAMLConfig>, RemoteConfigParserError> {
     let remote_config_value = remote_config.get_unique().map_err(|err| {
-        RemoteConfigHandlerError::InvalidValues(format!(
+        RemoteConfigParserError::InvalidValues(format!(
             "could not load remote configuration values: {err}"
         ))
     })?;
@@ -85,7 +85,7 @@ fn extract_remote_config_values(
     }
 
     let yaml_config = YAMLConfig::try_from(remote_config_value.to_string())
-        .map_err(|err| RemoteConfigHandlerError::InvalidValues(err.to_string()))?;
+        .map_err(|err| RemoteConfigParserError::InvalidValues(err.to_string()))?;
 
     Ok(Some(yaml_config))
 }
@@ -94,7 +94,7 @@ fn extract_remote_config_values(
 pub mod tests {
     use std::collections::HashMap;
 
-    use super::{AgentRemoteConfigHandler, RemoteConfigHandler, RemoteConfigHandlerError};
+    use super::{AgentRemoteConfigParser, RemoteConfigParser, RemoteConfigParserError};
     use crate::opamp::remote_config::hash::Hash;
     use crate::opamp::remote_config::validators::tests::MockRemoteConfigValidatorMock;
     use crate::opamp::remote_config::{ConfigurationMap, RemoteConfig};
@@ -107,25 +107,25 @@ pub mod tests {
     use rstest::rstest;
 
     mock! {
-        pub RemoteConfigHandlerMock {}
+        pub RemoteConfigParserMock {}
 
-        impl RemoteConfigHandler for RemoteConfigHandlerMock{
-            fn handle(
+        impl RemoteConfigParser for RemoteConfigParserMock{
+            fn parse(
                 &self,
                 agent_identity: AgentIdentity,
                 config: &RemoteConfig
-            ) -> Result<Option<YAMLConfig>, RemoteConfigHandlerError>;
+            ) -> Result<Option<YAMLConfig>, RemoteConfigParserError>;
         }
     }
 
-    impl MockRemoteConfigHandlerMock {
-        pub fn should_handle(
+    impl MockRemoteConfigParserMock {
+        pub fn should_parse(
             &mut self,
             agent_identity: AgentIdentity,
             config: RemoteConfig,
             yaml_config: Option<YAMLConfig>,
         ) {
-            self.expect_handle()
+            self.expect_parse()
                 .once()
                 .with(predicate::eq(agent_identity), predicate::eq(config))
                 .return_once(|_, _| Ok(yaml_config));
@@ -133,7 +133,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_agent_remote_config_handler_config_with_previous_errors() {
+    fn test_agent_remote_config_parser_config_with_previous_errors() {
         let agent_identity = test_agent_identity();
         // The hash had some previous errors
         let hash = Hash::failed("some-hash".into(), "some error".into());
@@ -143,15 +143,15 @@ pub mod tests {
             Some(ConfigurationMap::default()),
         );
 
-        let handler = AgentRemoteConfigHandler::<MockRemoteConfigValidatorMock>::new(Vec::new());
-        let result = handler.handle(agent_identity, &remote_config);
-        assert_matches!(result, Err(RemoteConfigHandlerError::RemoteConfigLoad(s)) => {
+        let handler = AgentRemoteConfigParser::<MockRemoteConfigValidatorMock>::new(Vec::new());
+        let result = handler.parse(agent_identity, &remote_config);
+        assert_matches!(result, Err(RemoteConfigParserError::RemoteConfigLoad(s)) => {
             assert_eq!(s, "some error".to_string());
         });
     }
 
     #[test]
-    fn test_agent_remote_config_handler_config_validation_error() {
+    fn test_agent_remote_config_parser_config_validation_error() {
         let agent_identity = test_agent_identity();
 
         let hash = Hash::new("some-hash".into());
@@ -173,10 +173,10 @@ pub mod tests {
         );
         validator3.expect_validate().never();
 
-        let handler = AgentRemoteConfigHandler::new(vec![validator1, validator2, validator3]);
+        let handler = AgentRemoteConfigParser::new(vec![validator1, validator2, validator3]);
 
-        let result = handler.handle(agent_identity.clone(), &remote_config);
-        assert_matches!(result, Err(RemoteConfigHandlerError::Validation(s)) => {
+        let result = handler.parse(agent_identity.clone(), &remote_config);
+        assert_matches!(result, Err(RemoteConfigParserError::Validation(s)) => {
             assert_eq!(s, "validation2 error".to_string());
         });
     }
@@ -187,7 +187,7 @@ pub mod tests {
     )]
     #[case::invalid_yaml_config_single_value(r#"{"config": "single-value"}"#)]
     #[case::invalid_yaml_config_array(r#"{"config": "[1, 2, 3]"}"#)]
-    fn test_agent_remote_config_handler_config_invalid_values(#[case] config: &str) {
+    fn test_agent_remote_config_parser_config_invalid_values(#[case] config: &str) {
         let agent_identity = test_agent_identity();
 
         let hash = Hash::new("some-hash".into());
@@ -195,14 +195,14 @@ pub mod tests {
             ConfigurationMap::new(serde_json::from_str::<HashMap<String, String>>(config).unwrap());
         let remote_config = RemoteConfig::new(agent_identity.id.clone(), hash, Some(config_map));
 
-        let handler = AgentRemoteConfigHandler::<MockRemoteConfigValidatorMock>::new(Vec::new());
+        let handler = AgentRemoteConfigParser::<MockRemoteConfigValidatorMock>::new(Vec::new());
 
-        let result = handler.handle(agent_identity.clone(), &remote_config);
-        assert_matches!(result, Err(RemoteConfigHandlerError::InvalidValues(_)));
+        let result = handler.parse(agent_identity.clone(), &remote_config);
+        assert_matches!(result, Err(RemoteConfigParserError::InvalidValues(_)));
     }
 
     #[test]
-    fn test_agent_remote_config_handler_some_config() {
+    fn test_agent_remote_config_parser_some_config() {
         let agent_identity = test_agent_identity();
 
         let hash = Hash::new("some-hash".into());
@@ -217,18 +217,18 @@ pub mod tests {
         let mut validator = MockRemoteConfigValidatorMock::new();
         validator.should_validate(&agent_identity, &remote_config, Ok(()));
 
-        let handler = AgentRemoteConfigHandler::new(vec![validator]);
+        let handler = AgentRemoteConfigParser::new(vec![validator]);
 
         let expected: YAMLConfig = serde_yaml::from_str("key: value").unwrap();
 
-        let result = handler.handle(agent_identity.clone(), &remote_config);
+        let result = handler.parse(agent_identity.clone(), &remote_config);
         assert_matches!(result, Ok(Some(yaml_config)) => {
             assert_eq!(yaml_config, expected);
         });
     }
 
     #[test]
-    fn test_agent_remote_config_handler_empty_config() {
+    fn test_agent_remote_config_parser_empty_config() {
         let agent_identity = test_agent_identity();
 
         let hash = Hash::new("some-hash".into());
@@ -240,9 +240,9 @@ pub mod tests {
         let mut validator = MockRemoteConfigValidatorMock::new();
         validator.should_validate(&agent_identity, &remote_config, Ok(()));
 
-        let handler = AgentRemoteConfigHandler::new(vec![validator]);
+        let handler = AgentRemoteConfigParser::new(vec![validator]);
 
-        let result = handler.handle(agent_identity.clone(), &remote_config);
+        let result = handler.parse(agent_identity.clone(), &remote_config);
 
         assert!(result.unwrap().is_none());
     }


### PR DESCRIPTION
# What this PR does / why we need it

Changes the name and location of the sub-agent's remote-config-handler since the scope of this component changed in #1241 (this PR is on top of that).

## Summary of changes:

- `RemoteConfigHandler` -> `RemoteConfigParser`
- `subagent/event_handler/opamp/remote_config_handler.rs` -> `subagent/remote_config_parser.rs`