### PR TITLE
feat: introduce agent-control health-check configuration [NR-420264]

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -1,16 +1,20 @@
+pub mod agent_id;
 pub mod config;
 pub mod config_storer;
+pub mod config_validator;
 pub mod defaults;
 pub mod error;
-pub(super) mod event_handler;
-pub use agent_control::*;
-#[allow(clippy::module_inception)]
-mod agent_control;
-pub mod agent_id;
-pub mod config_validator;
 pub mod http_server;
 pub mod pid_cache;
 pub mod resource_cleaner;
 pub mod run;
 pub mod uptime_report;
 pub mod version_updater;
+
+pub(super) mod event_handler;
+
+mod health_checker;
+
+pub use agent_control::*;
+#[allow(clippy::module_inception)]
+mod agent_control;

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -1,6 +1,7 @@
 use super::agent_id::AgentID;
 use super::http_server::config::ServerConfig;
 use super::uptime_report::UptimeReportConfig;
+use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
 use crate::http::config::ProxyConfig;
 use crate::instrumentation::config::logs::config::LoggingConfig;
 use crate::opamp::auth::config::AuthConfig;
@@ -51,6 +52,9 @@ pub struct AgentControlConfig {
 
     #[serde(default)]
     pub uptime_report: UptimeReportConfig,
+
+    #[serde(default)]
+    pub health_check: AgentControlHealthCheckerConfig,
 }
 
 #[derive(Error, Debug)]

--- a/agent-control/src/agent_control/health_checker.rs
+++ b/agent-control/src/agent_control/health_checker.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+use crate::health::health_checker::HealthCheckInterval;
+
+/// Holds the Agent Control configuration fields for setting up the health-check.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+pub struct AgentControlHealthCheckerConfig {
+    interval: HealthCheckInterval,
+}

--- a/agent-control/src/agent_type/runtime_config.rs
+++ b/agent-control/src/agent_type/runtime_config.rs
@@ -13,14 +13,9 @@ pub mod templateable_value;
 use super::definition::Variables;
 use super::error::AgentTypeError;
 use super::templates::Templateable;
-use duration_str::deserialize_duration;
 use k8s::K8s;
 use onhost::OnHost;
 use serde::Deserialize;
-use std::time::Duration;
-use wrapper_with_default::WrapperWithDefault;
-
-const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Strict structure that describes how to start a given agent with all needed binaries, arguments, env, etc.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -106,10 +101,6 @@ impl Templateable for Runtime {
         })
     }
 }
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
-#[wrapper_default_value(DEFAULT_HEALTH_CHECK_INTERVAL)]
-pub struct HealthCheckInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 #[cfg(test)]
 mod tests {

--- a/agent-control/src/agent_type/runtime_config/health_config.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config.rs
@@ -5,8 +5,8 @@ use wrapper_with_default::WrapperWithDefault;
 
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
-use crate::agent_type::runtime_config::HealthCheckInterval;
 use crate::agent_type::templates::Templateable;
+use crate::health::health_checker::HealthCheckInterval;
 
 use super::templateable_value::TemplateableValue;
 

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -1,7 +1,6 @@
-use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
-use crate::agent_type::runtime_config::HealthCheckInterval;
 use crate::agent_type::templates::Templateable;
+use crate::{agent_type::definition::Variables, health::health_checker::HealthCheckInterval};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 

--- a/agent-control/src/health.rs
+++ b/agent-control/src/health.rs
@@ -1,7 +1,4 @@
 pub mod health_checker;
-
 pub mod k8s;
-
 pub mod on_host;
-
 pub mod with_start_time;

--- a/agent-control/src/health/health_checker.rs
+++ b/agent-control/src/health/health_checker.rs
@@ -1,22 +1,19 @@
-use super::with_start_time::StartTime;
-use crate::agent_control::agent_id::AgentID;
-use crate::agent_type::runtime_config::HealthCheckInterval;
-use crate::event::SubAgentInternalEvent;
-use crate::event::cancellation::CancellationMessage;
-use crate::event::channel::{EventConsumer, EventPublisher};
-
 use crate::health::with_start_time::HealthWithStartTime;
 use crate::k8s;
-use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
-use crate::sub_agent::supervisor::starter::SupervisorStarterError;
-use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
+use duration_str::deserialize_duration;
+use serde::Deserialize;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, SystemTimeError};
-use tracing::{debug, error, info_span};
+use tracing::{debug, error};
+use wrapper_with_default::WrapperWithDefault;
 
