### PR TITLE
feat: expose k8s client timeout config (NR-421964)

### DIFF
--- a/agent-control/src/cli/utils.rs
+++ b/agent-control/src/cli/utils.rs
@@ -1,4 +1,5 @@
 use crate::cli::errors::CliError;
+use crate::k8s::client::ClientConfig;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use std::collections::BTreeMap;
@@ -46,7 +47,8 @@ pub fn try_new_k8s_client(namespace: String) -> Result<SyncK8sClient, CliError> 
     );
 
     debug!("Starting the k8s client");
-    SyncK8sClient::try_new(runtime, namespace).map_err(|err| CliError::K8sClient(err.to_string()))
+    SyncK8sClient::try_new(runtime, &ClientConfig::new(namespace))
+        .map_err(|err| CliError::K8sClient(err.to_string()))
 }
 
 pub fn retry<F>(max_attempts: usize, interval: Duration, mut f: F) -> Result<(), CliError>

--- a/agent-control/src/flags.rs
+++ b/agent-control/src/flags.rs
@@ -142,7 +142,14 @@ impl Flags {
             proxy,
 
             k8s_config: match mode {
-                Environment::OnHost => K8sConfig::default(),
+                // This config is not used on the OnHost environment, a blank config is used.
+                // K8sConfig has not default since cluster_name is a required.
+                Environment::OnHost => K8sConfig {
+                    cluster_name: Default::default(),
+                    client_config: Default::default(),
+                    chart_version: Default::default(),
+                    cr_type_meta: Default::default(),
+                },
                 Environment::K8s => agent_control_config.k8s.ok_or(InitError::K8sConfig())?,
             },
         };

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -214,7 +214,6 @@ pub mod tests {
     use std::collections::HashMap;
 
     const TEST_CLUSTER_NAME: &str = "cluster_name";
-    const TEST_NAMESPACE: &str = "test-namespace";
     const TEST_AGENT_ID: &str = "k8s-test";
 
     #[test]
@@ -229,7 +228,6 @@ pub mod tests {
 
         let k8s_config = K8sConfig {
             cluster_name: TEST_CLUSTER_NAME.to_string(),
-            namespace: TEST_NAMESPACE.to_string(),
             cr_type_meta: K8sConfig::default().cr_type_meta,
             ..Default::default()
         };
@@ -265,7 +263,6 @@ pub mod tests {
 
         let k8s_config = K8sConfig {
             cluster_name: TEST_CLUSTER_NAME.to_string(),
-            namespace: TEST_NAMESPACE.to_string(),
             cr_type_meta: K8sConfig::default().cr_type_meta,
             ..Default::default()
         };
@@ -432,7 +429,6 @@ pub mod tests {
 
         let k8s_config = K8sConfig {
             cluster_name: TEST_CLUSTER_NAME.to_string(),
-            namespace: TEST_NAMESPACE.to_string(),
             cr_type_meta: K8sConfig::default().cr_type_meta,
             ..Default::default()
         };

--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -45,10 +45,22 @@ pub fn start_agent_control_with_custom_config(
             proxy: agent_control_config.proxy,
 
             k8s_config: match mode {
-                Environment::OnHost => K8sConfig::default(),
-                Environment::K8s => agent_control_config
-                    .k8s
-                    .expect("K8s config must be present when running in K8s"),
+                // This config is not used on the OnHost environment, a blank config is used.
+                // K8sConfig has not default since cluster_name is a required.
+                Environment::OnHost => K8sConfig {
+                    cluster_name: Default::default(),
+                    client_config: Default::default(),
+                    chart_version: Default::default(),
+                    cr_type_meta: Default::default(),
+                },
+                Environment::K8s => {
+                    let mut cfg = agent_control_config
+                        .k8s
+                        .expect("K8s config must be present when running in K8s");
+
+                    cfg.client_config.client_timeout = Duration::from_secs(30).into();
+                    cfg
+                }
             },
         };
 

--- a/agent-control/tests/common/global_logger.rs
+++ b/agent-control/tests/common/global_logger.rs
@@ -14,7 +14,7 @@ pub fn init_logger() {
         format:
           target: true
           ansi_colors: true
-        insecure_fine_grained_level: "newrelic_agent_control=trace,opamp_client=info,kube=debug,off"
+        insecure_fine_grained_level: "newrelic_agent_control=trace,kube=debug,off"
         show_spans: true
                 "#,
         )

--- a/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
+++ b/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
@@ -27,7 +27,7 @@ fn k8s_cli_install_agent_control_creates_resources() {
     cmd.arg("--skip-installation-check"); // Skipping checks because we are merely checking that the resources are created.
     cmd.assert().success();
 
-    let k8s_client = SyncK8sClient::try_new(runtime.clone(), namespace.clone()).unwrap();
+    let k8s_client = SyncK8sClient::try_from_namespace(runtime.clone(), namespace.clone()).unwrap();
     let agent_identity = AgentIdentity::new_agent_control_identity();
 
     // Assert repository data
@@ -125,7 +125,7 @@ fn k8s_cli_install_agent_control_creates_resources_with_specific_repository_url(
     cmd.arg("--repository-url").arg(repository_url);
     cmd.assert().success();
 
-    let k8s_client = SyncK8sClient::try_new(runtime.clone(), namespace.clone()).unwrap();
+    let k8s_client = SyncK8sClient::try_from_namespace(runtime.clone(), namespace.clone()).unwrap();
     let repository = k8s_client
         .get_dynamic_object(&helmrepository_type_meta(), REPOSITORY_NAME)
         .unwrap()

--- a/agent-control/tests/k8s/client.rs
+++ b/agent-control/tests/k8s/client.rs
@@ -26,7 +26,11 @@ const TEST_LABEL_VALUE: &str = "value";
 #[ignore = "needs k8s cluster"]
 async fn k8s_missing_namespace_creation_fail() {
     let test_ns = "test-not-existing-namespace";
-    assert!(AsyncK8sClient::try_new(test_ns.to_string()).await.is_err());
+    assert!(
+        AsyncK8sClient::try_from_namespace(test_ns.to_string())
+            .await
+            .is_err()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -45,7 +49,9 @@ async fn k8s_create_dynamic_resource() {
     .unwrap();
     let obj: DynamicObject = serde_yaml::from_str(cr.as_str()).unwrap();
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     k8s_client.apply_dynamic_object(&obj).await.unwrap();
 
@@ -63,7 +69,9 @@ async fn k8s_get_dynamic_resource() {
 
     let cr_name = "get-test";
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     assert!(
         k8s_client
@@ -117,7 +125,9 @@ async fn k8s_dynamic_resource_has_changed() {
 
     let cr_name = "has-changed-test";
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     assert!(
         k8s_client
@@ -208,7 +218,9 @@ async fn k8s_dynamic_resource_has_changed_secret() {
 
     let secret_name = "secret-name";
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     let secret_type_meta = TypeMeta {
         api_version: "v1".into(),
@@ -279,7 +291,9 @@ async fn k8s_delete_dynamic_resource() {
     )
     .await;
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     k8s_client
         .delete_dynamic_object(&foo_type_meta(), cr_name)
@@ -310,7 +324,9 @@ async fn k8s_update_dynamic_resource() {
     let obj: DynamicObject =
         serde_yaml::from_str(serde_yaml::to_string(&cr).unwrap().as_str()).unwrap();
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
     k8s_client
         .apply_dynamic_object(&obj)
         .await
@@ -349,7 +365,9 @@ async fn k8s_update_dynamic_resource_metadata() {
 
     let obj: DynamicObject =
         serde_yaml::from_str(serde_yaml::to_string(&cr).unwrap().as_str()).unwrap();
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
     k8s_client
         .apply_dynamic_object(&obj)
         .await
@@ -378,7 +396,9 @@ async fn k8s_patch_dynamic_resource() {
     let test_ns = test.test_namespace().await;
     let cr_name = "patch-test";
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
     assert!(
         k8s_client
             .patch_dynamic_object(
@@ -441,7 +461,9 @@ async fn k8s_dynamic_resource_missing_kind() {
         data: Default::default(),
     };
 
-    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client: AsyncK8sClient = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     assert_matches!(
         k8s_client
@@ -512,7 +534,9 @@ async fn k8s_remove_crd_after_dynamic_resource_initialized() {
         .await
         .expect("Error creating the Bar CRD");
 
-    let k8s_client = AsyncK8sClient::try_new(test_ns.to_string()).await.unwrap();
+    let k8s_client = AsyncK8sClient::try_from_namespace(test_ns.to_string())
+        .await
+        .unwrap();
 
     let cr = ClientTest::new(
         "test-cr",

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -79,7 +79,7 @@ fn k8s_garbage_collector_cleans_removed_agent_resources() {
     ));
 
     let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.to_string()).unwrap());
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.to_string()).unwrap());
 
     let resource_name = "test-different-from-agent-id";
     let secret_name = "test-secret-name";
@@ -234,7 +234,9 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
     };
 
     let gc = K8sGarbageCollector {
-        k8s_client: Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.to_string()).unwrap()),
+        k8s_client: Arc::new(
+            SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.to_string()).unwrap(),
+        ),
         cr_type_meta: vec![missing_kind, foo_type_meta()],
     };
 
@@ -264,7 +266,7 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
     ));
 
     let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.to_string()).unwrap());
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.to_string()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
 
     let instance_id_getter = InstanceIDWithIdentifiersGetter::new_k8s_instance_id_getter(
@@ -353,7 +355,9 @@ agents:
     );
 
     let gc = K8sGarbageCollector {
-        k8s_client: Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.to_string()).unwrap()),
+        k8s_client: Arc::new(
+            SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.to_string()).unwrap(),
+        ),
         cr_type_meta: vec![foo_type_meta()],
     };
 

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -37,7 +37,8 @@ fn k8s_instance_id_store() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
 
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
@@ -78,7 +79,8 @@ fn k8s_hash_in_config_map() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
     let agent_id_2 = AgentID::new(AGENT_ID_2).unwrap();
@@ -138,7 +140,8 @@ fn k8s_value_repository_config_map() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client));
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
     let agent_id_2 = AgentID::new(AGENT_ID_2).unwrap();
@@ -229,7 +232,8 @@ fn k8s_sa_config_map() {
 
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
 
     // This is the cached local config
@@ -295,7 +299,8 @@ fn k8s_multiple_store_entries() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone()));
     let agent_id = AgentID::new(AGENT_ID_1).unwrap();
 

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -19,7 +19,8 @@ fn k8s_run_updater() {
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());
     let test_ns = block_on(k8s.test_namespace());
-    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime(), test_ns.clone()).unwrap());
+    let k8s_client =
+        Arc::new(SyncK8sClient::try_from_namespace(tokio_runtime(), test_ns.clone()).unwrap());
 
     let current_version = "1.2.3-beta".to_string();
     let new_version = "1.2.3".to_string();
@@ -63,10 +64,10 @@ fn k8s_run_updater() {
         .expect("no error should occur during update");
 
     retry(15, Duration::from_secs(5), || {
-        let obj = k8s_client
-            .get_dynamic_object(&helmrelease_v2_type_meta(), RELEASE_NAME)
-            .expect("no error is expected during fetching the helm release")
-            .unwrap();
+        let Some(obj) = k8s_client.get_dynamic_object(&helmrelease_v2_type_meta(), RELEASE_NAME)?
+        else {
+            return Err("Helm Release not found".into());
+        };
 
         if new_version.as_str()
             == obj


### PR DESCRIPTION
We have detected many integration tests failing due to a blocking call to the API server. And also in some occasions this has failed locally when executing the install cli.  

[This](https://github.com/newrelic/newrelic-agent-control/blob/fb4ab134db3130c29f17f99202feda12c8b0f54c/agent-control/src/k8s/dynamic_object.rs#L45) is the call that the API Server is taking too long to answer some times, as we have detected analysing some Integration tests logs
here is a correct fast initialisation for `HelmRepo`:
```log
2025-06-04T10:35:10.8941187Z 2025-06-04T10:35:10 DEBUG k8s_garbage_collector_retain: newrelic_agent_control::k8s::dynamic_object: Initializing dynamic object manager for type: TypeMeta { api_version: "source.toolkit.fluxcd.io/v1", kind: "HelmRepository" }
2025-06-04T10:35:10.8954374Z 2025-06-04T10:35:10 DEBUG k8s_garbage_collector_retain:HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1, otel.name: "HTTP", otel.kind: "client"}: kube_client::client::builder: requesting
2025-06-04T10:35:10.9397455Z 2025-06-04T10:35:10 TRACE k8s_garbage_collector_retain: newrelic_agent_control::k8s::reflector::definition: Building k8s reflector for ApiResource { group: "source.toolkit.fluxcd.io", version: "v1", api_version: "source.toolkit.fluxcd.io/v1", kind: "HelmRepository", plural: "helmrepositories" }
2025-06-04T10:35:10.9403741Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&limit=500, otel.name: "list", otel.kind: "client"}: kube_client::client::builder: requesting
2025-06-04T10:35:10.9425871Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&limit=500, otel.name: "list", otel.kind: "client" http.status_code: 200}: kube_client::client::builder: close, time.busy: 210µs, time.idle: 1.72ms
2025-06-04T10:35:10.9433222Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&watch=true&timeoutSeconds=290&allowWatchBookmarks=true&resourceVersion=3137, otel.name: "watch", otel.kind: "client"}: kube_client::client::builder: requesting
```
And here a failing one for `HelmRelease`:
```log
2025-06-04T10:35:10.8941187Z 2025-06-04T10:35:10 DEBUG k8s_garbage_collector_retain: newrelic_agent_control::k8s::dynamic_object: Initializing dynamic object manager for type: TypeMeta { api_version: "source.toolkit.fluxcd.io/v1", kind: "HelmRepository" }
2025-06-04T10:35:10.8954374Z 2025-06-04T10:35:10 DEBUG k8s_garbage_collector_retain:HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1, otel.name: "HTTP", otel.kind: "client"}: kube_client::client::builder: requesting
2025-06-04T10:35:10.9397455Z 2025-06-04T10:35:10 TRACE k8s_garbage_collector_retain: newrelic_agent_control::k8s::reflector::definition: Building k8s reflector for ApiResource { group: "source.toolkit.fluxcd.io", version: "v1", api_version: "source.toolkit.fluxcd.io/v1", kind: "HelmRepository", plural: "helmrepositories" }
2025-06-04T10:35:10.9403741Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&limit=500, otel.name: "list", otel.kind: "client"}: kube_client::client::builder: requesting
2025-06-04T10:35:10.9425871Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&limit=500, otel.name: "list", otel.kind: "client" http.status_code: 200}: kube_client::client::builder: close, time.busy: 210µs, time.idle: 1.72ms
2025-06-04T10:35:10.9433222Z 2025-06-04T10:35:10 DEBUG HTTP{http.method: GET, http.url: https://192.168.49.2:8443/apis/source.toolkit.fluxcd.io/v1/namespaces/agent-control-test-674np/helmrepositories?&watch=true&timeoutSeconds=290&allowWatchBookmarks=true&resourceVersion=3137, otel.name: "watch", otel.kind: "client"}: kube_client::client::builder: requesting
```

Is not clear what is the root cause of the issue, and maybe is on the API server side, but as workaround to mitigate the current issue we could split the inner k8s client as explained [here](https://github.com/kube-rs/kube/discussions/1777).
But before that, this PR is exposing the current client timeout  config and lowering it on the integration tests so we can further collect more data about this. 