### PR TITLE
fix: auth cli binary from tar.gz

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -164,7 +164,7 @@ nfpms:
       # NR Otel Collector - Important to note the binary name is nrdot-collector-host matching nrdot binary
       - src: build/embedded/artifacts/{{- .Arch }}/nr-otel-collector/nrdot-collector-host
         dst: /usr/bin/nrdot-collector-host
-      - src: build/embedded/artifacts/{{- .Arch }}/newrelic-auth-cli
+      - src: build/embedded/artifacts/{{- .Arch }}/newrelic-auth-cli/newrelic-auth-cli
         dst: /usr/bin/newrelic-auth-cli
       - src: build/examples/
         dst: /etc/newrelic-agent-control/examples

--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -66,8 +66,8 @@ artifacts:
 
   - name: newrelic-auth-cli
     # Version now should be added in goreleaser.yaml global envs
-    url: https://github.com/newrelic/newrelic-auth-rs/releases/download/{{.Version | trimv}}/newrelic-auth-cli-{{.Arch}}
+    url: https://github.com/newrelic/newrelic-auth-rs/releases/download/{{.Version | trimv}}/newrelic-auth-cli_{{.Arch}}.tar.gz
     files:
       - name: newrelic-auth-cli binary
-        src: newrelic-auth-cli-{{.Arch}}
+        src: newrelic-auth-cli
         dest: artifacts/{{.Arch}}/newrelic-auth-cli


### PR DESCRIPTION
# What this PR does / why we need it

Now the binaries of auth cli are compress in tar.gz and these are the changes need to manage this changes

<img width="268" alt="image" src="https://github.com/user-attachments/assets/92a27472-c5fe-43b0-baf8-f0d95867d643" />


## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
