### PR TITLE
test: simplify on-host e2e condition

### DIFF
--- a/test/e2e/ansible/sub_agent_remote_config.yaml
+++ b/test/e2e/ansible/sub_agent_remote_config.yaml
@@ -110,7 +110,7 @@
             service_name: "newrelic-agent-control"
             action: "restart"
 
-        - name: Assert that AC and sub agent is running with local config
+        - name: Assert that the sub-agent is reporting data
           include_role:
             name: nrql_api_request
             apply:
@@ -119,8 +119,7 @@
             nrql_query: >-
               SELECT *
               FROM SystemSample
-              WHERE `config_origin` = 'local'
-              AND `test_id` = '{{ test_id }}'
+              WHERE `test_id` = '{{ test_id }}'
               LIMIT 1
             retries: 60
             delay: 5


### PR DESCRIPTION
# What this PR does / why we need it

This PR simplifies the condition to check if the infra-agent is reporting data in the on-host e2e test for remote configuration. The previos condition presented  issues if the remote configuration was received before the infra agent started with local configuration started reporting data.

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
