### PR TITLE
fix(self-instrumentation): metrics reporting [NR-404440]

### DIFF
--- a/agent-control/src/instrumentation/tracing.rs
+++ b/agent-control/src/instrumentation/tracing.rs
@@ -103,7 +103,9 @@ pub fn try_init_tracing(config: TracingConfig) -> Result<Vec<TracingGuardBox>, T
     }
 
     if let Some(otel_config) = config.instrumentation_config.opentelemetry.as_ref() {
-        layers.push(OtelLayers::try_build(otel_config)?);
+        let (otel_layers, otel_guard) = OtelLayers::try_build(otel_config)?;
+        layers.push(otel_layers);
+        guards.push(Box::new(otel_guard));
 
         // Allows including the log information on spans that contain them when send to otlp.
         opentelemetry::global::set_text_map_propagator(


### PR DESCRIPTION
## Issues fixed

This PR fixes two issues with the self-instrumentation's metrics reporting:
1. The metrics `SdkMeterProvider` was dropped (as a result it automatically shut down the corresponding exporter) when the subscriber layer was created.
2. The metrics where filtered by the level set and were only reported when level was set to `trace` for self-instrumentation.

## Additional context

[MetricsLayer::new](https://docs.rs/tracing-opentelemetry/0.30.0/src/tracing_opentelemetry/metrics.rs.html#394) consumes the `SdkMeterProvider` and doesn't hold a copy of it (the provider holds an underlying `Arc` that can be cloned as needed). Conversely, a reference is hold for the corresponding logs and traces layer. Therefore, keeping a reference to the `SdkMeterProvider` would be enough.
But, since this is an internal implementation detail (which would change in the future), the `OtelGuard` holds references to every provider which guarantees that a reference until the application ends.

### Testing

The new unit-test checks that metrics are actually sent when the corresponding layer is configured in a subscriber, the test was failing both when the `SdkMeterProvider` was dropped and when the metrics where filtered.

The metrics reporting has also been tested manually, and the `uptime` metric is reported as expected:

![image](https://github.com/user-attachments/assets/0da39e6a-ea04-46aa-879a-7a0c6821d094)