### PR TITLE
fix: revisit HelmRelease configs (NR-436357)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.ebpf-0.1.0.yaml
@@ -19,6 +19,7 @@ variables:
       type: string
       required: true
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -31,10 +32,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
@@ -45,7 +42,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           default.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
@@ -67,7 +63,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: nr-ebpf-agent
@@ -79,12 +75,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -93,12 +86,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -37,7 +37,13 @@ variables:
       required: false
       default: 18003
   k8s:
+    # HelmChart based sub agents should always have `chart_values`.
     chart_values:
+      # Chart values should always must go under a key that has the chart name.
+      # In this case there are multiple sub-charts so each key is the sub-chart name.
+      # chart_values:
+      #   <chart name>: {values of the sub chart}
+      #   global: {}
       newrelic-infrastructure:
         description: "newrelic-infrastructure chart values"
         type: yaml
@@ -58,11 +64,13 @@ variables:
         type: yaml
         required: false
         default: { }
+      # Global values must have their own key, even if there is only one sub-chart.
       global:
         description: "Global chart values"
         type: yaml
         required: false
         default: { }
+    # HelmChart based sub agents should always have `chart_version`.
     chart_version:
       description: "nri-bundle chart version"
       type: string
@@ -96,11 +104,14 @@ deployment:
       interval: 30s
       initial_delay: 30s
     objects:
+      # Flux [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/).
       repository:
         apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
+          # The agent-id is a unique identifier. It is used to have an expected name without collision between agents.
           name: ${nr-sub:agent_id}
+          # All resources directly managed by AC are expected to be created in the same ns where AC is installed.
           namespace: ${nr-ac:namespace}
         spec:
           # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
@@ -108,8 +119,13 @@ deployment:
           # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
           # delaying the application of important updates.
           interval: 30m
+          # This value gets rendered when not specified, with "generic" as the default value.
+          # If we don't set the value explicitly here, in the agent type, the AC supervisor will detect
+          # a configuration drift and trigger the re-apply of the config in each interval.
+          # We want to avoid it, so we set it explicitly.
           provider: generic
           url: https://helm-charts.newrelic.com
+      # Creates HelmCharts values inside Secrets to avoid exposing any sensible information.
       values:
         apiVersion: v1
         kind: Secret
@@ -117,6 +133,9 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
+          # These values contains default configuration that can be inherited from AC chart values,
+          # enhancing user experience when deploying sub-agents with minimal configuration.
+          # The env vars defined here are mounted into the AC pod.
           default.yaml: |
             newrelic-infrastructure:
               enabled: true
@@ -132,6 +151,7 @@ deployment:
               nrStaging: ${nr-env:NR_STAGING}
               lowDataMode: ${nr-env:NR_LOW_DATA_MODE}
               verboseLog: ${nr-env:NR_VERBOSE_LOG}
+          # These values are the ones that are expected to be configured by the user.
           values.yaml: |
             newrelic-infrastructure: 
               ${nr-var:chart_values.newrelic-infrastructure | indent 2}
@@ -163,6 +183,7 @@ deployment:
               enabled: false
             newrelic-k8s-metrics-adapter:
               enabled: false 
+      # Flux [HelmRelease](https://fluxcd.io/flux/components/helmreleases/) that installs the nri-bundle chart.
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -170,13 +191,23 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
+          # sub-agent charts workloads are installed under a different namespace for security reasons.
           targetNamespace: ${nr-ac:namespace_agents}
+          # The agent-id is a unique identifier. It is used to have an expected name without collision between agents.
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          # An small interval has chosen to provide a faster feedback to values upgrades and HelmChart status errors.
+          # This is the interval at which any change in the chart values defined at the values-${nr-sub:agent_id} secret is re-applied.
+          # We also have detected that whenever there is an not-ready condition at the HelmChart (Flux CR) it doesn't get updated into
+          # the HelmRelease Status until one interval has finish.
+          interval: 30s
+          # Reference to the created HelmRepository.
           chart:
             spec:
               chart: nri-bundle
+              # This is where the chart version to be installed is defined. Whenever AC updates this Flux triggers a reconciliation.
               version: ${nr-var:chart_version}
+              # This value gets rendered even if not specified so, even 'ChartVersion' is the default, it is required to specify 
+              # it to avoid the drift detection on AC supervisor, and trigger re-apply on each interval.
               reconcileStrategy: ChartVersion
               sourceRef:
                 kind: HelmRepository
