### PR TITLE
feat: dynamic dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,7 @@ name = "newrelic_agent_control"
 version = "0.44.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "assert_cmd",
  "assert_matches",
  "async-trait",

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -15,6 +15,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
+anyhow = "1.0.98"
 nix = { workspace = true, features = ["signal", "user", "hostname"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "chrono"] }
 tracing = { workspace = true, features = ["attributes"] }

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -15,7 +15,6 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
-anyhow = "1.0.98"
 nix = { workspace = true, features = ["signal", "user", "hostname"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "chrono"] }
 tracing = { workspace = true, features = ["attributes"] }

--- a/agent-control/src/secrets_provider.rs
+++ b/agent-control/src/secrets_provider.rs
@@ -10,10 +10,9 @@ use crate::secrets_provider::k8s_secret::K8sSecretProvider;
 use crate::secrets_provider::vault::{Vault, VaultConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
-
-use anyhow::Result;
 
 /// Configuration for supported secrets providers.
 ///
@@ -47,7 +46,7 @@ pub struct SecretsProvidersConfig {
 pub trait SecretsProvider {
     /// Gets a secret
     /// By default is recommended to use get_secret_with_retry.
-    fn get_secret(&self, secret_path: &str) -> Result<String>;
+    fn get_secret(&self, secret_path: &str) -> Result<String, Box<dyn Error>>;
 }
 
 #[derive(Default)]
@@ -76,7 +75,7 @@ impl SecretsProviders {
         self
     }
 
-    pub fn with_config(mut self, config: SecretsProvidersConfig) -> Result<Self> {
+    pub fn with_config(mut self, config: SecretsProvidersConfig) -> Result<Self, Box<dyn Error>> {
         if let Some(vault_config) = config.vault {
             let vault = Vault::try_build(vault_config)?;
             self.0.insert(Namespace::Vault, Box::new(vault));

--- a/agent-control/src/secrets_provider/env.rs
+++ b/agent-control/src/secrets_provider/env.rs
@@ -1,14 +1,28 @@
+use std::error::Error;
+use std::fmt;
+
 use crate::secrets_provider::SecretsProvider;
-use anyhow::{Result, anyhow};
+
+#[derive(Debug, Clone)]
+struct EnvError(String, String);
+
+impl fmt::Display for EnvError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "failed to retrieve env var secret '{}': {}",
+            self.0, self.1
+        )
+    }
+}
+
+impl Error for EnvError {}
 
 pub struct Env {}
 
 impl SecretsProvider for Env {
-    fn get_secret(&self, secret_path: &str) -> Result<String> {
-        std::env::var(secret_path).map_err(|e| {
-            anyhow!(format!(
-                "failed to retrieve env var secret '{secret_path}': {e}"
-            ))
-        })
+    fn get_secret(&self, secret_path: &str) -> Result<String, Box<dyn Error>> {
+        std::env::var(secret_path)
+            .map_err(|e| EnvError(secret_path.to_string(), e.to_string()).into())
     }
 }

--- a/agent-control/src/secrets_provider/env.rs
+++ b/agent-control/src/secrets_provider/env.rs
@@ -1,4 +1,4 @@
-use crate::secrets_provider::SecretsProvider;
+use crate::secrets_provider::{SecretsProvider, SecretsProvidersError};
 
 pub struct Env {}
 
@@ -7,9 +7,8 @@ pub struct Env {}
 pub struct EnvError(String);
 
 impl SecretsProvider for Env {
-    type Error = EnvError;
-
-    fn get_secret(&self, secret_path: &str) -> Result<String, Self::Error> {
-        std::env::var(secret_path).map_err(|e| EnvError(e.to_string()))
+    fn get_secret(&self, secret_path: &str) -> Result<String, SecretsProvidersError> {
+        std::env::var(secret_path)
+            .map_err(|e| SecretsProvidersError::EnvError(EnvError(e.to_string())))
     }
 }

--- a/agent-control/src/secrets_provider/env.rs
+++ b/agent-control/src/secrets_provider/env.rs
@@ -1,14 +1,14 @@
-use crate::secrets_provider::{SecretsProvider, SecretsProvidersError};
+use crate::secrets_provider::SecretsProvider;
+use anyhow::{Result, anyhow};
 
 pub struct Env {}
 
-#[derive(Debug, thiserror::Error)]
-#[error("failed to retrieve secret from environment variable: {0}")]
-pub struct EnvError(String);
-
 impl SecretsProvider for Env {
-    fn get_secret(&self, secret_path: &str) -> Result<String, SecretsProvidersError> {
-        std::env::var(secret_path)
-            .map_err(|e| SecretsProvidersError::EnvError(EnvError(e.to_string())))
+    fn get_secret(&self, secret_path: &str) -> Result<String> {
+        std::env::var(secret_path).map_err(|e| {
+            anyhow!(format!(
+                "failed to retrieve env var secret '{secret_path}': {e}"
+            ))
+        })
     }
 }


### PR DESCRIPTION
PoC on how secrets would have been simpler if we broke with consistency.

Commit 1 - dynamic dispatch
Commit 2 - anyhow
Commit 3 - box dyn error

---

**Static vs dynamic**

I know we discussed a couple of times static dispatch vs dynamic dispatch and I'm aware why we are using static dispatch. However, I wasn't sure if a comparison had been done before. Thus, I decided to modify the secrets feature to use dynamic dispatch. Now it's easier to see and discuss if we really want to keep being consistent at the expense of complexity.

The change can be seen in the first commit. It might seem insignificant, but we are removing a couple of generics here and there, an enum and aliases. In my opinion, it's less overhead in the brain. I'm not again static dispatch, but I think that we should start using both approaches in the code, and only push for static where it makes sense. For example, if we see the performance improvement is huge after some benchmarks.

**Error handling**

(This will serve as context to discuss in a tech talk how we want to proceed).

This was already discussed, but we didn't reach an agreement nor write down a path forward. We should revisit it and check what we want to do. Do we want to keep using thiserror but super minimal. Like @gsanchezgavier did with the k8s secrets provider? Do we want to go to anyhow? Do we want to use box dyn errors? Do we want to keep building huge enums with error types?

As with the previous point, we are deciding to be consistent, but sometimes I feel like we are just going on with the inertia. At the end, these different techniques con live together and each of them can have their space. I know some people don't want to introduce anyhow just for the sake of introducing it, so maybe we can start by limiting ourselves to a single error type for each module? For example, one error type for agent errors instead of having an enum `AgentError`. Maybe this is not the best case but I think you get the point.