### PR TITLE
test: parse full remote config structure

### DIFF
--- a/agent-control/src/values/config.rs
+++ b/agent-control/src/values/config.rs
@@ -64,6 +64,10 @@ impl RemoteConfig {
         self.config_hash.is_applying()
     }
 
+    pub fn is_failed(&self) -> bool {
+        self.config_hash.is_failed()
+    }
+
     pub fn hash(&self) -> Hash {
         self.config_hash.clone()
     }
@@ -76,6 +80,7 @@ impl RemoteConfig {
 #[cfg(test)]
 mod tests {
 
+    use rstest::rstest;
     use serde_yaml::Value;
 
     use super::*;
@@ -87,19 +92,33 @@ mod tests {
     state: applying
     "#;
 
-    #[test]
-    fn basic_serde() {
-        let remote_config: RemoteConfig = serde_yaml::from_str(EXAMPLE_REMOTE_CONFIG).unwrap();
+    const EXAMPLE_REMOTE_CONFIG_WITH_ERROR: &str = r#"
+    config:
+        key: value
+    hash: "examplehash"
+    state: failed
+    error_message: "An error occurred"
+    "#;
+
+    #[rstest]
+    #[case(EXAMPLE_REMOTE_CONFIG, RemoteConfig::is_applying, "applying")]
+    #[case(EXAMPLE_REMOTE_CONFIG_WITH_ERROR, RemoteConfig::is_failed, "failed")]
+    fn basic_serde(
+        #[case] example: &str,
+        #[case] check_state: impl Fn(&RemoteConfig) -> bool,
+        #[case] expected_state: &str,
+    ) {
+        let remote_config: RemoteConfig = serde_yaml::from_str(example).unwrap();
         assert_eq!(remote_config.config.get("key").unwrap(), "value");
         assert_eq!(remote_config.hash().get(), "examplehash");
-        assert!(remote_config.is_applying());
+        assert!(check_state(&remote_config));
 
         let serialized_yaml_value = serde_yaml::to_value(&remote_config).unwrap();
         assert_eq!(serialized_yaml_value["config"]["key"], "value");
         assert_eq!(serialized_yaml_value["hash"], "examplehash");
-        assert_eq!(serialized_yaml_value["state"], "applying");
+        assert_eq!(serialized_yaml_value["state"], expected_state);
 
-        let deserialized_yaml_value = serde_yaml::from_str::<Value>(EXAMPLE_REMOTE_CONFIG).unwrap();
+        let deserialized_yaml_value = serde_yaml::from_str::<Value>(example).unwrap();
         assert_eq!(deserialized_yaml_value, serialized_yaml_value);
     }
 }


### PR DESCRIPTION
# What this PR does / why we need it

Adds the same test present in https://github.com/newrelic/newrelic-agent-control/pull/1352/files so we are sure the structure has not changed.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
