### PR TITLE
ci: point to helm charts master

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -64,7 +64,7 @@ docker_build(
 
 ######## Feature Branch ########
 # We are leveraging master branch or the feature branch to install both the agent-control and the agent-control-deployment charts.
-feature_branch = 'feat/flux-install-update'
+feature_branch = 'master'
 
 #### Set-up charts
 

--- a/agent-control/tests/k8s/Tiltfile
+++ b/agent-control/tests/k8s/Tiltfile
@@ -98,7 +98,7 @@ helm_resource(
 #### build data/charts and upload it to chart museum
 ### Feature Branch Workaround ###
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-feature_branch = "feat/flux-install-update"
+feature_branch = "master"
 
 # We're modifying the default image in the charts for different versions because we don't expose the values to be
 # modified by the remote_config but we do tests upgrading charts that require image modification


### PR DESCRIPTION
# What this PR does / why we need it

Points back to the `master` branch of `helm-charts` on our Tilt-based CI.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
