### PR TITLE
feat(logs): allow setting up span information as logs [NR-416658]

### DIFF
--- a/agent-control/src/instrumentation/config/logs/config.rs
+++ b/agent-control/src/instrumentation/config/logs/config.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use tracing::Level;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::filter::{Directive, FilterExt, FilterFn};
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::{EnvFilter, Registry};
 
@@ -45,6 +46,9 @@ pub struct LoggingConfig {
     /// Defines options to report logs to files
     #[serde(default)]
     pub(crate) file: FileLoggingConfig,
+    /// When set, tracing information is also shown as logs
+    #[serde(default)]
+    pub(crate) show_spans: bool,
 }
 
 impl LoggingConfig {
@@ -60,6 +64,14 @@ impl LoggingConfig {
         let filter = allow_spans_filter.or(configured_logs_filter);
 
         Ok(filter)
+    }
+
+    pub fn fmt_span_events(&self) -> FmtSpan {
+        if self.show_spans {
+            FmtSpan::CLOSE // Show a line when the span is close, including busy and idle time
+        } else {
+            FmtSpan::NONE
+        }
     }
 
     fn logging_filter(&self) -> Result<EnvFilter, LoggingConfigError> {

--- a/agent-control/src/instrumentation/tracing_layers/file.rs
+++ b/agent-control/src/instrumentation/tracing_layers/file.rs
@@ -29,6 +29,7 @@ pub fn file(
             let layer = tracing_subscriber::fmt::layer()
                 .with_writer(file_writer)
                 .with_ansi(false) // Disable colors for file
+                .with_span_events(config.fmt_span_events())
                 .with_target(target)
                 .with_timer(ChronoLocal::new(timestamp_fmt.clone()))
                 .fmt_fields(PrettyFields::new())

--- a/agent-control/src/instrumentation/tracing_layers/stdout.rs
+++ b/agent-control/src/instrumentation/tracing_layers/stdout.rs
@@ -13,6 +13,7 @@ pub fn stdout(config: &LoggingConfig) -> Result<LayerBox, LoggingConfigError> {
         .with_writer(std::io::stdout)
         .with_ansi(config.format.ansi_colors)
         .with_target(target)
+        .with_span_events(config.fmt_span_events())
         .with_timer(ChronoLocal::new(timestamp_fmt))
         .fmt_fields(PrettyFields::new())
         .with_filter(config.filter()?)

--- a/agent-control/tests/common/global_logger.rs
+++ b/agent-control/tests/common/global_logger.rs
@@ -11,10 +11,12 @@ pub fn init_logger() {
     INIT_LOGGER.call_once(|| {
         let logging_config: LoggingConfig = serde_yaml::from_str(
             r#"
-format:
-  target: true
-insecure_fine_grained_level: "newrelic_agent_control=trace,opamp_client=info,kube=debug,off"
-        "#,
+        format:
+          target: true
+          ansi_colors: true
+        insecure_fine_grained_level: "newrelic_agent_control=trace,opamp_client=info,kube=debug,off"
+        show_spans: true
+                "#,
         )
         .unwrap();
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -39,6 +39,7 @@ log:
   file:
     enabled: true # Enabled logging to files.
     path: /some/path/logs.log # Optional path to write logs to, if not set it will use 'newrelic-agent-control.log' in the application logging directory.
+  show_spans: false # Show spans information as logs. It includes additional details which may be useful for debugging purposes.
 ```
 
 ### fleet_control


### PR DESCRIPTION
# What this PR does / why we need it

This PR extends the logs configuration in order to include a field that enables showing span information as logs. Additionally, it enables ansi_colors and spans information in integration tests.

## Special notes for your reviewer

[The integration tests in the pipeline show the results](https://github.com/newrelic/newrelic-agent-control/actions/runs/15189614018/job/42718701239?pr=1307). If we find them too verbose we can either disable or simply close this PR.

Fragment:

<img width="2078" alt="image" src="https://github.com/user-attachments/assets/51fb1134-3dcf-4cc6-bf68-aa2bfc9302f1" />


[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
