### PR TITLE
refactor: agent control test harness [NR-424892]

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -251,9 +251,12 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::instrumentation::config::logs::{
-        file_logging::{FileLoggingConfig, LogFilePath},
-        format::{LoggingFormat, TimestampFormat},
+    use crate::{
+        instrumentation::config::logs::{
+            file_logging::{FileLoggingConfig, LogFilePath},
+            format::{LoggingFormat, TimestampFormat},
+        },
+        sub_agent::identity::AgentIdentity,
     };
     use std::{path::PathBuf, time::Duration};
 
@@ -632,21 +635,36 @@ k8s:
     // Test helpers
     ////////////////////////////////////////////////////////////////////////////////////
 
+    pub fn infra_identity() -> AgentIdentity {
+        let id = AgentID::new("infra-agent").unwrap();
+        let agent_type_id =
+            AgentTypeID::try_from("newrelic/com.newrelic.infrastructure:0.0.1").unwrap();
+        AgentIdentity { id, agent_type_id }
+    }
+
     fn infra() -> HashMap<AgentID, SubAgentConfig> {
+        let identity = infra_identity();
         HashMap::from([(
-            AgentID::new("infra-agent").unwrap(),
+            identity.id,
             SubAgentConfig {
-                agent_type: AgentTypeID::try_from("newrelic/com.newrelic.infrastructure:0.0.1")
-                    .unwrap(),
+                agent_type: identity.agent_type_id,
             },
         )])
     }
+
+    pub fn nrdot_identity() -> AgentIdentity {
+        let id = AgentID::new("nrdot").unwrap();
+        let agent_type_id =
+            AgentTypeID::try_from("newrelic/io.opentelemetry.collector:0.0.1").unwrap();
+        AgentIdentity { id, agent_type_id }
+    }
+
     fn nrdot() -> HashMap<AgentID, SubAgentConfig> {
+        let identity = nrdot_identity();
         HashMap::from([(
-            AgentID::new("nrdot").unwrap(),
+            identity.id,
             SubAgentConfig {
-                agent_type: AgentTypeID::try_from("newrelic/io.opentelemetry.collector:0.0.1")
-                    .unwrap(),
+                agent_type: identity.agent_type_id,
             },
         )])
     }
@@ -658,7 +676,7 @@ k8s:
         agents
     }
 
-    pub fn sub_agents_default_config() -> AgentControlDynamicConfig {
+    pub fn sub_agents_infra_and_nrdot() -> AgentControlDynamicConfig {
         AgentControlDynamicConfig {
             agents: helper_get_agent_list(),
             chart_version: None,

--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -64,6 +64,27 @@ pub mod tests {
         }
     }
 
+    /// A [DynamicConfigValidator] implementation for testing purposes. It always returns Ok when valid is true
+    /// and an Error when valid is false.
+    pub struct TestDynamicConfigValidator {
+        pub valid: bool,
+    }
+
+    impl DynamicConfigValidator for TestDynamicConfigValidator {
+        fn validate(
+            &self,
+            _dynamic_config: &AgentControlDynamicConfig,
+        ) -> Result<(), DynamicConfigValidatorError> {
+            if self.valid {
+                Ok(())
+            } else {
+                Err(DynamicConfigValidatorError::AgentRepositoryError(
+                    AgentRepositoryError::NotFound("not-found".to_string()),
+                ))
+            }
+        }
+    }
+
     #[test]
     fn test_existing_agent_type_validation() {
         let mut registry = MockAgentRegistry::new();

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -41,4 +41,13 @@ pub mod tests {
             fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError>;
         }
     }
+
+    impl MockVersionUpdater {
+        /// Returns a mock that always returns `Ok()` regardless of the times it is called
+        pub fn new_no_op() -> Self {
+            let mut mock = Self::new();
+            mock.expect_update().returning(|_| Ok(()));
+            mock
+        }
+    }
 }

--- a/agent-control/src/sub_agent/sub_agent.rs
+++ b/agent-control/src/sub_agent/sub_agent.rs
@@ -757,21 +757,7 @@ pub mod tests {
         }
     }
 
-    impl MockSubAgentBuilder {
-        // should_build provides a helper method to create a subagent which runs and stops
-        // successfully
-        pub(crate) fn should_build(&mut self, times: usize) {
-            self.expect_build().times(times).returning(|_| {
-                let mut not_started_sub_agent = MockNotStartedSubAgent::new();
-                not_started_sub_agent.expect_run().times(1).returning(|| {
-                    let mut started_agent = MockStartedSubAgent::new();
-                    started_agent.expect_stop().times(1).returning(|| Ok(()));
-                    started_agent
-                });
-                Ok(not_started_sub_agent)
-            });
-        }
-    }
+    impl MockSubAgentBuilder {}
 
     #[rstest]
     #[case::healthy_states_same_status(Some(healthy("status")), healthy("status"))]


### PR DESCRIPTION
# What this PR does / why we need it

This PR add some harness for unit test of Agent Control and _simplifies_ the existing tests.

The behavior of the current tests is unchanged because in a follow-up review the existing tests will be reviewed in order to avoid duplicates and cover uncovered use cases.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
