### PR TITLE
feat(client): split clients

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -5,7 +5,6 @@ use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
 use crate::agent_type::variable::constraints::VariableConstraints;
 use crate::http::config::ProxyConfig;
 use crate::instrumentation::config::logs::config::LoggingConfig;
-use crate::k8s::client::ClientConfig;
 use crate::opamp::auth::config::AuthConfig;
 use crate::opamp::client_builder::PollInterval;
 use crate::opamp::remote_config::OpampRemoteConfigError;
@@ -214,9 +213,6 @@ impl<'de> Deserialize<'de> for OpAMPClientConfig {
 pub struct K8sConfig {
     /// cluster_name is an attribute used to identify all monitored data in a particular kubernetes cluster. Required
     pub cluster_name: String,
-    /// client configuration
-    #[serde(flatten)]
-    pub client_config: ClientConfig,
     /// namespace where all resources directly managed by the agent control will be created.
     pub namespace: String,
     /// namespace where all resources managed by flux will be created.
@@ -296,7 +292,6 @@ impl Default for K8sConfig {
     fn default() -> Self {
         Self {
             cluster_name: Default::default(),
-            client_config: Default::default(),
             namespace: Default::default(),
             namespace_agents: Default::default(),
             current_chart_version: Default::default(),
@@ -315,7 +310,7 @@ pub(crate) mod tests {
         },
         sub_agent::identity::AgentIdentity,
     };
-    use std::{path::PathBuf, time::Duration};
+    use std::path::PathBuf;
 
     impl Default for OpAMPClientConfig {
         fn default() -> Self {
@@ -584,7 +579,6 @@ k8s:
   namespace: some-namespace
   namespace_agents: some-namespace-agents
   cluster_name: some-cluster
-  client_timeout: 3s
   cr_type_meta:
     - apiVersion: "custom.io/v1"
       kind: "CustomKind"
@@ -602,10 +596,6 @@ k8s:
         assert_eq!(k8s.cr_type_meta, vec![custom_type_meta]);
         assert_eq!(k8s.namespace, "some-namespace");
         assert_eq!(k8s.cluster_name, "some-cluster");
-        assert_eq!(
-            k8s.client_config.client_timeout,
-            Duration::from_secs(3).into()
-        );
     }
 
     #[test]

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -47,7 +47,7 @@ impl AgentControlRunner {
     pub(super) fn run_k8s(self) -> Result<(), AgentError> {
         info!("Starting the k8s client");
         let k8s_client = Arc::new(
-            SyncK8sClient::try_new(self.runtime, &self.k8s_config.client_config)
+            SyncK8sClient::try_new(self.runtime)
                 .map_err(|e| AgentError::ExternalError(e.to_string()))?,
         );
         let k8s_store = Arc::new(K8sStore::new(

--- a/agent-control/src/cli/utils.rs
+++ b/agent-control/src/cli/utils.rs
@@ -1,5 +1,4 @@
 use crate::cli::errors::CliError;
-use crate::k8s::client::ClientConfig;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use std::collections::BTreeMap;
@@ -46,8 +45,7 @@ pub fn try_new_k8s_client() -> Result<SyncK8sClient, CliError> {
     );
 
     debug!("Starting the k8s client");
-    SyncK8sClient::try_new(runtime, &ClientConfig::new())
-        .map_err(|err| CliError::K8sClient(err.to_string()))
+    SyncK8sClient::try_new(runtime).map_err(|err| CliError::K8sClient(err.to_string()))
 }
 
 pub fn retry<F>(max_attempts: usize, interval: Duration, mut f: F) -> Result<(), CliError>

--- a/agent-control/src/k8s/reflectors.rs
+++ b/agent-control/src/k8s/reflectors.rs
@@ -31,13 +31,13 @@ const REFLECTOR_START_MAX_ATTEMPTS: u32 = 3;
 /// let deployment_reflector = builder.try_build::<Deployment>().unwrap();
 /// ```
 pub struct ReflectorBuilder {
-    client: Client,
+    reflector_client: Client,
 }
 
 impl ReflectorBuilder {
     /// Returns a reflector builder, consuming the provided client.
-    pub fn new(client: Client) -> Self {
-        ReflectorBuilder { client }
+    pub fn new(reflector_client: Client) -> Self {
+        ReflectorBuilder { reflector_client }
     }
 
     /// Builds the DynamicObject reflector using the builder.
@@ -56,7 +56,7 @@ impl ReflectorBuilder {
         trace!("Building k8s reflector for {:?}", api_resource);
         Reflector::retry_build_on_timeout(REFLECTOR_START_MAX_ATTEMPTS, || async {
             Reflector::try_new(
-                Api::namespaced_with(self.client.clone(), ns, api_resource),
+                Api::namespaced_with(self.reflector_client.clone(), ns, api_resource),
                 REFLECTOR_START_TIMEOUT,
                 Writer::new(api_resource.clone()),
             )

--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -10,7 +10,6 @@ use newrelic_agent_control::event::channel::{EventPublisher, pub_sub};
 use newrelic_agent_control::http::tls::install_rustls_default_crypto_provider;
 use newrelic_agent_control::values::file::ConfigRepositoryFile;
 use std::sync::Arc;
-use std::time::Duration;
 
 /// Starts the agent-control in a separate thread. The agent-control will be stopped when the `StartedAgentControl` is dropped.
 /// Take into account that some of the logic from main is not present here.
@@ -42,14 +41,9 @@ pub fn start_agent_control_with_custom_config(
             k8s_config: match mode {
                 // This config is not used on the OnHost environment, a blank config is used.
                 Environment::OnHost => K8sConfig::default(),
-                Environment::K8s => {
-                    let mut cfg = agent_control_config
-                        .k8s
-                        .expect("K8s config must be present when running in K8s");
-
-                    cfg.client_config.client_timeout = Duration::from_secs(30).into();
-                    cfg
-                }
+                Environment::K8s => agent_control_config
+                    .k8s
+                    .expect("K8s config must be present when running in K8s"),
             },
         };
 

--- a/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
+++ b/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
@@ -6,7 +6,7 @@ use newrelic_agent_control::agent_control::config::{
     helmrelease_v2_type_meta, helmrepository_type_meta,
 };
 use newrelic_agent_control::cli::install_agent_control::{RELEASE_NAME, REPOSITORY_NAME};
-use newrelic_agent_control::k8s::client::{ClientConfig, SyncK8sClient};
+use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL};
 use newrelic_agent_control::sub_agent::identity::AgentIdentity;
 use std::collections::BTreeMap;
@@ -31,8 +31,7 @@ fn k8s_cli_install_agent_control_creates_resources() {
     print_cli_output(&assert);
     assert.success();
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let agent_identity = AgentIdentity::new_agent_control_identity();
 
     // Assert repository data
@@ -165,8 +164,7 @@ fn k8s_cli_install_agent_control_creates_resources_with_specific_repository_url(
     print_cli_output(&assert);
     assert.success();
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let repository = k8s_client
         .get_dynamic_object(&helmrepository_type_meta(), REPOSITORY_NAME, &namespace)
         .unwrap()

--- a/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
+++ b/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
@@ -10,7 +10,7 @@ use crate::k8s::tools::logs::print_pod_logs;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::config::helmrelease_v2_type_meta;
 use newrelic_agent_control::cli::install_agent_control::RELEASE_NAME;
-use newrelic_agent_control::k8s::client::{ClientConfig, SyncK8sClient};
+use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL};
 use newrelic_agent_control::sub_agent::version::version_checker::VersionCheckError;
 use std::error::Error;
@@ -30,8 +30,7 @@ fn k8s_cli_local_and_remote_updates() {
     let mut k8s_env = block_on(K8sEnv::new());
     let ac_namespace = block_on(k8s_env.test_namespace());
     let subagents_namespace = block_on(k8s_env.test_namespace());
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
 
     print_pod_logs(k8s_env.client.clone(), &ac_namespace, CLI_AC_LABEL_SELECTOR);
 

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -11,7 +11,6 @@ use k8s_openapi::api::core::v1::Secret;
 use kube::{api::Api, core::TypeMeta};
 use mockall::mock;
 use newrelic_agent_control::agent_control::config_repository::repository::AgentControlDynamicConfigRepository;
-use newrelic_agent_control::k8s::client::ClientConfig;
 use newrelic_agent_control::opamp::remote_config::hash::ConfigState;
 use newrelic_agent_control::sub_agent::k8s::supervisor::NotStartedSupervisorK8s;
 use newrelic_agent_control::values::config::RemoteConfig;
@@ -79,8 +78,7 @@ fn k8s_garbage_collector_cleans_removed_agent_resources() {
         AgentTypeID::try_from("ns/test:1.2.3").unwrap(),
     ));
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
 
     let resource_name = "test-different-from-agent-id";
     let secret_name = "test-secret-name";
@@ -240,9 +238,7 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
     };
 
     let gc = K8sGarbageCollector {
-        k8s_client: Arc::new(
-            SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap(),
-        ),
+        k8s_client: Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap()),
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![missing_kind, foo_type_meta()],
@@ -273,8 +269,7 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
         None,
     ));
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone(), test_ns.clone()));
 
     let instance_id_getter = InstanceIDWithIdentifiersGetter::new_k8s_instance_id_getter(
@@ -365,9 +360,7 @@ agents:
     );
 
     let gc = K8sGarbageCollector {
-        k8s_client: Arc::new(
-            SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap(),
-        ),
+        k8s_client: Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap()),
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![foo_type_meta()],

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -7,7 +7,7 @@ use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::config_repository::repository::AgentControlDynamicConfigRepository;
 use newrelic_agent_control::agent_control::config_repository::store::AgentControlConfigStore;
 use newrelic_agent_control::agent_control::defaults::default_capabilities;
-use newrelic_agent_control::k8s::client::{ClientConfig, SyncK8sClient};
+use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::Labels;
 use newrelic_agent_control::k8s::store::{
     CM_NAME_LOCAL_DATA_PREFIX, CM_NAME_OPAMP_DATA_PREFIX, K8sStore, STORE_KEY_INSTANCE_ID,
@@ -37,8 +37,7 @@ fn k8s_instance_id_store() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone(), test_ns.clone()));
 
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
@@ -79,8 +78,7 @@ fn k8s_hash_in_config_map() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone(), test_ns.clone()));
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
     let agent_id_2 = AgentID::new(AGENT_ID_2).unwrap();
@@ -140,8 +138,7 @@ fn k8s_value_repository_config_map() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client, test_ns.clone()));
     let agent_id_1 = AgentID::new(AGENT_ID_1).unwrap();
     let agent_id_2 = AgentID::new(AGENT_ID_2).unwrap();
@@ -233,8 +230,7 @@ fn k8s_sa_config_map() {
 
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone(), test_ns.clone()));
 
     // This is the cached local config
@@ -300,8 +296,7 @@ fn k8s_multiple_store_entries() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
     let k8s_store = Arc::new(K8sStore::new(k8s_client.clone(), test_ns.clone()));
     let agent_id = AgentID::new(AGENT_ID_1).unwrap();
 

--- a/agent-control/tests/k8s/tools/k8s_env.rs
+++ b/agent-control/tests/k8s/tools/k8s_env.rs
@@ -53,10 +53,14 @@ pub struct K8sEnv {
 
 impl K8sEnv {
     pub async fn new() -> Self {
+        init_logger();
+        K8sEnv::new_without_logs().await
+    }
+
+    pub async fn new_without_logs() -> Self {
         INIT_RUSTLS.call_once(|| {
             install_rustls_default_crypto_provider();
         });
-        init_logger();
 
         // Forces the client to use the dev kubeconfig file.
         unsafe { env::set_var("KUBECONFIG", KUBECONFIG_PATH) };

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -10,7 +10,7 @@ use newrelic_agent_control::agent_control::config::{
 use newrelic_agent_control::agent_control::version_updater::k8s::K8sACUpdater;
 use newrelic_agent_control::agent_control::version_updater::updater::VersionUpdater;
 use newrelic_agent_control::cli::install_agent_control::RELEASE_NAME;
-use newrelic_agent_control::k8s::client::{ClientConfig, SyncK8sClient};
+use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -22,8 +22,7 @@ fn k8s_run_updater() {
     // set up the k8s environment
     let mut k8s = block_on(K8sEnv::new());
     let test_ns = block_on(k8s.test_namespace());
-    let k8s_client =
-        Arc::new(SyncK8sClient::try_new(tokio_runtime(), &ClientConfig::new()).unwrap());
+    let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
 
     let current_version = "1.2.3-beta".to_string();
     let new_version = "1.2.3".to_string();


### PR DESCRIPTION
# What this PR does / why we need it
I removed entirely the possibility to add a timeout since it was difficult to explain its behaviour and no longer needed
Moreover, keeping the timeout would have creating issues if in the future we want to unify back the clients

The test fails if the client is the same or if any changes forces the client to start hanging.

Related to https://github.com/kube-rs/kube/issues/1796

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