@@ -185,25 +216,24 @@ deployment:
               interval: 3m
           install:
             # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
+            # Having this disable is equal to execute a `helm install` without the `--wait` flag.
+            # AC has it's own health check system that will flag the status of the installed chart.
             disableWait: true
             disableWaitForJobs: true
+            # TODO document why these
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
+            # This makes Flux create the agents namespace for AC (i.e. targetNamespace), if it doesn't exist.
             createNamespace: true
           upgrade:
+            # Same as the installation phase, waits are disabled.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
+
+          # The values are applied in order, so latest always have precedence.
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -19,6 +19,7 @@ variables:
       type: string
       required: true
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -31,10 +32,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://newrelic.github.io/k8s-agents-operator
@@ -45,7 +42,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           # ${nr-env:NR_STAGING}, ${nr-env:NR_LOW_DATA_MODE} and ${nr-env:NR_VERBOSE_LOG} are not set because they are
           # not supported by the chart.
           default.yaml: |
@@ -67,7 +63,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: k8s-agents-operator
@@ -79,12 +75,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -93,12 +86,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.prometheus-0.1.0.yaml
@@ -19,6 +19,7 @@ variables:
       type: string
       required: true
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -31,10 +32,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://newrelic.github.io/newrelic-prometheus-configurator
@@ -45,7 +42,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           default.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
@@ -68,7 +64,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: newrelic-prometheus-agent
@@ -80,12 +76,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -94,12 +87,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.fluentbit-0.1.0.yaml
@@ -19,6 +19,7 @@ variables:
       type: string
       required: true
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -31,10 +32,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
@@ -45,7 +42,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           # ${nr-env:NR_VERBOSE_LOG} is not set, since it is not used in the chart.
           default.yaml: |
             global:
@@ -68,7 +64,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: newrelic-logging
@@ -80,12 +76,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -94,12 +87,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -66,7 +66,7 @@ deployment:
         backoff_strategy:
           type: fixed
           backoff_delay: ${nr-var:backoff_delay}
