### PR TITLE
fix(tiltfile): some values are still missing

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -129,7 +129,6 @@ ac_flags = [
   '--create-namespace',
   '--set=installationJob.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080',
   '--set=installationJob.chartVersion=0.0.1',
-  '--set=agent-control-cd.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080',
   '--version=>=0.0.0-beta',
   '--set=agent-control-deployment.image.imagePullPolicy=Always',
   '--values=' + sa_chart_values_file,


### PR DESCRIPTION
# What this PR does / why we need it
tiltfile is currenlty broken and not picking up the right chart

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
