### PR TITLE
fix(ci/cd): improve cache management and split integration test job

### DIFF
--- a/.github/workflows/push_pr_check.yml
+++ b/.github/workflows/push_pr_check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461
   fmt:
     runs-on: ubuntu-latest
-    name: stable / fmt
+    name: cargo fmt
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,15 +38,6 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{ env.RUST_VERSION }}
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
       - name: Check code formatting
         run: cargo fmt --check
 
@@ -74,7 +65,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -82,19 +73,19 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
-          
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
+
+
       - name: cargo clippy
         run: cargo clippy --workspace --tests -- -D clippy::all
 
   doc:
     runs-on: ubuntu-latest
-    name: stable / doc
+    name: cargo doc
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-  
       - name: Obtain Rust version from project
         run: |
           RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
@@ -105,7 +96,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -114,7 +105,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
-          
+
       - name: Create documentation
         run: cargo doc --no-deps --package newrelic_agent_control
         env:
@@ -138,16 +129,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-checks
-
       - name: Fetch dependencies
         run: cargo fetch
 
@@ -156,7 +137,7 @@ jobs:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
 
   unused-dependencies-check:
-    name: Check unused dependencies
+    name: cargo shear (unused dependencies)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push_pr_coverage.yml
+++ b/.github/workflows/push_pr_coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -44,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
       - name: Generate coverage report
         run: COVERAGE_OUT_FORMAT=json COVERAGE_OUT_FILEPATH=jcov.info make coverage
       - name: Calculate and print total coverage

--- a/.github/workflows/push_pr_test.yml
+++ b/.github/workflows/push_pr_test.yml
@@ -48,10 +48,7 @@ jobs:
 
   required:
     runs-on: ubuntu-latest
-    name: ubuntu / ${{ matrix.toolchain }}
-    strategy:
-      matrix:
-        toolchain: [ stable, beta ]
+    name: Unit, docs and onhost integration tests
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,13 +62,13 @@ jobs:
       - name: Install Rust ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -79,7 +76,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
+
 
       - name: Run workspace tests excluding the agent control package
         run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
@@ -117,7 +115,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -125,7 +123,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
+
 
       - name: Run onHost root-required lib tests only
         run: make -C agent-control test/onhost/root
@@ -149,6 +148,9 @@ jobs:
     name: K8s integration tests
     # minikube action requires ubuntu-22.04 at the moment
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        group: [ part1, part2 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -181,14 +183,14 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
 
       - name: Run k8s integration tests
         env:
           # Tilt configs
           ARCH: amd64
           BUILD_WITH: cargo
-        run: make -C agent-control test/k8s/integration
+        run: make -C agent-control test/k8s/integration-${{ matrix.group }}
 
   # These tests are using (by default) the released charts
   # In case a breaking change is introduced by the PR, a feature branch can be used as explained
@@ -198,7 +200,7 @@ jobs:
     # minikube action requires ubuntu-22.04 at the moment
     runs-on: ubuntu-22.04
     strategy:
-      matrix: 
+      matrix:
         group: [ collector, apm, infra ]
     steps:
       - uses: actions/checkout@v4
@@ -224,7 +226,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -232,7 +234,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-debug          
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-dev
+
 
       - name: Run k8s e2e-test ${{ matrix.group }}
         uses: newrelic/newrelic-integration-e2e-action@v1

--- a/agent-control/Makefile
+++ b/agent-control/Makefile
@@ -36,6 +36,24 @@ test/onhost/root/integration:
 .PHONY: test/k8s
 test/k8s:
 	cargo $(CARGO_CMD) $(PACKAGE_SA) --all-targets -- --skip on_host
+
 .PHONY: test/k8s/integration
-test/k8s/integration:
-	$(MAKE) -C tests/k8s
+test/k8s/integration: test/k8s/integration-part1 test/k8s/integration-part2
+
+
+
+.PHONY: test/k8s/integration-part1
+test/k8s/integration-part1:
+	KUBECONFIG='./tests/k8s/.kubeconfig-dev' minikube update-context
+	tilt ci --file ./tests/k8s/Tiltfile
+	# reducing the number of threads to 1 forces the tests to run sequentially
+	cargo test k8s::scenarios -- --nocapture --ignored  --test-threads=1
+	cargo test k8s::agent_control_cli -- --nocapture --ignored  --test-threads=1
+
+.PHONY: test/k8s/integration-part2
+test/k8s/integration-part2:
+	KUBECONFIG='./tests/k8s/.kubeconfig-dev' minikube update-context
+	tilt ci --file ./tests/k8s/Tiltfile
+	# reducing the number of threads to 1 forces the tests to run sequentially
+	# We use this approach to split the k8s tests into two parts. We need to update it if this takes too long to run.
+	cargo test k8s_ --  --skip k8s::scenarios --skip k8s::agent_control_cli --nocapture --ignored  --test-threads=1

--- a/agent-control/tests/k8s/Makefile
+++ b/agent-control/tests/k8s/Makefile
@@ -1,9 +1,0 @@
-.PHONY: all
-all: test-integration-minikube
-
-.PHONY: test-integration-minikube
-test-integration-minikube:
-	KUBECONFIG='./.kubeconfig-dev' minikube update-context
-	tilt ci
-	# reducing the number of threads to 1 forces the tests to run sequentially
-	cargo test k8s_ -- --nocapture --ignored  --test-threads=1


### PR DESCRIPTION
# What this PR does / why we need it
There were two main issues with the cache:
 - The 10Gb limit is trashing the cache usefulness (ending up discarding everything everyday). 
  > Approaching total cache storage limit (18.21 GB of 10 GB Used)

 Therefore, I removed some caches to make sure we are not saving too much 

 - We were leveraging the same cach-key from multiple jobs. The first one finishing was the actually the one committing the cache. Therefore:
   - the integration tests were never really caching the whole /target since normal tests were committing before
   - all checks were leveraging a useless 7Mb cache from the cargo fmt job that was bot building anything and finishing in 3-s

As a counteraction I changed all workflows to retrieve the cache from everywhere, but to push it just from one per each key.


Moreover, I split the integration tests into two targets


Notice that pipelines are pending since they are marked as required in GH settings, the name changed and therefore they will never be executed

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
