### PR TITLE
fix(on-host): download NRDOT config

### DIFF
--- a/build/scripts/download_collector_config.sh
+++ b/build/scripts/download_collector_config.sh
@@ -16,7 +16,7 @@ cp ${TEMPLATE_DEFAULT} ${FINAL_DEFAULT}
 mkdir -p ${BUILD_TMP_FOLDER}
 
 # Download nr-otel-collector config
-curl -s -o "${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}" "${URL}/${DEFAULT_CONFIG_FILENAME}"
+curl -s -o "${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}" "${URL}"
 
 # Add spaces to be embedded in the values.yaml
 docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ubuntu /bin/bash -c "sed -i 's/^/  /g' ${BUILD_TMP_FOLDER}/${DEFAULT_CONFIG_FILENAME}"


### PR DESCRIPTION
# What this PR does / why we need it

When we tested on-host we discovered that the configuration for NRDOT was not correctly interpolated in the templates we use. While reviewing the build setup we have for on-host I discovered the place where this templating goes wrong, so I fix it here.

To protect us against this happening in the future, we should probably review the scripts we call as part of the build and have some testing in place.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
