### PR TITLE
feat(agentType): support 'Null' Yaml default values on variables (NR-436892)

### DIFF
--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -359,7 +359,7 @@ variables:
     integrations:
       description: "Newrelic integrations configuration yamls"
       type: map[string]file
-      required: true
+      required: false
       default:
         kafka: |
           bootstrap: zookeeper

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -12,8 +12,8 @@ pub enum AgentTypeError {
     UnexpectedValueForKey(String, String),
     #[error("Missing required template key: `{0}`")]
     MissingTemplateKey(String),
-    #[error("Missing default value for a non-required spec key")]
-    MissingDefault,
+    #[error("Parsing AgentType variables: `{0}`")]
+    Parse(String),
     #[error("Not all values for this agent type have been populated: {0:?}")]
     ValuesNotPopulated(Vec<String>),
     #[error("Template value not parseable from the string `{0}")]

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -9,7 +9,7 @@ use crate::agent_type::{
     trivial_value::{FilePathWithContent, TrivialValue},
     variable::{
         constraints::VariableConstraints,
-        fields::{StringFields, StringFieldsDefinition},
+        fields::{StringFields, StringFieldsDefinition, YamlFieldsDefinition},
     },
 };
 
@@ -33,7 +33,7 @@ pub enum VariableTypeDefinition {
     #[serde(rename = "map[string]file")]
     MapStringFile(FieldsWithPathDefinition<HashMap<String, FilePathWithContent>>),
     #[serde(rename = "yaml")]
-    Yaml(FieldsDefinition<serde_yaml::Value>),
+    Yaml(YamlFieldsDefinition),
 }
 
 /// [VariableTypeDefinition] including information known at runtime.

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -93,11 +93,13 @@ The value type that is accepted for this variable. As of now, the following type
 
 ##### `required` (`bool`)
 
-Specifies if providing a value for this variable is required or not. If `required` is `false`, a `default` value of its specified [type](#type-string) needs to be provided.
+Specifies if providing a value for this variable is required or not. If `required` is `false`, a `default` value of its specified [type](#type-string) needs to be provided. If `required` is `true`, then a `default` value cannot be specified.
 
 ##### `default` (optional)
 
 A default value for this variable, for the cases where no configuration value has been passed for this variable when creating an instance for the agent type. Its value must be of the same type as the one declared for the variable.
+
+In the case of the `yaml` variable type, is recommended to explicitly set a 'null' default value as `default: null`.
 
 ##### `file_path` (`String`, optional)
 


### PR DESCRIPTION
- Adds support for default `null` yaml values on variables: These missing feature is needed in order to support #1461 
- Adds a check that verify no required variable can have a default.