-const HEALTH_CHECKER_THREAD_NAME: &str = "health_checker";
+const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 pub type StatusTime = SystemTime;
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_HEALTH_CHECK_INTERVAL)]
+pub struct HealthCheckInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Health {
@@ -244,83 +241,9 @@ pub trait HealthChecker {
     }
 }
 
-pub(crate) fn spawn_health_checker<H>(
-    agent_id: AgentID,
-    health_checker: H,
-    sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
-    interval: HealthCheckInterval,
-    sub_agent_start_time: StartTime,
-) -> StartedThreadContext
-where
-    H: HealthChecker + Send + 'static,
-{
-    let callback = move |stop_consumer: EventConsumer<CancellationMessage>| loop {
-        let span = info_span!(
-            "health_check",
-            { ID_ATTRIBUTE_NAME } = %agent_id
-        );
-        let _guard = span.enter();
-
-        debug!("starting to check health with the configured checker");
-
-        let health = health_checker.check_health().unwrap_or_else(|err| {
-            debug!( last_error = %err, "the configured health check failed");
-            HealthWithStartTime::from_unhealthy(Unhealthy::from(err), sub_agent_start_time)
-        });
-
-        publish_health_event(
-            &sub_agent_internal_publisher,
-            SubAgentInternalEvent::AgentHealthInfo(health),
-        );
-
-        // Check the cancellation signal
-        if stop_consumer.is_cancelled(interval.into()) {
-            break;
-        }
-    };
-
-    NotStartedThreadContext::new(HEALTH_CHECKER_THREAD_NAME, callback).start()
-}
-
-pub(crate) fn publish_health_event(
-    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
-    event: SubAgentInternalEvent,
-) {
-    let event_type_str = format!("{:?}", event);
-    _ = sub_agent_internal_publisher
-        .publish(event)
-        .inspect_err(|e| {
-            error!(
-                err = e.to_string(),
-                event_type = event_type_str,
-                "could not publish sub agent event"
-            )
-        });
-}
-
-/// Logs the provided error and publishes the corresponding unhealthy event.
-pub fn log_and_report_unhealthy(
-    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
-    err: &SupervisorStarterError,
-    msg: &str,
-    start_time: SystemTime,
-) {
-    let last_error = format!("{msg}: {err}");
-
-    let event = SubAgentInternalEvent::AgentHealthInfo(HealthWithStartTime::new(
-        Unhealthy::new(String::default(), last_error).into(),
-        start_time,
-    ));
-
-    error!(%err, msg);
-    publish_health_event(sub_agent_internal_publisher, event);
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::time::{Duration, UNIX_EPOCH};
-
-    use crate::event::channel::pub_sub;
 
     use super::*;
     use assert_matches::assert_matches;
@@ -477,189 +400,5 @@ pub mod tests {
             assert!(!health.is_healthy());
             assert_eq!(health.last_error().unwrap(), "persistent unhealthy".to_string());
         });
