### PR TITLE
refactor: avoid requiring status for healthy/unhealthy builders

### DIFF
--- a/agent-control/src/agent_control/agent_control.rs
+++ b/agent-control/src/agent_control/agent_control.rs
@@ -193,11 +193,9 @@ where
             <<S as SubAgentBuilder>::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
         >,
     ) {
-        let _ = self
-            .report_health(Healthy::new(String::default()).into())
-            .inspect_err(
-                |err| error!(error_msg = %err,"Error reporting health on Agent Control start"),
-            );
+        let _ = self.report_health(Healthy::new().into()).inspect_err(
+            |err| error!(error_msg = %err,"Error reporting health on Agent Control start"),
+        );
 
         debug!("Listening for events from agents");
         let never_receive = EventConsumer::from(never());
@@ -273,7 +271,7 @@ where
                 error!(error_message);
                 OpampRemoteConfigStatus::Error(error_message.clone())
                     .report(opamp_client, opamp_remote_config.hash.get())?;
-                Ok(self.report_health(Unhealthy::new(String::default(), error_message).into())?)
+                Ok(self.report_health(Unhealthy::new(error_message).into())?)
             }
             Ok(()) => {
                 self.sa_dynamic_config_store
@@ -281,7 +279,7 @@ where
                 OpampRemoteConfigStatus::Applied
                     .report(opamp_client, opamp_remote_config.hash.get())?;
                 opamp_client.update_effective_config()?;
-                Ok(self.report_health(Healthy::new(String::default()).into())?)
+                Ok(self.report_health(Healthy::new().into())?)
             }
         }
     }
@@ -601,7 +599,7 @@ mod tests {
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
 
@@ -669,7 +667,7 @@ mod tests {
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
@@ -1440,14 +1438,14 @@ agents:
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
         assert_eq!(expected, ev);
 
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
@@ -1525,7 +1523,7 @@ agents:
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
@@ -1533,7 +1531,6 @@ agents:
 
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
             Unhealthy::new(
-            String::default(),
             String::from(
                 "Error applying Agent Control remote config: remote config error: `config hash: `a-hash` config error: `some error message``",
             ),
@@ -1596,7 +1593,7 @@ agents:
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
@@ -1714,7 +1711,7 @@ agents:
 
         // process_events always starts with AgentControlHealthy
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();
@@ -1725,7 +1722,7 @@ agents:
         assert_eq!(expected, ev);
 
         let expected = AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
-            Healthy::default().into(),
+            Healthy::new().into(),
             SystemTime::UNIX_EPOCH,
         ));
         let ev = agent_control_consumer.as_ref().recv().unwrap();

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -160,7 +160,7 @@ mod tests {
                     update_sub_agent_status(sub_agent_event, self.current_status.clone()).await;
                 }
                 let st = self.current_status.read().await;
-                assert_eq!(self.expected_status, *st);
+                assert_eq!(self.expected_status, *st, "{}", self._name);
             }
         }
 
@@ -175,7 +175,7 @@ mod tests {
                 _name: "Unhealthy Agent Control becomes healthy",
                 agent_control_event: Some(AgentControlEvent::HealthUpdated(
                     HealthWithStartTime::new(
-                        Healthy::new("some status".to_string()).into(),
+                        Healthy::new().with_status("some status".to_string()).into(),
                         SystemTime::UNIX_EPOCH,
                     ),
                 )),
@@ -199,9 +199,9 @@ mod tests {
                 agent_control_event: Some(AgentControlEvent::HealthUpdated(
                     HealthWithStartTime::new(
                         Unhealthy::new(
-                            "some status".to_string(),
                             "some error message for agent control unhealthy".to_string(),
                         )
+                        .with_status("some status".to_string())
                         .into(),
                         SystemTime::UNIX_EPOCH,
                     ),

--- a/agent-control/src/health/k8s/health_checker.rs
+++ b/agent-control/src/health/k8s/health_checker.rs
@@ -148,7 +148,7 @@ where
             }
         }
         Ok(HealthWithStartTime::from_healthy(
-            Healthy::new(String::default()),
+            Healthy::new(),
             self.start_time,
         ))
     }

--- a/agent-control/src/health/k8s/health_checker/resources.rs
+++ b/agent-control/src/health/k8s/health_checker/resources.rs
@@ -34,7 +34,7 @@ where
             return Ok(obj_health);
         }
     }
