### PR TITLE
chore: disable nightlies on-host e2e temporarily

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,17 +77,18 @@ jobs:
           local_packages_path: "/srv/dist/"
           apt_skip_mirror: true
 
-  onhost-e2e:
-    uses: ./.github/workflows/component_onhost_e2e.yaml
-    needs: [ upload-packages-s3 ]
-    with:
-      UNIQUE_NAME: "nightly:e2e"
-      EC2_FILTERS: '[\"ubuntu22.04\"]'
-      REPOSITORY_ENDPOINT: "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/preview"
-      PACKAGE_VERSION: 0.100.${{ github.run_id }}
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
+ # TODO: enable back when tackling <https://new-relic.atlassian.net/browse/NR-428719>
+ # onhost-e2e:
+ #   uses: ./.github/workflows/component_onhost_e2e.yaml
+ #   needs: [ upload-packages-s3 ]
+ #   with:
+ #     UNIQUE_NAME: "nightly:e2e"
+ #     EC2_FILTERS: '[\"ubuntu22.04\"]'
+ #     REPOSITORY_ENDPOINT: "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/preview"
+ #     PACKAGE_VERSION: 0.100.${{ github.run_id }}
+ #   secrets:
+ #     AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+ #     AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   k8s-e2e-tests:
     name: K8s e2e tests
@@ -144,19 +145,22 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
-  onhost_canaries:
-    uses: ./.github/workflows/component_onhost_canaries.yml
-    needs: [ build-packages ]
-    with:
-      environment: staging
-      operation: apply
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
+# TODO: enable back when tackling <https://new-relic.atlassian.net/browse/NR-428719>
+#  onhost_canaries:
+#    uses: ./.github/workflows/component_onhost_canaries.yml
+#    needs: [ build-packages ]
+#    with:
+#      environment: staging
+#      operation: apply
+#    secrets:
+#      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+#      AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
 
   notify-failure:
     if: ${{ always() && failure() }}
-    needs: [ onhost-e2e, k8s_canaries, security-image, security-source-code, build-image, build-packages, k8s-e2e-tests ]
+    #needs: [ onhost-e2e, k8s_canaries, security-image, security-source-code, build-image, build-packages, k8s-e2e-tests ]
+    # TODO: and onhost-e2e back when tackling <https://new-relic.atlassian.net/browse/NR-428719> and also add on-host canaries
+    needs: [ k8s_canaries, security-image, security-source-code, build-image, build-packages, k8s-e2e-tests ]
     runs-on: ubuntu-latest
     steps:
     - name: Notify failure via Slack


### PR DESCRIPTION
# What this PR does / why we need it

Disables on-host e2e from nightlies in order to acknowledge a known issue while working on the corresponding fix. See: https://github.com/newrelic/newrelic-agent-control/actions/runs/15749174728


- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