-    }
-
-    #[test]
-    fn test_spawn_health_checker() {
-        let (health_publisher, health_consumer) = pub_sub();
-
-        let start_time = SystemTime::now();
-
-        let mut health_checker = MockHealthCheck::new();
-        let mut seq = Sequence::new();
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Ok(HealthWithStartTime::from_healthy(
-                    Healthy::new("status: 0".to_string()),
-                    start_time,
-                ))
-            });
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Err(HealthCheckerError::Generic(
-                    "mocked health check error!".to_string(),
-                ))
-            });
-
-        let started_thread_context = spawn_health_checker(
-            AgentID::default(),
-            health_checker,
-            health_publisher,
-            Duration::from_millis(10).into(), // Give room to publish and consume the events
-            start_time,
-        );
-
-        // Check that we received the two expected health events
-        assert_eq!(
-            SubAgentInternalEvent::from(HealthWithStartTime::new(
-                Healthy::new("status: 0".to_string()).into(),
-                start_time
-            )),
-            health_consumer.as_ref().recv().unwrap()
-        );
-        assert_eq!(
-            SubAgentInternalEvent::from(HealthWithStartTime::new(
-                Unhealthy::new(
-                    "Health check error".to_string(),
-                    "mocked health check error!".to_string(),
-                )
-                .into(),
-                start_time,
-            )),
-            health_consumer.as_ref().recv().unwrap()
-        );
-
-        // Check that the thread is finished
-        started_thread_context.stop_blocking().unwrap();
-
-        // Check there are no more events
-        assert!(health_consumer.as_ref().recv().is_err());
-    }
-
-    #[test]
-    fn test_repeating_healthy() {
-        let (health_publisher, health_consumer) = pub_sub();
-
-        let start_time = SystemTime::now();
-
-        let mut health_checker = MockHealthCheck::new();
-        let mut seq = Sequence::new();
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Ok(HealthWithStartTime::from_healthy(
-                    Healthy::new("status: 0".to_string()),
-                    start_time,
-                ))
-            });
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Ok(HealthWithStartTime::from_healthy(
-                    Healthy::new("status: 1".to_string()),
-                    start_time,
-                ))
-            });
-
-        let started_thread_context = spawn_health_checker(
-            AgentID::default(),
-            health_checker,
-            health_publisher,
-            Duration::from_millis(10).into(), // Give room to publish and consume the events
-            start_time,
-        );
-
-        // Check that we received the two expected health events
-        assert_eq!(
-            SubAgentInternalEvent::from(HealthWithStartTime::new(
-                Healthy::new("status: 0".to_string()).into(),
-                start_time
-            )),
-            health_consumer.as_ref().recv().unwrap()
-        );
-        assert_eq!(
-            SubAgentInternalEvent::from(HealthWithStartTime::new(
-                Healthy::new("status: 1".to_string()).into(),
-                start_time
-            )),
-            health_consumer.as_ref().recv().unwrap()
-        );
-
-        // Check that the thread is finished
-        started_thread_context.stop_blocking().unwrap();
-
-        // Check there are no more events
-        assert!(health_consumer.as_ref().recv().is_err());
-    }
-
-    #[test]
-    fn test_repeating_unhealthy() {
-        let (health_publisher, health_consumer) = pub_sub();
-
-        let mut health_checker = MockHealthCheck::new();
-        let mut seq = Sequence::new();
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(|| {
-                Err(HealthCheckerError::Generic(
-                    "mocked health check error!".to_string(),
-                ))
-            });
-        health_checker
-            .expect_check_health()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                // Ensure the health checker will quit after the second loop
-                Err(HealthCheckerError::Generic(
-                    "mocked health check error!".to_string(),
-                ))
-            });
-
-        let start_time = SystemTime::now();
-
-        let started_thread_context = spawn_health_checker(
-            AgentID::default(),
-            health_checker,
-            health_publisher,
-            Duration::from_millis(10).into(), // Give room to publish and consume the events
-            start_time,
-        );
-
-        // Check that we received the two expected health events
-        let expected_health_event = SubAgentInternalEvent::from(HealthWithStartTime::new(
-            Unhealthy::new(
-                "Health check error".to_string(),
-                "mocked health check error!".to_string(),
-            )
-            .into(),
-            start_time,
-        ));
-        assert_eq!(
-            expected_health_event.clone(),
-            health_consumer.as_ref().recv().unwrap()
-        );
-        assert_eq!(
-            expected_health_event,
-            health_consumer.as_ref().recv().unwrap()
-        );
-
-        // Check that the thread is finished
-        started_thread_context.stop_blocking().unwrap();
-
-        // Check there are no more events
-        assert!(health_consumer.as_ref().recv().is_err());
     }
 }

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -1,7 +1,12 @@
 pub mod collection;
 pub mod effective_agents_assembler;
 pub mod error;
+pub mod identity;
 pub mod remote_config_parser;
+
+pub(crate) mod event_handler;
+
+mod health_checker;
 
 pub mod k8s;
 