-    Ok(Healthy::new(String::default()).into())
+    Ok(Healthy::new().into())
 }
 
 /// Returns a closure which can be used as filter predicate. It will filter objects labeled with the key
@@ -78,11 +78,11 @@ mod tests {
     #[test]
     fn test_items_health_check_healthy() {
         let items = vec!["a", "b", "c", "d"].into_iter().map(Arc::new);
-        let result = check_health_for_items(items.into_iter(), |_| Ok(Healthy::default().into()))
+        let result = check_health_for_items(items.into_iter(), |_| Ok(Healthy::new().into()))
             .unwrap_or_else(|err| panic!("unexpected error {err} when all items are healthy"));
         assert_eq!(
             result,
-            Health::Healthy(Healthy::default()),
+            Health::Healthy(Healthy::new()),
             "Expected healthy when all items are healthy"
         );
 
@@ -92,7 +92,7 @@ mod tests {
         .unwrap_or_else(|err| panic!("unexpected error {err} when there are no items"));
         assert_eq!(
             result,
-            Health::Healthy(Healthy::default()),
+            Health::Healthy(Healthy::new()),
             "expected healthy when there are no items"
         );
     }
@@ -101,8 +101,8 @@ mod tests {
     fn test_items_health_check_unhealthy() {
         let items = vec!["a", "b", "c", "d"].into_iter().map(Arc::new);
         let result = check_health_for_items(items.into_iter(), |s| match s {
-            &"a" | &"b" => Ok(Healthy::default().into()),
-            _ => Ok(Unhealthy::new(String::default(), s.to_string()).into()),
+            &"a" | &"b" => Ok(Healthy::new().into()),
+            _ => Ok(Unhealthy::new(s.to_string()).into()),
         })
         .unwrap_or_else(|err| panic!("unexpected error {err} when unhealthy is expected"));
         assert_eq!(
@@ -119,7 +119,7 @@ mod tests {
     fn test_items_health_check_err() {
         let items = vec!["a", "b", "c", "d"].into_iter().map(Arc::new);
         let result = check_health_for_items(items.into_iter(), |s| match s {
-            &"a" | &"b" => Ok(Healthy::default().into()),
+            &"a" | &"b" => Ok(Healthy::new().into()),
             _ => Err(HealthCheckerError::Generic(s.to_string())),
         })
         .unwrap_err();

--- a/agent-control/src/health/k8s/health_checker/resources/daemon_set.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/daemon_set.rs
@@ -56,13 +56,10 @@ impl K8sHealthDaemonSet {
         let name = n.as_str();
         let status = Self::get_daemon_set_status(name, ds)?;
         if status.number_ready < status.desired_number_scheduled {
-            return Ok(Unhealthy::new(
-                String::default(),
-                format!(
-                    "DaemonSet `{}`: the number of pods ready `{}` is less that the desired `{}`",
-                    name, status.number_ready, status.desired_number_scheduled
-                ),
-            )
+            return Ok(Unhealthy::new(format!(
+                "DaemonSet `{}`: the number of pods ready `{}` is less that the desired `{}`",
+                name, status.number_ready, status.desired_number_scheduled
+            ))
             .into());
         }
 
@@ -70,14 +67,11 @@ impl K8sHealthDaemonSet {
             .number_unavailable
             .is_some_and(|number_unavailable| number_unavailable > 0)
         {
-            return Ok(Unhealthy::new(
-                String::default(),
-                format!(
-                    "DaemonSet `{}`: the are {} unavailable pods",
-                    name,
-                    status.number_unavailable.unwrap_or_default()
-                ),
-            )
+            return Ok(Unhealthy::new(format!(
+                "DaemonSet `{}`: the are {} unavailable pods",
+                name,
+                status.number_unavailable.unwrap_or_default()
+            ))
             .into());
         }
 
@@ -88,7 +82,6 @@ impl K8sHealthDaemonSet {
 
             if updated_number_scheduled < status.desired_number_scheduled {
                 return Ok(Unhealthy::new(
-                    String::default(),
                     format!(
                         "DaemonSet `{}`: the number of nodes having an updated and ready replica `{}` is less that the desired `{}`",
                         name,
@@ -100,7 +93,7 @@ impl K8sHealthDaemonSet {
             }
         }
 
-        Ok(Healthy::new(String::default()).into())
+        Ok(Healthy::new().into())
     }
 
     fn get_daemon_set_status(
@@ -348,7 +341,7 @@ pub mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
             TestCase {
                 name: "everything is good",
@@ -369,7 +362,7 @@ pub mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
         ];
 
@@ -438,7 +431,7 @@ pub mod tests {
         assert_eq!(
             health,
             HealthWithStartTime::from_unhealthy(
-                Unhealthy::new(String::default(), "DaemonSet `unhealthy-daemon-set`: the number of pods ready `2` is less that the desired `5`".into()),
+                Unhealthy::new("DaemonSet `unhealthy-daemon-set`: the number of pods ready `2` is less that the desired `5`".into()),
                 start_time
             )
         );

--- a/agent-control/src/health/k8s/health_checker/resources/deployment.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/deployment.rs
@@ -55,10 +55,9 @@ impl K8sHealthDeployment {
         // The deployment is unhealthy if any of the pods are unavailable, i.e. not running or not ready.
         if let Some(unavailable_replicas) = status.unavailable_replicas {
             if unavailable_replicas > 0 {
-                return Ok(Unhealthy::new(
-                    String::default(),
-                    format!("Deployment `{name}`: has {unavailable_replicas} unavailable replicas"),
-                )
+                return Ok(Unhealthy::new(format!(
+                    "Deployment `{name}`: has {unavailable_replicas} unavailable replicas"
+                ))
                 .into());
             }
         };
@@ -75,13 +74,12 @@ impl K8sHealthDeployment {
         let available_replicas = status.available_replicas.unwrap_or_default();
         if available_replicas < desired_replicas {
             return Ok(Unhealthy::new(
-                    String::default(),
                     format!("Deployment `{name}`: available replicas `{available_replicas}` is less than desired `{desired_replicas}`"),
                 )
                 .into());
         }
 
-        Ok(Healthy::new(String::default()).into())
+        Ok(Healthy::new().into())
     }
 }
 
@@ -130,7 +128,7 @@ mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
             TestCase {
                 name: "Deployment with zero replicas, zero values",
@@ -146,7 +144,7 @@ mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
             TestCase {
                 name: "Deployment with replicas",
@@ -161,7 +159,7 @@ mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
             // Unhealthy cases
             TestCase {
@@ -179,7 +177,6 @@ mod tests {
                     }),
                 },
                 expected: Unhealthy::new(
-                    String::default(),
                     "Deployment `test-deployment`: has 1 unavailable replicas".into(),
                 )
                 .into(),
@@ -199,7 +196,6 @@ mod tests {
                     }),
                 },
                 expected: Unhealthy::new(
-                    String::default(),
                     "Deployment `test-deployment`: available replicas `9` is less than desired `10`"
                         .into(),
                 )
@@ -220,7 +216,6 @@ mod tests {
                     }),
                 },
                 expected: Unhealthy::new(
-                    String::default(),
                     "Deployment `test-deployment`: available replicas `0` is less than desired `10`"
                         .into(),
                 )
@@ -401,7 +396,7 @@ mod tests {
                     Arc::new(healthy_deployment.clone()),
                     Arc::new(healthy_deployment.clone()),
                 ],
-                expected_health: Healthy::default().into(),
+                expected_health: Healthy::new().into(),
             },
             TestCase {
                 name: "One unhealthy deployment",

--- a/agent-control/src/health/k8s/health_checker/resources/helm_release.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/helm_release.rs
@@ -158,12 +158,12 @@ impl HealthChecker for K8sHealthFluxHelmRelease {
         let (is_healthy, message) = self.is_healthy_and_message(&conditions);
         if is_healthy {
             Ok(HealthWithStartTime::from_healthy(
-                Healthy::new(String::default()),
+                Healthy::new(),
                 self.start_time,
             ))
         } else {
             Ok(HealthWithStartTime::from_unhealthy(
-                Unhealthy::new(String::default(), message),
+                Unhealthy::new(message),
                 self.start_time,
             ))
         }
@@ -190,7 +190,7 @@ pub mod tests {
         let test_cases : Vec<TestCase> = vec![
             (
                 "Helm release healthy when ready and status true",
-                Ok(Healthy::default().into()),
+                Ok(Healthy::new().into()),
                 |mock: &mut MockSyncK8sClient| {
                     let status_conditions = json!({
                         "conditions": [
@@ -202,7 +202,7 @@ pub mod tests {
             ),
             (
                 "Helm release unhealthy when ready and status false",
-                Ok(Unhealthy::new(String::default(),"HelmRelease not ready: test error".to_string()).into()),
+                Ok(Unhealthy::new("HelmRelease not ready: test error".to_string()).into()),
                 |mock: &mut MockSyncK8sClient| {
                     let status_conditions = json!({
                         "conditions": [
@@ -214,7 +214,7 @@ pub mod tests {
             ),
             (
                 "Helm release unhealthy when not ready conditions",
-                Ok(Unhealthy::new(String::default(),"No 'Ready' condition was found".to_string()).into()),
+                Ok(Unhealthy::new("No 'Ready' condition was found".to_string()).into()),
                 |mock: &mut MockSyncK8sClient| {
                     let status_conditions = json!({
                         "conditions": [
@@ -226,7 +226,7 @@ pub mod tests {
             ),
             (
                 "Helm release unhealthy when not ready and other true condition types",
-                Ok(Unhealthy::new(String::default(),"HelmRelease not ready: No specific message found".to_string()).into()),
+                Ok(Unhealthy::new("HelmRelease not ready: No specific message found".to_string()).into()),
                 |mock: &mut MockSyncK8sClient| {
                     let status_conditions = json!({
                         "conditions": [
@@ -239,7 +239,7 @@ pub mod tests {
             ),
             (
                 "Helm release unhealthy when no conditions",
-                Ok(Unhealthy::new(String::default(),"No 'Ready' condition was found".to_string()).into()),
+                Ok(Unhealthy::new("No 'Ready' condition was found".to_string()).into()),
                 |mock: &mut MockSyncK8sClient| {
                     let status_conditions = json!({"conditions": []});
                     setup_mock_client_with_conditions(mock, status_conditions);

--- a/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
@@ -95,9 +95,9 @@ impl InstrumentationStatus {
     /// any case not being one of the previous cases.
     pub(crate) fn get_health(&self) -> Health {
         if self.is_healthy() {
-            Health::Healthy(Healthy::new(self.to_string()))
+            Health::Healthy(Healthy::new().with_status(self.to_string()))
         } else {
-            Health::Unhealthy(Unhealthy::new(self.to_string(), self.last_error()))
+            Health::Unhealthy(Unhealthy::new(self.last_error()).with_status(self.to_string()))
         }
     }
 
@@ -371,10 +371,10 @@ mod tests {
             TestData {
                 case: "default case",
                 status: InstrumentationStatus::default(),
-                expected: Health::Unhealthy(Unhealthy::new(
+                expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                     "podsMatching:0, podsHealthy:0, podsInjected:0, podsNotReady:0, podsOutdated:0, podsUnhealthy:0"
-                        .to_string(), String::default()
-                )),
+                        .to_string()),
+                ),
             },
             TestData {
                 case: "healthy case",
@@ -384,7 +384,7 @@ mod tests {
                     pods_injected: 1,
                     ..Default::default()
                 },
-                expected: Health::Healthy(Healthy::new(
+                expected: Health::Healthy(Healthy::new().with_status(
                     "podsMatching:1, podsHealthy:1, podsInjected:1, podsNotReady:0, podsOutdated:0, podsUnhealthy:0"
                         .to_string()
                 )),
@@ -396,11 +396,10 @@ mod tests {
                     pods_healthy: 1,
                     ..Default::default()
                 },
-                expected: Health::Unhealthy(Unhealthy::new(
+                expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                     "podsMatching:1, podsHealthy:1, podsInjected:0, podsNotReady:0, podsOutdated:0, podsUnhealthy:0"
-                        .to_string(),
-                    "".to_string(),
-                )),
+                        .to_string()),
+                ),
             },
             TestData {
                 case: "unhealthy case with errors",
@@ -415,11 +414,11 @@ mod tests {
                     }],
                     ..Default::default()
                 },
-                expected: Health::Unhealthy(Unhealthy::new(
+                expected: Health::Unhealthy(Unhealthy::new("pod pod1:error1".to_string()).with_status(
                     "podsMatching:1, podsHealthy:1, podsInjected:1, podsNotReady:0, podsOutdated:0, podsUnhealthy:1"
                         .to_string(),
-                    "pod pod1:error1".to_string(),
-                )),},
+                )),
+                },
                 TestData {
                     case: "unhealthy case with multiple errors",
                     status: InstrumentationStatus {
@@ -439,10 +438,9 @@ mod tests {
                         ],
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new("pod pod1:error1, pod pod2:error2".to_string()).with_status(
                         "podsMatching:1, podsHealthy:1, podsInjected:1, podsNotReady:0, podsOutdated:0, podsUnhealthy:2"
                             .to_string(),
-                        "pod pod1:error1, pod pod2:error2".to_string(),
                     )),
                 },
                 TestData {
@@ -456,12 +454,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:0, podsHealthy:1, podsInjected:1, podsNotReady:1, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
-
+                            .to_string()),
+                    ),
                 },
                 TestData {
                     case: "0 healthy pods",
@@ -474,11 +470,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:1, podsHealthy:0, podsInjected:1, podsNotReady:1, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
+                            .to_string()),
+                    ),
                 },
 
                 TestData {
@@ -492,11 +487,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:1, podsHealthy:1, podsInjected:0, podsNotReady:1, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
+                            .to_string()),
+                    ),
                 },
 
                 TestData {
@@ -510,11 +504,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:1, podsHealthy:1, podsInjected:1, podsNotReady:0, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
+                            .to_string()),
+                    ),
                 },
 
                 TestData {
@@ -528,11 +521,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:1, podsHealthy:1, podsInjected:2, podsNotReady:1, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
+                            .to_string()),
+                    ),
                 },
                 TestData {
                     case: "not ready pods",
@@ -545,11 +537,10 @@ mod tests {
                         pods_unhealthy: 1,
                         ..Default::default()
                     },
-                    expected: Health::Unhealthy(Unhealthy::new(
+                    expected: Health::Unhealthy(Unhealthy::new(String::default()).with_status(
                         "podsMatching:1, podsHealthy:1, podsInjected:1, podsNotReady:1, podsOutdated:1, podsUnhealthy:1"
-                            .to_string(),
-                        "".to_string(),
-                    )),
+                            .to_string()),
+                    ),
                 },
 
 

--- a/agent-control/src/health/k8s/health_checker/resources/stateful_set.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/stateful_set.rs
@@ -64,17 +64,14 @@ impl K8sHealthStatefulSet {
             .ok_or_else(|| missing_field_error(sts, &name, ".status.readyReplicas"))?;
 
         if replicas != ready_replicas {
-            return Ok(Unhealthy::new(
-                String::default(),
-                format!(
-                    "StatefulSet `{}` not ready: replicas `{}` different from ready_replicas `{}`",
-                    name, replicas, ready_replicas,
-                ),
-            )
+            return Ok(Unhealthy::new(format!(
+                "StatefulSet `{}` not ready: replicas `{}` different from ready_replicas `{}`",
+                name, replicas, ready_replicas,
+            ))
             .into());
         }
 
-        Ok(Healthy::new(String::default()).into())
+        Ok(Healthy::new().into())
     }
 }
 
@@ -145,7 +142,7 @@ mod tests {
                         ..Default::default()
                     }),
                 },
-                expected: Healthy::default().into(),
+                expected: Healthy::new().into(),
             },
             TestCase {
                 name: "Ready replicas is lower than expected replicas",
@@ -158,7 +155,6 @@ mod tests {
                     }),
                 },
                 expected: Unhealthy::new(
-                    String::default(),
                     "StatefulSet `name` not ready: replicas `5` different from ready_replicas `4`"
                         .into(),
                 )
@@ -293,7 +289,7 @@ mod tests {
         let result = health_checker.check_health().unwrap();
         assert_eq!(
             result,
-            HealthWithStartTime::from_healthy(Healthy::default(), start_time)
+            HealthWithStartTime::from_healthy(Healthy::new(), start_time)
         );
     }
 }

--- a/agent-control/src/health/on_host/file.rs
+++ b/agent-control/src/health/on_host/file.rs
@@ -56,12 +56,16 @@ impl From<FileHealthContent> for HealthWithStartTime {
 
         if content.healthy {
             HealthWithStartTime::from_healthy(
-                Healthy::new(content.status).with_status_time(status_time),
+                Healthy::new()
+                    .with_status(content.status)
+                    .with_status_time(status_time),
                 start_time,
             )
         } else {
             HealthWithStartTime::from_unhealthy(
-                Unhealthy::new(content.status, content.last_error).with_status_time(status_time),
+                Unhealthy::new(content.last_error)
+                    .with_status(content.status)
+                    .with_status_time(status_time),
                 start_time,
             )
         }
@@ -119,7 +123,8 @@ start_time_unix_nano: 1725444000
 status_time_unix_nano: 1725444001               
 "#,
                 expected_health: HealthWithStartTime::from_healthy(
-                    Healthy::new("some agent-specific message".into())
+                    Healthy::new()
+                        .with_status("some agent-specific message".into())
                         .with_status_time(UNIX_EPOCH + Duration::from_nanos(1725444001)),
                     UNIX_EPOCH + Duration::from_nanos(1725444000),
                 ),
@@ -134,7 +139,8 @@ start_time_unix_nano: 1725444000
 status_time_unix_nano: 1725444001               
 "#,
                 expected_health: HealthWithStartTime::from_healthy(
-                    Healthy::new("some agent-specific message".into())
+                    Healthy::new()
+                        .with_status("some agent-specific message".into())
                         .with_status_time(UNIX_EPOCH + Duration::from_nanos(1725444001)),
                     UNIX_EPOCH + Duration::from_nanos(1725444000),
                 ),
@@ -149,11 +155,9 @@ start_time_unix_nano: 1725444000
 status_time_unix_nano: 1725444001               
 "#,
                 expected_health: HealthWithStartTime::from_unhealthy(
-                    Unhealthy::new(
-                        "some agent-specific message".into(),
-                        "some error message".into(),
-                    )
-                    .with_status_time(UNIX_EPOCH + Duration::from_nanos(1725444001)),
+                    Unhealthy::new("some error message".into())
+                        .with_status("some agent-specific message".into())
+                        .with_status_time(UNIX_EPOCH + Duration::from_nanos(1725444001)),
                     UNIX_EPOCH + Duration::from_nanos(1725444000),
                 ),
             },
@@ -167,7 +171,8 @@ start_time_unix_nano: 1725444000
 status_time_unix_nano: 1725444001               
 "#,
                 expected_health: HealthWithStartTime::from_unhealthy(
-                    Unhealthy::new("some agent-specific message".into(), "".into())
+                    Unhealthy::new("".into())
+                        .with_status("some agent-specific message".into())
                         .with_status_time(UNIX_EPOCH + Duration::from_nanos(1725444001)),
                     UNIX_EPOCH + Duration::from_nanos(1725444000),
                 ),

--- a/agent-control/src/health/on_host/http.rs
+++ b/agent-control/src/health/on_host/http.rs
@@ -117,7 +117,7 @@ impl<C: HttpClient> HealthChecker for HttpHealthChecker<C> {
             || self.healthy_status_codes.contains(&status_code.as_u16())
         {
             return Ok(HealthWithStartTime::from_healthy(
-                Healthy::new(status),
+                Healthy::new().with_status(status),
                 self.start_time,
             ));
         }
@@ -128,7 +128,7 @@ impl<C: HttpClient> HealthChecker for HttpHealthChecker<C> {
         );
 
         Ok(HealthWithStartTime::from_unhealthy(
-            Unhealthy::new(status, last_error),
+            Unhealthy::new(last_error).with_status(status),
             self.start_time,
         ))
     }

--- a/agent-control/src/health/with_start_time.rs
+++ b/agent-control/src/health/with_start_time.rs
@@ -30,12 +30,14 @@ impl From<opamp_client::opamp::proto::ComponentHealth> for HealthWithStartTime {
 
         if component_health.healthy {
             HealthWithStartTime::from_healthy(
-                Healthy::new(component_health.status).with_status_time(status_time),
+                Healthy::new()
+                    .with_status(component_health.status)
+                    .with_status_time(status_time),
                 start_time,
             )
         } else {
             HealthWithStartTime::from_unhealthy(
-                Unhealthy::new(component_health.status, component_health.last_error),
+                Unhealthy::new(component_health.last_error).with_status(component_health.status),
                 start_time,
             )
         }

--- a/agent-control/src/sub_agent/health_checker.rs
+++ b/agent-control/src/sub_agent/health_checker.rs
@@ -33,7 +33,7 @@ pub mod tests {
     #[test]
     fn test_publish_health_event() {
         let (publisher, consumer) = pub_sub::<SubAgentInternalEvent>();
-        let health = HealthWithStartTime::new(Healthy::default().into(), SystemTime::now());
+        let health = HealthWithStartTime::new(Healthy::new().into(), SystemTime::now());
         publisher.publish_health_event(health.clone());
         let event = consumer.as_ref().recv().unwrap();
         assert_matches!(event, SubAgentInternalEvent::AgentHealthInfo(h) => {
@@ -48,7 +48,7 @@ pub mod tests {
         // Drop the consumer to close the channel
         drop(consumer);
 
-        let health = HealthWithStartTime::new(Healthy::default().into(), SystemTime::now());
+        let health = HealthWithStartTime::new(Healthy::new().into(), SystemTime::now());
         publisher.publish_health_event(health.clone());
 
         logs_contain("Error publishing sub agent event:");

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -209,7 +209,7 @@ impl NotStartedSupervisorOnHost {
 
             let supervisor_start_time = SystemTime::now();
 
-            let init_health = Healthy::new(String::default());
+            let init_health = Healthy::new();
 
             internal_event_publisher.publish_health_event(HealthWithStartTime::new(
                 init_health.into(),
@@ -266,7 +266,6 @@ impl NotStartedSupervisorOnHost {
                     );
 
                     let unhealthy = Unhealthy::new(
-                        String::default(),
                         "supervisor exceeded its defined restart policy".to_string(),
                     );
 
@@ -313,13 +312,10 @@ fn handle_termination(
     start_time: SystemTime,
 ) -> i32 {
     if !exit_status.success() {
-        let unhealthy: Unhealthy = Unhealthy::new(
-            format!(
-                "process exited with code: {:?}",
-                exit_status.code().unwrap_or_default()
-            ),
-            exit_status.to_string(),
-        );
+        let unhealthy: Unhealthy = Unhealthy::new(exit_status.to_string()).with_status(format!(
+            "process exited with code: {:?}",
+            exit_status.code().unwrap_or_default()
+        ));
         internal_event_publisher
             .publish_health_event(HealthWithStartTime::new(unhealthy.into(), start_time));
         error!(
@@ -626,16 +622,12 @@ pub mod tests {
 
         // It starts once and restarts 3 times, hence 4 healthy events and a final unhealthy one
         let expected_ordered_events: Vec<SubAgentInternalEvent> = [
-            HealthWithStartTime::new(Healthy::default().into(), start_time),
-            HealthWithStartTime::new(Healthy::default().into(), start_time),
-            HealthWithStartTime::new(Healthy::default().into(), start_time),
-            HealthWithStartTime::new(Healthy::default().into(), start_time),
+            HealthWithStartTime::new(Healthy::new().into(), start_time),
+            HealthWithStartTime::new(Healthy::new().into(), start_time),
+            HealthWithStartTime::new(Healthy::new().into(), start_time),
+            HealthWithStartTime::new(Healthy::new().into(), start_time),
             HealthWithStartTime::new(
-                Unhealthy::new(
-                    String::default(),
-                    "supervisor exceeded its defined restart policy".to_string(),
-                )
-                .into(),
+                Unhealthy::new("supervisor exceeded its defined restart policy".to_string()).into(),
                 start_time,
             ),
         ]

--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -561,7 +561,7 @@ where
             .start(self.sub_agent_internal_publisher.clone())
             .inspect_err(|err| {
                 let unhealthy = HealthWithStartTime::from_unhealthy(
-                    Unhealthy::new(String::default(), err.to_string()),
+                    Unhealthy::new(err.to_string()),
                     SystemTime::now(),
                 );
                 error!("Failure starting supervisor: {err}");
@@ -825,11 +825,11 @@ pub mod tests {
     }
 
     fn healthy(status: &str) -> Health {
-        Health::Healthy(Healthy::new(status.to_string()))
+        Health::Healthy(Healthy::new().with_status(status.to_string()))
     }
 
     fn unhealthy(status: &str, error: &str) -> Health {
-        Health::Unhealthy(Unhealthy::new(status.to_string(), error.to_string()))
+        Health::Unhealthy(Unhealthy::new(error.to_string()).with_status(status.to_string()))
     }
 
     /// Helpers for testing the config scenarios which some of the data their produce are related to each other.


### PR DESCRIPTION
# What this PR does / why we need it

This PR updates the builder functions for Healthy and Unhealthy structs in order to stop requiring the `status` argument. The `status` is not define yet and there are plenty of usages where we simply provide an empty string.

## Special notes for your reviewer

On top of #1345 

See: https://github.com/newrelic/newrelic-agent-control/pull/1345#discussion_r2137748723

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
