### PR TITLE
ci(e2e, nightly, prerelease): remove non-existent matrix reference

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,7 +113,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - name: Run k8s e2e-test ${{ matrix.group }}
+      - name: Run k8s e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1
         env:
           # SI L2 for AC

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -143,7 +143,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - name: Run k8s e2e-test ${{ matrix.group }}
+      - name: Run k8s e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1
         env:
           # SI L2 for AC


### PR DESCRIPTION
# What this PR does / why we need it

The E2E tests in the nightlies and pre-release seem to reference a `${{ matrix.group }}` but this does not exist and evaluates to an empty string. The e2e test is selected by hardcoding the spec path. Just removing the `matrix` reference for clarity.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
