### PR TITLE
refactor: move sub-agent's internal event publisher to the corresponding builders

### DIFF
--- a/agent-control/src/agent_control/agent_control.rs
+++ b/agent-control/src/agent_control/agent_control.rs
@@ -8,8 +8,8 @@ use crate::agent_control::config_validator::DynamicConfigValidator;
 use crate::agent_control::error::AgentError;
 use crate::agent_control::uptime_report::UptimeReporter;
 use crate::event::{
-    AgentControlEvent, ApplicationEvent, OpAMPEvent, SubAgentEvent,
-    broadcaster::unbounded::UnboundedBroadcast, channel::EventConsumer,
+    AgentControlEvent, ApplicationEvent, OpAMPEvent, broadcaster::unbounded::UnboundedBroadcast,
+    channel::EventConsumer,
 };
 use crate::health::health_checker::{Health, Healthy, Unhealthy};
 use crate::health::with_start_time::HealthWithStartTime;
@@ -42,7 +42,6 @@ where
     start_time: SystemTime,
     pub(super) sa_dynamic_config_store: Arc<SL>,
     pub(super) agent_control_publisher: UnboundedBroadcast<AgentControlEvent>,
-    sub_agent_publisher: UnboundedBroadcast<SubAgentEvent>,
     application_event_consumer: EventConsumer<ApplicationEvent>,
     agent_control_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
     dynamic_config_validator: DV,
@@ -66,7 +65,6 @@ where
         sub_agent_builder: S,
         sa_dynamic_config_store: Arc<SL>,
         agent_control_publisher: UnboundedBroadcast<AgentControlEvent>,
-        sub_agent_publisher: UnboundedBroadcast<SubAgentEvent>,
         application_event_consumer: EventConsumer<ApplicationEvent>,
         agent_control_opamp_consumer: Option<EventConsumer<OpAMPEvent>>,
         dynamic_config_validator: DV,
@@ -81,7 +79,6 @@ where
             start_time: SystemTime::now(),
             sa_dynamic_config_store,
             agent_control_publisher,
-            sub_agent_publisher,
             application_event_consumer,
             agent_control_opamp_consumer,
             dynamic_config_validator,
