### PR TITLE
feat: health-check initial_delay config (NR-436357)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -37,6 +37,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       instrumentation:
         apiVersion: newrelic.com/v1beta1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -37,6 +37,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       instrumentation:
         apiVersion: newrelic.com/v1beta1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -37,6 +37,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       instrumentation:
         apiVersion: newrelic.com/v1beta1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -37,6 +37,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       instrumentation:
         apiVersion: newrelic.com/v1beta1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -37,6 +37,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       instrumentation:
         apiVersion: newrelic.com/v1beta1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
@@ -22,6 +22,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -72,6 +72,7 @@ deployment:
     enable_file_logging: ${nr-var:enable_file_logging}
     health:
       interval: 5s
+      initial_delay: 5s
       timeout: 5s
       http:
         path: "/v1/status/health"
@@ -93,6 +94,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -22,6 +22,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -22,6 +22,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -22,6 +22,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -48,6 +48,7 @@ deployment:
   on_host:
     health:
       interval: 5s
+      initial_delay: 5s
       timeout: 5s
       http:
         path: "${nr-var:health_check.path}"
@@ -69,6 +70,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -22,6 +22,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -161,6 +161,7 @@ where
                     health_checker,
                     self.agent_control_internal_publisher.clone(),
                     self.initial_config.health_check.interval,
+                    self.initial_config.health_check.initial_delay,
                     self.start_time,
                 )
             });