-
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -79,10 +79,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
@@ -93,7 +89,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           default.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
@@ -116,7 +111,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: nr-k8s-otel-collector
@@ -128,12 +123,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -142,12 +134,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-0.1.0.yaml
@@ -19,6 +19,7 @@ variables:
       type: string
       required: true
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -31,10 +32,6 @@ deployment:
           name: ${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         spec:
-          # Increasing the interval to 30 minutes because the HelmRepository is not as prone to frequent changes
-          # as HelmRelease objects might be. Given repositories typically have fewer updates than the resources
-          # they trigger, a longer interval helps in reducing unnecessary load on the cluster without significantly
-          # delaying the application of important updates.
           interval: 30m
           provider: generic
           url: https://helm-charts.newrelic.com
@@ -45,7 +42,6 @@ deployment:
           name: values-${nr-sub:agent_id}
           namespace: ${nr-ac:namespace}
         stringData:
-          # These env variables are attached to the AC pod on the Helm Chart.
           default.yaml: |
             global:
               licenseKey: ${nr-env:NR_LICENSE_KEY}
@@ -68,7 +64,7 @@ deployment:
         spec:
           targetNamespace: ${nr-ac:namespace_agents}
           releaseName: ${nr-sub:agent_id}
-          interval: 3m
+          interval: 30s
           chart:
             spec:
               chart: pipeline-control-gateway
@@ -80,12 +76,9 @@ deployment:
                 namespace: ${nr-ac:namespace}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
             disableTakeOwnership: true
-            remediation:
-              retries: 3
             replace: true
             createNamespace: true
           upgrade:
@@ -94,12 +87,6 @@ deployment:
             disableTakeOwnership: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           valuesFrom:
             - kind: Secret
               name: values-${nr-sub:agent_id}

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -230,6 +230,7 @@ Then, for a Kubernetes deployment, we use the following format:
 
 ```yaml
 deployment:
+  # See com.newrelic.infrastructure Agent type for description of fields.
   k8s:
     health:
       interval: 30s
@@ -254,29 +255,19 @@ deployment:
             spec:
               chart: nr-k8s-otel-collector
               version: ${nr-var:chart_version}
-              reconcileStrategy: ChartVersion
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
               interval: 3m
           install:
-            # Wait are disabled to avoid blocking the modifications/deletions of this CR while in reconciling state.
             disableWait: true
             disableWaitForJobs: true
-            remediation:
-              retries: 3
             replace: true
           upgrade:
             disableWait: true
             disableWaitForJobs: true
             cleanupOnFail: true
             force: true
-            remediation:
-              retries: 3
-              strategy: rollback
-          rollback:
-            disableWait: true
-            disableWaitForJobs: true
           values:
             ${nr-var:chart_values}
 ```

--- a/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
+++ b/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
@@ -2,6 +2,7 @@ use crate::common::retry::retry;
 use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::agent_control_cli::installation::{ac_install_cmd, create_simple_values_secret};
 use crate::k8s::self_update::{LOCAL_CHART_NEW_VERSION, LOCAL_CHART_PREVIOUS_VERSION};
+use crate::k8s::tools::cmd::print_cli_output;
 use crate::k8s::tools::k8s_env::K8sEnv;
 use newrelic_agent_control::agent_control::config::{
     AgentControlDynamicConfig, helmrelease_v2_type_meta,
@@ -41,7 +42,9 @@ fn k8s_cli_local_and_remote_updates() {
         LOCAL_CHART_PREVIOUS_VERSION,
         "test-secret=values.yaml",
     );
-    cmd.assert().success();
+    let assert = cmd.assert();
+    print_cli_output(&assert);
+    assert.success();
 
     retry(15, Duration::from_secs(5), || {
         check_version_and_source(
@@ -58,7 +61,9 @@ fn k8s_cli_local_and_remote_updates() {
         LOCAL_CHART_NEW_VERSION,
         "test-secret=values.yaml",
     );
-    cmd.assert().success();
+    let assert = cmd.assert();
+    print_cli_output(&assert);
+    assert.success();
 
     retry(15, Duration::from_secs(5), || {
         check_version_and_source(&k8s_client, LOCAL_CHART_NEW_VERSION, LOCAL_VAL, &namespace)
@@ -90,7 +95,9 @@ fn k8s_cli_local_and_remote_updates() {
         "test-secret=values.yaml",
     );
     cmd.arg("--extra-labels").arg("env=testing");
-    cmd.assert().success();
+    let assert = cmd.assert();
+    print_cli_output(&assert);
+    assert.success();
 
     retry(15, Duration::from_secs(5), || {
         check_version_and_source(&k8s_client, latest_version, REMOTE_VAL, &namespace)?;

--- a/agent-control/tests/k8s/data/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type.yml
@@ -23,7 +23,6 @@ deployment:
         spec:
           # we don't want to trigger this in the test to avoid extra load in the cluster
           interval: 99m
-          provider: generic
           url: https://helm.github.io/examples
       release:
         apiVersion: helm.toolkit.fluxcd.io/v2
@@ -33,19 +32,29 @@ deployment:
           namespace: ${nr-ac:namespace}
         spec:
           # we don't want to trigger this in the test to avoid extra load in the cluster
-          interval: 99m
+          interval: 10s
+          releaseName: ${nr-sub:agent_id}
+          targetNamespace: ${nr-ac:namespace_agents}
           chart:
             spec:
               chart: hello-world
               version: 0.1.0
-              reconcileStrategy: ChartVersion
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
                 namespace: ${nr-ac:namespace}
           install:
             disableWait: true
+            disableWaitForJobs: true
+            disableTakeOwnership: true
+            replace: true
+            # namespaces lifecycle is handled by the test.
+            # createNamespace: true
           upgrade:
             disableWait: true
+            disableWaitForJobs: true
+            disableTakeOwnership: true 
+            cleanupOnFail: true
+            force: true
           values:
             ${nr-var:chart_values}

--- a/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
@@ -23,7 +23,6 @@ deployment:
         spec:
           # we don't want to trigger this in the test to avoid extra load in the cluster
           interval: 99m
-          provider: generic
           url: https://helm.github.io/examples
       default-values:
         apiVersion: v1
@@ -49,15 +48,22 @@ deployment:
             spec:
               chart: hello-world
               version: 0.1.0
-              reconcileStrategy: ChartVersion
               sourceRef:
                 kind: HelmRepository
                 name: ${nr-sub:agent_id}
           install:
             disableWait: true
-            createNamespace: true
+            disableWaitForJobs: true
+            disableTakeOwnership: true
+            replace: true
+            # namespaces lifecycle is handled by the test.
+            # createNamespace: true
           upgrade:
             disableWait: true
+            disableWaitForJobs: true
+            disableTakeOwnership: true 
+            cleanupOnFail: true
+            force: true
           valuesFrom:
             - kind: Secret
               name: default-values-${nr-sub:agent_id}

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -270,9 +270,9 @@ chart_version: {MISSING_VERSION}
         )?;
         check_latest_health_status(&opamp_server, &ac_instance_id, |status| {
             !status.healthy
-                && status
-                    .last_error
-                    .contains("latest generation of object has not been reconciled") // Expected error when chart version doesn't exist
+                && status.last_error.contains(
+                    &format!("no 'agent-control-deployment' chart with version matching '{MISSING_VERSION}' found"),
+                )
         })
     });
 
@@ -368,7 +368,7 @@ chart_version: {LOCAL_CHART_FAILING_VERSION}
         }
 
         check_latest_health_status(&opamp_server, &ac_instance_id, |status| {
-            !status.healthy && status.last_error.contains("HelmRelease status unknown:")
+            !status.healthy && status.last_error.contains("has 1 unavailable replicas")
         })
     });
 }

--- a/agent-control/tests/k8s/tools/cmd.rs
+++ b/agent-control/tests/k8s/tools/cmd.rs
@@ -1,0 +1,13 @@
+use assert_cmd::assert::Assert;
+use std::io::{self, Write};
+
+pub fn print_cli_output(assert: &Assert) {
+    let output = assert.get_output();
+    io::stdout().write_all(&output.stdout).unwrap();
+    io::stderr().write_all(&output.stderr).unwrap();
+}
+
+pub fn assert_stdout_contains(assert: &Assert, value: &str) {
+    let stderr = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stderr.contains(value))
+}

--- a/agent-control/tests/k8s/tools/mod.rs
+++ b/agent-control/tests/k8s/tools/mod.rs
@@ -2,6 +2,8 @@
 /// and specific initial configuration. Any helper receiving a `folder_name` assumes that the folder exists
 /// in the path `tests/k8s/data/`.
 pub mod agent_control;
+/// Helpers for assert_cmd.
+pub mod cmd;
 pub mod instance_id;
 /// Provides tools to perform queries through the k8s API in order to perform assertions.
 pub mod k8s_api;

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -287,7 +287,7 @@ The health configuration for Kubernetes. See [Health status](#health-status) bel
 
 ##### `objects`
 
-Key-value pairs of the [Kubernetes Objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/) to be created by this sub-agent on deployment. The key is the name of the object, while the value is the object itself which accepts the following values:
+Key-value pairs of the [Kubernetes Objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/) to be created by this sub-agent on deployment. The key is an internal identifier of the object, while the value is the object itself which accepts the following values:
 
 - `apiVersion`, a string.
 - `kind`, a string.
@@ -296,9 +296,10 @@ Key-value pairs of the [Kubernetes Objects](https://kubernetes.io/docs/concepts/
   - `namespace`, a string.
   - `labels`: key-value pair of strings representing Kubernetes labels.
 - And a collection of arbitrary fields representing the actual data (e.g. the `spec`) of the object.
-  - `targetNamespace`, a string. Relevant for installing the sub-agent in the agents namespace.
+  
+Most of Agent Control sub-agents currently deploy [Flux](https://fluxcd.io) CRs which end up in helm chart installation. 
 
-[Flux](https://fluxcd.io) is expected to be installed in the cluster to manage Flux resources.
+A detailed example of a Kubernetes deployment AgentType is available [here](../agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml). This file includes all necessary Flux CR configurations required for Agent Control to manage sub-agent deployments effectively. It serves as a comprehensive reference for understanding the integration and deployment process.
 
 ## Applying configurations
 


### PR DESCRIPTION
During AC self update demo I noticed that the AC HelmRelease was "in progress" state during 5m whenever i was exercising a failure scenario like trying to install a missing chart version. This was causing the HelmRelease status not showing the HelmChart error ( something like version 9.9.9 of the chart doesn't exists) but instead showing something like in progress. 

This is caused because the HelmRelease doesn't get the not-ready state message of the HelmChart until the next reconcile interval. https://github.com/fluxcd/helm-controller/issues/1252. In order to fix this the reconcile interval has been lowered.

Also AC helmRelease didn't have many configuration that AC is expecting for a HelmRelease like `disableWait`, the pr also change this and documents all behaviours.

This PR changes:
- Document chosen configuration on Flux CRs,
- Use the standard configs for the AC Flux CRs
- Removes the remediation configurations: Is AC/FC responsibility to detect a failing scenario and trigger a rollback . With remediation activated, this is kind of gray because since disableWait==disable many failing scenarios were not being handled by this remediation so the solution was not consistent.
