### PR TITLE
feat: add flux updater

### DIFF
--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -18,18 +18,18 @@ thiserror = { workspace = true }
 nix = { workspace = true, features = ["signal", "user", "hostname"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "chrono"] }
 tracing = { workspace = true, features = ["attributes"] }
-ctrlc = { version = "3.4.5", features = ["termination"] }
+ctrlc = { version = "3.4.7", features = ["termination"] }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
 futures = { version = "0.3.31" }
-tokio = { version = "1.44.0", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros", "sync"] }
 console-subscriber = { version = "0.4.1", optional = true }
 duration-str = "0.17.0"
 konst = { workspace = true }
 http = { workspace = true }
 reqwest = { workspace = true }
 url = { version = "2.5.4", features = ["serde"] }
-actix-web = "4.10.2"
+actix-web = "4.11.0"
 serde_json = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
@@ -53,18 +53,18 @@ either = { version = "1.15.0" }
 
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 tracing-appender = "0.2.3"
-cfg-if = "1.0.0"
+cfg-if = "1.0.1"
 # HOST_ID and HOST_NAME attributes are experimental fields and after 0.26.0 are not included by default.
 # Check <https://github.com/open-telemetry/opentelemetry-rust/pull/2098> for details.
 opentelemetry-semantic-conventions = { version = "0.30.0", features = [
   "semconv_experimental",
 ] }
 http-serde = "2.1.1"
-config = { version = "0.15.9", features = ["yaml"] }
-rustls = { version = "0.23.23", features = ["ring"] }
+config = { version = "0.15.13", features = ["yaml"] }
+rustls = { version = "0.23.31", features = ["ring"] }
 webpki = { version = "0.22.4", features = ["alloc"] }
 x509-parser = "0.17.0"
-ring = "0.17.13"
+ring = "0.17.14"
 bytes = "1.10.1"
 opentelemetry = { version = "0.30.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["trace"] }
@@ -74,7 +74,7 @@ opentelemetry-http = { version = "0.30.0" }
 opentelemetry-appender-tracing = { version = "0.30.1", features = [
   "experimental_use_tracing_span_context",
 ] }
-async-trait = "0.1.86"
+async-trait = "0.1.88"
 
 
 [dev-dependencies]
@@ -90,16 +90,16 @@ mockall_double = { workspace = true }
 tracing-test = { workspace = true }
 jsonwebtoken = { workspace = true }
 fs = { path = "../fs", features = ["mocks"] }
-tokio = { version = "1.44.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros"] }
 fake = { version = "4.0.0", features = ["derive", "http"] }
-prost = "0.14"
+prost = "0.14.1"
 # Alpha version needed to test proxy the feature, it is safe because it is only used as dev-dependency
 httpmock = { version = "0.8.0-alpha.1", features = ["proxy"] }
 serial_test = "3.2.0"
 futures = "0.3.31"
-rcgen = { version = "0.14.0", features = ["crypto"] }
+rcgen = { version = "0.14.3", features = ["crypto"] }
 rustls-pemfile = { version = "2.2.0" }
-rstest = "0.26.0"
+rstest = "0.26.1"
 tokio-stream = { version = "0.1.17", features = ["net"] }
 
 [build-dependencies]

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -94,6 +94,8 @@ pub struct AgentControlDynamicConfig {
     pub agents: SubAgentsMap,
     /// chart_version represent the AC version that needs to be executed.
     pub chart_version: Option<String>,
+    /// cd_chart_version represent the agent control cd chart version that needs to be executed.
+    pub cd_chart_version: Option<String>,
 }
 
 pub type SubAgentsMap = HashMap<AgentID, SubAgentConfig>;
@@ -232,6 +234,9 @@ pub struct K8sConfig {
     /// cd_remote_update enables or disables remote update for the agent-control-cd chart
     #[serde(default)]
     pub cd_remote_update: bool,
+    /// agent_control_cd release name
+    #[serde(default)]
+    pub cd_release_name: String,
 }
 
 pub fn helmrelease_v2_type_meta() -> TypeMeta {
@@ -304,6 +309,7 @@ impl Default for K8sConfig {
             cr_type_meta: default_group_version_kinds(),
             ac_remote_update: Default::default(),
             cd_remote_update: Default::default(),
+            cd_release_name: Default::default(),
         }
     }
 }

