### PR TITLE
chore: increase remote config check timeout

### DIFF
--- a/test/e2e/ansible/sub_agent_remote_config.yaml
+++ b/test/e2e/ansible/sub_agent_remote_config.yaml
@@ -140,7 +140,7 @@
               AND `test_id` = '{{ test_id }}'
               LIMIT 1
             # This was taking about 5m when the test was created
-            retries: 90
+            retries: 120
             delay: 10
 
       always:


### PR DESCRIPTION
# What this PR does / why we need it

The on-host e2e failed in the latest nightly because it didn't get the remote configuration on time:

https://github.com/newrelic/newrelic-agent-control/actions/runs/14828810372/attempts/1

```
2025-05-05T04:35:45Z    TASK [Assert that remote config has been applied] ******************************
2025-05-05T04:36:43Z    FAILED - RETRYING: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: Execute NRQL (90 retries left).
2025-05-05T04:36:43Z    FAILED - RETRYING: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: Execute NRQL (89 retries left).
2025-05-05T04:36:43Z    FAILED - RETRYING: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: Execute NRQL (88 retries left).
2025-05-05T04:36:43Z    FAILED - RETRYING: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: Execute NRQL (87 retries left).
2025-05-05T04:36:43Z    FAILED - RETRYING: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: Execute NRQL (86 retries left).
2025-05-05T04:36:43Z    TASK [nrql_api_request : Execute NRQL] *****************************************
2025-05-05T04:36:43Z    fatal: [nightly:e2e:amd64:ubuntu22.04 -> 127.0.0.1]: FAILED! => {"msg": "The conditional check 'response.json is defined and response.json.data.actor.account.nrql is defined and response.json.data.actor.account.nrql.results != []' failed. The error was: error w
hile evaluating conditional (response.json is defined and response.json.data.actor.account.nrql is defined and response.json.data.actor.account.nrql.results != []): 'None' has no attribute 'results'. 'None' has no attribute 'results'"}
2025-05-05T04:36:44Z    TASK [AC logs] *****************************************************************
```

Since retrying the test worked, this PR increases the number of attempts to check that the remote configuration was applied.
