### PR TITLE
feat: add e2e tests to the Nightly testing the latest flux version

### DIFF
--- a/.github/workflows/component_k8s_e2e.yml
+++ b/.github/workflows/component_k8s_e2e.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ''
+      use_latest_flux:
+        description: 'enables using the latest flux chart'
+        required: false
+        type: boolean
+        default: false
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID:
         required: false
@@ -78,6 +83,7 @@ jobs:
           # SI L2->L2 for AC
           NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.NR_SYSTEM_IDENTITY_CLIENT_ID }}
           NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
+          USE_LATEST_FLUX: ${{ inputs.use_latest_flux }}
           # Tilt configs
           ARCH: amd64
           BUILD_WITH: cargo

--- a/.github/workflows/latest_flux_e2e.yml
+++ b/.github/workflows/latest_flux_e2e.yml
@@ -1,5 +1,8 @@
 name: Latest Flux e2e
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/latest_flux_e2e.yml
+++ b/.github/workflows/latest_flux_e2e.yml
@@ -1,0 +1,37 @@
+name: Latest Flux e2e
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Scheduled to run at 5 a.m on mondays.
+    - cron: "0 5 * * 1"
+
+jobs:
+  k8s-e2e-tests-latest-flux:
+    uses: ./.github/workflows/component_k8s_e2e.yml
+    with:
+      scenarios: '["apm", "collector", "fleet-control", "ebpf", "dynamic"]'
+      use_latest_flux: true
+    secrets:
+      NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
+      NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs:
+      - k8s-e2e-tests-latest-flux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: slackapi/slack-github-action@v1.22.0
+        with:
+          payload: |
+            {
+              "text": ":warning: [Latest Flux e2e workflow failed] @hero check <${{ env.GITHUB_JOB_URL }}>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
+          GITHUB_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,6 +103,18 @@ jobs:
       E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
       E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
+  k8s-e2e-tests-latest-flux:
+    uses: ./.github/workflows/component_k8s_e2e.yml
+    with:
+      scenarios: '["apm", "collector", "fleet-control", "ebpf", "dynamic"]'
+      use_latest_flux: true
+    secrets:
+      NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
+      NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
+      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
+      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
+
   k8s_canaries:
     uses: ./.github/workflows/component_k8s_canaries.yml
     needs: [ build-image ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,18 +103,6 @@ jobs:
       E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
       E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
-  k8s-e2e-tests-latest-flux:
-    uses: ./.github/workflows/component_k8s_e2e.yml
-    with:
-      scenarios: '["apm", "collector", "fleet-control", "ebpf", "dynamic"]'
-      use_latest_flux: true
-    secrets:
-      NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}
-      NR_SYSTEM_IDENTITY_PRIVATE_KEY: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_PRIVATE_KEY }}
-      E2E_ACCOUNT_ID: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
-      E2E_API_KEY: ${{ secrets.AC_PROD_E2E_API_KEY }}
-      E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
-
   k8s_canaries:
     uses: ./.github/workflows/component_k8s_canaries.yml
     needs: [ build-image ]

--- a/Tiltfile
+++ b/Tiltfile
@@ -104,10 +104,12 @@ helm_resource(
   port_forwards=['8080']
 )
 
