### PR TITLE
fix(update): include chart_version in effective config

### DIFF
--- a/agent-control/tests/common/effective_config.rs
+++ b/agent-control/tests/common/effective_config.rs
@@ -14,16 +14,18 @@ pub fn check_latest_effective_config_is_expected(
         let cfg_body = effective_cfg.config_map.clone().unwrap().config_map[""]
             .body
             .to_vec();
-        if expected_config.as_bytes() != cfg_body {
+        let cfg_body_str = String::from_utf8(cfg_body).unwrap();
+        // Avoid ordering and whitespace issues when comparing
+        let cfg_yaml: serde_yaml::Value = serde_yaml::from_str(&cfg_body_str).unwrap();
+        let expected_yaml: serde_yaml::Value = serde_yaml::from_str(&expected_config).unwrap();
+        if cfg_yaml != expected_yaml {
             return Err(format!(
-                "Effective config not as expected, Expected: {:?}, Found: {:?}",
-                expected_config,
-                String::from_utf8(cfg_body).unwrap(),
+                "Effective config not as expected, Expected: {expected_config:?}, Found: {cfg_body_str:?}",
             )
             .into());
         }
     } else {
-        return Err("No effective config created".into());
+        return Err(format!("No effective config received for {instance_id}").into());
     }
 
     Ok(())

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -108,17 +108,16 @@ fn k8s_self_update_bump_chart_version_with_new_config() {
     agent_type: newrelic/io.opentelemetry.collector:0.1.0
 "#;
 
-    opamp_server.set_config_response(
-        ac_instance_id.clone(),
-        ConfigResponse::from(
-            format!(
-                r#"
+    let ac_config = format!(
+        r#"
 {agents_config}
 chart_version: {LOCAL_CHART_NEW_VERSION}
 "#
-            )
-            .as_str(),
-        ),
+    );
+
+    opamp_server.set_config_response(
+        ac_instance_id.clone(),
+        ConfigResponse::from(ac_config.as_str()),
     );
 
     // Assert that opamp server receives Agent description with updated version.
@@ -147,7 +146,7 @@ chart_version: {LOCAL_CHART_NEW_VERSION}
         check_latest_effective_config_is_expected(
             &opamp_server,
             &ac_instance_id,
-            agents_config.to_string(),
+            ac_config.clone(),
         )?;
         check_latest_remote_config_status_is_expected(
             &opamp_server,


### PR DESCRIPTION
# What this PR does / why we need it

This PR includes the `chart_version` in AC effective config.

On top of #1365 

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
