### PR TITLE
feat: add kubectl and helm to AC CLI container image

### DIFF
--- a/Dockerfiles/Dockerfile_agent_control_cli
+++ b/Dockerfiles/Dockerfile_agent_control_cli
@@ -3,12 +3,26 @@
 FROM debian:trixie-slim
 
 ARG TARGETARCH
+ARG KUBECTL_VERSION=1.33.3
+ARG HELM_VERSION=3.17.4
 
 COPY --chmod=755 bin/newrelic-agent-control-cli-${TARGETARCH} /bin/newrelic-agent-control-cli
 
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y ca-certificates curl && \
     apt-get clean
+
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/$TARGETARCH/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
+
+# Install Helm
+RUN curl -LO "https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
+    tar -xzf "helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
+    mv "linux-$TARGETARCH/helm" /usr/local/bin/helm && \
+    rm -rf "helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" linux-$TARGETARCH
 
 USER nobody
 


### PR DESCRIPTION
# What this PR does / why we need it

This image will be used in the AC Helm chart as part of the operations done for (un)installing Flux that now involve the AC CLI, instead of the former `alpine/helm` or `alpine/k8s`.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