@@ -177,9 +174,7 @@ where
     ) -> Result<(), AgentError> {
         running_sub_agents.insert(
             agent_identity.id.clone(),
-            self.sub_agent_builder
-                .build(agent_identity, self.sub_agent_publisher.clone())?
-                .run(),
+            self.sub_agent_builder.build(agent_identity)?.run(),
         );
 
         Ok(())
@@ -483,7 +478,6 @@ mod tests {
             MockSubAgentBuilder::new(),
             Arc::new(sa_dynamic_config_store),
             UnboundedBroadcast::default(),
-            UnboundedBroadcast::default(),
             application_event_consumer,
             Some(opamp_consumer),
             dynamic_config_validator,
@@ -537,7 +531,6 @@ mod tests {
             sub_agent_builder,
             Arc::new(sa_dynamic_config_store),
             UnboundedBroadcast::default(),
-            UnboundedBroadcast::default(),
             application_event_consumer,
             Some(opamp_consumer),
             dynamic_config_validator,
@@ -582,7 +575,6 @@ mod tests {
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,
@@ -645,7 +637,6 @@ mod tests {
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,
@@ -753,7 +744,6 @@ mod tests {
                     Some(started_client),
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
-                    UnboundedBroadcast::default(),
                     UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
@@ -883,7 +873,6 @@ agents:
             None::<MockStartedOpAMPClient>,
             sub_agent_builder,
             Arc::new(sa_dynamic_config_store),
-            UnboundedBroadcast::default(),
             UnboundedBroadcast::default(),
             pub_sub().1,
             Some(opamp_consumer),
@@ -1035,7 +1024,6 @@ agents:
             sub_agent_builder,
             Arc::new(sa_dynamic_config_store),
             UnboundedBroadcast::default(),
-            UnboundedBroadcast::default(),
             pub_sub().1,
             Some(opamp_consumer),
             dynamic_config_validator,
@@ -1130,7 +1118,6 @@ agents:
             sub_agent_builder,
             Arc::new(sa_dynamic_config_store),
             UnboundedBroadcast::default(),
-            UnboundedBroadcast::default(),
             pub_sub().1,
             Some(opamp_consumer),
             dynamic_config_validator,
@@ -1220,7 +1207,6 @@ agents:
             Some(started_client),
             sub_agent_builder,
             Arc::new(dynamic_config_store),
-            UnboundedBroadcast::default(),
             UnboundedBroadcast::default(),
             pub_sub().1,
             Some(opamp_consumer),
@@ -1322,7 +1308,6 @@ agents:
             sub_agent_builder,
             Arc::new(dynamic_config_store),
             UnboundedBroadcast::default(),
-            UnboundedBroadcast::default(),
             pub_sub().1,
             Some(opamp_consumer),
             dynamic_config_validator,
@@ -1413,7 +1398,6 @@ agents:
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,
@@ -1496,7 +1480,6 @@ agents:
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,
@@ -1570,7 +1553,6 @@ agents:
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,
@@ -1686,7 +1668,6 @@ agents:
                     sub_agent_builder,
                     Arc::new(sa_dynamic_config_store),
                     agent_control_publisher,
-                    UnboundedBroadcast::default(),
                     application_event_consumer,
                     Some(opamp_consumer),
                     dynamic_config_validator,

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -133,6 +133,7 @@ impl AgentControlRunner {
             Arc::new(remote_config_parser),
             yaml_config_repository.clone(),
             agents_assembler.clone(),
+            self.sub_agent_publisher,
         );
 
         let garbage_collector = K8sGarbageCollector {
@@ -160,7 +161,6 @@ impl AgentControlRunner {
             sub_agent_builder,
             config_storer,
             self.agent_control_publisher,
-            self.sub_agent_publisher,
             self.application_event_consumer,
             maybe_opamp_consumer,
             dynamic_config_validator,

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -156,6 +156,7 @@ impl AgentControlRunner {
             Arc::new(remote_config_parser),
             yaml_config_repository,
             agents_assembler,
+            self.sub_agent_publisher,
         );
 
         let dynamic_config_validator =
@@ -169,7 +170,6 @@ impl AgentControlRunner {
             sub_agent_builder,
             config_storer,
             self.agent_control_publisher,
-            self.sub_agent_publisher,
             self.application_event_consumer,
             maybe_sa_opamp_consumer,
             dynamic_config_validator,

--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -57,7 +57,6 @@ pub trait SubAgentBuilder {
     fn build(
         &self,
         agent_identity: &AgentIdentity,
-        sub_agent_publisher: UnboundedBroadcast<SubAgentEvent>,
     ) -> Result<Self::NotStartedSubAgent, SubAgentBuilderError>;
 }
 
@@ -773,7 +772,6 @@ pub mod tests {
             fn build(
                 &self,
                 agent_identity: &AgentIdentity,
-                sub_agent_publisher: UnboundedBroadcast<SubAgentEvent>,
             ) -> Result<<Self as SubAgentBuilder>::NotStartedSubAgent,  SubAgentBuilderError>;
         }
     }
@@ -782,7 +780,7 @@ pub mod tests {
         // should_build provides a helper method to create a subagent which runs and stops
         // successfully
         pub(crate) fn should_build(&mut self, times: usize) {
-            self.expect_build().times(times).returning(|_, _| {
+            self.expect_build().times(times).returning(|_| {
                 let mut not_started_sub_agent = MockNotStartedSubAgent::new();
                 not_started_sub_agent.expect_run().times(1).returning(|| {
                     let mut started_agent = MockStartedSubAgent::new();


### PR DESCRIPTION
# What this PR does / why we need it

Moves the internal event publisher for sub-agent from AgentControl to the corresponding builders.

## Special notes for your reviewer

The Agent Control component merely provided a copy of the publisher to each agent. This is actually responsibility of the corresponding builder. This change allows us simplifying the Agent Control component a bit.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
