### PR TITLE
fix(provision-clean): the target is no longer automatically published

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -98,7 +98,7 @@ jobs:
         if: always()
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=${{ env.UNIQUE_NAME }}"
+          container_make_target: "-C test/provision clean TAG_OR_UNIQUE_NAME=${{ env.UNIQUE_NAME }}"
           ecs_cluster_name: agent_control
           task_definition_name: agent_control
           cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control


### PR DESCRIPTION
Le me know if you prefer to rollback the -clean feature instead

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
