### PR TITLE
chore: bump ac version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,9 +1057,12 @@ dependencies = [
 
 [[package]]
 name = "const_panic"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98d1483e98c9d67f341ab4b3915cfdc54740bd6f5cccc9226ee0535d86aa8fb"
+checksum = "bb8a602185c3c95b52f86dc78e55a6df9a287a7a93ddbcf012509930880cf879"
+dependencies = [
+ "typewit",
+]
 
 [[package]]
 name = "convert_case"
@@ -1469,7 +1472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2623,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2786,7 +2789,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "newrelic_agent_control"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "actix-web",
  "assert_cmd",
@@ -3873,7 +3876,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "newrelic_agent_control"
 description = "New Relic Agent Control Limited Preview"
-version = "0.45.0"
+version = "0.46.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
# What this PR does / why we need it

Bump newrelic-agent-control version.
