### PR TITLE
test: sub agent config flow tests

### DIFF
--- a/agent-control/src/agent_type/embedded_registry.rs
+++ b/agent-control/src/agent_type/embedded_registry.rs
@@ -108,6 +108,14 @@ pub mod tests {
         }
     }
 
+    impl From<AgentTypeDefinition> for EmbeddedRegistry {
+        fn from(value: AgentTypeDefinition) -> Self {
+            let mut registry = Self(HashMap::new());
+            registry.insert(value).unwrap();
+            registry
+        }
+    }
+
     const AGENT_TYPE_AMOUNT: usize = 11;
 
     #[test]

--- a/agent-control/src/opamp/client_builder.rs
+++ b/agent-control/src/opamp/client_builder.rs
@@ -107,7 +107,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use mockall::{mock, predicate};
+    use mockall::{Sequence, mock, predicate};
     use opamp_client::operation::settings::StartSettings;
     use opamp_client::{
         Client, ClientResult, NotStartedClient, NotStartedClientResult, StartedClient,
@@ -181,21 +181,22 @@ pub(crate) mod tests {
             self.expect_stop().times(times).returning(|| Ok(()));
         }
 
-        // assertion just for the call of the method but not the remote
-        // status itself (so any remote config status)
-        pub fn should_set_any_remote_config_status(&mut self, times: usize) {
-            self.expect_set_remote_config_status()
-                .times(times)
-                .returning(|_| Ok(()));
-        }
-
-        // assertion just for the call of the method but not the remote
-        // status itself (so any remote config status)
         pub fn should_set_remote_config_status(&mut self, status: RemoteConfigStatus) {
             self.expect_set_remote_config_status()
                 .once()
                 .with(predicate::eq(status))
                 .returning(|_| Ok(()));
+        }
+
+        pub fn should_set_remote_config_status_seq(&mut self, status_seq: Vec<RemoteConfigStatus>) {
+            let mut sequence = Sequence::new();
+            for status in status_seq {
+                self.expect_set_remote_config_status()
+                    .once()
+                    .in_sequence(&mut sequence)
+                    .with(predicate::eq(status))
+                    .returning(|_| Ok(()));
+            }
         }
     }
 

--- a/agent-control/src/opamp/hash_repository/repository.rs
+++ b/agent-control/src/opamp/hash_repository/repository.rs
@@ -18,6 +18,27 @@ pub trait HashRepository {
 pub mod tests {
     use super::{AgentID, Hash, HashRepository, HashRepositoryError};
     use mockall::{mock, predicate};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryHashRepository {
+        storage: Arc<Mutex<HashMap<AgentID, Hash>>>,
+    }
+
+    impl HashRepository for InMemoryHashRepository {
+        fn save(&self, agent_id: &AgentID, hash: &Hash) -> Result<(), HashRepositoryError> {
+            self.storage
+                .lock()
+                .unwrap()
+                .insert(agent_id.clone(), hash.clone());
+            Ok(())
+        }
+
+        fn get(&self, agent_id: &AgentID) -> Result<Option<Hash>, HashRepositoryError> {
+            Ok(self.storage.lock().unwrap().get(agent_id).cloned())
+        }
+    }
 
     mock! {
         pub(crate) HashRepository {}

--- a/agent-control/src/sub_agent/identity.rs
+++ b/agent-control/src/sub_agent/identity.rs
@@ -58,6 +58,16 @@ impl Display for AgentIdentity {
 pub mod tests {
     use super::*;
 
+    impl Default for AgentIdentity {
+        fn default() -> Self {
+            AgentIdentity {
+                id: AgentID::new("default").unwrap(),
+                agent_type_id: AgentTypeID::try_from("default/default:0.0.1").unwrap(),
+            }
+        }
+    }
+
+    // TODO replace for default
     pub fn test_agent_identity() -> AgentIdentity {
         AgentIdentity {
             id: AgentID::new("test").unwrap(),


### PR DESCRIPTION
- Adds missing unit tests for different config flows for the bootstrapping and remote config handling face of the SubAgent. 
- Removes obsolete tests replaced by added ones.

Pending:
- ~Currently the bootstrap is being reproduced by starting/stopping the sub agent, this should be ideally tested running a func that contains the whole bootstrap logic.~
- ~Looks like there are two bugs in the code from the branch, to sync with @DavSanchez 
  `sub_agent::sub_agent::tests::test_bootstrap_remote_config_failed_hash_use_last_remote`
  `sub_agent::sub_agent::tests::test_bootstrap_remote_config_failed_hash_use_local`~
- ~Work on the remote configs test cases (another PR)~


On top of #1284 