### PR TITLE
test: remove cleanup manage resources flag

### DIFF
--- a/agent-control/tests/k8s/agent_control_cli/installation.rs
+++ b/agent-control/tests/k8s/agent_control_cli/installation.rs
@@ -104,11 +104,8 @@ pub(crate) fn create_simple_values_secret(
     secret_name: &str,
     values_key: &str,
 ) {
-    // We set cleanupManagedResources: false to avoid race conditions between the old way to uninstall and the new one
-    // TODO remove it once it is not needed anymore.
     let values = serde_json::json!({
         "nameOverride": "",
-        "cleanupManagedResources": false,
         "config": {
             "fleet_control": {
                 "enabled": false,


### PR DESCRIPTION
# What this PR does / why we need it

Updates a test to stop using a flag, now that we have the new installation job.

## Which issue this PR fixes

Related to #NR-418111

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
