### PR TITLE
chore: increase the memory limit after activating debug logs

### DIFF
--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -35,7 +35,7 @@ module "alerts" {
       name          = "Memory usage (bytes)"
       metric        = "memoryWorkingSetBytes"
       sample        = "K8sContainerSample"
-      threshold     = 14000000 # 14 MB, +25% of observed value https://staging.onenr.io/0dQeV0JdVwe
+      threshold     = 16000000 # +25% of observed value https://staging.onenr.io/0dQeV0JdVwe
       duration      = 600
       operator      = "above"
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -37,7 +37,7 @@ module "alerts" {
       name          = "Memory usage (bytes)"
       metric        = "memoryWorkingSetBytes"
       sample        = "K8sContainerSample"
-      threshold     = 14000000 # 14 MB, +25% of observed value https://staging.onenr.io/0dQeV0JdVwe
+      threshold     = 16000000 # +25% of observed value https://staging.onenr.io/0dQeV0JdVwe
       duration      = 600
       operator      = "above"
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"


### PR DESCRIPTION
Memory consumption has slightly increased after the debug logs activation, this PR rises that limit to avoid false positives.
<img width="720" height="211" alt="image" src="https://github.com/user-attachments/assets/15fed843-97e0-490a-b7e4-6e7ef0da8134" />
