### PR TITLE
feat: leverage target namespace (NR-406242)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -43,7 +43,7 @@ deployment:
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
-          namespace: ${nr-ac:namespace}
+          namespace: ${nr-ac:namespace_agents}
         spec:
           agent:
             language: dotnet

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -43,7 +43,7 @@ deployment:
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
-          namespace: ${nr-ac:namespace}
+          namespace: ${nr-ac:namespace_agents}
         spec:
           agent:
             language: java

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -43,7 +43,7 @@ deployment:
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
-          namespace: ${nr-ac:namespace}
+          namespace: ${nr-ac:namespace_agents}
         spec:
           agent:
             language: nodejs

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -43,7 +43,7 @@ deployment:
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
-          namespace: ${nr-ac:namespace}
+          namespace: ${nr-ac:namespace_agents}
         spec:
           agent:
             language: python

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -43,7 +43,7 @@ deployment:
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
-          namespace: ${nr-ac:namespace}
+          namespace: ${nr-ac:namespace_agents}
         spec:
           agent:
             language: ruby

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
@@ -64,6 +64,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -73,6 +75,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -82,6 +85,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -168,6 +168,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -177,6 +179,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -186,6 +189,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -64,6 +64,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -73,6 +75,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -82,6 +85,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -65,6 +65,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -74,6 +76,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -83,6 +86,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -65,6 +65,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -74,6 +76,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -83,6 +86,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -112,6 +112,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -121,6 +123,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -130,6 +133,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -65,6 +65,8 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          targetNamespace: ${nr-ac:namespace_agents}
+          releaseName: ${nr-sub:agent_id}
           interval: 3m
           chart:
             spec:
@@ -74,6 +76,7 @@ deployment:
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
+                namespace: ${nr-ac:namespace}
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
@@ -83,6 +86,7 @@ deployment:
             remediation:
               retries: 3
             replace: true
+            createNamespace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -40,7 +40,7 @@ use std::time::SystemTime;
 use tracing::{debug, error, info, warn};
 
 pub const NAMESPACE_VARIABLE_NAME: &str = "namespace";
-const NAMESPACE_AGENTS_VARIABLE_NAME: &str = "namespace_agents";
+pub const NAMESPACE_AGENTS_VARIABLE_NAME: &str = "namespace_agents";
 
 impl AgentControlRunner {
     pub(super) fn run_k8s(self) -> Result<(), AgentError> {

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::HashMap, iter, ops::Deref, sync::LazyLock};
 
-use crate::agent_control::run::k8s::NAMESPACE_VARIABLE_NAME;
+use crate::agent_control::run::k8s::{NAMESPACE_AGENTS_VARIABLE_NAME, NAMESPACE_VARIABLE_NAME};
 use crate::agent_control::run::on_host::HOST_ID_VARIABLE_NAME;
 use crate::{
     agent_control::{agent_id::AgentID, run::Environment},
@@ -580,12 +580,21 @@ fn iterate_test_cases(environment: &Environment) {
 
         // Create the renderer with specifics for the environment
         let renderer: TemplateRenderer<ConfigurationPersisterFile> = match environment {
-            Environment::K8s => {
-                TemplateRenderer::default().with_agent_control_variables(iter::once((
-                    NAMESPACE_VARIABLE_NAME.to_string(),
-                    VariableDefinition::new_final_string_variable("host-id".to_string()),
-                )))
-            }
+            Environment::K8s => TemplateRenderer::default().with_agent_control_variables(
+                HashMap::from([
+                    (
+                        NAMESPACE_VARIABLE_NAME.to_string(),
+                        VariableDefinition::new_final_string_variable("test-namespace".to_string()),
+                    ),
+                    (
+                        NAMESPACE_AGENTS_VARIABLE_NAME.to_string(),
+                        VariableDefinition::new_final_string_variable(
+                            "test-namespace-agents".to_string(),
+                        ),
+                    ),
+                ])
+                .into_iter(),
+            ),
             Environment::OnHost => {
                 TemplateRenderer::default().with_agent_control_variables(iter::once((
                     HOST_ID_VARIABLE_NAME.to_string(),

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -157,6 +157,7 @@ objects:
     fn test_template_k8s() {
         let untouched_val = "${nr-var:any} no templated";
         let test_agent_id = "id";
+        let test_namespace = "test-namespace";
         let k8s_template: K8s = serde_yaml::from_str(
             format!(
                 r#"
@@ -166,7 +167,7 @@ objects:
     kind: {untouched_val}
     metadata:
       name: ${{nr-sub:agent_id}}
-      namespace: test-namespace
+      namespace: ${{nr-ac:namespace}}
       labels:
         foo: ${{nr-var:any}}
         ${{nr-var:any}}: bar
@@ -187,6 +188,10 @@ objects:
                 "nr-sub:agent_id".to_string(),
                 VariableDefinition::new_final_string_variable(test_agent_id.to_string()),
             ),
+            (
+                "nr-ac:namespace".to_string(),
+                VariableDefinition::new_final_string_variable(test_namespace.to_string()),
+            ),
         ]);
 
         let k8s = k8s_template.template_with(&variables).unwrap();
@@ -202,6 +207,9 @@ objects:
 
         // Expect template works on name.
         assert_eq!(cr1.metadata.name, test_agent_id);
+
+        // Expect template works on namespace.
+        assert_eq!(cr1.metadata.namespace, test_namespace);
 
         // Expect template works on labels.
         let labels = cr1.metadata.labels;

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -424,7 +424,7 @@ deployment:
           kind: SomeKind
           metadata:
             name: ${nr-sub:agent_id}
-            namespace: test-namespace
+            namespace: ${nr-ac:namespace}
           spec:
             some_key: ${nr-var:config.really_common}
             other: ${nr-avar:config.var}


### PR DESCRIPTION
# What this PR does / why we need it

Prepares AC to handle two namespaces in the near future. One for agents and one for flux.

## Which issue this PR fixes

- fixes #NR-406242

## Special notes for your reviewer

### Instrumentation CRs

We have seen with @paologallinaharbur that the `Instrumentation` CR must be in the same namespace as the operator. We created a [thread](https://newrelic.slack.com/archives/C04S2FT1LU9/p1751014632246429) asking why is that. We must follow it.

### Docs

Nothing to update as of now. There is a task to handle that. Besides, this just prepares some part of AC, but doesn't include the final version of the changes.

### Optional `namespace_agents` field

The helm chart hasn't been updated yet. This means that the `namespace_agents` field isn't present in the required `ConfigMap`. Thus, for now, we have to live with an `Option` field that shouldn't be `Option` at the end.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
