### PR TITLE
style: string interpolation

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -366,10 +366,8 @@ where
         ) {
             // Remote config partially applied, the config was stored so it needs to be updated to fail state.
             Err(AgentError::BuildingSubagents(err)) => {
-                let error_message = format!(
-                    "Error applying Agent Control remote config for some agents: {}",
-                    err
-                );
+                let error_message =
+                    format!("Error applying Agent Control remote config for some agents: {err}");
                 let config_state = ConfigState::Failed { error_message };
                 self.sa_dynamic_config_store
                     .update_state(config_state.clone())?;
@@ -379,7 +377,7 @@ where
             }
             // Remote config failed to apply, the config was not stored.
             Err(err) => {
-                let error_message = format!("Error applying Agent Control remote config: {}", err);
+                let error_message = format!("Error applying Agent Control remote config: {err}");
                 let config_state = ConfigState::Failed { error_message };
                 report_state(config_state, opamp_remote_config.hash, opamp_client)?;
                 Err(err)

--- a/agent-control/src/agent_control/pid_cache.rs
+++ b/agent-control/src/agent_control/pid_cache.rs
@@ -104,7 +104,7 @@ where
             }
         }
 
-        let pid_string = format!("{}", pid);
+        let pid_string = format!("{pid}");
         Ok(self.file_rw.write(
             self.file_path.as_path(),
             pid_string,

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -333,7 +333,7 @@ deployment:
             serde_yaml::from_str(AGENT_GIVEN_BAD_YAML);
 
         assert!(raw_agent_err.is_err());
-        println!("{:?}", raw_agent_err);
+        println!("{raw_agent_err:?}");
         assert_eq!(
             raw_agent_err.unwrap_err().to_string(),
             "missing field `variables` at line 2 column 1"

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -549,8 +549,7 @@ fn all_agent_types_covered_by_tests() {
     agent_type_names_from_registry.for_each(|name| {
         assert!(
             agent_type_names_from_test_cases.contains(&name),
-            "Agent type {} not covered by test cases",
-            name
+            "Agent type {name} not covered by test cases"
         )
     })
 }

--- a/agent-control/src/agent_type/trivial_value.rs
+++ b/agent-control/src/agent_type/trivial_value.rs
@@ -92,7 +92,7 @@ impl TrivialValue {
 impl Display for TrivialValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TrivialValue::String(s) => write!(f, "{}", s),
+            TrivialValue::String(s) => write!(f, "{s}"),
             TrivialValue::File(file) => write!(f, "{}", file.path.to_string_lossy()),
             TrivialValue::Yaml(yaml) => write!(
                 f,
@@ -100,8 +100,8 @@ impl Display for TrivialValue {
                 serde_yaml::to_string(yaml)
                     .expect("A value of type serde_yaml::Value should always be serializable")
             ),
-            TrivialValue::Bool(b) => write!(f, "{}", b),
-            TrivialValue::Number(n) => write!(f, "{}", n),
+            TrivialValue::Bool(b) => write!(f, "{b}"),
+            TrivialValue::Number(n) => write!(f, "{n}"),
             TrivialValue::MapStringString(n) => {
                 let flatten: Vec<String> = n
                     .iter()

--- a/agent-control/src/bin/main_k8s.rs
+++ b/agent-control/src/bin/main_k8s.rs
@@ -20,7 +20,7 @@ const AGENT_CONTROL_MODE: Environment = Environment::K8s;
 
 fn main() -> ExitCode {
     let Ok(command) = Flags::init(AGENT_CONTROL_MODE)
-        .inspect_err(|init_err| println!("Error parsing Flags: {}", init_err))
+        .inspect_err(|init_err| println!("Error parsing Flags: {init_err}"))
     else {
         return ExitCode::FAILURE;
     };

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -22,7 +22,7 @@ const AGENT_CONTROL_MODE: Environment = Environment::OnHost;
 
 fn main() -> ExitCode {
     let Ok(command) = Flags::init(AGENT_CONTROL_MODE)
-        .inspect_err(|init_err| println!("Error parsing Flags: {}", init_err))
+        .inspect_err(|init_err| println!("Error parsing Flags: {init_err}"))
     else {
         return ExitCode::FAILURE;
     };
@@ -73,7 +73,7 @@ fn _main(
 
     #[cfg(all(unix, not(feature = "multiple-instances")))]
     if let Err(err) = PIDCache::default().store(std::process::id()) {
-        return Err(format!("Error saving main process id: {}", err).into());
+        return Err(format!("Error saving main process id: {err}").into());
     }
 
     install_rustls_default_crypto_provider();

--- a/agent-control/src/cli/utils.rs
+++ b/agent-control/src/cli/utils.rs
@@ -30,11 +30,10 @@ pub fn parse_key_value_pairs(data: &str) -> BTreeMap<String, String> {
     let pairs = data.split(',');
     let key_values = pairs.map(|pair| pair.split_once('='));
     let valid_key_values = key_values.flatten();
-    let parsed_key_values = valid_key_values
-        .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
-        .collect();
 
-    parsed_key_values
+    valid_key_values
+        .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+        .collect()
 }
 
 pub fn try_new_k8s_client() -> Result<SyncK8sClient, CliError> {

--- a/agent-control/src/config_migrate/migration/agent_config_getter.rs
+++ b/agent-control/src/config_migrate/migration/agent_config_getter.rs
@@ -46,7 +46,7 @@ where
             .map(|at| format!(", <{}", at.version()))
             .unwrap_or_default();
         let version_req =
-            VersionReq::parse(format!("{}{}", version_req_min, version_req_max).as_str())?;
+            VersionReq::parse(format!("{version_req_min}{version_req_max}").as_str())?;
 
         for agent in agent_control_dynamic_config.agents.clone() {
             if agent.1.agent_type.namespace() != agent_type_namespace

--- a/agent-control/src/config_migrate/migration/agent_value_spec.rs
+++ b/agent-control/src/config_migrate/migration/agent_value_spec.rs
@@ -134,7 +134,7 @@ mod tests {
 
         merge_agent_values_recursive(from, &mut to);
 
-        println!("{:?}", to);
+        println!("{to:?}");
     }
 
     #[test]
@@ -170,7 +170,7 @@ mod tests {
 
         merge_agent_values_recursive(from, &mut to);
 
-        println!("{:?}", to);
+        println!("{to:?}");
     }
 
     #[test]
@@ -193,6 +193,6 @@ mod tests {
 
         merge_agent_values_recursive(from, &mut to);
 
-        println!("{:?}", to);
+        println!("{to:?}");
     }
 }

--- a/agent-control/src/config_migrate/migration/config.rs
+++ b/agent-control/src/config_migrate/migration/config.rs
@@ -108,7 +108,7 @@ impl DirInfo {
     pub fn valid_filename(&self, filename: &str) -> bool {
         for filename_pattern in &self.filename_patterns {
             let re = Regex::new(filename_pattern)
-                .unwrap_or_else(|_| panic!("invalid filename_pattern: {}", filename_pattern));
+                .unwrap_or_else(|_| panic!("invalid filename_pattern: {filename_pattern}"));
             if re.is_match(filename) {
                 return true;
             }

--- a/agent-control/src/config_migrate/migration/converter.rs
+++ b/agent-control/src/config_migrate/migration/converter.rs
@@ -118,7 +118,7 @@ impl<R: AgentRegistry, F: FileReader> ConfigConverter<R, F> {
             // replace the file separator to not be treated as a leaf
             let escaped_filename = filename.replace(FILE_SEPARATOR, FILE_SEPARATOR_REPLACE);
             let full_agent_type_field_fqn: AgentTypeFieldFQN =
-                format!("{}.{}", agent_type_field_fqn, escaped_filename).into();
+                format!("{agent_type_field_fqn}.{escaped_filename}").into();
             res.push(self.file_to_agent_value_spec(full_agent_type_field_fqn, path)?);
         }
         Ok(merge_agent_values(res)?)

--- a/agent-control/src/flags.rs
+++ b/agent-control/src/flags.rs
@@ -179,7 +179,7 @@ impl OneShotCommand {
             OneShotCommand::PrintDebugInfo(flags) => {
                 println!("Printing debug info");
                 println!("Agent Control Mode: {env:?}");
-                println!("FLAGS: {:#?}", flags);
+                println!("FLAGS: {flags:#?}");
             }
         }
     }

--- a/agent-control/src/health/k8s/health_checker/resources/helm_release.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/helm_release.rs
@@ -125,7 +125,7 @@ impl K8sHealthFluxHelmRelease {
                             .get("message")
                             .and_then(Value::as_str)
                             .unwrap_or("No specific message found");
-                        (false, format!("HelmRelease not ready: {}", message))
+                        (false, format!("HelmRelease not ready: {message}"))
                     }
                     _ => (false, "HelmRelease status unknown or missing".to_string()),
                 }
@@ -285,7 +285,7 @@ pub mod tests {
                 }
                 Err(expected_err) => {
                     let result_err = result.unwrap_err();
-                    assert_eq!(result_err.to_string(), expected_err.to_string(), "{}", name);
+                    assert_eq!(result_err.to_string(), expected_err.to_string(), "{name}");
                 }
             }
         }

--- a/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
@@ -196,8 +196,7 @@ impl HealthChecker for K8sHealthNRInstrumentation {
 
         let status: InstrumentationStatus = serde_json::from_value(status).map_err(|e| {
             HealthCheckerError::Generic(format!(
-                "could not deserialize a valid instrumentation status: {}",
-                e
+                "could not deserialize a valid instrumentation status: {e}"
             ))
         })?;
 

--- a/agent-control/src/health/k8s/health_checker/resources/stateful_set.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/stateful_set.rs
@@ -68,8 +68,7 @@ impl K8sHealthStatefulSet {
 
         if replicas != ready_replicas {
             return Ok(Unhealthy::new(format!(
-                "StatefulSet `{}` not ready: replicas `{}` different from ready_replicas `{}`",
-                name, replicas, ready_replicas,
+                "StatefulSet `{name}` not ready: replicas `{replicas}` different from ready_replicas `{ready_replicas}`",
             ))
             .into());
         }
@@ -128,10 +127,10 @@ mod tests {
                 let (name, sts, expected) = (self.name, self.sts, self.expected);
                 let result = K8sHealthStatefulSet::stateful_set_health(&sts)
                     .inspect_err(|err| {
-                        panic!("Unexpected error getting health: {} - {}", err, name);
+                        panic!("Unexpected error getting health: {err} - {name}");
                     })
                     .unwrap();
-                assert_eq!(expected, result, "{}", name);
+                assert_eq!(expected, result, "{name}");
             }
         }
 

--- a/agent-control/src/health/on_host/http.rs
+++ b/agent-control/src/health/on_host/http.rs
@@ -122,10 +122,8 @@ impl<C: HttpClient> HealthChecker for HttpHealthChecker<C> {
             ));
         }
 
-        let last_error = format!(
-            "Health check failed with HTTP response status code {}",
-            status_code
-        );
+        let last_error =
+            format!("Health check failed with HTTP response status code {status_code}");
 
         Ok(HealthWithStartTime::from_unhealthy(
             Unhealthy::new(last_error).with_status(status),

--- a/agent-control/src/k8s/reflectors.rs
+++ b/agent-control/src/k8s/reflectors.rs
@@ -206,7 +206,7 @@ where
         Ok(tokio::time::timeout(timeout, reader.wait_until_ready())
             .await
             .map_err(|_| {
-                K8sError::ReflectorTimeout(format!("reader not ready after {:?}", timeout))
+                K8sError::ReflectorTimeout(format!("reader not ready after {timeout:?}"))
             })??)
     }
 }
@@ -282,7 +282,7 @@ mod tests {
         let timeout = Duration::from_millis(50);
         let result = Reflector::wait_until_reader_is_ready(&reader, timeout).await;
         assert_matches!(result.unwrap_err(), K8sError::ReflectorTimeout(s) => {
-            s.contains(format!("{:?}", timeout).as_str());
+            s.contains(format!("{timeout:?}").as_str());
         });
     }
 
@@ -326,8 +326,7 @@ mod tests {
         assert_eq!(
             receiver.len(),
             max_attempts as usize,
-            "The builder is expected to be called {} times",
-            max_attempts
+            "The builder is expected to be called {max_attempts} times"
         )
     }
 

--- a/agent-control/src/k8s/store.rs
+++ b/agent-control/src/k8s/store.rs
@@ -112,7 +112,7 @@ impl K8sStore {
     }
 
     pub fn build_cm_name(agent_id: &AgentID, prefix: &str) -> String {
-        format!("{}{}", prefix, agent_id)
+        format!("{prefix}{agent_id}")
     }
 }
 

--- a/agent-control/src/k8s/utils.rs
+++ b/agent-control/src/k8s/utils.rs
@@ -108,10 +108,10 @@ impl IntOrPercentage {
 impl std::fmt::Display for IntOrPercentage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IntOrPercentage::Int(i) => write!(f, "{}", i),
+            IntOrPercentage::Int(i) => write!(f, "{i}"),
             IntOrPercentage::Percentage(float) => {
                 let percent = (*float * 100.0) as i32;
-                write!(f, "{}%", percent)
+                write!(f, "{percent}%")
             }
         }
     }

--- a/agent-control/src/opamp/callbacks.rs
+++ b/agent-control/src/opamp/callbacks.rs
@@ -85,7 +85,7 @@ where
             Err(err) => {
                 // the hash must be created to keep track of the failing remote config.
                 state = ConfigState::Failed {
-                    error_message: format!("Invalid hash: {}", err),
+                    error_message: format!("Invalid hash: {err}"),
                 };
                 Hash::default()
             }
@@ -96,7 +96,7 @@ where
                 .try_into()
                 .inspect_err(|err: &OpampRemoteConfigError| {
                     state = ConfigState::Failed {
-                        error_message: format!("Invalid remote config format: {}", err),
+                        error_message: format!("Invalid remote config format: {err}"),
                     };
                 })
                 .ok(),
@@ -116,11 +116,11 @@ where
                     },
                     SignatureError::InvalidData(err) => {
                         error!(%self.agent_id, %err, "parsing config signature message: {:?}", custom_message);
-                        state = ConfigState::Failed { error_message: format!("Invalid remote config signature format: {}", err) };
+                        state = ConfigState::Failed { error_message: format!("Invalid remote config signature format: {err}") };
                     },
                     SignatureError::UnsupportedAlgorithm(err) => {
                         error!(%self.agent_id, %err, "unsupported signature algorithm: {:?}", custom_message);
-                        state = ConfigState::Failed { error_message: format!("Unsupported signature algorithm: {}", err) };
+                        state = ConfigState::Failed { error_message: format!("Unsupported signature algorithm: {err}") };
                     }
                 }).ok()
             );

--- a/agent-control/src/opamp/effective_config/agent_control.rs
+++ b/agent-control/src/opamp/effective_config/agent_control.rs
@@ -63,15 +63,13 @@ impl TryFrom<YAMLConfig> for AgentControlEffectiveConfig {
         tracing::debug!("Get effective config: {value:?}");
         let config_string: String = value.try_into().map_err(|err| {
             AgentControlEffectiveConfigError::Conversion(format!(
-                "converting effective config from stored values: {}",
-                err
+                "converting effective config from stored values: {err}"
             ))
         })?;
 
         let effective_config = serde_yaml::from_str(&config_string).map_err(|err| {
             AgentControlEffectiveConfigError::Conversion(format!(
-                "converting effective config: {}",
-                err
+                "converting effective config: {err}"
             ))
         })?;
 

--- a/agent-control/src/opamp/http/client.rs
+++ b/agent-control/src/opamp/http/client.rs
@@ -46,21 +46,21 @@ where
         let mut headers = self.headers.clone();
 
         // Get authorization token from the token retriever
-        let token = self.token_retriever.retrieve().map_err(|e| {
-            AuthorizationHeadersError(format!("cannot retrieve auth header: {}", e))
-        })?;
+        let token = self
+            .token_retriever
+            .retrieve()
+            .map_err(|e| AuthorizationHeadersError(format!("cannot retrieve auth header: {e}")))?;
 
         // Insert auth token header
         if !token.access_token().is_empty() {
             let access_token: String = token.access_token().parse().map_err(|e| {
-                AuthorizationHeadersError(format!("unable to parse the authorization token: {}", e))
+                AuthorizationHeadersError(format!("unable to parse the authorization token: {e}"))
             })?;
             let auth_header_string = format!("Bearer {access_token}");
             let mut auth_header_value = HeaderValue::from_str(auth_header_string.as_str())
                 .map_err(|e| {
                     AuthorizationHeadersError(format!(
-                        "error converting '{}' to a header string: {}",
-                        auth_header_string, e
+                        "error converting '{auth_header_string}' to a header string: {e}"
                     ))
                 })?;
             auth_header_value.set_sensitive(true);

--- a/agent-control/src/opamp/instance_id/getter.rs
+++ b/agent-control/src/opamp/instance_id/getter.rs
@@ -287,7 +287,7 @@ pub mod tests {
             .unwrap()
             .into();
         assert_eq!(id, id_from_bytes);
-        assert_eq!(uuid_as_str, format!("{}", id_from_bytes));
+        assert_eq!(uuid_as_str, format!("{id_from_bytes}"));
     }
 
     fn get_different_identifier() -> MockIdentifiers {

--- a/agent-control/src/opamp/instance_id/on_host/storer.rs
+++ b/agent-control/src/opamp/instance_id/on_host/storer.rs
@@ -281,7 +281,7 @@ mod tests {
                 p == instance_id_path.as_path()
             }))
             .once()
-            .return_once(|_| Err(io::Error::new(ErrorKind::Other, "some error message").into()));
+            .return_once(|_| Err(io::Error::other("some error message").into()));
 
         let storer = Storer::new(file_rw, dir_manager, sa_path, sub_agent_path);
         let expected = storer.get(&agent_id);
@@ -309,8 +309,7 @@ mod tests {
 
     fn expected_file(instance_id: InstanceID) -> String {
         format!(
-            "instance_id: {}\nidentifiers:\n  hostname: {}\n  machine_id: {}\n  cloud_instance_id: {}\n  host_id: {}\n  fleet_id: {}\n",
-            instance_id, HOSTNAME, MICHINE_ID, CLOUD_INSTANCE_ID, HOST_ID, FLEET_ID,
+            "instance_id: {instance_id}\nidentifiers:\n  hostname: {HOSTNAME}\n  machine_id: {MICHINE_ID}\n  cloud_instance_id: {CLOUD_INSTANCE_ID}\n  host_id: {HOST_ID}\n  fleet_id: {FLEET_ID}\n",
         )
     }
 

--- a/agent-control/src/opamp/remote_config/signature.rs
+++ b/agent-control/src/opamp/remote_config/signature.rs
@@ -204,8 +204,7 @@ fn parse_first_valid(
             Ok(valid_signature) => return Ok(valid_signature),
             Err(err) => {
                 errors_accumulator.push_str(&format!(
-                    "Cannot process the signature data in position {}: {}\n",
-                    i, err
+                    "Cannot process the signature data in position {i}: {err}\n"
                 ));
             }
         }
@@ -637,7 +636,7 @@ mod tests {
             fn run(self) {
                 let err = Signatures::try_from(&self.custom_message)
                     .expect_err(format!("case: {}", self.name).as_str());
-                assert!(format!("{:?}", err).contains("no valid signature data"));
+                assert!(format!("{err:?}").contains("no valid signature data"));
             }
         }
         let test_cases = vec![

--- a/agent-control/src/opamp/remote_config/validators/regexes.rs
+++ b/agent-control/src/opamp/remote_config/validators/regexes.rs
@@ -238,7 +238,7 @@ pub(super) mod tests {
         let agent_identity = AgentIdentity {
             id: test_id(),
             agent_type_id: AgentTypeID::try_from(
-                format!("newrelic/{}:0.0.1", AGENT_TYPE_NAME_INFRA_AGENT).as_str(),
+                format!("newrelic/{AGENT_TYPE_NAME_INFRA_AGENT}:0.0.1").as_str(),
             )
             .unwrap(),
         };
@@ -652,7 +652,7 @@ config: |
         AgentIdentity {
             id: test_id(),
             agent_type_id: AgentTypeID::try_from(
-                format!("newrelic/{}:0.0.1", AGENT_TYPE_NAME_INFRA_AGENT).as_str(),
+                format!("newrelic/{AGENT_TYPE_NAME_INFRA_AGENT}:0.0.1").as_str(),
             )
             .unwrap(),
         }
@@ -662,7 +662,7 @@ config: |
         AgentIdentity {
             id: test_id(),
             agent_type_id: AgentTypeID::try_from(
-                format!("newrelic/{}:0.0.1", AGENT_TYPE_NAME_NRDOT).as_str(),
+                format!("newrelic/{AGENT_TYPE_NAME_NRDOT}:0.0.1").as_str(),
             )
             .unwrap(),
         }

--- a/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
@@ -43,13 +43,10 @@ impl CertificateFetcher {
             .method("HEAD")
             .body(Vec::default())
             .map_err(|err| {
-                CertificateFetcherError::CertificateFetch(format!(
-                    "error building request: {}",
-                    err
-                ))
+                CertificateFetcherError::CertificateFetch(format!("error building request: {err}"))
             })?;
         let response = client.send(request).map_err(|e| {
-            CertificateFetcherError::CertificateFetch(format!("fetching certificate: {}", e))
+            CertificateFetcherError::CertificateFetch(format!("fetching certificate: {e}"))
         })?;
         let tls_info = response.extensions().get::<TlsInfo>().ok_or(
             CertificateFetcherError::CertificateFetch("missing tls information".to_string()),
@@ -67,10 +64,7 @@ impl CertificateFetcher {
 
     fn fetch_file(pem_file_path: &PathBuf) -> Result<DerCertificateBytes, CertificateFetcherError> {
         let cert = CertificateDer::from_pem_file(pem_file_path).map_err(|e| {
-            CertificateFetcherError::CertificateFetch(format!(
-                "reading certificate from file: {}",
-                e
-            ))
+            CertificateFetcherError::CertificateFetch(format!("reading certificate from file: {e}"))
         })?;
         Ok(cert.as_ref().to_vec())
     }

--- a/agent-control/src/sub_agent/identity.rs
+++ b/agent-control/src/sub_agent/identity.rs
@@ -16,10 +16,8 @@ pub struct AgentIdentity {
 
 impl AgentIdentity {
     pub fn new_agent_control_identity() -> Self {
-        let ac_agent_type_id = format!(
-            "{}/{}:{}",
-            AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION
-        );
+        let ac_agent_type_id =
+            format!("{AGENT_CONTROL_NAMESPACE}/{AGENT_CONTROL_TYPE}:{AGENT_CONTROL_VERSION}");
         Self::from((
             AgentID::new_agent_control_id(),
             // This is a safe unwrap because we are creating the AgentTypeID from a string that we know is valid.

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -110,7 +110,7 @@ impl NotStartedSupervisorK8s {
         };
 
         let data = serde_json::to_value(&k8s_obj.fields).map_err(|e| {
-            SupervisorStarterError::ConfigError(format!("Error serializing fields: {}", e))
+            SupervisorStarterError::ConfigError(format!("Error serializing fields: {e}"))
         })?;
 
         Ok(DynamicObject {

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -462,8 +462,7 @@ pub mod tests {
         let max_duration = Duration::from_millis(100);
         assert!(
             duration < max_duration,
-            "stopping the supervisor took to much time: {:?}",
-            duration
+            "stopping the supervisor took to much time: {duration:?}"
         );
 
         for log in contain_logs {
@@ -472,8 +471,7 @@ pub mod tests {
                     "newrelic_agent_control::sub_agent::on_host::supervisor",
                     log,
                 ),
-                "log: {}",
-                log
+                "log: {log}"
             );
         }
     }
@@ -578,8 +576,7 @@ pub mod tests {
             |lines| match lines.iter().filter(|line| line.contains("hello!")).count() {
                 4 => Ok(()),
                 n => Err(format!(
-                    "Expected 4 lines with 'hello!' corresponding to 1 run + 3 retries, got {}",
-                    n
+                    "Expected 4 lines with 'hello!' corresponding to 1 run + 3 retries, got {n}"
                 )),
             },
         )

--- a/agent-control/src/sub_agent/version/k8s/helmrelease.rs
+++ b/agent-control/src/sub_agent/version/k8s/helmrelease.rs
@@ -237,12 +237,12 @@ pub mod tests {
             "chart": {{
                 "spec": {{
                     "chart": "default-test",
-                    "version": "{}"
+                    "version": "{chart_version}"
                 }}
             }}
         }},
         "status": {{
-            "lastAttemptedRevision": "{}",
+            "lastAttemptedRevision": "{last_attempted_version}",
             "history": [
                 {{
                     "chartName": "default-test",
@@ -264,8 +264,7 @@ pub mod tests {
                 }}
             ]
         }}    
-    }}"#,
-            chart_version, last_attempted_version
+    }}"#
         )
     }
     fn get_dynamic_object(json_data: String) -> DynamicObject {

--- a/agent-control/src/sub_agent/version/onhost.rs
+++ b/agent-control/src/sub_agent/version/onhost.rs
@@ -43,8 +43,7 @@ fn retrieve_version(agent_type_id: &AgentTypeID) -> Result<AgentVersion, Version
             OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
         )),
         _ => Err(VersionCheckError::Generic(format!(
-            "no match found for agent type: {}",
-            agent_type_id
+            "no match found for agent type: {agent_type_id}"
         ))),
     }
 }

--- a/agent-control/src/sub_agent/version/version_checker.rs
+++ b/agent-control/src/sub_agent/version/version_checker.rs
@@ -94,7 +94,7 @@ pub(crate) fn publish_version_event(
     sub_agent_internal_publisher: &EventPublisher<SubAgentInternalEvent>,
     event: SubAgentInternalEvent,
 ) {
-    let event_type_str = format!("{:?}", event);
+    let event_type_str = format!("{event:?}");
     _ = sub_agent_internal_publisher
         .publish(event)
         .inspect_err(|e| {

--- a/agent-control/src/values/file.rs
+++ b/agent-control/src/values/file.rs
@@ -103,7 +103,7 @@ where
         let values_result = self.file_rw.read(path.as_path());
         match values_result {
             Err(FileReaderError::FileNotFound(e)) => {
-                trace!("file not found! {}", e);
+                trace!("file not found! {e}");
                 //actively fallback to load local file
                 Ok(None)
             }

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -17,7 +17,7 @@ pub fn check_latest_identifying_attributes_match_expected(
         expected_identifying_attributes.clone(),
         current_attributes.identifying_attributes.clone(),
     )
-    .map_err(|e| format!("Identifying attributes don't match {}:", e))
+    .map_err(|e| format!("Identifying attributes don't match {e}:"))
 }
 
 pub fn check_latest_non_identifying_attributes_match_expected(
@@ -33,7 +33,7 @@ pub fn check_latest_non_identifying_attributes_match_expected(
         expected_non_identifying_attributes.clone(),
         current_attributes.non_identifying_attributes.clone(),
     )
-    .map_err(|e| format!("Non identifying attributes don't match: {}", e))
+    .map_err(|e| format!("Non identifying attributes don't match: {e}"))
 }
 
 fn check_opamp_attributes(
@@ -44,8 +44,7 @@ fn check_opamp_attributes(
     current_vec.sort_by(|a, b| a.key.cmp(&b.key));
     if expected_vec != current_vec {
         return Err(format!(
-            "Expected != Found\nExpected:\n{:?}\nFound:\n{:?}\n",
-            expected_vec, current_vec
+            "Expected != Found\nExpected:\n{expected_vec:?}\nFound:\n{current_vec:?}\n"
         ));
     }
     Ok(())

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -134,11 +134,9 @@ chart_version: {LOCAL_CHART_NEW_VERSION}
                 }),
             })
         {
-            return Err(format!(
-                "new version has not been reported: {:?}",
-                current_attributes
-            )
-            .into());
+            return Err(
+                format!("new version has not been reported: {current_attributes:?}").into(),
+            );
         }
 
         check_latest_effective_config_is_expected(

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -157,7 +157,7 @@ fn k8s_value_repository_config_map() {
         test_ns.as_str(),
         test_ns.as_str(),
         "k8s_value_repository_config_map",
-        format!("local-data-{}", AGENT_ID_1).as_str(),
+        format!("local-data-{AGENT_ID_1}").as_str(),
     ));
     let local_values = YAMLConfig::try_from("test: 1".to_string()).unwrap();
     let res = value_repository
@@ -344,7 +344,7 @@ fn k8s_multiple_store_entries() {
 }
 
 fn assert_agent_cm(cm_client: &Api<ConfigMap>, agent_id: &AgentID, store_key: &StoreKey) {
-    let cm_name = format!("{}{}", CM_NAME_OPAMP_DATA_PREFIX, agent_id);
+    let cm_name = format!("{CM_NAME_OPAMP_DATA_PREFIX}{agent_id}");
     let cm = block_on(cm_client.get(&cm_name));
     assert!(cm.is_ok());
     let cm_un = cm.unwrap();

--- a/agent-control/tests/k8s/tools/agent_control.rs
+++ b/agent-control/tests/k8s/tools/agent_control.rs
@@ -88,7 +88,7 @@ pub async fn create_local_config_map(
     name: &str,
 ) {
     let mut content = String::new();
-    File::open(format!("tests/k8s/data/{}/{}.yaml", folder_name, name))
+    File::open(format!("tests/k8s/data/{folder_name}/{name}.yaml"))
         .unwrap()
         .read_to_string(&mut content)
         .unwrap();
@@ -136,8 +136,7 @@ pub fn create_local_agent_control_config(
 ) {
     let mut content = String::new();
     File::open(format!(
-        "tests/k8s/data/{}/local-data-agent-control.template",
-        folder_name
+        "tests/k8s/data/{folder_name}/local-data-agent-control.template"
     ))
     .unwrap()
     .read_to_string(&mut content)

--- a/agent-control/tests/k8s/tools/logs.rs
+++ b/agent-control/tests/k8s/tools/logs.rs
@@ -34,16 +34,13 @@ pub fn spawn_pod_logger(client: Client, namespace: String, pod_name: String) {
             match block_on(pods.log_stream(&pod_name, &log_params)) {
                 Ok(stream) => break stream.lines(),
                 Err(err) => {
-                    println!(
-                        "Failed to get log stream for pod {}: {}. Retrying...",
-                        pod_name, err
-                    );
+                    println!("Failed to get log stream for pod {pod_name}: {err}. Retrying...");
                     std::thread::sleep(Duration::from_secs(1));
                 }
             }
         };
         while let Some(Ok(line)) = block_on(lines_stream.next()) {
-            println!("{} {}", pod_name, line);
+            println!("{pod_name} {line}");
         }
     });
 }

--- a/agent-control/tests/on_host/opamp_auth.rs
+++ b/agent-control/tests/on_host/opamp_auth.rs
@@ -30,7 +30,7 @@ fn test_auth_local_provider_as_root() {
     let opamp_server = MockServer::start();
     let opamp_server_mock = opamp_server.mock(|when, then| {
         when.method(POST)
-            .header(AUTHORIZATION.as_str(), format!("Bearer {}", token))
+            .header(AUTHORIZATION.as_str(), format!("Bearer {token}"))
             .path("/");
         then.status(200);
     });

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -37,9 +37,8 @@ fn test_attributes_from_non_existing_agent_type() {
     let agents = format!(
         r#"
   test-agent:
-    agent_type: "{}/{}:{}"
-"#,
-        DEFAULT_NAMESPACE, DEFAULT_NAME, DEFAULT_VERSION
+    agent_type: "{DEFAULT_NAMESPACE}/{DEFAULT_NAME}:{DEFAULT_VERSION}"
+"#
     );
 
     create_agent_control_config(
@@ -116,9 +115,8 @@ fn test_attributes_from_an_existing_agent_type() {
     let agents = format!(
         r#"
   test-agent:
-    agent_type: "{}/{}:0.1.0"
-"#,
-        AGENT_CONTROL_NAMESPACE, AGENT_TYPE_NAME_INFRA_AGENT
+    agent_type: "{AGENT_CONTROL_NAMESPACE}/{AGENT_TYPE_NAME_INFRA_AGENT}:0.1.0"
+"#
     );
 
     create_agent_control_config(

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -37,9 +37,8 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
     let agents = format!(
         r#"
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     create_agent_control_config(
@@ -60,10 +59,8 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 
     // And the custom-agent has also remote config values
     let remote_values_config_body = "fake_variable: from remote\n";
-    let remote_values_config = format!(
-        "config:\n  {}hash: hash-test\nstate: applying\n",
-        remote_values_config_body
-    );
+    let remote_values_config =
+        format!("config:\n  {remote_values_config_body}hash: hash-test\nstate: applying\n");
     create_sub_agent_values(
         agent_id.to_string(),
         remote_values_config.to_string(),
@@ -121,9 +118,8 @@ fn onhost_opamp_sub_agent_with_no_local_config() {
     let agents = format!(
         r#"
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     let agent_id = "nr-sleep-agent";

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -115,9 +115,8 @@ fn onhost_opamp_agent_control_remote_effective_config() {
         r#"
 agents:
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     // When a new config with an agent is received from OpAMP
@@ -130,9 +129,8 @@ agents:
     let expected_config = format!(
         r#"agents:
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
     let expected_config_parsed =
         serde_yaml::from_str::<YAMLConfig>(expected_config.as_str()).unwrap();
@@ -144,8 +142,7 @@ agents:
         let content_parsed = serde_yaml::from_str::<RemoteConfig>(remote_config.as_str()).unwrap();
         if content_parsed.config != expected_config_parsed {
             return Err(format!(
-                "Agent Control config not as expected, Expected: {:?}, Found: {:?}",
-                expected_config, remote_config,
+                "Agent Control config not as expected, Expected: {expected_config:?}, Found: {remote_config:?}",
             )
             .into());
         }
@@ -223,8 +220,7 @@ non-existing: {}
                 std::fs::read_to_string(remote_file.as_path()).unwrap_or("agents:".to_string());
             if !remote_config.contains(expected_containing) {
                 return Err(format!(
-                    "Agent Control config not as expected, Expected containing: {:?}, Config Found: {:?}",
-                    expected_containing, remote_config,
+                    "Agent Control config not as expected, Expected containing: {expected_containing:?}, Config Found: {remote_config:?}",
                 )
                 .into());
             }
@@ -270,9 +266,8 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
     let agents = format!(
         r#"
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     create_agent_control_config(
@@ -347,9 +342,8 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
     let agents = format!(
         r#"
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     create_agent_control_config(
@@ -370,10 +364,8 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
 
     // And the custom-agent has also remote config values
     let remote_values_config_body = "fake_variable: from remote\n";
-    let remote_values_config = format!(
-        "config:\n  {}hash: hash-test\nstate: applying\n",
-        remote_values_config_body
-    );
+    let remote_values_config =
+        format!("config:\n  {remote_values_config_body}hash: hash-test\nstate: applying\n");
     create_sub_agent_values(
         agent_id.to_string(),
         remote_values_config.to_string(),
@@ -423,9 +415,8 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
     let agents = format!(
         r#"
   nr-sleep-agent:
-    agent_type: "{}"
-"#,
-        sleep_agent_type
+    agent_type: "{sleep_agent_type}"
+"#
     );
 
     create_agent_control_config(
@@ -496,9 +487,8 @@ fn onhost_executable_less_reports_local_effective_config() {
         r#"
 agents:
   no-executables:
-    agent_type: "{}"
-"#,
-        agent_type_wo_exec
+    agent_type: "{agent_type_wo_exec}"
+"#
     );
 
     create_agent_control_config(

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -62,7 +62,7 @@ agents: {}
 
 pub fn create_file(content: String, path: PathBuf) {
     let mut local_file = File::create(path).expect("failed to create local config file");
-    write!(local_file, "{}", content).unwrap();
+    write!(local_file, "{content}").unwrap();
 }
 
 /// Creates a sub-agent values config for the agent_id provided on the base_dir

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -23,12 +23,11 @@ variables:
 deployment:
   on_host:
     executable:
-      path: {}
-      args: {}
-"#,
-        path, args
+      path: {path}
+      args: {args}
+"#
     );
-    write!(local_file, "{}", custom_agent_type).unwrap();
+    write!(local_file, "{custom_agent_type}").unwrap();
 
     "newrelic/com.newrelic.custom_agent:0.1.0".to_string()
 }
@@ -61,7 +60,7 @@ deployment:
 "#,
         health_file_path.to_str().unwrap()
     );
-    write!(local_file, "{}", custom_agent_type).unwrap();
+    write!(local_file, "{custom_agent_type}").unwrap();
 
     "newrelic/com.newrelic.custom_agent:0.1.0".to_string()
 }


### PR DESCRIPTION
# What this PR does / why we need it

Passed `cargo clippy --fix` as of Rust 1.88 and fixed some potential warnings that will break our CI/CD once we bump the Rust version of the project. The majority of the fixed lints make sure the variables are used inside the string literals where possible. There's also two minor, different lints included.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