@@ -10,7 +15,5 @@ pub mod supervisor;
 pub mod version;
 
 pub use sub_agent::*;
-pub(crate) mod event_handler;
-pub mod identity;
 #[allow(clippy::module_inception)]
 mod sub_agent;

--- a/agent-control/src/sub_agent/health_checker.rs
+++ b/agent-control/src/sub_agent/health_checker.rs
@@ -1,0 +1,292 @@
+use std::time::SystemTime;
+
+use tracing::{debug, error, info_span};
+
+use crate::{
+    agent_control::agent_id::AgentID,
+    event::{
+        SubAgentInternalEvent,
+        cancellation::CancellationMessage,
+        channel::{EventConsumer, EventPublisher},
+    },
+    health::{
+        health_checker::{HealthCheckInterval, HealthChecker, Unhealthy},
+        with_start_time::{HealthWithStartTime, StartTime},
+    },
+    sub_agent::{identity::ID_ATTRIBUTE_NAME, supervisor::starter::SupervisorStarterError},
+    utils::thread_context::{NotStartedThreadContext, StartedThreadContext},
+};
+
+const HEALTH_CHECKER_THREAD_NAME: &str = "health_checker";
+
+pub(super) fn spawn_health_checker<H>(
+    agent_id: AgentID,
+    health_checker: H,
+    sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
+    interval: HealthCheckInterval,
+    sub_agent_start_time: StartTime,
+) -> StartedThreadContext
+where
+    H: HealthChecker + Send + 'static,
+{
+    let callback = move |stop_consumer: EventConsumer<CancellationMessage>| loop {
+        let span = info_span!(
+            "health_check",
+            { ID_ATTRIBUTE_NAME } = %agent_id
+        );
+        let _guard = span.enter();
+
+        debug!("starting to check health with the configured checker");
+
+        let health = health_checker.check_health().unwrap_or_else(|err| {
+            debug!( last_error = %err, "the configured health check failed");
+            HealthWithStartTime::from_unhealthy(Unhealthy::from(err), sub_agent_start_time)
+        });
+
+        publish_health_event(
+            &sub_agent_internal_publisher,
+            SubAgentInternalEvent::AgentHealthInfo(health),
+        );
+
+        // Check the cancellation signal
+        if stop_consumer.is_cancelled(interval.into()) {
+            break;
+        }
+    };
+
+    NotStartedThreadContext::new(HEALTH_CHECKER_THREAD_NAME, callback).start()
+}
+
+pub(super) fn publish_health_event(
+    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
+    event: SubAgentInternalEvent,
+) {
+    let event_type_str = format!("{:?}", event);
+    _ = sub_agent_internal_publisher
+        .publish(event)
+        .inspect_err(|e| {
+            error!(
+                err = e.to_string(),
+                event_type = event_type_str,
+                "could not publish sub agent event"
+            )
+        });
+}
+
+/// Logs the provided error and publishes the corresponding unhealthy event.
+pub(super) fn log_and_report_unhealthy(
+    sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
+    err: &SupervisorStarterError,
+    msg: &str,
+    start_time: SystemTime,
+) {
+    let last_error = format!("{msg}: {err}");
+
+    let event = SubAgentInternalEvent::AgentHealthInfo(HealthWithStartTime::new(
+        Unhealthy::new(String::default(), last_error).into(),
+        start_time,
+    ));
+
+    error!(%err, msg);
+    publish_health_event(sub_agent_internal_publisher, event);
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::Sequence;
+    use std::time::{Duration, SystemTime};
+
+    use crate::{
+        agent_control::agent_id::AgentID,
+        event::{SubAgentInternalEvent, channel::pub_sub},
+        health::{
+            health_checker::{HealthCheckerError, Healthy, Unhealthy, tests::MockHealthCheck},
+            with_start_time::HealthWithStartTime,
+        },
+        sub_agent::health_checker::spawn_health_checker,
+    };
+
+    #[test]
+    fn test_spawn_health_checker() {
+        let (health_publisher, health_consumer) = pub_sub();
+
+        let start_time = SystemTime::now();
+
+        let mut health_checker = MockHealthCheck::new();
+        let mut seq = Sequence::new();
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Ok(HealthWithStartTime::from_healthy(
+                    Healthy::new("status: 0".to_string()),
+                    start_time,
+                ))
+            });
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Err(HealthCheckerError::Generic(
+                    "mocked health check error!".to_string(),
+                ))
+            });
+
+        let started_thread_context = spawn_health_checker(
+            AgentID::default(),
+            health_checker,
+            health_publisher,
+            Duration::from_millis(10).into(), // Give room to publish and consume the events
+            start_time,
+        );
+
+        // Check that we received the two expected health events
+        assert_eq!(
+            SubAgentInternalEvent::from(HealthWithStartTime::new(
+                Healthy::new("status: 0".to_string()).into(),
+                start_time
+            )),
+            health_consumer.as_ref().recv().unwrap()
+        );
+        assert_eq!(
+            SubAgentInternalEvent::from(HealthWithStartTime::new(
+                Unhealthy::new(
+                    "Health check error".to_string(),
+                    "mocked health check error!".to_string(),
+                )
+                .into(),
+                start_time,
+            )),
+            health_consumer.as_ref().recv().unwrap()
+        );
+
+        // Check that the thread is finished
+        started_thread_context.stop_blocking().unwrap();
+
+        // Check there are no more events
+        assert!(health_consumer.as_ref().recv().is_err());
+    }
+
+    #[test]
+    fn test_repeating_healthy() {
+        let (health_publisher, health_consumer) = pub_sub();
+
+        let start_time = SystemTime::now();
+
+        let mut health_checker = MockHealthCheck::new();
+        let mut seq = Sequence::new();
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Ok(HealthWithStartTime::from_healthy(
+                    Healthy::new("status: 0".to_string()),
+                    start_time,
+                ))
+            });
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Ok(HealthWithStartTime::from_healthy(
+                    Healthy::new("status: 1".to_string()),
+                    start_time,
+                ))
+            });
+
+        let started_thread_context = spawn_health_checker(
+            AgentID::default(),
+            health_checker,
+            health_publisher,
+            Duration::from_millis(10).into(), // Give room to publish and consume the events
+            start_time,
+        );
+
+        // Check that we received the two expected health events
+        assert_eq!(
+            SubAgentInternalEvent::from(HealthWithStartTime::new(
+                Healthy::new("status: 0".to_string()).into(),
+                start_time
+            )),
+            health_consumer.as_ref().recv().unwrap()
+        );
+        assert_eq!(
+            SubAgentInternalEvent::from(HealthWithStartTime::new(
+                Healthy::new("status: 1".to_string()).into(),
+                start_time
+            )),
+            health_consumer.as_ref().recv().unwrap()
+        );
+
+        // Check that the thread is finished
+        started_thread_context.stop_blocking().unwrap();
+
+        // Check there are no more events
+        assert!(health_consumer.as_ref().recv().is_err());
+    }
+
+    #[test]
+    fn test_repeating_unhealthy() {
+        let (health_publisher, health_consumer) = pub_sub();
+
+        let mut health_checker = MockHealthCheck::new();
+        let mut seq = Sequence::new();
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|| {
+                Err(HealthCheckerError::Generic(
+                    "mocked health check error!".to_string(),
+                ))
+            });
+        health_checker
+            .expect_check_health()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                // Ensure the health checker will quit after the second loop
+                Err(HealthCheckerError::Generic(
+                    "mocked health check error!".to_string(),
+                ))
+            });
+
+        let start_time = SystemTime::now();
+
+        let started_thread_context = spawn_health_checker(
+            AgentID::default(),
+            health_checker,
+            health_publisher,
+            Duration::from_millis(10).into(), // Give room to publish and consume the events
+            start_time,
+        );
+
+        // Check that we received the two expected health events
+        let expected_health_event = SubAgentInternalEvent::from(HealthWithStartTime::new(
+            Unhealthy::new(
+                "Health check error".to_string(),
+                "mocked health check error!".to_string(),
+            )
+            .into(),
+            start_time,
+        ));
+        assert_eq!(
+            expected_health_event.clone(),
+            health_consumer.as_ref().recv().unwrap()
+        );
+        assert_eq!(
+            expected_health_event,
+            health_consumer.as_ref().recv().unwrap()
+        );
+
+        // Check that the thread is finished
+        started_thread_context.stop_blocking().unwrap();
+
+        // Check there are no more events
+        assert!(health_consumer.as_ref().recv().is_err());
+    }
+}

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -4,13 +4,13 @@ use crate::agent_type::version_config::VersionCheckerInterval;
 use crate::event::SubAgentInternalEvent;
 use crate::event::cancellation::CancellationMessage;
 use crate::event::channel::{EventConsumer, EventPublisher};
