### PR TITLE
fix: agent control container binary version

### DIFF
--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -10,6 +10,10 @@ on:
         description: 'Image tag'
         type: string
         required: true
+      ac-version:
+        description: 'Agent Control version to embed in the binary'
+        type: string
+        required: true
       push:
         description: 'Push image'
         type: boolean
@@ -40,7 +44,7 @@ jobs:
 
       - name: Build Agent Control for K8s
         env:
-          AGENT_CONTROL_VERSION: ${{ inputs.image-tag }}
+          AGENT_CONTROL_VERSION: ${{ inputs.ac-version }}
         run: |
           make build-agent-control-k8s ARCH=arm64 PKG=newrelic_agent_control
           make build-agent-control-k8s ARCH=amd64 PKG=newrelic_agent_control

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       # the packages are created with 0.100.run_id, however we still push the image with nightly
       image-tag: nightly
+      ac-version: nightly
       push: true
     secrets: inherit
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,6 +22,9 @@ jobs:
     uses: ./.github/workflows/component_image.yml
     with:
       image-tag: ${{ github.event.release.tag_name }}-rc
+      # The binary remains the same between the rc and released image
+      # so here we burn the final released one.
+      ac-version: ${{ github.event.release.tag_name }}
       push: true
     secrets: inherit
 

--- a/.github/workflows/push_pr_package.yml
+++ b/.github/workflows/push_pr_package.yml
@@ -27,5 +27,6 @@ jobs:
     uses: ./.github/workflows/component_image.yml
     with:
       image-tag: 0.100.0
+      ac-version: 0.100.0
       push: false
     secrets: inherit


### PR DESCRIPTION
Noticed that the binary version was not right one on the release version, this pr fixes this.

``` shell
$ docker run --rm newrelic/newrelic-agent-control:0.41.0-rc --version
New Relic Agent Control Version: 0.41.0-rc, Rust Version: 1.86.0, GitCommit: 1244585d1ab23a138b7d92bbacb07d42943a674d, Environment: k8s
$ docker run --rm newrelic/newrelic-agent-control:0.41.0 --version
New Relic Agent Control Version: 0.41.0-rc, Rust Version: 1.86.0, GitCommit: 1244585d1ab23a138b7d92bbacb07d42943a674d, Environment: k8s
```
