### PR TITLE
chore(renovate): enable lockFileMaintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'dependencies',
   ],
   automerge: false,
+  lockFileMaintenance: { enabled: true }, // Update transitive dependencies by keeping lockfile updated
   enabledManagers: [
     'cargo',
     'custom.regex',


### PR DESCRIPTION
# What this PR does / why we need it

Enable `lockFileMaintenance` in renovate's configuration in order to update transitive dependencies. PRs such as #1537 should be open automatically by renovate.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
