### PR TITLE
refactor: lock on R/W of AC config loader/storer

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -153,13 +153,13 @@ impl AgentControlRunner {
             yaml_config_repository.clone(),
         );
 
-        let gcc = NotStartedK8sGarbageCollector::new(
+        let _garbage_collector = NotStartedK8sGarbageCollector::new(
             config_storer.clone(),
             k8s_client,
             self.k8s_config.cr_type_meta,
             self.garbage_collector_interval,
-        );
-        let _started_gcc = gcc.start();
+        )
+        .start();
 
         let dynamic_config_validator =
             RegistryDynamicConfigValidator::new(self.agent_type_registry);

--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -10,7 +10,6 @@ use newrelic_agent_control::event::ApplicationEvent;
 use newrelic_agent_control::http::tls::install_rustls_default_crypto_provider;
 use newrelic_agent_control::values::file::YAMLConfigRepositoryFile;
 use std::sync::Arc;
-use std::thread::sleep;
 use std::time::Duration;
 
 pub const K8S_GC_INTERVAL: Duration = Duration::from_secs(20);
@@ -66,9 +65,6 @@ pub fn start_agent_control_with_custom_config(
             .run(mode)
             .unwrap();
     });
-
-    // to avoid k8s GC first executions collision with the first remote configs that are set in the tests.
-    sleep(Duration::from_secs(5));
 
     StartedAgentControl {
         application_event_publisher,


### PR DESCRIPTION
# What this PR does / why we need it

Adds a locking mechanism wrapping the `YAMLConfigRepository` on the `AgentControlConfigStore` so when there's a write happening from it any reads are prevented.

I have been continuously running the flaky tests locally (`test-integration-minikube` make target) for 1,5 hours and I haven't run into any failures.

However, I'm not sure if we should wrap the whole `YAMLConfigRepository` instead, so we apply the locking on all usages throughout the codebase. Let me know your thoughts.

Further PRs will be working on improvements to the GC.

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes [NR-343594](https://new-relic.atlassian.net/browse/NR-343594)

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).


[NR-343594]: https://new-relic.atlassian.net/browse/NR-343594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