### PR TITLE
fix(k8s-e2e-apm): default commands and endpoints for test apps

### DIFF
--- a/test/k8s-e2e/e2e-apm.yml
+++ b/test/k8s-e2e/e2e-apm.yml
@@ -24,7 +24,8 @@ scenarios:
       - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null 127.0.0.1:9292; do echo 'Ruby not ready yet. Retrying...';sleep 5;done"
       - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null 127.0.0.1:9292
       # dotnet image does not have wget available, we use one from a different pod
-      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`
+      - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`/rolldice; do echo 'Dotnet not ready yet. Retrying...';sleep 5;done"
+      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`/rolldice
 
     after:
       - kubectl logs -l app.kubernetes.io/name=agent-control --all-containers --prefix=true


### PR DESCRIPTION
# What this PR does / why we need it

This fixes a consistent failure on the APM tests that appeared recently. The issue is related to the example e2e test images that we leverage from the OpenTelemetry project. Given we are using the main revision of these images, any time these change our tests will fail. I have provided fixes for Python and DotNet which were the ones causing the consistent failures.

It seems [the OTel team is streamlining all the e2e test apps](https://github.com/open-telemetry/opentelemetry-operator/pull/3946#issuecomment-2838693513) so, even if this same thing caused our failures (additional changes will be required for the other languages when the remaining images are updated), chances are they will remain stable from now on, but we should talk about how to ensure this doesn't break under our noses anymore. Should we maintain our own copies of these e2e test apps?

## Which issue this PR fixes

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