+chart_resource = 'local-child-chart-upload'
+
 ## we are saving the chart version for agent-control-deployment that is expected by agent-control
 ## also nri-bundle that is expected by some tests.
 local_resource(
-    'local-child-chart-upload',
+    chart_resource,
     cmd="""
      rm -rf local/helm-charts-tmp &&
      git clone --depth=1 https://github.com/newrelic/helm-charts --branch """ + feature_branch +"""  local/helm-charts-tmp &&
@@ -134,6 +136,29 @@ ac_flags = [
   '--values=' + sa_chart_values_file,
 ]
 
+latest_flux = os.getenv('LATEST_FLUX', 'false').lower() == 'true'
+
+if latest_flux:
+    ## we are saving the latest flux version chart in the local repository and updating the dependencies to point to it in
+    ## agent-control-cd so we can test the latest version of flux.
+    local_resource(
+        'local-latest-flux-chart-upload',
+        cmd="""
+         flux_latest_version=$(curl -s https://fluxcd-community.github.io/helm-charts/index.yaml | yq eval '.entries.flux2[0].version' -) &&
+         cd_latest_version=$(curl -s https://newrelic.github.io/helm-charts/index.yaml | yq eval '.entries.agent-control-cd[0].version' -) &&
+         yq eval ".dependencies |= map(select(.name == \\"flux2\\") | .version = \\"$flux_latest_version\\")" -i local/helm-charts-tmp/charts/agent-control-cd/Chart.yaml &&
+         helm package --dependency-update --version "$cd_latest_version" --destination local/helm-charts-tmp local/helm-charts-tmp/charts/agent-control-cd &&
+         curl -u testUser:testPassword -X DELETE http://localhost:8080/api/charts/agent-control-cd/${cd_latest_version} &&
+         curl -u testUser:testPassword --data-binary "@local/helm-charts-tmp/agent-control-cd-${cd_latest_version}.tgz" http://localhost:8080/api/charts
+        """,
+        resource_deps=[chart_resource],
+    )
+
+    # overwriting chart_resource to the one with latest flux so next resource waits on it.
+    chart_resource = 'local-latest-flux-chart-upload'
+
+    ac_flags.append('--set=agent-control-cd.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080')
+
 if license_key != '':
   ac_flags.append('--set=global.licenseKey='+license_key)
   
@@ -154,7 +179,7 @@ helm_resource(
   image_keys=[('agent-control-deployment.image.registry', 'agent-control-deployment.image.repository', 'agent-control-deployment.image.tag'),
               [('toolkitImage.registry', 'toolkitImage.repository', 'toolkitImage.tag'),
               ('agent-control-cd.installer.image.registry', 'agent-control-cd.installer.image.repository', 'agent-control-cd.installer.image.tag')]],
-  resource_deps=['build-binary', 'local-child-chart-upload']
+  resource_deps=['build-binary', 'chart_resource']
 )
 
 # We had flaky e2e test failing due to timeout applying the chart on 30s

--- a/Tiltfile
+++ b/Tiltfile
@@ -179,7 +179,7 @@ helm_resource(
   image_keys=[('agent-control-deployment.image.registry', 'agent-control-deployment.image.repository', 'agent-control-deployment.image.tag'),
               [('toolkitImage.registry', 'toolkitImage.repository', 'toolkitImage.tag'),
               ('agent-control-cd.installer.image.registry', 'agent-control-cd.installer.image.repository', 'agent-control-cd.installer.image.tag')]],
-  resource_deps=['build-binary', 'chart_resource']
+  resource_deps=['build-binary', chart_resource]
 )
 
 # We had flaky e2e test failing due to timeout applying the chart on 30s

--- a/test/k8s-e2e/apm/e2e-apm.yml
+++ b/test/k8s-e2e/apm/e2e-apm.yml
@@ -5,7 +5,7 @@ custom_test_key: appName
 scenarios:
   - description: Deploy SA with APM operator and Java, Python and Node.js agents
     before:
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/apm/ac-values-apm.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/apm/ac-values-apm.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
       # we need wait and retry since the resource might me not created yet
       - timeout 600s bash -c "until kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 deploy/operator-k8s-agents-operator -n newrelic-agents; do sleep 5; echo waiting on operator ; done"
       - sleep 60

--- a/test/k8s-e2e/collector/e2e-collector.yml
+++ b/test/k8s-e2e/collector/e2e-collector.yml
@@ -5,7 +5,7 @@ custom_test_key: k8s.cluster.name
 scenarios:
   - description: Deploy SA with single k8s otel-collector
     before:
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/collector/ac-values-collector.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/collector/ac-values-collector.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=nr-k8s-otel-collector --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/custom-repo/e2e-custom-repo.yml
+++ b/test/k8s-e2e/custom-repo/e2e-custom-repo.yml
@@ -7,7 +7,7 @@ custom_test_key: cluster_name
 scenarios:
   - description: Asserts custom helm chart repo configuration works as expected
     before:
-      - cd ../../../ && CHARTMUSEUM_BASIC_AUTH=true SA_CHART_VALUES_FILE="test/k8s-e2e/custom-repo/ac-values-custom-repo.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && CHARTMUSEUM_BASIC_AUTH=true SA_CHART_VALUES_FILE="test/k8s-e2e/custom-repo/ac-values-custom-repo.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=prometheus --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/dynamic/e2e-dynamic.yml
+++ b/test/k8s-e2e/dynamic/e2e-dynamic.yml
@@ -6,7 +6,7 @@ scenarios:
   - description: Deploy all infra agents
     before:
       - kubectl create configmap dynamic-agent --from-file=logging=./dynamic-agent-type-logging.yml
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/dynamic/ac-values-dynamic.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/dynamic/ac-values-dynamic.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/ebpf/e2e-ebpf.yml
+++ b/test/k8s-e2e/ebpf/e2e-ebpf.yml
@@ -5,7 +5,7 @@ custom_test_key: k8s.cluster.name
 scenarios:
   - description: Deploy eBPF Agent
     before:
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/ebpf/ac-values-ebpf.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/ebpf/ac-values-ebpf.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=ebpf --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/fleet-control/e2e-fleet-control.yml
+++ b/test/k8s-e2e/fleet-control/e2e-fleet-control.yml
@@ -6,7 +6,7 @@ scenarios:
   - description: Deploy all infra agents
     before:
       - kubectl get secret sys-identity || kubectl create secret generic sys-identity --from-literal=CLIENT_ID="${NR_SYSTEM_IDENTITY_CLIENT_ID}" --from-literal=private_key="${NR_SYSTEM_IDENTITY_PRIVATE_KEY}"
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/fleet-control/ac-values-fleet-control.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/fleet-control/ac-values-fleet-control.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=infra --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/infra/e2e-infra.yml
+++ b/test/k8s-e2e/infra/e2e-infra.yml
@@ -5,7 +5,7 @@ custom_test_key: cluster_name
 scenarios:
   - description: Deploy all infra agents
     before:
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/infra/ac-values-infra.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/infra/ac-values-infra.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=infra --all-containers --prefix=true -n newrelic-agents

--- a/test/k8s-e2e/proxy/e2e-proxy.yml
+++ b/test/k8s-e2e/proxy/e2e-proxy.yml
@@ -11,7 +11,7 @@ scenarios:
       # save the NR_SYSTEM_IDENTITY_PRIVATE_KEY to a file
       - printf '%s' "$NR_SYSTEM_IDENTITY_PRIVATE_KEY" > ./.key.temp
       - kubectl get secret sys-identity-creds || kubectl create secret generic sys-identity-creds --from-literal=NEW_RELIC_AUTH_CLIENT_ID="${NR_SYSTEM_IDENTITY_CLIENT_ID}" --from-literal=NEW_RELIC_AUTH_TOKEN="$(docker run --volume ./.key.temp:/key newrelic/agent-control-system-identity-registration authenticate --client-id="${NR_SYSTEM_IDENTITY_CLIENT_ID}" --environment "${REGION}" --output-token-format PLAIN  --private-key-path /key)"
-      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/proxy/ac-values-proxy.yml" CLUSTER=${SCENARIO_TAG} tilt ci
+      - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/proxy/ac-values-proxy.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
     after:
       - kubectl logs --tail=-1 job/assert-policy-proxy
       - kubectl logs --tail=-1 -l app=mitmproxy --all-containers --prefix=true


### PR DESCRIPTION
# What this PR does / why we need it

This PR adds new e2e test  `k8s-e2e-tests-latest-flux`. 
This test defines the variable `use_latest_flux` that will make all the e2e tests executed by it to modify the `agent-control-cd` chart to use the latest released flux chart from the flux repository.

We have added the following scenarios so we can ensure the `helmrelease` and `helmrepository` defined in the agent types work with the latest flux:
- apm
- collector
- fleet-control
- ebpf
- dynamic
   

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
