### PR TITLE
feat: introduce AC health-checker [NR-420264]

### DIFF
--- a/agent-control/src/agent_control/health_checker.rs
+++ b/agent-control/src/agent_control/health_checker.rs
@@ -1,9 +1,26 @@
 use serde::Deserialize;
+use tracing::error;
 
-use crate::health::health_checker::HealthCheckInterval;
+use crate::{
+    event::{AgentControlInternalEvent, channel::EventPublisher},
+    health::{
+        events::HealthEventPublisher, health_checker::HealthCheckInterval,
+        with_start_time::HealthWithStartTime,
+    },
+};
 
 /// Holds the Agent Control configuration fields for setting up the health-check.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 pub struct AgentControlHealthCheckerConfig {
-    interval: HealthCheckInterval,
+    pub interval: HealthCheckInterval,
+}
+
+impl HealthEventPublisher for EventPublisher<AgentControlInternalEvent> {
+    fn publish_health_event(&self, health: HealthWithStartTime) {
+        let event = AgentControlInternalEvent::HealthUpdated(health);
+        let event_type = format!("{event:?}");
+        let _ = self.publish(event).map_err(|err| {
+            error!(%event_type, "Error publishing Agent Control internal event {err}");
+        });
+    }
 }

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -13,6 +13,7 @@ use crate::agent_control::resource_cleaner::k8s_garbage_collector::K8sGarbageCol
 use crate::agent_control::run::AgentControlRunner;
 use crate::agent_control::version_updater::k8s::K8sACUpdater;
 use crate::agent_type::render::renderer::TemplateRenderer;
+use crate::health::noop::NONE_HEALTH_CHECKER_BUILDER;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
@@ -34,6 +35,7 @@ use opamp_client::operation::settings::DescriptionValueType;
 use resource_detection::system::hostname::HostnameGetter;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tracing::{debug, error, info, warn};
 
 impl AgentControlRunner {
@@ -159,6 +161,7 @@ impl AgentControlRunner {
         AgentControl::new(
             maybe_client,
             sub_agent_builder,
+            SystemTime::now(),
             config_storer,
             self.agent_control_publisher,
             self.application_event_consumer,
@@ -166,6 +169,7 @@ impl AgentControlRunner {
             dynamic_config_validator,
             garbage_collector,
             k8s_ac_updater,
+            NONE_HEALTH_CHECKER_BUILDER, // TODO: use actual health-checker builder and check current behavior in AC
             agent_control_config,
         )
         .run()

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -13,6 +13,7 @@ use crate::agent_control::version_updater::updater::NoOpUpdater;
 use crate::agent_type::render::persister::config_persister_file::ConfigurationPersisterFile;
 use crate::agent_type::render::renderer::TemplateRenderer;
 use crate::agent_type::variable::definition::VariableDefinition;
+use crate::health::noop::NONE_HEALTH_CHECKER_BUILDER;
 use crate::http::client::HttpClient;
 use crate::http::config::{HttpConfig, ProxyConfig};
 use crate::opamp::effective_config::loader::DefaultEffectiveConfigLoaderBuilder;
@@ -36,6 +37,7 @@ use opamp_client::operation::settings::DescriptionValueType;
 use resource_detection::cloud::http_client::DEFAULT_CLIENT_TIMEOUT;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tracing::{debug, info};
 
 impl AgentControlRunner {
@@ -168,6 +170,7 @@ impl AgentControlRunner {
         AgentControl::new(
             maybe_client,
             sub_agent_builder,
+            SystemTime::now(),
             config_storer,
             self.agent_control_publisher,
             self.application_event_consumer,
@@ -175,6 +178,7 @@ impl AgentControlRunner {
             dynamic_config_validator,
             NoOpResourceCleaner,
             NoOpUpdater,
+            NONE_HEALTH_CHECKER_BUILDER, // TODO: use actual health-checker builder and check current behavior in AC
             agent_control_config,
         )
         .run()

--- a/agent-control/src/health.rs
+++ b/agent-control/src/health.rs
@@ -1,5 +1,6 @@
 pub mod events;
 pub mod health_checker;
+pub mod noop;
 pub mod with_start_time;
 
 pub mod k8s;

--- a/agent-control/src/health/noop.rs
+++ b/agent-control/src/health/noop.rs
@@ -1,0 +1,43 @@
+use std::time::SystemTime;
+
+use super::{
+    health_checker::{HealthChecker, HealthCheckerError, Healthy},
+    with_start_time::HealthWithStartTime,
+};
+
+/// HealthCheckerBuilder that always return None.
+pub const NONE_HEALTH_CHECKER_BUILDER: fn(SystemTime) -> Option<NoOpHealthChecker> = |_| None;
+
+/// No-op implementation for [HealthChecker]. It always returns healthy.
+pub struct NoOpHealthChecker {
+    start_time: SystemTime,
+}
+
+impl NoOpHealthChecker {
+    pub fn new(start_time: SystemTime) -> Self {
+        Self { start_time }
+    }
+}
+
+impl HealthChecker for NoOpHealthChecker {
+    fn check_health(&self) -> Result<HealthWithStartTime, HealthCheckerError> {
+        Ok(HealthWithStartTime::from_healthy(
+            Healthy::new(),
+            self.start_time,
+        ))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+
+    impl Default for NoOpHealthChecker {
+        fn default() -> Self {
+            Self {
+                start_time: SystemTime::UNIX_EPOCH,
+            }
+        }
+    }
+}

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -7,9 +7,7 @@ use newrelic_agent_control::agent_control::config::{
     AgentControlDynamicConfig, helmrelease_v2_type_meta,
 };
 use newrelic_agent_control::agent_control::version_updater::k8s::K8sACUpdater;
-use newrelic_agent_control::agent_control::version_updater::updater::{
-    UpdaterError, VersionUpdater,
-};
+use newrelic_agent_control::agent_control::version_updater::updater::VersionUpdater;
 use newrelic_agent_control::cli::install_agent_control::RELEASE_NAME;
 use newrelic_agent_control::k8s::client::SyncK8sClient;
 use std::sync::Arc;


### PR DESCRIPTION
# What this PR does / why we need it

This PR introduces a health-checker in the Agent Control component.

## Special notes for your reviewer

The AgentControl component now includes:
- An Internal events channell
- An health-checker builder.

When the builder returns some health-checker a separate thread is launched that will report the results to Agent Control through the internal events channel.

Currently **no behavior is changed** since both on-host and k8s instances receive a health-checker returning `None`. This will be addressed in a follow-up PR. However, a unit-tests has been introduced to check that the health-check is properly handled when a builder returning a health-checker is provided to AgentControl. 

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
