### PR TITLE
chore: automate ac cli tools bump (NR-447489)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,17 @@
     {
       customType: 'regex',
       managerFilePatterns: [
+        '/^.Dockerfile_agent_control_cli$/',
+      ],
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
+      matchStrings: [
+        'ARG HELM_VERSION=(?<currentValue>.+)',
+      ],
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
         '/^.goreleaser.yml$/',
       ],
       depNameTemplate: 'newrelic/infrastructure-agent',

--- a/Dockerfiles/Dockerfile_agent_control_cli
+++ b/Dockerfiles/Dockerfile_agent_control_cli
@@ -3,8 +3,8 @@
 FROM debian:trixie-slim
 
 ARG TARGETARCH
-ARG KUBECTL_VERSION=1.33.3
-ARG HELM_VERSION=3.17.4
+# Automatically bumpled by a Renovate regex rule.
+ARG HELM_VERSION=v3.17.4
 
 COPY --chmod=755 bin/newrelic-agent-control-cli-${TARGETARCH} /bin/newrelic-agent-control-cli
 
@@ -13,17 +13,17 @@ RUN apt-get update && \
     apt-get install -y ca-certificates curl && \
     apt-get clean
 
-# Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/$TARGETARCH/kubectl" && \
+# Install latest stable kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl"&& \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 
 # Install Helm
-RUN curl -LO "https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
-    tar -xzf "helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
+RUN curl -LO "https://get.helm.sh/helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
+    tar -xzf "helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
     chmod +x "linux-$TARGETARCH/helm" && \
     mv "linux-$TARGETARCH/helm" /usr/local/bin/helm && \
-    rm -rf "helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" linux-$TARGETARCH
+    rm -rf "helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" linux-$TARGETARCH
 
 # Create a home directory for nobody user and set ownership
 # This is so Helm can actually run as it tries to write to the home directory


### PR DESCRIPTION
- Makes kubectl automatically pick the latest on each release
- Adds a renovate rule for bumping helm