--- a/agent-control/src/agent_control/config_repository/store.rs
+++ b/agent-control/src/agent_control/config_repository/store.rs
@@ -246,6 +246,7 @@ pub(crate) mod tests {
                     },
                 )]),
                 chart_version: Some("1.0.0".to_string()),
+                cd_chart_version: None,
             },
             host_id: "some".to_string(),
             ..Default::default()

--- a/agent-control/src/agent_control/health_checker/k8s.rs
+++ b/agent-control/src/agent_control/health_checker/k8s.rs
@@ -1,10 +1,10 @@
 use std::{sync::Arc, time::SystemTime};
 
+use crate::cli::install::agent_control::RELEASE_NAME;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::{
     agent_control::config::helmrelease_v2_type_meta,
-    cli::install::agent_control::RELEASE_NAME,
     health::k8s::health_checker::{K8sHealthChecker, health_checkers_for_type_meta},
 };
 

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -205,6 +205,7 @@ impl AgentControlRunner {
             k8s_client,
             self.k8s_config.namespace.clone(),
             self.k8s_config.current_chart_version.clone(),
+            self.k8s_config.cd_release_name,
         );
 
         AgentControl::new(

--- a/agent-control/src/agent_control/version_updater/k8s.rs
+++ b/agent-control/src/agent_control/version_updater/k8s.rs
@@ -5,55 +5,63 @@ use crate::cli::install::agent_control::RELEASE_NAME;
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, REMOTE_VAL};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
 use tracing::{debug, info};
 
