### PR TITLE
feat: introduce agent-control health-check configuration [NR-420264]

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -1,16 +1,20 @@
+pub mod agent_id;
 pub mod config;
 pub mod config_storer;
+pub mod config_validator;
 pub mod defaults;
 pub mod error;
-pub(super) mod event_handler;
-pub use agent_control::*;
-#[allow(clippy::module_inception)]
-mod agent_control;
-pub mod agent_id;
-pub mod config_validator;
 pub mod http_server;
 pub mod pid_cache;
 pub mod resource_cleaner;
 pub mod run;
 pub mod uptime_report;
 pub mod version_updater;
+
+pub(super) mod event_handler;
+
+mod health_checker;
+
+pub use agent_control::*;
+#[allow(clippy::module_inception)]
+mod agent_control;

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -1,6 +1,7 @@
 use super::agent_id::AgentID;
 use super::http_server::config::ServerConfig;
 use super::uptime_report::UptimeReportConfig;
+use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
 use crate::http::config::ProxyConfig;
 use crate::instrumentation::config::logs::config::LoggingConfig;
 use crate::opamp::auth::config::AuthConfig;
@@ -51,6 +52,9 @@ pub struct AgentControlConfig {
 
     #[serde(default)]
     pub uptime_report: UptimeReportConfig,
+
+    #[serde(default)]
+    pub health_check: AgentControlHealthCheckerConfig,
 }
 
 #[derive(Error, Debug)]

--- a/agent-control/src/agent_control/health_checker.rs
+++ b/agent-control/src/agent_control/health_checker.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+use crate::health::health_checker::HealthCheckInterval;
+
+/// Holds the Agent Control configuration fields for setting up the health-check.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+pub struct AgentControlHealthCheckerConfig {
+    interval: HealthCheckInterval,
+}

--- a/agent-control/src/agent_type/runtime_config.rs
+++ b/agent-control/src/agent_type/runtime_config.rs
@@ -13,14 +13,9 @@ pub mod templateable_value;
 use super::definition::Variables;
 use super::error::AgentTypeError;
 use super::templates::Templateable;
-use duration_str::deserialize_duration;
 use k8s::K8s;
 use onhost::OnHost;
 use serde::Deserialize;
-use std::time::Duration;
-use wrapper_with_default::WrapperWithDefault;
-
-const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Strict structure that describes how to start a given agent with all needed binaries, arguments, env, etc.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -106,10 +101,6 @@ impl Templateable for Runtime {
         })
     }
 }
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
-#[wrapper_default_value(DEFAULT_HEALTH_CHECK_INTERVAL)]
-pub struct HealthCheckInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 #[cfg(test)]
 mod tests {

--- a/agent-control/src/agent_type/runtime_config/health_config.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config.rs
@@ -5,8 +5,8 @@ use wrapper_with_default::WrapperWithDefault;
 
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
-use crate::agent_type::runtime_config::HealthCheckInterval;
 use crate::agent_type::templates::Templateable;
+use crate::health::health_checker::HealthCheckInterval;
 
 use super::templateable_value::TemplateableValue;
 

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -1,7 +1,7 @@
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
-use crate::agent_type::runtime_config::HealthCheckInterval;
 use crate::agent_type::templates::Templateable;
+use crate::health::health_checker::HealthCheckInterval;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -92,6 +92,15 @@ server:
   enabled: true # The status server is enabled by default
 ```
 
+### health_check
+
+Configuration fields to set-up Agent Control health-check
+
+```yaml
+health_check:
+  interval: 120s # Defaults to 60s
+```
+
 ### self_instrumentation
 
 Agent Control can be configured to instrument itself and report traces, logs and metrics through OpenTelemetry. If proxy is configured globally it will also apply to self-instrumentation.


### PR DESCRIPTION
# What this PR does / why we need it

This PR introduces the configuration for AC health-checker.

## Special notes for your reviewer

* The configuration is defined and can be set but its values is **not** used yet.
* We might need different configuration values for on-host and k8s, but we'll cross that bridge when we come to it.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