@@ -553,6 +554,7 @@ mod tests {
     use super::resource_cleaner::tests::MockResourceCleaner;
     use super::version_updater::updater::UpdaterError;
     use super::version_updater::updater::tests::MockVersionUpdater;
+    use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
     use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::event::broadcaster::unbounded::UnboundedBroadcast;
     use crate::event::channel::{EventConsumer, EventPublisher, pub_sub};
@@ -776,6 +778,14 @@ agents:
             let resource_cleaner = MockResourceCleaner::new();
             let version_updater = MockVersionUpdater::new();
 
+            let ac_config = AgentControlConfig {
+                health_check: AgentControlHealthCheckerConfig {
+                    initial_delay: Duration::ZERO.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
             let agent_control = {
                 AgentControl::new(
                     Some(started_client),
@@ -789,7 +799,7 @@ agents:
                     resource_cleaner,
                     version_updater,
                     NONE_MOCK_HEALTH_CHECKER_BUILDER,
-                    AgentControlConfig::default(),
+                    ac_config,
                 )
             };
             let test_data = TestData {

--- a/agent-control/src/agent_control/health_checker.rs
+++ b/agent-control/src/agent_control/health_checker.rs
@@ -1,10 +1,13 @@
+use std::time::Duration;
+
 use serde::Deserialize;
 use tracing::error;
 
 use crate::{
     event::{AgentControlInternalEvent, channel::EventPublisher},
     health::{
-        events::HealthEventPublisher, health_checker::HealthCheckInterval,
+        events::HealthEventPublisher,
+        health_checker::{HealthCheckInterval, InitialDelay},
         with_start_time::HealthWithStartTime,
     },
 };
@@ -12,11 +15,22 @@ use crate::{
 pub mod k8s;
 
 /// Holds the Agent Control configuration fields for setting up the health-check.
-#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentControlHealthCheckerConfig {
+    /// The duration to wait between health checks.
     pub interval: HealthCheckInterval,
+    /// The initial delay before the first health check is performed.
+    pub initial_delay: InitialDelay,
 }
 
+impl Default for AgentControlHealthCheckerConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(30).into(),
+            initial_delay: Duration::from_secs(30).into(),
+        }
+    }
+}
 impl HealthEventPublisher for EventPublisher<AgentControlInternalEvent> {
     fn publish_health_event(&self, health: HealthWithStartTime) {
         let event = AgentControlInternalEvent::HealthUpdated(health);

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -280,6 +280,7 @@ deployment:
   on_host:
     health:
       interval: 3s
+      initial_delay: 3s
       timeout: 10s
       http:
         path: /healthz
@@ -413,6 +414,7 @@ deployment:
   on_host:
     health:
       interval: 3s
+      initial_delay: 3s
       timeout: 10s
       http:
         path: /v1/status

--- a/agent-control/src/agent_type/runtime_config/health_config.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config.rs
@@ -6,7 +6,7 @@ use wrapper_with_default::WrapperWithDefault;
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
-use crate::health::health_checker::HealthCheckInterval;
+use crate::health::health_checker::{HealthCheckInterval, InitialDelay};
 
 use super::templateable_value::TemplateableValue;
 
@@ -19,9 +19,15 @@ const DEFAULT_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct OnHostHealthConfig {
     /// The duration to wait between health checks.
+    #[serde(default)]
     pub(crate) interval: HealthCheckInterval,
 
+    /// The initial delay before the first health check is performed.
+    #[serde(default)]
+    pub(crate) initial_delay: InitialDelay,
+
     /// The maximum duration a health check may run before considered failed.
+    #[serde(default)]
     pub(crate) timeout: HealthCheckTimeout,
 
     /// Details on the type of health check. Defined by the `HealthCheck` enumeration.

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -1,7 +1,7 @@
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
-use crate::health::health_checker::HealthCheckInterval;
+use crate::health::health_checker::{HealthCheckInterval, InitialDelay};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
@@ -76,7 +76,11 @@ impl Templateable for K8sObjectMeta {
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct K8sHealthConfig {
     /// The duration to wait between health checks.
+    #[serde(default)]
     pub(crate) interval: HealthCheckInterval,
+    /// The initial delay before the first health check is performed.
+    #[serde(default)]
+    pub(crate) initial_delay: InitialDelay,
 }
 
 #[cfg(test)]

--- a/agent-control/src/agent_type/runtime_config/onhost.rs
+++ b/agent-control/src/agent_type/runtime_config/onhost.rs
@@ -560,6 +560,7 @@ restart_policy:
     pub const AGENT_GIVEN_YAML: &str = r#"
 health:
   interval: 3s
+  initial_delay: 3s
   timeout: 10s
   http:
     path: /healthz

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -173,6 +173,7 @@ impl NotStartedSupervisorK8s {
             k8s_health_checker,
             sub_agent_internal_publisher,
             health_config.interval,
+            health_config.initial_delay,
             start_time,
         );
 
@@ -497,6 +498,7 @@ pub mod tests {
         let mut k8s_obj = k8s_sample_runtime_config(true);
         k8s_obj.health = Some(K8sHealthConfig {
             interval: Duration::from_millis(500).into(),
+            ..Default::default()
         });
 
         // instance K8s client mock

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -143,6 +143,7 @@ impl NotStartedSupervisorOnHost {
                 health_checker,
                 sub_agent_internal_publisher,
                 health_config.interval,
+                health_config.initial_delay,
                 start_time,
             );
             return Ok(Some(started_thread_context));

--- a/agent-control/tests/k8s/data/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type.yml
@@ -12,6 +12,7 @@ deployment:
   k8s:
     health:
       interval: 5s
+      initial_delay: 2s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
@@ -12,6 +12,7 @@ deployment:
   k8s:
     health:
       interval: 5s
+      initial_delay: 2s
     objects:
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -11,13 +11,12 @@ use crate::k8s::tools::logs::{AC_LABEL_SELECTOR, print_pod_logs};
 use assert_cmd::Command;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::ListParams;
-use kube::{Api, Client, ResourceExt};
+use kube::{Api, Client};
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::OPAMP_CHART_VERSION_ATTRIBUTE_KEY;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 use opamp_client::opamp::proto::any_value::Value;
 use opamp_client::opamp::proto::{AnyValue, KeyValue, RemoteConfigStatuses};
-use std::io;
 use std::str::FromStr;
 use std::time::Duration;
 use url::Url;
@@ -253,12 +252,6 @@ fn k8s_self_update_new_version_fails_to_start_next_receives_correct_version() {
         LOCAL_CHART_PREVIOUS_VERSION,
     );
 
-    // AC should start correctly and finally report healthy
-    retry(60, Duration::from_secs(5), || {
-        check_latest_health_status_was_healthy(&opamp_server, &ac_instance_id)?;
-        Ok(())
-    });
-
     opamp_server.set_config_response(
         ac_instance_id.clone(),
         ConfigResponse::from(
@@ -331,12 +324,6 @@ fn k8s_self_update_new_version_failing_image() {
         LOCAL_CHART_NEW_VERSION,
     );
 
-    // AC should start correctly and finally report healthy
-    retry(60, Duration::from_secs(5), || {
-        check_latest_health_status_was_healthy(&opamp_server, &ac_instance_id)?;
-        Ok(())
-    });
-
     opamp_server.set_config_response(
         ac_instance_id.clone(),
         ConfigResponse::from(
@@ -365,7 +352,6 @@ chart_version: {LOCAL_CHART_FAILING_VERSION}
         // Iterate over the Pods matching the label to ensure are crashing.
         let mut pod_crashing = false;
         'pods_loop: for p in pod_list.iter() {
-            let pod_name = p.name_any();
             if p.status
                 .as_ref()
                 .map(|status| &status.container_statuses)
@@ -384,7 +370,7 @@ chart_version: {LOCAL_CHART_FAILING_VERSION}
         }
 
         check_latest_health_status(&opamp_server, &ac_instance_id, |status| {
-            !status.healthy && status.last_error.contains("HelmRelease status unknown:") // Expected error when chart version doesn't exist
+            !status.healthy && status.last_error.contains("HelmRelease status unknown:")
         })
     });
 }
@@ -444,6 +430,11 @@ fn ac_chart_values(opamp_endpoint: Url, name_override: &str) -> String {
             "content": {
               "log": {
                 "level":"debug",
+              },
+              // To make health assertions faster
+              "health_check":{
+                "initial_delay": "1s",
+                "interval": "5s",
               },
               "fleet_control": {
                 "endpoint": opamp_endpoint.as_str(),

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -35,6 +35,7 @@ deployment:
   on_host:
     health:
       interval: 1s
+      initial_delay: 0s
       timeout: 1s
       file:
         path: {}
@@ -146,6 +147,7 @@ deployment:
   on_host:
     health:
       interval: 1s
+      initial_delay: 0s
       timeout: 1s
       http:
         path: /health

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -52,6 +52,7 @@ deployment:
   on_host:
     health:
       interval: 2s
+      initial_delay: 0s
       timeout: 1s
       file:
           path: "{}"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -98,7 +98,8 @@ Configuration fields to set-up Agent Control health-check
 
 ```yaml
 health_check:
-  interval: 120s # Defaults to 60s
+  interval: 120s # Defaults to 30s
+  initial_delay: 120s # Defaults to 30s
 ```
 
 ### self_instrumentation

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -167,6 +167,7 @@ deployment:
     enable_file_logging: ${nr-var:enable_file_logging}
     health:
       interval: 5s
+      initial_delay: 5s
       timeout: 5s
       http:
         path: "/v1/status/health"
@@ -185,6 +186,7 @@ deployment:
   k8s:
     health:
       interval: 30s
+      initial_delay: 30s
     objects:
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
@@ -248,6 +250,7 @@ When set, this redirects the `stdout` and `stderr` of the created process to fil
 Enables periodically checking the health of the sub-agent. See [Health status](#health-status) below for more details. Accepts the following values:
 
 - `interval`: Periodicity of the check. A duration string.
+- `initial_delay`: Initial delay before the first health check is performed. A duration string.
 - `timeout`: Maximum duration a health check may run before considered failed.
 - `http` or `file`: The type of health check used.
   - `http` means that the supervisor for this sub-agent will attempt to query an HTTP endpoint and will decide on healthiness depending on the status code. Accepts the following fields:
@@ -279,7 +282,8 @@ The following fields are used for configuring the Kubernetes deployment of a sub
 
 The health configuration for Kubernetes. See [Health status](#health-status) below for more details. Accepts the following values:
 
-- `interval`: Periodicity pf the check. A duration string.
+- `interval`: Periodicity of the check. A duration string. Default to 60s
+- `initial_delay`: Initial delay before the first health check is performed. A duration string. Default to zero.
 
 ##### `objects`
 


### PR DESCRIPTION
The main goal of this PR is to reduce the initial unhealthy state noise.

Introduce the `initial_delay` health checker configuration. 
- To on-host and k8s AgentType deployment health check configuration.
- To AC health check configuration

Modify all current AgentTypes to make use this. As a rule of thumb i have added an initial delay equivalent to the interval.

Note: During this Pr creation we noticed other issue regarding health that perhaps were more likely to be the root cause of the reason that triggered this PR ( handling `unknown` HelmRelease state) , that was fixed on #1406 . But anyway this feature should avoid the `missing status` issues and probably some in progress states that are expected during rolling out.