-use crate::health::health_checker::spawn_health_checker;
 use crate::health::k8s::health_checker::K8sHealthChecker;
 use crate::health::with_start_time::StartTime;
 use crate::k8s::annotations::Annotations;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::labels::Labels;
+use crate::sub_agent::health_checker::spawn_health_checker;
 use crate::sub_agent::identity::{AgentIdentity, ID_ATTRIBUTE_NAME};
 use crate::sub_agent::supervisor::starter::{SupervisorStarter, SupervisorStarterError};
 use crate::sub_agent::supervisor::stopper::SupervisorStopper;

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -4,14 +4,13 @@ use crate::agent_type::version_config::VersionCheckerInterval;
 use crate::context::Context;
 use crate::event::SubAgentInternalEvent;
 use crate::event::channel::EventPublisher;
-use crate::health::health_checker::{
-    HealthCheckerError, publish_health_event, spawn_health_checker,
-};
+use crate::health::health_checker::HealthCheckerError;
 use crate::health::health_checker::{Healthy, Unhealthy};
 use crate::health::on_host::health_checker::OnHostHealthChecker;
 use crate::health::with_start_time::{HealthWithStartTime, StartTime};
 use crate::http::client::HttpClient;
 use crate::http::config::{HttpConfig, ProxyConfig};
