### PR TITLE
fix: add update for all packages into base image

### DIFF
--- a/Dockerfiles/Dockerfile_agent_control
+++ b/Dockerfiles/Dockerfile_agent_control
@@ -9,6 +9,7 @@ COPY --chmod=755 bin/newrelic-agent-control-${TARGETARCH} /bin/newrelic-agent-co
 
 RUN apt-get update && \
     apt-get install -y ca-certificates && \
+    apt-get upgrade -y && \
     apt-get clean
 
 USER nobody

--- a/Dockerfiles/Dockerfile_agent_control_cli
+++ b/Dockerfiles/Dockerfile_agent_control_cli
@@ -6,6 +6,10 @@ ARG TARGETARCH
 
 COPY --chmod=755 bin/newrelic-agent-control-cli-${TARGETARCH} /bin/newrelic-agent-control-cli
 
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean
+
 USER nobody
 
 ENTRYPOINT ["/bin/newrelic-agent-control-cli"]


### PR DESCRIPTION
# What this PR does / why we need it

## Which issue this PR fixes

Add upgrade to update all the packages into base image of the AC  "debian:bookworm-slim" to avoid big delays between image releases

<img width="747" alt="image" src="https://github.com/user-attachments/assets/be6655f7-6404-487e-bdfc-2b93d024acea" />

<img width="868" alt="image" src="https://github.com/user-attachments/assets/41a4f5dc-616d-4ebc-b5a8-51219f2b8ccc" />


- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
