### PR TITLE
fix(updater): flaky test

### DIFF
--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -92,7 +92,7 @@ fn k8s_run_updater() {
             return Ok(());
         }
 
-        Err(UpdaterError::UpdateFailed(format!("HelmRelease version not updated: {obj:?}")).into())
+        Err(format!("HelmRelease version not updated: {obj:?}").into())
     })
 }
 


### PR DESCRIPTION
# What this PR does / why we need it
Somehow I forgot that Kubernetes could take some time to reflect changes
I think that the patch apply should not be affected by the race condition, if we notice something I could add a retry there as well
## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