+use crate::sub_agent::health_checker::{publish_health_event, spawn_health_checker};
 use crate::sub_agent::identity::{AgentIdentity, ID_ATTRIBUTE_NAME};
 use crate::sub_agent::on_host::command::command::CommandError;
 use crate::sub_agent::on_host::command::command_os::CommandOSNotStarted;

--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -9,7 +9,6 @@ use crate::event::broadcaster::unbounded::UnboundedBroadcast;
 use crate::event::channel::{EventConsumer, EventPublisher};
 use crate::event::{OpAMPEvent, SubAgentEvent, SubAgentInternalEvent};
 use crate::health::health_checker::Health;
-use crate::health::health_checker::log_and_report_unhealthy;
 use crate::opamp::hash_repository::HashRepository;
 use crate::opamp::operations::stop_opamp_client;
 use crate::opamp::remote_config::RemoteConfig;
@@ -19,6 +18,7 @@ use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgen
 use crate::sub_agent::error::{SubAgentBuilderError, SubAgentError, SupervisorCreationError};
 use crate::sub_agent::event_handler::on_health::on_health;
 use crate::sub_agent::event_handler::on_version::on_version;
+use crate::sub_agent::health_checker::log_and_report_unhealthy;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::remote_config_parser::RemoteConfigParser;
 use crate::sub_agent::supervisor::starter::{SupervisorStarter, SupervisorStarterError};

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -92,6 +92,15 @@ server:
   enabled: true # The status server is enabled by default
 ```
 
+### health_check
+
+Configuration fields to set-up Agent Control health-check
+
+```yaml
+health_check:
+  interval: 120s # Defaults to 60s
+```
+
 ### self_instrumentation
 
 Agent Control can be configured to instrument itself and report traces, logs and metrics through OpenTelemetry. If proxy is configured globally it will also apply to self-instrumentation.


### PR DESCRIPTION
# What this PR does / why we need it

This PR introduces a configuration section to set-up the Agent Control health-check

## Special notes for your reviewer

- The configuration is **not** used yet
  - Follow-up PRs will use it when introducing HealthCheck in AgentControl 
- The PR also includes a small refactor to introduce specific `health_check` modules under `sub_agent` and `agent_control` and move most specific code there.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
