### PR TITLE
style: string interpolation in format macros

### DIFF
--- a/agent-control/src/secrets_provider/vault.rs
+++ b/agent-control/src/secrets_provider/vault.rs
@@ -314,11 +314,11 @@ pub mod tests {
     fn test_get_secrets() {
         let target_server = MockServer::start();
         target_server.mock(|when, then| {
-            when.method(GET).path(format!("/v1{}", KV1_PATH));
+            when.method(GET).path(format!("/v1{KV1_PATH}"));
             then.status(200).body(KV1_RESPONSE);
         });
         target_server.mock(|when, then| {
-            when.method(GET).path(format!("/v1{}", KV2_PATH));
+            when.method(GET).path(format!("/v1{KV2_PATH}"));
             then.status(200).body(KV2_RESPONSE);
         });
 

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -138,7 +138,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         ))?;
         let health = health_checker.check_health()?;
         if let Some(error) = health.last_error() {
-            return Err(format!("HelmRelease unhealthy with: {}", error).into());
+            return Err(format!("HelmRelease unhealthy with: {error}").into());
         }
         Ok(())
     });
@@ -155,7 +155,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         ))?;
         let health = health_checker.check_health()?;
         if let Some(error) = health.last_error() {
-            return Err(format!("HelmRelease unhealthy with: {}", error).into());
+            return Err(format!("HelmRelease unhealthy with: {error}").into());
         }
         Ok(())
     });

--- a/agent-control/tests/k8s/tools/k8s_api.rs
+++ b/agent-control/tests/k8s/tools/k8s_api.rs
@@ -74,8 +74,7 @@ pub async fn check_helmrelease_labels_contains(
     let found_labels = &obj.metadata.labels;
     if found_labels.is_none() && expected_labels.is_some() {
         return Err(format!(
-            "helm release spec labels are None, but expected: {:?}",
-            expected_labels
+            "helm release spec labels are None, but expected: {expected_labels:?}"
         )
         .into());
     }
@@ -85,8 +84,7 @@ pub async fn check_helmrelease_labels_contains(
     for (key, value) in &expected_labels {
         if found_labels.get(key) != Some(value) {
             return Err(format!(
-                "helm release spec labels don't match with expected. Expected: {:?}, Found: {:?}",
-                expected_labels, found_labels,
+                "helm release spec labels don't match with expected. Expected: {expected_labels:?}, Found: {found_labels:?}",
             )
             .into());
         }

--- a/agent-control/tests/k8s/tools/k8s_env.rs
+++ b/agent-control/tests/k8s/tools/k8s_env.rs
@@ -123,7 +123,7 @@ impl K8sEnv {
                 let addr = SocketAddr::from(([127, 0, 0, 1], local_port));
                 let server =
                     TcpListenerStream::new(TcpListener::bind(addr).await.map_err(|e| {
-                        PortForwardError::ConnectionFailed(format!("Failed to bind: {}", e))
+                        PortForwardError::ConnectionFailed(format!("Failed to bind: {e}"))
                     })?)
                     .try_for_each(|client_conn| async {
                         if let Ok(peer_addr) = client_conn.peer_addr() {
@@ -147,7 +147,7 @@ impl K8sEnv {
 
                 server
                     .await
-                    .map_err(|e| PortForwardError::Other(format!("Server error: {}", e)))?;
+                    .map_err(|e| PortForwardError::Other(format!("Server error: {e}")))?;
                 info!("Shutting down");
                 Ok::<(), PortForwardError>(())
             }


### PR DESCRIPTION
# What this PR does / why we need it

Will produce warnings in  rust 1.88+, so fixing them before we bump the version used.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
