### PR TITLE
feat: add self instrumentation to canaries

### DIFF
--- a/test/k8s-canaries/Makefile
+++ b/test/k8s-canaries/Makefile
@@ -6,6 +6,7 @@ K8S_HELM_DIR := $(CURR_DIR)helm
 
 AWS_REGION := us-east-2
 .DEFAULT_GOAL := all
+OTLP_ENDPOINT=https://otlp.nr-data.net:4318
 
 # Generate a random key to add to the helm deployment annotation
 # This way, whenever there is a helm upgrade the pod will be recreated and its image pulled, even if the tag didn't change
@@ -27,6 +28,7 @@ ifeq ($(CANARY_DIR), production)
 	export NR_SYSTEM_IDENTITY_PRIVATE_KEY
 else
 	IS_STAGING = true
+	OTLP_ENDPOINT=https://staging-otlp.nr-data.net:4318
 endif
 
 .PHONY: all
@@ -112,6 +114,10 @@ endif
     --set global.cluster=$(CLUSTER_NAME) \
     --set global.nrStaging=$(IS_STAGING) \
     --set agent-control-deployment.image.tag=$(IMAGE_TAG) \
+    --set agent-control-deployment.config.agentControl.content.self_instrumentation.opentelemetry.custom_attributes.clusterName="$(CLUSTER_NAME)" \
+    --set agent-control-deployment.config.agentControl.content.self_instrumentation.opentelemetry.custom_attributes."label\.app\.kubernetes\.io/name"=agent-control \
+    --set agent-control-deployment.config.agentControl.content.self_instrumentation.opentelemetry.endpoint="$(OTLP_ENDPOINT)" \
+    --set agent-control-deployment.config.agentControl.content.self_instrumentation.opentelemetry.headers.api-key=$(NR_LICENSE_KEY) \
     --set agent-control-deployment.config.fleet_control.auth.secret.create=false \
     --set agent-control-deployment.config.fleet_control.auth.secret.name="sys-identity" \
     --set agent-control-deployment.config.fleet_control.fleet_id="$(FLEET_ID)" \

--- a/test/k8s-canaries/helm/agent-control.yml
+++ b/test/k8s-canaries/helm/agent-control.yml
@@ -7,6 +7,13 @@ agent-control-deployment:
       content:
         log:
           level: info
+        self_instrumentation:
+          opentelemetry:
+            insecure_level: "newrelic_agent_control=trace,opamp_client=trace,off"
+            metrics:
+              enabled: true
+            traces:
+              enabled: true
     subAgents:
       infra:
         type: newrelic/com.newrelic.infrastructure:0.1.0

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -77,5 +77,17 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
+    {
+      name          = "Opamp traces per minute"
+      metric        = "*"
+      sample        = "Span"
+      threshold     = 1
+      duration      = 3600
+      operator      = "below_or_equals"
+      wheres        = {
+        name = "opamp"
+      }
+      template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
+    },
   ]
 }

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -79,6 +79,18 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
+    {
+      name          = "Opamp traces per minute"
+      metric        = "*"
+      sample        = "Span"
+      threshold     = 1
+      duration      = 3600
+      operator      = "below_or_equals"
+      wheres        = {
+        name = "opamp"
+      }
+      template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
+    },
   ]
 }
 


### PR DESCRIPTION
# What this PR does / why we need it

Adds self instrumentation to the canaries, traces and metrics.
Adds an alert if only 1 opamp or less Span is received per minute.

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
