### PR TITLE
Fix(ci/cd): fleet control test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,9 +99,9 @@ jobs:
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
       NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
-      E2E_ACCOUNT_ID: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.COREINT_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
   k8s-e2e-tests:
     uses: ./.github/workflows/component_k8s_e2e.yml
@@ -110,9 +110,9 @@ jobs:
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
       NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
-      E2E_ACCOUNT_ID: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.COREINT_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
   k8s_canaries:
     uses: ./.github/workflows/component_k8s_canaries.yml
@@ -139,7 +139,7 @@ jobs:
 
   notify-failure:
     if: ${{ always() && failure() }}
-    needs: 
+    needs:
       - onhost-e2e
       - k8s_canaries
       - security-image

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -128,9 +128,9 @@ jobs:
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
       NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
-      E2E_ACCOUNT_ID: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.COREINT_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
   k8s-e2e-tests:
     uses: ./.github/workflows/component_k8s_e2e.yml
@@ -139,9 +139,9 @@ jobs:
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
       NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
-      E2E_ACCOUNT_ID: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.COREINT_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
   k8s_canaries:
     uses: ./.github/workflows/component_k8s_canaries.yml

--- a/.github/workflows/push_pr_test.yml
+++ b/.github/workflows/push_pr_test.yml
@@ -195,6 +195,6 @@ jobs:
     with:
       scenarios: '["infra"]'
     secrets:
-      E2E_ACCOUNT_ID: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.COREINT_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -91,7 +91,7 @@ local_resource(
     resource_deps=['chartmuseum'],
 )
 
-flags_helm = ['--create-namespace', '--set=installationJob.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080' ,'--version=>=0.0.0-beta','--set=agent-control-deployment.image.imagePullPolicy=Always','--values=' + sa_chart_values_file]
+flags_helm = ['--timeout=150s', '--create-namespace', '--set=installationJob.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080' ,'--version=>=0.0.0-beta','--set=agent-control-deployment.image.imagePullPolicy=Always','--values=' + sa_chart_values_file]
 
 if license_key != '':
   flags_helm.append('--set=global.licenseKey='+license_key)
@@ -114,6 +114,6 @@ helm_resource(
 )
 
 # We had flaky e2e test failing due to timeout applying the chart on 30s
-update_settings(k8s_upsert_timeout_secs=150)
+update_settings(k8s_upsert_timeout_secs=200)
 
 

--- a/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
+++ b/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
@@ -15,8 +15,6 @@ agent-control-deployment:
           name: "sys-identity"
     agentControl:
       content:
-        k8s:
-          namespace_newrelic-agents
         log:
           level: debug
     subAgents:


### PR DESCRIPTION
# What this PR does / why we need it
the issue was caused by the following string that was added by mistake:
```
        k8s:
          namespace_newrelic-agents
```

Moreover, the Tiltfile had a timeout lower than K8s itself killing the command abruptly. At least now we can see why it failed from Helm:
```
  agent-control │      Error: failed post-install: 1 error occurred:
  agent-control │      	* timed out waiting for the condition
```

We were also using wrong Vars

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
