### PR TITLE
feat: delay http status server startup

### DIFF
--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -94,9 +94,7 @@ pub struct AgentControlRunner {
 
     runtime: Arc<Runtime>,
 
-    // Since _http_server_runner drop depends on agent_control_publisher being drop before we need it
-    // to be the last field of the struct. TODO Refactor runner so that this is not a risk anymore.
-    _http_server_runner: Runner,
+    http_server_runner: Runner,
 }
 
 impl AgentControlRunner {
@@ -136,7 +134,8 @@ impl AgentControlRunner {
                 .build()?,
         );
         let (sub_agent_publisher, sub_agent_consumer) = pub_sub();
-        let _http_server_runner = Runner::start(
+
+        let http_server_runner = Runner::new(
             config.http_server,
             runtime.clone(),
             agent_control_consumer,
@@ -160,7 +159,7 @@ impl AgentControlRunner {
             .unwrap_or(SignatureValidator::Noop);
 
         Ok(AgentControlRunner {
-            _http_server_runner,
+            http_server_runner,
             runtime,
             k8s_config: config.k8s_config,
             agent_type_registry,

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -156,6 +156,9 @@ impl AgentControlRunner {
         let dynamic_config_validator =
             RegistryDynamicConfigValidator::new(self.agent_type_registry);
 
+        // The http server stops on Drop. We need to keep it while the agent control is running.
+        let _http_server = self.http_server_runner.start();
+
         AgentControl::new(
             maybe_client,
             hash_repository,

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -167,6 +167,9 @@ impl AgentControlRunner {
         let dynamic_config_validator =
             RegistryDynamicConfigValidator::new(self.agent_type_registry);
 
+        // The http server stops on Drop. We need to keep it while the agent control is running.
+        let _http_server = self.http_server_runner.start();
+
         AgentControl::new(
             maybe_client,
             agent_control_hash_repository,

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -75,7 +75,15 @@ fn basic_startup() -> Result<(), Box<dyn std::error::Error>> {
     use crate::on_host::logging::level::TIME_FORMAT;
 
     let dir = TempDir::new()?;
-    let _file_path = create_temp_file(&dir, AGENT_CONTROL_CONFIG_FILENAME, r"agents: {}")?;
+    let _file_path = create_temp_file(
+        &dir,
+        AGENT_CONTROL_CONFIG_FILENAME,
+        r#"
+agents: {}
+server:
+  enabled: false
+"#,
+    )?;
 
     let mut cmd = Command::cargo_bin("newrelic-agent-control-onhost")?;
     cmd.arg("--local-dir").arg(dir.path());
@@ -121,6 +129,8 @@ log:
   format:
     target: true
     timestamp: "%Y"
+server:
+  enabled: false
 "#,
     )?;
 
@@ -181,6 +191,8 @@ log:
   file:
     enabled: true
 agents: {{}}
+server:
+  enabled: false
     "#,
             opamp_server.url("/"),
         )


### PR DESCRIPTION
# What this PR does / why we need it

This PR delays the status server startup in order to assure that Agent Control is actually running when the corresponding server returns a successful response. If there was a deadlock when the Agent Control starts, the corresponding status-server wouldn't be started and this situation can be detected by Readiness proves in k8s.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
