### PR TITLE
chore: ignore root-required tests by default

### DIFF
--- a/agent-control/Makefile
+++ b/agent-control/Makefile
@@ -14,22 +14,22 @@ onhost/cargo:
 .PHONY: test/onhost
 test/onhost:
 	@echo "testing-machine-id" > /tmp/machine-id
-	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --lib -- --skip as_root
+	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --lib
 
 .PHONY: test/onhost/integration
 test/onhost/integration:
 	@echo "testing-machine-id" > /tmp/machine-id
-	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests -- --skip as_root --test-threads=1
+	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests -- --test-threads=1
 
 .PHONY: test/onhost/root
 test/onhost/root:
 	@echo "testing-machine-id" > /tmp/machine-id
-	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --lib -- --skip no_root --skip k8s
+	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --lib _as_root -- --ignored --skip no_root --skip k8s
 
 .PHONY: test/onhost/root/integration
 test/onhost/root/integration:
 	@echo "testing-machine-id" > /tmp/machine-id
-	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests -- --skip no_root --skip k8s --test-threads=1
+	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests _as_root -- --ignored --skip no_root --skip k8s --test-threads=1
 
 # K8S
 

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -69,7 +69,7 @@ fn does_not_run_if_no_root() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(unix)]
 #[test]
-fn runs_as_root() -> Result<(), Box<dyn std::error::Error>> {
+fn basic_startup() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Duration;
 
     use crate::on_host::logging::level::TIME_FORMAT;
@@ -108,7 +108,7 @@ fn runs_as_root() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(unix)]
 #[test]
-fn custom_logging_format_as_root() -> Result<(), Box<dyn std::error::Error>> {
+fn custom_logging_format() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Duration;
 
     let dir = TempDir::new()?;
@@ -155,6 +155,7 @@ log:
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root"]
 fn custom_directory_overrides_as_root() -> Result<(), Box<dyn std::error::Error>> {
     use httpmock::Method::POST;
     use httpmock::MockServer;
@@ -225,7 +226,7 @@ agents: {{}}
 
 #[cfg(unix)]
 #[test]
-fn runs_with_no_config_as_root() -> Result<(), Box<dyn std::error::Error>> {
+fn runs_with_no_config() -> Result<(), Box<dyn std::error::Error>> {
     use std::{env, time::Duration};
 
     let dir = TempDir::new()?;

--- a/agent-control/tests/on_host/logging/file_logging.rs
+++ b/agent-control/tests/on_host/logging/file_logging.rs
@@ -57,6 +57,7 @@ fn default_log_level_no_root() {
 }
 
 #[test]
+#[ignore = "requires root"]
 fn default_log_level_as_root() {
     let dir = TempDir::new().unwrap();
     let config_path = dir.path().join(AGENT_CONTROL_CONFIG_FILENAME);

--- a/agent-control/tests/on_host/logging/level.rs
+++ b/agent-control/tests/on_host/logging/level.rs
@@ -34,6 +34,7 @@ fn default_log_level_no_root() {
 }
 
 #[test]
+#[ignore = "requires root"]
 fn default_log_level_as_root() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join(AGENT_CONTROL_CONFIG_FILENAME), EMPTY_CONFIG).unwrap();
@@ -88,6 +89,7 @@ fn debug_log_level_no_root() {
 }
 
 #[test]
+#[ignore = "requires root"]
 fn trace_log_level_as_root() {
     let dir = TempDir::new().unwrap();
     std::fs::write(

--- a/agent-control/tests/on_host/opamp_auth.rs
+++ b/agent-control/tests/on_host/opamp_auth.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 #[test]
+#[ignore = "requires root"]
 fn test_auth_local_provider_as_root() {
     use crate::on_host::cli::create_temp_file;
 
@@ -77,6 +78,7 @@ agents: {{}}
 // This test verifies that empty Auth config doesn't inject any token.
 // This is a temporal behavior until auth config is mandatory.
 #[test]
+#[ignore = "requires root"]
 fn test_empty_auth_config_as_root() {
     use crate::on_host::cli::create_temp_file;
 
@@ -127,6 +129,7 @@ agents: {{}}
 }
 
 #[test]
+#[ignore = "requires root"]
 fn test_unauthorized_token_retrieve_as_root() {
     use super::cli::create_temp_file;
 

--- a/agent-control/tests/on_host/scenarios/restarting_processes.rs
+++ b/agent-control/tests/on_host/scenarios/restarting_processes.rs
@@ -14,6 +14,7 @@ use tempfile::TempDir;
 /// The agent control is configured with no OpAMP and a custom agent-type to check that
 /// a process gets restarted as expected when killing it externally.
 #[test]
+#[ignore = "requires root"]
 fn killing_subprocess_with_signal_restarts_as_root() -> Result<(), Box<dyn std::error::Error>> {
     use crate::on_host::cli::create_temp_file;
 


### PR DESCRIPTION
# What this PR does / why we need it

This is done so quick calls to `cargo test` can be run without additional options enabled, such as `--skip as_root`. The `as_root` tests can be run again by using something like `cargo test _as_root -- --ignored`, as is now done in the CI.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
