### PR TITLE
feat: make load_remote_fallback_local be part of the repository trait

### DIFF
--- a/agent-control/src/opamp/effective_config/agent_control.rs
+++ b/agent-control/src/opamp/effective_config/agent_control.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::default_capabilities;
 use crate::opamp::remote_config::ConfigurationMap;
-use crate::values::config_repository::{ConfigRepository, load_remote_fallback_local};
+use crate::values::config_repository::ConfigRepository;
 use crate::values::yaml_config::YAMLConfig;
 
 use super::error::LoaderError;
@@ -88,17 +88,15 @@ where
 
         // For the effective config load, we can follow the load remote or fallback to local, since only the dynamic part is needed.
 
-        let maybe_config = load_remote_fallback_local(
-            self.yaml_config_repository.as_ref(),
-            &self.agent_id,
-            &self.agent_control_capabilities,
-        )
-        .map_err(|err| {
-            LoaderError::from(format!(
-                "could not load {} config values: {}",
-                &self.agent_id, err
-            ))
-        })?;
+        let maybe_config = self
+            .yaml_config_repository
+            .load_remote_fallback_local(&self.agent_id, &self.agent_control_capabilities)
+            .map_err(|err| {
+                LoaderError::from(format!(
+                    "could not load {} config values: {}",
+                    &self.agent_id, err
+                ))
+            })?;
         // No configuration is considered as empty remote configuration
         let config = maybe_config.unwrap_or_default();
 

--- a/agent-control/src/opamp/effective_config/sub_agent.rs
+++ b/agent-control/src/opamp/effective_config/sub_agent.rs
@@ -3,7 +3,7 @@ use super::loader::EffectiveConfigLoader;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::default_capabilities;
 use crate::opamp::remote_config::ConfigurationMap;
-use crate::values::config_repository::{ConfigRepository, load_remote_fallback_local};
+use crate::values::config_repository::ConfigRepository;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -34,17 +34,15 @@ where
     Y: ConfigRepository,
 {
     fn load(&self) -> Result<ConfigurationMap, LoaderError> {
-        let maybe_values = load_remote_fallback_local(
-            self.yaml_config_repository.as_ref(),
-            &self.agent_id,
-            &default_capabilities(),
-        )
-        .map_err(|err| {
-            LoaderError::from(format!(
-                "could not load {} config values: {}",
-                &self.agent_id, err
-            ))
-        })?;
+        let maybe_values = self
+            .yaml_config_repository
+            .load_remote_fallback_local(&self.agent_id, &default_capabilities())
+            .map_err(|err| {
+                LoaderError::from(format!(
+                    "could not load {} config values: {}",
+                    &self.agent_id, err
+                ))
+            })?;
         // No configuration is considered as empty effective-configuration
         let values = maybe_values.unwrap_or_default();
 

--- a/agent-control/src/values/file.rs
+++ b/agent-control/src/values/file.rs
@@ -315,9 +315,7 @@ pub mod tests {
     use crate::opamp::remote_config::hash::Hash;
     use crate::values;
     use crate::values::config::RemoteConfig;
-    use crate::values::config_repository::{
-        ConfigRepository, ConfigRepositoryError, load_remote_fallback_local,
-    };
+    use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
     use assert_matches::assert_matches;
     use fs::directory_manager::DirectoryManagementError::ErrorCreatingDirectory;
     use fs::directory_manager::DirectoryManager;
@@ -410,7 +408,8 @@ state: applied
             yaml_config_content.to_string(),
         );
 
-        let config = load_remote_fallback_local(&repo, &agent_id, &default_capabilities())
+        let config = repo
+            .load_remote_fallback_local(&agent_id, &default_capabilities())
             .expect("unexpected error loading config")
             .expect("expected some configuration, got None");
 
@@ -439,7 +438,8 @@ state: applied
             yaml_config_content.to_string(),
         );
 
-        let config = load_remote_fallback_local(&repo, &agent_id, &default_capabilities())
+        let config = repo
+            .load_remote_fallback_local(&agent_id, &default_capabilities())
             .expect("unexpected error loading config")
             .expect("expected some configuration, got None");
 
@@ -461,8 +461,9 @@ state: applied
             "some message".to_string(),
         );
 
-        let yaml_config =
-            load_remote_fallback_local(&repo, &agent_id, &default_capabilities()).unwrap();
+        let yaml_config = repo
+            .load_remote_fallback_local(&agent_id, &default_capabilities())
+            .unwrap();
 
         assert!(yaml_config.is_none());
     }
@@ -476,7 +477,7 @@ state: applied
             concatenate_sub_agent_dir_path(get_conf_path(&repo), &agent_id).as_path(),
         );
 
-        let result = load_remote_fallback_local(&repo, &agent_id, &default_capabilities());
+        let result = repo.load_remote_fallback_local(&agent_id, &default_capabilities());
         let err = result.unwrap_err();
         assert_matches!(err, ConfigRepositoryError::LoadError(s) => {
             assert!(s.contains("file read error"));


### PR DESCRIPTION
Make load_remote_fallback_local be part of the trait and repository instead of a separate function.

# What this PR does / why we need it

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
