### PR TITLE
test(garbage-collector): increase time

### DIFF
--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -184,7 +184,7 @@ agents:
         &second_agents_config,
     ))
     .unwrap();
-    retry(60, Duration::from_secs(1), || {
+    retry(120, Duration::from_secs(1), || {
         if block_on(api_foo.get(resource_name)).is_ok() {
             return Err("CR should be removed".into());
         };


### PR DESCRIPTION
# What this PR does / why we need it

A test driving the actual GC implementation is still flaky because the timeout for checking that the resources were actually deleted might expire. This increases the time for this test.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
