### PR TITLE
style: static dispatch on DeferredCommand

### DIFF
--- a/agent-control/tests/common/retry.rs
+++ b/agent-control/tests/common/retry.rs
@@ -19,17 +19,17 @@ where
 }
 
 /// DeferredCommand is a struct that allows you to register a cleanup function that is executed on Drop.
-pub struct DeferredCommand {
-    cleanup_fn: Box<dyn Fn()>,
+pub struct DeferredCommand<F: Fn()> {
+    cleanup_fn: F,
 }
 
-impl DeferredCommand {
-    pub fn new(cleanup_fn: Box<dyn Fn()>) -> Self {
+impl<F: Fn()> DeferredCommand<F> {
+    pub fn new(cleanup_fn: F) -> Self {
         Self { cleanup_fn }
     }
 }
 
-impl Drop for DeferredCommand {
+impl<F: Fn()> Drop for DeferredCommand<F> {
     fn drop(&mut self) {
         (self.cleanup_fn)()
     }

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -48,9 +48,9 @@ fn k8s_cli_install_and_update_flux_resources_success() {
     let ns = namespace.to_string();
     // Flux resources need to be removed before the test ends, otherwise the namespace will fail to be removed
     // as these resources include finalizers pointing to flux.
-    let _remove_resources = DeferredCommand::new(Box::new(move || {
+    let _remove_resources = DeferredCommand::new(move || {
         remove_flux_resources(&ns);
-    }));
+    });
 
     // Installs flux resources
     create_flux_resources(&namespace, CHART_VERSION_UPSTREAM_1);
@@ -73,9 +73,9 @@ fn k8s_remote_flux_update() {
     let ns = namespace.to_string();
     // Flux resources need to be removed before the test ends, otherwise the namespace will fail to be removed
     // as these resources include finalizers pointing to flux.
-    let _remove_resources = DeferredCommand::new(Box::new(move || {
+    let _remove_resources = DeferredCommand::new(move || {
         remove_flux_resources(&ns);
-    }));
+    });
 
     // Installs flux resources
     create_flux_resources(&namespace, CHART_VERSION_UPSTREAM_1);


### PR DESCRIPTION
# What this PR does / why we need it

Removes unneeded boxing for `impl Fn()`s in the `DeferredCommand` structure, making it generic.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