+#[derive(Debug, Clone, Copy)]
+pub enum Component {
+    AgentControl,
+    FluxCD,
+}
+
+impl fmt::Display for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Component::AgentControl => write!(f, "Agent Control"),
+            Component::FluxCD => write!(f, "Flux"),
+        }
+    }
+}
 pub struct K8sACUpdater {
-    #[allow(dead_code)]
     ac_remote_update: bool,
-    #[allow(dead_code)]
     cd_remote_update: bool,
     k8s_client: Arc<SyncK8sClient>,
     namespace: String,
     // current_chart_version is the version of the agent control that is currently running.
     // It is loaded at startup, and it is populated by the HelmChart.
     current_chart_version: String,
+    // release name for agent control cd loaded from config
+    cd_release_name: String,
 }
 
 impl VersionUpdater for K8sACUpdater {
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError> {
-        let Some(version) = config.chart_version.as_ref() else {
-            debug!("Chart version is not specified");
-            return Ok(());
-        };
-
-        if version == &self.current_chart_version {
-            debug!("Current version is already up to date");
-            return Ok(());
+        if self.ac_remote_update {
+            self.update_helm_release_version(
+                Component::AgentControl,
+                config.chart_version.as_ref(),
+                &self.current_chart_version,
+                RELEASE_NAME,
+            )?;
+        }
+        if !self.ac_remote_update {
+            debug!("Remote updates for Agent Control are disabled. Nothing to do.");
         }
 
-        // To avoid overwriting existing labels we need to get the object and to add manually the label
-        // since the strategic merge is not available for CRs
-        let labels = self.get_helm_release_labels()?;
+        if self.cd_remote_update {
+            let current_version = self.get_cd_helm_release_version()?;
 
-        let patch_to_apply = self.create_helm_release_patch(version, labels);
-
-        info!(
-            "Updating Agent Control to version: {} -> {}",
-            self.current_chart_version, version
-        );
-        self.k8s_client
-            .patch_dynamic_object(
-                &helmrelease_v2_type_meta(),
-                RELEASE_NAME,
-                &self.namespace,
-                patch_to_apply,
-            )
-            .map_err(|err| {
-                UpdaterError::UpdateFailed(format!(
-                    "applying patch to {RELEASE_NAME} helmRelease: {err}",
-                ))
-            })?;
+            self.update_helm_release_version(
+                Component::FluxCD,
+                config.cd_chart_version.as_ref(),
+                current_version.as_str(),
+                self.cd_release_name.as_str(),
+            )?;
+        }
+        if !self.cd_remote_update {
+            debug!("Remote updates for Agent Control cd are disabled. Nothing to do.");
+        }
 
         Ok(())
     }
@@ -66,6 +74,7 @@ impl K8sACUpdater {
         k8s_client: Arc<SyncK8sClient>,
         namespace: String,
         current_chart_version: String,
+        cd_deployment_name: String,
     ) -> Self {
         Self {
             ac_remote_update,
@@ -73,6 +82,7 @@ impl K8sACUpdater {
             k8s_client,
             namespace,
             current_chart_version,
+            cd_release_name: cd_deployment_name,
         }
     }
 
@@ -99,66 +109,391 @@ impl K8sACUpdater {
         })
     }
 
-    fn get_helm_release_labels(&self) -> Result<BTreeMap<String, String>, UpdaterError> {
+    fn get_helm_release_labels(
+        &self,
+        release_name: &str,
+    ) -> Result<BTreeMap<String, String>, UpdaterError> {
         Ok(self
             .k8s_client
-            .get_dynamic_object(&helmrelease_v2_type_meta(), RELEASE_NAME, &self.namespace)
+            .get_dynamic_object(&helmrelease_v2_type_meta(), release_name, &self.namespace)
             .map_err(|err| {
                 UpdaterError::UpdateFailed(format!(
-                    "error fetching {RELEASE_NAME} helmRelease: {err}",
+                    "error fetching {release_name} helmRelease: {err}",
                 ))
             })?
             .map(|obj| obj.metadata.clone().labels.unwrap_or_default())
             .unwrap_or_default())
     }
+
+    /// Updates a HelmRelease resource in Kubernetes to a new version.
+    ///
+    /// If the new version is specified and differs from the current version, this function
+    /// applies a JSON patch to the HelmRelease to update its `spec.chart.spec.version`.
+    fn update_helm_release_version(
+        &self,
+        component_name: Component,
+        new_version: Option<&String>,
+        current_version: &str,
+        release_name: &str,
+    ) -> Result<(), UpdaterError> {
+        let Some(version) = new_version else {
+            debug!("Version for '{component_name}' is not specified in the dynamic config.");
+            return Ok(());
+        };
+
+        if version == current_version {
+            debug!("Current version of '{component_name}' is already up to date: {version}");
+            return Ok(());
+        }
+
+        info!("Updating '{component_name}' from version: {current_version} to {version}");
+
+        let labels = self.get_helm_release_labels(release_name)?;
+        let patch_to_apply = self.create_helm_release_patch(version, labels);
+
+        self.k8s_client
+            .patch_dynamic_object(
+                &helmrelease_v2_type_meta(),
+                release_name,
+                &self.namespace,
+                patch_to_apply,
+            )
+            .map_err(|err| {
+                UpdaterError::UpdateFailed(format!(
+                    "Error applying patch to HelmRelease '{release_name}' for '{component_name}': {err}",
+                ))
+            })?;
+        Ok(())
+    }
+
+    fn get_cd_helm_release_version(&self) -> Result<String, UpdaterError> {
+        let helm_release = self
+            .k8s_client
+            .get_dynamic_object(
+                &helmrelease_v2_type_meta(),
+                &self.cd_release_name,
+                &self.namespace,
+            )
+            .map_err(|k8s_err| {
+                UpdaterError::UpdateFailed(format!(
+                    "Failed to fetch HelmRelease '{}': {}",
+                    &self.cd_release_name, k8s_err
+                ))
+            })?
+            .ok_or_else(|| {
+                UpdaterError::UpdateFailed(format!(
+                    "HelmRelease '{}' not found",
+                    &self.cd_release_name
+                ))
+            })?;
+
+        let version = helm_release
+            .data
+            .get("spec")
+            .and_then(|spec| spec.get("chart"))
+            .and_then(|chart| chart.get("spec"))
+            .and_then(|chart_spec| chart_spec.get("version"))
+            .and_then(|version_val| version_val.as_str())
+            .map(String::from)
+            .ok_or_else(|| {
+                UpdaterError::UpdateFailed(format!(
+                    "Could not find version at 'spec.chart.spec.version' in HelmRelease '{}'",
+                    &self.cd_release_name
+                ))
+            })?;
+
+        Ok(version)
+    }
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::*;
-    const TEST_NAMESPACE: &str = "test-namespace";
+    use crate::cli::install::agent_control::RELEASE_NAME;
+    use crate::k8s::Error as K8sError;
+    use crate::k8s::client::MockSyncK8sClient;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use kube::core::DynamicObject;
+    use mockall::predicate::*;
+    use serde_json::json;
+
+    const TEST_NAMESPACE: &str = "test-ns";
+    const CURRENT_AC_VERSION: &str = "1.0.0";
+    const NEW_AC_VERSION: &str = "1.1.0";
+    const CURRENT_CD_VERSION: &str = "2.0.0";
+    const NEW_CD_VERSION: &str = "2.1.0";
+    const CD_RELEASE_NAME_TEST: &str = "flux-cd";
+
+    /// Creates a dynamic configuration for tests.
+    fn test_config(
+        ac_version: Option<&str>,
+        cd_version: Option<&str>,
+    ) -> AgentControlDynamicConfig {
+        AgentControlDynamicConfig {
+            chart_version: ac_version.map(String::from),
+            cd_chart_version: cd_version.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a DynamicObject mock to simulate a HelmRelease.
+    fn mock_helm_release(
+        name: &str,
+        version: &str,
+        labels: BTreeMap<String, String>,
+    ) -> DynamicObject {
+        DynamicObject {
+            types: Some(helmrelease_v2_type_meta()),
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(TEST_NAMESPACE.to_string()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            data: json!({
+                "spec": { "chart": { "spec": { "version": version } } }
+            }),
+        }
+    }
+
     #[test]
-    fn test_missing_chart_version_does_no_op() {
-        let mut k8s_client = SyncK8sClient::default();
-        k8s_client.expect_patch_dynamic_object().never();
+    fn test_update_only_agent_control_when_enabled() {
+        let mut mock_client = MockSyncK8sClient::new();
+
+        // Expect AC labels to be fetched
+        mock_client
+            .expect_get_dynamic_object()
+            .with(
+                eq(helmrelease_v2_type_meta()),
+                eq(RELEASE_NAME),
+                eq(TEST_NAMESPACE),
+            )
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(Some(Arc::new(mock_helm_release(
+                    RELEASE_NAME,
+                    CURRENT_AC_VERSION,
+                    BTreeMap::new(),
+                ))))
+            });
+
+        // Expect only AC to be patched
+        mock_client
+            .expect_patch_dynamic_object()
+            .withf(|_, name, _, patch| {
+                name == RELEASE_NAME
+                    && patch
+                        .pointer("/spec/chart/spec/version")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        == NEW_AC_VERSION
+            })
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(mock_helm_release(
+                    RELEASE_NAME,
+                    CURRENT_AC_VERSION,
+                    BTreeMap::new(),
+                ))
+            });
+
+        let updater = K8sACUpdater::new(
+            true,
+            false,
+            Arc::new(mock_client),
+            TEST_NAMESPACE.to_string(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
+        );
+
+        let result = updater.update(&test_config(Some(NEW_AC_VERSION), None));
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_only_flux_when_enabled() {
+        let mut mock_client = MockSyncK8sClient::new();
+
+        // Expect CD version and labels to be fetched
+        mock_client
+            .expect_get_dynamic_object()
+            .with(
+                eq(helmrelease_v2_type_meta()),
+                eq(CD_RELEASE_NAME_TEST),
+                eq(TEST_NAMESPACE),
+            )
+            .times(2)
+            .returning(|_, _, _| {
+                Ok(Some(Arc::new(mock_helm_release(
+                    CD_RELEASE_NAME_TEST,
+                    CURRENT_CD_VERSION,
+                    BTreeMap::new(),
+                ))))
+            });
+
+        // Expect only Flux/CD to be patched
+        mock_client
+            .expect_patch_dynamic_object()
+            .withf(|_, name, _, patch| {
+                name == CD_RELEASE_NAME_TEST
+                    && patch
+                        .pointer("/spec/chart/spec/version")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        == NEW_CD_VERSION
+            })
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(mock_helm_release(
+                    CD_RELEASE_NAME_TEST,
+                    CURRENT_CD_VERSION,
+                    BTreeMap::new(),
+                ))
+            });
+
+        let updater = K8sACUpdater::new(
+            false,
+            true,
+            Arc::new(mock_client),
+            TEST_NAMESPACE.to_string(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
+        );
+
+        let result = updater.update(&test_config(None, Some(NEW_CD_VERSION)));
+
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn test_update_both_when_both_enabled() {
+        let mut mock_client = MockSyncK8sClient::new();
+
+        // Expect calls for both: AC and CD
+        mock_client
+            .expect_get_dynamic_object()
+            .returning(|_, name, _| {
+                if name == RELEASE_NAME {
+                    Ok(Some(Arc::new(mock_helm_release(
+                        RELEASE_NAME,
+                        CURRENT_AC_VERSION,
+                        BTreeMap::new(),
+                    ))))
+                } else if name == CD_RELEASE_NAME_TEST {
+                    Ok(Some(Arc::new(mock_helm_release(
+                        CD_RELEASE_NAME_TEST,
+                        CURRENT_CD_VERSION,
+                        BTreeMap::new(),
+                    ))))
+                } else {
+                    Ok(None)
+                }
+            });
+
+        // Expect two patch calls
+        mock_client
+            .expect_patch_dynamic_object()
+            .times(2)
+            .returning(|_, name, _, patch| {
+                let version = patch
+                    .pointer("/spec/chart/spec/version")
+                    .unwrap()
+                    .as_str()
+                    .unwrap();
+                Ok(mock_helm_release(name, version, BTreeMap::new()))
+            });
 
         let updater = K8sACUpdater::new(
             true,
             true,
-            Arc::new(k8s_client),
+            Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
-            "1.0.0".to_string(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
         );
 
-        updater
-            .update(&AgentControlDynamicConfig {
-                chart_version: None,
-                ..Default::default()
-            })
-            .expect("updater should return Ok without making any calls to the k8s client");
-    }
-    #[test]
-    fn test_update_to_current_version_does_no_op() {
-        let mut k8s_client = SyncK8sClient::default();
-        k8s_client.expect_patch_dynamic_object().never();
+        let result = updater.update(&test_config(Some(NEW_AC_VERSION), Some(NEW_CD_VERSION)));
 
-        let current_version = "1.0.0".to_string();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_does_nothing_when_both_disabled() {
+        let mock_client = MockSyncK8sClient::new();
+        let updater = K8sACUpdater::new(
+            false,
+            false,
+            Arc::new(mock_client),
+            TEST_NAMESPACE.to_string(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
+        );
+
+        let result = updater.update(&test_config(Some(NEW_AC_VERSION), Some(NEW_CD_VERSION)));
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_does_not_patch_if_version_is_the_same() {
+        let mut mock_client = MockSyncK8sClient::new();
+        // Expect the call to get the CD version, but not to patch
+        mock_client
+            .expect_get_dynamic_object()
+            .with(
+                eq(helmrelease_v2_type_meta()),
+                eq(CD_RELEASE_NAME_TEST),
+                eq(TEST_NAMESPACE),
+            )
+            .returning(|_, _, _| {
+                Ok(Some(Arc::new(mock_helm_release(
+                    CD_RELEASE_NAME_TEST,
+                    CURRENT_CD_VERSION,
+                    BTreeMap::new(),
+                ))))
+            });
 
         let updater = K8sACUpdater::new(
             true,
             true,
-            Arc::new(k8s_client),
+            Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
-            current_version.clone(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
         );
 
-        updater
-            .update(&AgentControlDynamicConfig {
-                chart_version: Some(current_version),
-                ..Default::default()
-            })
-            .expect("updater should return Ok without making any calls to the k8s client");
+        // We pass the current versions, not the new ones
+        let result = updater.update(&test_config(
+            Some(CURRENT_AC_VERSION),
+            Some(CURRENT_CD_VERSION),
+        ));
+
+        assert!(result.is_ok());
     }
 
-    // Update test case is covered with an integration test.
+    #[test]
+    fn test_returns_error_if_get_helm_release_fails() {
+        let mut mock_client = MockSyncK8sClient::new();
+        mock_client
+            .expect_get_dynamic_object()
+            .returning(|_, _, _| Err(K8sError::GetDynamic("API server is down".to_string())));
+
+        let updater = K8sACUpdater::new(
+            true,
+            false,
+            Arc::new(mock_client),
+            TEST_NAMESPACE.to_string(),
+            CURRENT_AC_VERSION.to_string(),
+            CD_RELEASE_NAME_TEST.to_string(),
+        );
+
+        let result = updater.update(&test_config(Some(NEW_AC_VERSION), None));
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(matches!(error, UpdaterError::UpdateFailed(_)));
+        assert!(error.to_string().contains("API server is down"));
+    }
 }

--- a/agent-control/src/cli/install.rs
+++ b/agent-control/src/cli/install.rs
@@ -22,6 +22,7 @@ use crate::{
     },
 };
 
+pub const CD_RELEASE_NAME: &str = "agent-control-cd";
 const REPOSITORY_URL: &str = "https://helm-charts.newrelic.com";
 const INSTALLATION_CHECK_DEFAULT_INITIAL_DELAY: &str = "10s";
 const INSTALLATION_CHECK_DEFAULT_TIMEOUT: &str = "5m";
@@ -441,7 +442,7 @@ mod tests {
         DynamicObject {
             types: Some(helmrelease_v2_type_meta()),
             metadata: ObjectMeta {
-                name: Some(agent_control::RELEASE_NAME.to_string()),
+                name: Some(RELEASE_NAME.to_string()),
                 namespace: Some(TEST_NAMESPACE.to_string()),
                 labels: Some(BTreeMap::from_iter(vec![
                     (
@@ -469,7 +470,7 @@ mod tests {
                     "releaseName": RELEASE_NAME,
                     "chart": {
                         "spec": {
-                            "chart": agent_control::RELEASE_NAME,
+                            "chart": RELEASE_NAME,
                             "version": version,
                             "reconcileStrategy": "ChartVersion",
                             "sourceRef": {

--- a/agent-control/src/config_migrate/migration/agent_config_getter.rs
+++ b/agent-control/src/config_migrate/migration/agent_config_getter.rs
@@ -154,6 +154,7 @@ agents:
                         ),
                     ]),
                     chart_version: None,
+                    cd_chart_version: None,
                 },
             },
             TestCase {
@@ -203,6 +204,7 @@ agents:
                         ),
                     ]),
                     chart_version: None,
+                    cd_chart_version: None,
                 },
             },
         ];

--- a/agent-control/src/config_migrate/migration/migrator.rs
+++ b/agent-control/src/config_migrate/migration/migrator.rs
@@ -146,6 +146,7 @@ mod tests {
                 Ok(AgentControlDynamicConfig {
                     agents: agents.clone(),
                     chart_version: None,
+                    cd_chart_version: None,
                 })
             });
 

--- a/agent-control/src/k8s/client.rs
+++ b/agent-control/src/k8s/client.rs
@@ -292,7 +292,7 @@ impl AsyncK8sClient {
         };
 
         let v = std::str::from_utf8(&value.0)
-            .map_err(|e| K8sError::Generic(format!("decoding secret key: {}", e)))?;
+            .map_err(|e| K8sError::Generic(format!("decoding secret key: {e}")))?;
         Ok(Some(v.to_string()))
     }
 

--- a/agent-control/src/secrets_provider/vault.rs
+++ b/agent-control/src/secrets_provider/vault.rs
@@ -95,8 +95,8 @@ pub enum SecretEngine {
 impl SecretEngine {
     fn get_url(&self, url: Url, mount: &str, path: &str) -> Result<Url, VaultError> {
         match self {
-            SecretEngine::Kv1 => Ok(url.join(format!("{}/{}", mount, path).as_str())?),
-            SecretEngine::Kv2 => Ok(url.join(format!("{}/data/{}", mount, path).as_str())?),
+            SecretEngine::Kv1 => Ok(url.join(format!("{mount}/{path}").as_str())?),
+            SecretEngine::Kv2 => Ok(url.join(format!("{mount}/data/{path}").as_str())?),
         }
     }
 
@@ -160,7 +160,7 @@ impl VaultSource {
         let mut url = config.url;
         let path = url.path();
         if !path.ends_with('/') {
-            url.set_path(&format!("{}/", path));
+            url.set_path(&format!("{path}/"));
         }
 
         Self {

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -389,6 +389,8 @@ fn ac_chart_values(opamp_endpoint: Url, name_override: &str) -> String {
     serde_json::json!({
         // give a unique name per test to the cluster role to avoid collisions
         "nameOverride": name_override,
+        "acRemoteUpdate": true,
+        "cdRemoteUpdate": false,
         "config": {
           // Disable the SI creation
           "fleet_control": {

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -9,6 +9,7 @@ use newrelic_agent_control::agent_control::config::{
 };
 use newrelic_agent_control::agent_control::version_updater::k8s::K8sACUpdater;
 use newrelic_agent_control::agent_control::version_updater::updater::VersionUpdater;
+use newrelic_agent_control::cli::install::CD_RELEASE_NAME;
 use newrelic_agent_control::cli::install::agent_control::RELEASE_NAME;
 use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL};
@@ -16,62 +17,52 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+const CURRENT_AC_VERSION: &str = "1.2.3-beta";
+const NEW_AC_VERSION: &str = "1.2.3";
+const CURRENT_CD_VERSION: &str = "1.2.5-beta";
+const NEW_CD_VERSION: &str = "1.2.5";
+
 #[test]
 #[ignore = "needs k8s cluster"]
-fn k8s_run_updater() {
+fn k8s_run_updater_for_cd_and_ac() {
     // set up the k8s environment
     let mut k8s = block_on(K8sEnv::new());
     let test_ns = block_on(k8s.test_namespace());
     let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
-
-    let current_version = "1.2.3-beta".to_string();
-    let new_version = "1.2.3".to_string();
 
     let updater = K8sACUpdater::new(
         true,
         true,
         k8s_client.clone(),
         test_ns.clone(),
-        current_version.clone(),
+        CURRENT_AC_VERSION.to_string(),
+        CD_RELEASE_NAME.to_string(),
     );
 
     let config_to_update = &AgentControlDynamicConfig {
         agents: Default::default(),
-        chart_version: Some(new_version.clone()),
+        chart_version: Some(NEW_AC_VERSION.to_string()),
+        cd_chart_version: Some(NEW_CD_VERSION.to_string()),
     };
 
+    let ac_dynamic_object = create_helm_release(
+        test_ns.clone(),
+        RELEASE_NAME.to_string(),
+        CURRENT_AC_VERSION.to_string(),
+        AGENT_CONTROL_VERSION_SET_FROM.to_string(),
+    );
     k8s_client
-        .apply_dynamic_object(&DynamicObject {
-            types: Some(helmrelease_v2_type_meta()),
-            metadata: ObjectMeta {
-                name: Some(RELEASE_NAME.to_string()),
-                namespace: Some(test_ns.clone()),
-                labels: Some(BTreeMap::from([
-                    (
-                        AGENT_CONTROL_VERSION_SET_FROM.to_string(),
-                        LOCAL_VAL.to_string(),
-                    ),
-                    ("test_key".to_string(), "test_val".to_string()),
-                ])),
-                ..Default::default()
-            },
-            data: serde_json::json!({
-                "spec": {
-                    "interval": "5m",
-                    "timeout": "5m",
-                    "chart": {
-                        "spec": {
-                            "chart": "test",
-                            "version": current_version,
-                            "sourceRef": {
-                                "kind": "HelmRepository",
-                                "name": RELEASE_NAME,
-                            },
-                            "interval": "5m",
-                        },
-                    }
-            }}),
-        })
+        .apply_dynamic_object(&ac_dynamic_object)
+        .expect("no error should occur during the creation of the helm release");
+
+    let cd_dynamic_object = create_helm_release(
+        test_ns.clone(),
+        CD_RELEASE_NAME.to_string(),
+        CURRENT_CD_VERSION.to_string(),
+        AGENT_CONTROL_VERSION_SET_FROM.to_string(),
+    );
+    k8s_client
+        .apply_dynamic_object(&cd_dynamic_object)
         .expect("no error should occur during the creation of the helm release");
 
     updater
@@ -79,16 +70,85 @@ fn k8s_run_updater() {
         .expect("no error should occur during update");
 
     retry(15, Duration::from_secs(5), || {
-        let Some(obj) =
-            k8s_client.get_dynamic_object(&helmrelease_v2_type_meta(), RELEASE_NAME, &test_ns)?
-        else {
-            return Err("Helm Release not found".into());
-        };
+        verify_helm_release_state(
+            &k8s_client,
+            &test_ns,
+            RELEASE_NAME,
+            NEW_AC_VERSION,
+            AGENT_CONTROL_VERSION_SET_FROM,
+        )?;
 
-        if 2 != obj.metadata.clone().labels.unwrap_or_default().len() {
-            return Err(format!("labels were overwritten: {obj:?}").into());
-        }
+        verify_helm_release_state(
+            &k8s_client,
+            &test_ns,
+            CD_RELEASE_NAME,
+            NEW_CD_VERSION,
+            AGENT_CONTROL_VERSION_SET_FROM,
+        )?;
 
-        check_version_and_source(&k8s_client, new_version.as_str(), REMOTE_VAL, &test_ns)
+        Ok(())
     })
+}
+
+fn verify_helm_release_state(
+    k8s_client: &Arc<SyncK8sClient>,
+    namespace: &str,
+    release_name: &str,
+    expected_version: &str,
+    version_source_label: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let obj = k8s_client
+        .get_dynamic_object(&helmrelease_v2_type_meta(), release_name, namespace)?
+        .ok_or_else(|| format!("HelmRelease '{release_name}' not found"))?;
+
+    let labels = obj.metadata.labels.as_ref().ok_or("Object has no labels")?;
+
+    if !labels.contains_key(version_source_label) {
+        return Err(format!("Object '{release_name}' is missing a required label").into());
+    }
+
+    check_version_and_source(
+        k8s_client,
+        expected_version,
+        REMOTE_VAL,
+        namespace,
+        release_name,
+        version_source_label,
+    )?;
+
+    Ok(())
+}
+
+/// Helper function to create a DynamicObject that simulates a HelmRelease.
+fn create_helm_release(
+    namespace: String,
+    release_name: String,
+    version: String,
+    main_label: String,
+) -> DynamicObject {
+    DynamicObject {
+        types: Some(helmrelease_v2_type_meta()),
+        metadata: ObjectMeta {
+            name: Some(release_name.clone()),
+            namespace: Some(namespace),
+            labels: Some(BTreeMap::from([(main_label, LOCAL_VAL.to_string())])),
+            ..Default::default()
+        },
+        data: serde_json::json!({
+            "spec": {
+                "interval": "5m",
+                "suspend": true,
+                "chart": {
+                    "spec": {
+                        "chart": "test",
+                        "version": version,
+                        "sourceRef": {
+                            "kind": "HelmRepository",
+                            "name": release_name,
+                        },
+                    },
+                }
+            }
+        }),
+    }
 }


### PR DESCRIPTION
# What this PR does / why we need it

This PR is to extend the updater of AC to handle updates for flux too, and managing the booleans to be able to update or not (true, false).

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
