### PR TITLE
test: address tempdir method deprecations

### DIFF
--- a/agent-control/src/agent_control/config_storer/store.rs
+++ b/agent-control/src/agent_control/config_storer/store.rs
@@ -147,7 +147,8 @@ pub(crate) mod tests {
     #[test]
     #[serial]
     fn load_agents_local_remote() {
-        let local_dir = tempfile::tempdir().unwrap().into_path().to_path_buf();
+        let local_temp_dir = tempfile::tempdir().unwrap();
+        let local_dir = local_temp_dir.path().to_path_buf();
         let local_file = local_dir.join(AGENT_CONTROL_CONFIG_FILENAME);
         let local_config = r#"
 agents: {}
@@ -156,7 +157,8 @@ fleet_control:
 "#;
         std::fs::write(local_file.as_path(), local_config).unwrap();
 
-        let remote_dir = tempfile::tempdir().unwrap().into_path().to_path_buf();
+        let remote_temp_dir = tempfile::tempdir().unwrap();
+        let remote_dir = remote_temp_dir.path().to_path_buf();
         let remote_file = remote_dir.join(AGENT_CONTROL_CONFIG_FILENAME);
 
         let remote_config = r#"
@@ -195,7 +197,8 @@ fleet_control:
     #[test]
     #[serial]
     fn load_config_env_vars() {
-        let local_dir = tempfile::tempdir().unwrap().into_path().to_path_buf();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let local_dir = temp_dir.path().to_path_buf();
         let local_file = local_dir.join(AGENT_CONTROL_CONFIG_FILENAME);
 
         // Note the file contains no `agents` key, which would fail if this config was the only
@@ -244,7 +247,8 @@ fleet_control:
     #[test]
     #[serial]
     fn load_config_env_vars_override() {
-        let local_dir = tempfile::tempdir().unwrap().into_path().to_path_buf();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let local_dir = temp_dir.path().to_path_buf();
         let local_file = local_dir.join(AGENT_CONTROL_CONFIG_FILENAME);
         let local_config = r#"
 fleet_control:

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -229,7 +229,7 @@ agents: {{}}
 fn runs_with_no_config() -> Result<(), Box<dyn std::error::Error>> {
     use std::{env, time::Duration};
 
-    let dir = TempDir::new()?;
+    let dir = tempfile::tempdir()?;
     let mut cmd = Command::cargo_bin("newrelic-agent-control-onhost")?;
     cmd.arg("--local-dir").arg(dir.path());
 
@@ -249,7 +249,7 @@ fn runs_with_no_config() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().failure().stdout(
         predicate::str::is_match(format!(
             ".*Could not read Agent Control config from `{}`.*",
-            dir.into_path().to_string_lossy()
+            dir.path().to_string_lossy()
         ))
         .unwrap(),
     );


### PR DESCRIPTION
# What this PR does / why we need it

I saw some methods we use were marked as deprecated (and I think these method calls weren't working as we expected, or at least how I expected them to behave), so here's a quick PR to change these uses for supported ones.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
