### PR TITLE
docs: fix agent control config log field name

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -29,7 +29,7 @@ agents:
 Logs can be configured as follows:
 
 ```yaml
-logs:
+log:
   format:
     target: true # Defaults to false, includes extra information for debugging purposes
     timestamp: "%Y-%m-%dT%H:%M%S" # Defaults to "%Y-%m-%dT%H:%M%S", details in <https://docs.rs/chrono/0.4.40/chrono/format/strftime/index.html#fn7>


### PR DESCRIPTION
# What this PR does / why we need it

Fix the "logs" field name in the agent control config documentation.
I believe the field is "log" and not "logs" in the agent control config. https://github.com/newrelic/newrelic-agent-control/blob/1ef3ce0988a82d360d256ad4a5e726e7f065dd4e/agent-control/src/agent_control/config.rs#L25.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
