### PR TITLE
fix: unread `K8sACUpdater` struct fields

### DIFF
--- a/agent-control/src/agent_control/version_updater/k8s.rs
+++ b/agent-control/src/agent_control/version_updater/k8s.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use tracing::{debug, info};
 
 pub struct K8sACUpdater {
+    #[allow(dead_code)]
     ac_remote_update: bool,
+    #[allow(dead_code)]
     cd_remote_update: bool,
     k8s_client: Arc<SyncK8sClient>,
     namespace: String,


### PR DESCRIPTION
# What this PR does / why we need it

A previous change broke clippy checks, as some newly added fields to the `K8sACUpdater` struct are never read. From latest updates I get that these will be used in the future, so I'm just adding `#[allow(dead_code)]` in there until the fields are actually read.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
