### PR TITLE
ci: fix command interpolation caused by backquotes (e.g. `helm`) in PR title lint

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -21,4 +21,4 @@ jobs:
           npm i @commitlint/config-conventional
 
       - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --extends @commitlint/config-conventional
+        run: echo '${{ github.event.pull_request.title }}' | npx commitlint --extends @commitlint/config-conventional


### PR DESCRIPTION
# What this PR does / why we need it

Modifies how strings are interpolated in the Commitlint CI step.

## Which issue this PR fixes

If there's a word enclosed by `` `backticks` `` in the PR title, the word will be evaluated by the shell into a command invocation while running this CI step. If the backquoted word is a command it will be run by the shell, potentially causing issues.

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
