### PR TITLE
feat: make flux release name configurable

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -64,7 +64,7 @@ docker_build(
 
 ######## Feature Branch ########
 # We are leveraging master branch or the feature branch to install both the agent-control and the agent-control-deployment charts.
-feature_branch = 'feat/make-cd-release-name-configurable'
+feature_branch = 'feat/make-release-names-configurable'
 
 #### Set-up charts
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -64,7 +64,7 @@ docker_build(
 
 ######## Feature Branch ########
 # We are leveraging master branch or the feature branch to install both the agent-control and the agent-control-deployment charts.
-feature_branch = 'master'
+feature_branch = 'feat/make-cd-release-name-configurable'
 
 #### Set-up charts
 

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -1,6 +1,5 @@
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::cli::install::agent_control::AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME;
-use crate::cli::install::flux::AGENT_CONTROL_CD_RELEASE_NAME;
 use crate::opamp::remote_config::signature::SIGNATURE_CUSTOM_CAPABILITY;
 use crate::sub_agent::identity::AgentIdentity;
 use opamp_client::capabilities;
@@ -8,6 +7,7 @@ use opamp_client::opamp::proto::{AgentCapabilities, CustomCapabilities};
 use opamp_client::operation::capabilities::Capabilities;
 
 pub const AGENT_CONTROL_ID: &str = "agent-control";
+pub const AGENT_CONTROL_CD_RELEASE_NAME: &str = "agent-control-cd";
 
 pub const RESERVED_AGENT_IDS: [&str; 3] = [
     AGENT_CONTROL_ID,

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -7,13 +7,8 @@ use opamp_client::opamp::proto::{AgentCapabilities, CustomCapabilities};
 use opamp_client::operation::capabilities::Capabilities;
 
 pub const AGENT_CONTROL_ID: &str = "agent-control";
-pub const AGENT_CONTROL_CD_RELEASE_NAME: &str = "agent-control-cd";
 
-pub const RESERVED_AGENT_IDS: [&str; 3] = [
-    AGENT_CONTROL_ID,
-    AGENT_CONTROL_CD_RELEASE_NAME,
-    AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME,
-];
+pub const RESERVED_AGENT_IDS: [&str; 2] = [AGENT_CONTROL_ID, AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME];
 
 pub const AGENT_CONTROL_TYPE: &str = "com.newrelic.agent_control";
 pub const AGENT_CONTROL_NAMESPACE: &str = "newrelic";

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -32,6 +32,7 @@ pub struct K8sGarbageCollector {
     /// The namespace where agents are running. We are garbage collecting resources here only due to Instrumentation
     pub namespace_agents: String,
     pub cr_type_meta: Vec<TypeMeta>,
+    pub cd_release_name: String,
 }
 
 impl K8sGarbageCollector {
@@ -139,6 +140,10 @@ impl K8sGarbageCollector {
         let agent_id_from_labels = labels::get_agent_id(labels)
             .ok_or(K8sGarbageCollectorError::MissingLabels)?
             .as_str();
+
+        if agent_id_from_labels == self.cd_release_name {
+            return Ok(false);
+        }
 
         let agent_id_from_labels = match AgentID::try_from(agent_id_from_labels) {
             Ok(id) => id,
@@ -268,6 +273,7 @@ mod tests {
 
     const TEST_NAMESPACE: &str = "test-namespace";
     const TEST_NAMESPACE_AGENTS: &str = "test-namespace-agents";
+    const TEST_RELEASE_NAME: &str = "test-release-name";
 
     #[test]
     fn errors_if_ac_id() {
@@ -282,6 +288,7 @@ mod tests {
             cr_type_meta: vec![],
             namespace: TEST_NAMESPACE.to_string(),
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+            cd_release_name: TEST_RELEASE_NAME.to_string(),
         };
         let ac_id = &AgentID::AgentControl;
         let ac_type_id =
@@ -326,6 +333,7 @@ mod tests {
             cr_type_meta: vec![type_meta],
             namespace: TEST_NAMESPACE.to_string(),
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+            cd_release_name: TEST_RELEASE_NAME.to_string(),
         };
         let ac_id = &AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = &AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();

--- a/agent-control/src/bin/main_agent_control_cli.rs
+++ b/agent-control/src/bin/main_agent_control_cli.rs
@@ -70,20 +70,18 @@ fn main() -> ExitCode {
 
     let result = match cli.operation {
         Operations::InstallAgentControl(agent_control_data) => {
-            apply_resources(InstallAgentControl, &agent_control_data, &cli.namespace)
+            apply_resources(InstallAgentControl, &cli.namespace, &agent_control_data)
         }
-        Operations::UninstallAgentControl(agent_control_data) => uninstall_agent_control(
-            &cli.namespace,
-            &agent_control_data.namespace_agents,
-            &agent_control_data.release_name,
-        ),
-        Operations::CreateCDResources(cd_install_data) => {
+        Operations::UninstallAgentControl(agent_control_data) => {
+            uninstall_agent_control(&cli.namespace, &agent_control_data)
+        }
+        Operations::CreateCDResources(cd_data) => {
             // Currently this means installing Flux, but in the future it could mean other CD tool
             // or support different ones
-            apply_resources(InstallFlux, &cd_install_data, &cli.namespace)
+            apply_resources(InstallFlux, &cli.namespace, &cd_data)
         }
-        Operations::RemoveCDResources(cd_uninstall_data) => {
-            remove_flux_crs(&cli.namespace, &cd_uninstall_data.release_name)
+        Operations::RemoveCDResources(cd_data) => {
+            remove_flux_crs(&cli.namespace, &cd_data.release_name)
         }
     };
 

--- a/agent-control/src/cli/install.rs
+++ b/agent-control/src/cli/install.rs
@@ -113,8 +113,8 @@ fn parse_duration_arg(arg: &str) -> Result<Duration, String> {
 
 pub fn apply_resources(
     dyn_object_list_builder: impl DynamicObjectListBuilder,
-    install_data: &InstallData,
     namespace: &str,
+    install_data: &InstallData,
 ) -> Result<(), CliError> {
     let release_name = &install_data.release_name;
     info!("Installing release {release_name}");

--- a/agent-control/src/cli/install.rs
+++ b/agent-control/src/cli/install.rs
@@ -388,13 +388,13 @@ mod tests {
 
     const LOCAL_TEST_VERSION: &str = "1.0.0";
     const TEST_NAMESPACE: &str = "test-namespace";
-    const RELEASE_NAME: &str = "test-release-name";
+    const TEST_RELEASE_NAME: &str = "test-release-name";
 
     fn ac_install_data() -> InstallData {
         InstallData {
-            chart_name: RELEASE_NAME.to_string(),
+            chart_name: TEST_RELEASE_NAME.to_string(),
             chart_version: LOCAL_TEST_VERSION.to_string(),
-            release_name: RELEASE_NAME.to_string(),
+            release_name: TEST_RELEASE_NAME.to_string(),
             secrets: None,
             extra_labels: None,
             skip_installation_check: false,
@@ -448,7 +448,7 @@ mod tests {
         DynamicObject {
             types: Some(helmrelease_v2_type_meta()),
             metadata: ObjectMeta {
-                name: Some(RELEASE_NAME.to_string()),
+                name: Some(TEST_RELEASE_NAME.to_string()),
                 namespace: Some(TEST_NAMESPACE.to_string()),
                 labels: Some(BTreeMap::from_iter(vec![
                     (
@@ -473,10 +473,10 @@ mod tests {
             data: serde_json::json!({
                 "spec": {
                     "interval": "30s",
-                    "releaseName": RELEASE_NAME,
+                    "releaseName": TEST_RELEASE_NAME,
                     "chart": {
                         "spec": {
-                            "chart": RELEASE_NAME,
+                            "chart": TEST_RELEASE_NAME,
                             "version": version,
                             "reconcileStrategy": "ChartVersion",
                             "sourceRef": {
@@ -510,7 +510,7 @@ mod tests {
     fn test_existing_object_no_label() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta::default(),
@@ -541,7 +541,7 @@ mod tests {
 
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta {
@@ -576,7 +576,7 @@ mod tests {
     fn test_existing_object_local_label() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta {
@@ -611,7 +611,7 @@ mod tests {
     fn test_to_dynamic_objects_no_values() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             None,
             &ac_install_data(),
         );
@@ -634,7 +634,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             None,
             &agent_control_data,
         );
@@ -670,7 +670,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             None,
             &agent_control_data,
         );
@@ -740,7 +740,7 @@ mod tests {
     fn test_secret_ref() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             None,
             &InstallData {
                 repository_secret_reference_name: Some("secRef".to_string()),
@@ -768,7 +768,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
-            RELEASE_NAME,
+            TEST_RELEASE_NAME,
             None,
             &agent_control_data,
         );

--- a/agent-control/src/cli/install.rs
+++ b/agent-control/src/cli/install.rs
@@ -37,6 +37,10 @@ pub struct InstallData {
     #[arg(long)]
     pub chart_version: String,
 
+    /// Name of the Helm release
+    #[arg(long)]
+    pub release_name: String,
+
     /// Secret values
     ///
     /// List of secret names and values keys to be used in the Helm release.
@@ -95,6 +99,7 @@ pub trait DynamicObjectListBuilder {
     fn build_dynamic_object_list(
         &self,
         namespace: &str,
+        release_name: &str,
         maybe_existing_helm_release: Option<&DynamicObject>,
         data: &InstallData,
     ) -> Vec<DynamicObject>;
@@ -109,9 +114,9 @@ fn parse_duration_arg(arg: &str) -> Result<Duration, String> {
 pub fn apply_resources(
     dyn_object_list_builder: impl DynamicObjectListBuilder,
     install_data: &InstallData,
-    release_name: &str,
     namespace: &str,
 ) -> Result<(), CliError> {
+    let release_name = &install_data.release_name;
     info!("Installing release {release_name}");
     let k8s_client = try_new_k8s_client()?;
     let maybe_helm_release = k8s_client
@@ -129,6 +134,7 @@ pub fn apply_resources(
     let maybe_existing_helm_release = maybe_helm_release.as_ref().map(|o| o.as_ref());
     let dynamic_objects = dyn_object_list_builder.build_dynamic_object_list(
         namespace,
+        release_name,
         maybe_existing_helm_release,
         install_data,
     );
@@ -373,7 +379,7 @@ fn check_installation(
 mod tests {
     use crate::{
         agent_control::config::helmrepository_type_meta,
-        cli::install::agent_control::{AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME, InstallAgentControl},
+        cli::install::agent_control::InstallAgentControl,
         k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL},
         sub_agent::identity::AgentIdentity,
     };
@@ -382,11 +388,13 @@ mod tests {
 
     const LOCAL_TEST_VERSION: &str = "1.0.0";
     const TEST_NAMESPACE: &str = "test-namespace";
+    const RELEASE_NAME: &str = "test-release-name";
 
     fn ac_install_data() -> InstallData {
         InstallData {
-            chart_name: AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME.to_string(),
+            chart_name: RELEASE_NAME.to_string(),
             chart_version: LOCAL_TEST_VERSION.to_string(),
+            release_name: RELEASE_NAME.to_string(),
             secrets: None,
             extra_labels: None,
             skip_installation_check: false,
@@ -440,7 +448,7 @@ mod tests {
         DynamicObject {
             types: Some(helmrelease_v2_type_meta()),
             metadata: ObjectMeta {
-                name: Some(AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME.to_string()),
+                name: Some(RELEASE_NAME.to_string()),
                 namespace: Some(TEST_NAMESPACE.to_string()),
                 labels: Some(BTreeMap::from_iter(vec![
                     (
@@ -465,10 +473,10 @@ mod tests {
             data: serde_json::json!({
                 "spec": {
                     "interval": "30s",
-                    "releaseName": AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME,
+                    "releaseName": RELEASE_NAME,
                     "chart": {
                         "spec": {
-                            "chart": AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME,
+                            "chart": RELEASE_NAME,
                             "version": version,
                             "reconcileStrategy": "ChartVersion",
                             "sourceRef": {
@@ -502,6 +510,7 @@ mod tests {
     fn test_existing_object_no_label() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta::default(),
@@ -532,6 +541,7 @@ mod tests {
 
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta {
@@ -566,6 +576,7 @@ mod tests {
     fn test_existing_object_local_label() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             Some(&DynamicObject {
                 types: None,
                 metadata: ObjectMeta {
@@ -598,8 +609,12 @@ mod tests {
 
     #[test]
     fn test_to_dynamic_objects_no_values() {
-        let dynamic_objects =
-            InstallAgentControl.build_dynamic_object_list(TEST_NAMESPACE, None, &ac_install_data());
+        let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
+            TEST_NAMESPACE,
+            RELEASE_NAME,
+            None,
+            &ac_install_data(),
+        );
         assert_eq!(
             dynamic_objects,
             vec![
@@ -619,6 +634,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             None,
             &agent_control_data,
         );
@@ -654,6 +670,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             None,
             &agent_control_data,
         );
@@ -723,6 +740,7 @@ mod tests {
     fn test_secret_ref() {
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             None,
             &InstallData {
                 repository_secret_reference_name: Some("secRef".to_string()),
@@ -750,6 +768,7 @@ mod tests {
         };
         let dynamic_objects = InstallAgentControl.build_dynamic_object_list(
             TEST_NAMESPACE,
+            RELEASE_NAME,
             None,
             &agent_control_data,
         );

--- a/agent-control/src/cli/install/agent_control.rs
+++ b/agent-control/src/cli/install/agent_control.rs
@@ -29,6 +29,7 @@ impl DynamicObjectListBuilder for InstallAgentControl {
     fn build_dynamic_object_list(
         &self,
         namespace: &str,
+        release_name: &str,
         maybe_existing_helm_release: Option<&DynamicObject>,
         data: &InstallData,
     ) -> Vec<DynamicObject> {
@@ -60,12 +61,8 @@ impl DynamicObjectListBuilder for InstallAgentControl {
         let mut helm_release_labels = labels;
         helm_release_labels.insert(AGENT_CONTROL_VERSION_SET_FROM.to_string(), source);
 
-        let helm_release_obj_meta_data = obj_meta_data(
-            AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME,
-            namespace,
-            helm_release_labels,
-            annotations,
-        );
+        let helm_release_obj_meta_data =
+            obj_meta_data(release_name, namespace, helm_release_labels, annotations);
 
         vec![
             helm_repository(

--- a/agent-control/src/cli/install/flux.rs
+++ b/agent-control/src/cli/install/flux.rs
@@ -19,9 +19,7 @@ use crate::{
 /// To be applied via [`install_or_upgrade`](super::install_or_upgrade).
 pub struct InstallFlux;
 
-pub const AGENT_CONTROL_CD_RELEASE_NAME: &str = "agent-control-cd";
-const CHART_NAME: &str = "agent-control-cd";
-pub const HELM_REPOSITORY_NAME: &str = CHART_NAME;
+pub const HELM_REPOSITORY_NAME: &str = "agent-control-cd";
 
 impl DynamicObjectListBuilder for InstallFlux {
     // TODO this mostly duplicates the AgentControl implementation besides a few constants. Extracting to a function might be worth it.

--- a/agent-control/src/cli/install/flux.rs
+++ b/agent-control/src/cli/install/flux.rs
@@ -21,7 +21,6 @@ pub struct InstallFlux;
 
 pub const AGENT_CONTROL_CD_RELEASE_NAME: &str = "agent-control-cd";
 const CHART_NAME: &str = "agent-control-cd";
-pub const HELM_RELEASE_NAME: &str = CHART_NAME;
 pub const HELM_REPOSITORY_NAME: &str = CHART_NAME;
 
 impl DynamicObjectListBuilder for InstallFlux {
@@ -29,6 +28,7 @@ impl DynamicObjectListBuilder for InstallFlux {
     fn build_dynamic_object_list(
         &self,
         namespace: &str,
+        release_name: &str,
         maybe_existing_helm_release: Option<&DynamicObject>,
         data: &InstallData,
     ) -> Vec<kube::api::DynamicObject> {
@@ -54,7 +54,7 @@ impl DynamicObjectListBuilder for InstallFlux {
         helm_release_labels.insert(AGENT_CONTROL_VERSION_SET_FROM.to_string(), source);
 
         let helm_release_obj_meta_data = obj_meta_data(
-            HELM_RELEASE_NAME,
+            release_name,
             namespace,
             helm_release_labels,
             BTreeMap::default(),

--- a/agent-control/src/cli/uninstall/agent_control.rs
+++ b/agent-control/src/cli/uninstall/agent_control.rs
@@ -25,11 +25,14 @@ pub struct AgentControlUninstallData {
 
 pub fn uninstall_agent_control(
     namespace: &str,
-    namespace_agents: &str,
-    release_name: &str,
+    uninstall_data: &AgentControlUninstallData,
 ) -> Result<(), CliError> {
     let k8s_client = try_new_k8s_client()?;
     let kinds_available = retrieve_api_resources(&k8s_client)?;
+    let AgentControlUninstallData {
+        namespace_agents,
+        release_name,
+    } = uninstall_data;
 
     // we delete first the AC so that it does not interfere (by recreating resources that we have just deleted).
     delete_agent_control_crs(&k8s_client, &kinds_available, namespace, release_name)?;

--- a/agent-control/src/cli/uninstall/flux.rs
+++ b/agent-control/src/cli/uninstall/flux.rs
@@ -168,7 +168,7 @@ mod tests {
 
     use super::*;
 
-    const CD_RELEASE_NAME: &str = "test-cd-release";
+    const TEST_RELEASE_NAME: &str = "test-cd-release";
 
     /// Minimum release object for testing purposes.
     fn testing_helmrelease(
@@ -180,7 +180,7 @@ mod tests {
         DynamicObject {
             types: Some(helmrelease_v2_type_meta()),
             metadata: ObjectMeta {
-                name: Some(CD_RELEASE_NAME.to_string()),
+                name: Some(TEST_RELEASE_NAME.to_string()),
                 namespace: Some(namespace.to_string()),
                 resource_version: Some(resource_version.to_string()),
                 ..Default::default()
@@ -205,7 +205,7 @@ mod tests {
             .expect_patch_dynamic_object()
             .with(
                 predicate::eq(helmrelease_v2_type_meta()),
-                predicate::eq(CD_RELEASE_NAME),
+                predicate::eq(TEST_RELEASE_NAME),
                 predicate::eq(namespace),
                 predicate::eq(json!({"spec": {"suspend": true}})),
             )
@@ -259,7 +259,7 @@ mod tests {
 
         let result = suspend_helmrelease(
             &mock_k8s_client,
-            CD_RELEASE_NAME,
+            TEST_RELEASE_NAME,
             namespace,
             &helmrelease_type_meta,
             &helmrelease,
@@ -296,7 +296,7 @@ mod tests {
             max_attempts: 10,
             interval: Duration::from_millis(10),
         };
-        let result = delete_helmchart_object(&deleter, CD_RELEASE_NAME, &helmrelease);
+        let result = delete_helmchart_object(&deleter, TEST_RELEASE_NAME, &helmrelease);
         assert!(result.is_ok());
     }
 }

--- a/agent-control/src/cli/uninstall/flux.rs
+++ b/agent-control/src/cli/uninstall/flux.rs
@@ -168,7 +168,7 @@ mod tests {
 
     use super::*;
 
-    const HELM_RELEASE_NAME: &str = "test-helm-release";
+    const CD_RELEASE_NAME: &str = "test-cd-release";
 
     /// Minimum release object for testing purposes.
     fn testing_helmrelease(
@@ -180,7 +180,7 @@ mod tests {
         DynamicObject {
             types: Some(helmrelease_v2_type_meta()),
             metadata: ObjectMeta {
-                name: Some(HELM_RELEASE_NAME.to_string()),
+                name: Some(CD_RELEASE_NAME.to_string()),
                 namespace: Some(namespace.to_string()),
                 resource_version: Some(resource_version.to_string()),
                 ..Default::default()
@@ -205,7 +205,7 @@ mod tests {
             .expect_patch_dynamic_object()
             .with(
                 predicate::eq(helmrelease_v2_type_meta()),
-                predicate::eq(HELM_RELEASE_NAME),
+                predicate::eq(CD_RELEASE_NAME),
                 predicate::eq(namespace),
                 predicate::eq(json!({"spec": {"suspend": true}})),
             )
@@ -259,7 +259,7 @@ mod tests {
 
         let result = suspend_helmrelease(
             &mock_k8s_client,
-            HELM_RELEASE_NAME,
+            CD_RELEASE_NAME,
             namespace,
             &helmrelease_type_meta,
             &helmrelease,
@@ -296,7 +296,7 @@ mod tests {
             max_attempts: 10,
             interval: Duration::from_millis(10),
         };
-        let result = delete_helmchart_object(&deleter, HELM_RELEASE_NAME, &helmrelease);
+        let result = delete_helmchart_object(&deleter, CD_RELEASE_NAME, &helmrelease);
         assert!(result.is_ok());
     }
 }

--- a/agent-control/tests/k8s/Tiltfile
+++ b/agent-control/tests/k8s/Tiltfile
@@ -98,7 +98,7 @@ helm_resource(
 #### build data/charts and upload it to chart museum
 ### Feature Branch Workaround ###
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-feature_branch = 'master'
+feature_branch = 'feat/make-cd-release-name-configurable'
 
 # We're modifying the default image in the charts for different versions because we don't expose the values to be
 # modified by the remote_config but we do tests upgrading charts that require image modification

--- a/agent-control/tests/k8s/Tiltfile
+++ b/agent-control/tests/k8s/Tiltfile
@@ -98,7 +98,7 @@ helm_resource(
 #### build data/charts and upload it to chart museum
 ### Feature Branch Workaround ###
 # Use the branch source to get the chart form a feature branch in the NR helm-charts repo.
-feature_branch = 'feat/make-cd-release-name-configurable'
+feature_branch = 'feat/make-release-names-configurable'
 
 # We're modifying the default image in the charts for different versions because we don't expose the values to be
 # modified by the remote_config but we do tests upgrading charts that require image modification

--- a/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
+++ b/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
@@ -24,6 +24,7 @@ fn k8s_cli_install_agent_control_creates_resources() {
     cmd.arg("install-agent-control");
     cmd.arg("--chart-name").arg("agent-control-deployment");
     cmd.arg("--chart-version").arg("1.0.0");
+    cmd.arg("--release-name").arg("agent-control-deployment");
     cmd.arg("--namespace").arg(namespace.clone());
     cmd.arg("--extra-labels")
         .arg("chart=podinfo, env=testing, app=ac");
@@ -164,6 +165,7 @@ fn k8s_cli_install_agent_control_creates_resources_with_specific_repository_url(
     cmd.arg("install-agent-control");
     cmd.arg("--chart-name").arg("agent-control-deployment");
     cmd.arg("--chart-version").arg("1.0.0");
+    cmd.arg("--release-name").arg("agent-control-deployment");
     cmd.arg("--namespace").arg(namespace.clone());
     cmd.arg("--skip-installation-check"); // Skipping checks because we are merely checking that the resources are created.
     cmd.arg("--repository-url").arg(repository_url);

--- a/agent-control/tests/k8s/agent_control_cli/installation.rs
+++ b/agent-control/tests/k8s/agent_control_cli/installation.rs
@@ -11,6 +11,7 @@ use crate::k8s::tools::opamp::get_minikube_opamp_url_from_fake_server;
 use assert_cmd::Command;
 use kube::Client;
 use std::time::Duration;
+
 // NOTE: The tests below are using the latest '*' chart version, and they will likely fail
 // if breaking changes need to be introduced in the chart.
 // If this situation occurs, we need to temporarily skip the tests or use
@@ -125,6 +126,7 @@ pub fn ac_install_cmd(namespace: &str, chart_version: &str, secrets: &str) -> Co
     cmd.arg("--log-level").arg("debug");
     cmd.arg("--chart-name").arg("agent-control-deployment");
     cmd.arg("--chart-version").arg(chart_version);
+    cmd.arg("--release-name").arg("agent-control-deployment");
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets").arg(secrets);
     cmd.arg("--repository-url").arg(LOCAL_CHART_REPOSITORY);

--- a/agent-control/tests/k8s/agent_control_cli/uninstallation.rs
+++ b/agent-control/tests/k8s/agent_control_cli/uninstallation.rs
@@ -123,5 +123,6 @@ fn ac_uninstall_cmd(namespace: &str, namespace_agents: &str) -> Command {
     cmd.arg("uninstall-agent-control");
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--namespace-agents").arg(namespace_agents);
+    cmd.arg("--release-name").arg("agent-control-deployment");
     cmd
 }

--- a/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
@@ -4,7 +4,7 @@ k8s:
   cluster_name: <cluster-name>
   cd_remote_update: true
   ac_remote_update: false
-  cd_release_name: agent-control-cd
+  cd_release_name: test-agent-control-cd
 fleet_control:
   endpoint: <opamp-endpoint>
   poll_interval: 5s

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -24,7 +24,7 @@ use kube::api::PostParams;
 use kube::{Api, Client};
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::config::helmrelease_v2_type_meta;
-use newrelic_agent_control::cli::install::flux::{HELM_RELEASE_NAME, HELM_REPOSITORY_NAME};
+use newrelic_agent_control::cli::install::flux::HELM_REPOSITORY_NAME;
 use newrelic_agent_control::health::health_checker::HealthChecker;
 use newrelic_agent_control::health::k8s::health_checker::{
     K8sHealthChecker, health_checkers_for_type_meta,
@@ -35,6 +35,8 @@ use opamp_client::opamp::proto::RemoteConfigStatuses;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
+
+const HELM_RELEASE_NAME: &str = "agent-control-cd";
 
 #[test]
 #[ignore = "needs k8s cluster"]

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
-const TEST_RELEASE_NAME: &str = "agent-control-cd";
+const TEST_RELEASE_NAME: &str = "test-agent-control-cd";
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -114,7 +114,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         health_checkers_for_type_meta(
             helmrelease_v2_type_meta(),
             Arc::new(SyncK8sClient::try_new(runtime::tokio_runtime()).unwrap()),
-            HELM_REPOSITORY_NAME.to_string(),
+            TEST_RELEASE_NAME.to_string(),
             namespace.clone(),
             Some(namespace.clone()),
             StartTime::now(),

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
-const CD_RELEASE_NAME: &str = "agent-control-cd";
+const TEST_RELEASE_NAME: &str = "agent-control-cd";
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -131,7 +131,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         block_on(check_helmrelease_chart_version(
             k8s.client.clone(),
             &namespace,
-            CD_RELEASE_NAME,
+            TEST_RELEASE_NAME,
             CHART_VERSION_UPSTREAM_2,
         ))?;
         let health = health_checker.check_health()?;
@@ -148,7 +148,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         block_on(check_helmrelease_chart_version(
             k8s.client.clone(),
             &namespace,
-            CD_RELEASE_NAME,
+            TEST_RELEASE_NAME,
             CHART_VERSION_UPSTREAM_2,
         ))?;
         let health = health_checker.check_health()?;
@@ -174,7 +174,7 @@ fn create_flux_resources(namespace: &str, chart_version: &str) {
     cmd.arg("--repository-url").arg(LOCAL_CHART_REPOSITORY);
     cmd.arg("--chart-version").arg(chart_version);
     cmd.arg("--chart-name").arg(HELM_REPOSITORY_NAME);
-    cmd.arg("--release-name").arg(CD_RELEASE_NAME);
+    cmd.arg("--release-name").arg(TEST_RELEASE_NAME);
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets")
         .arg(format!("{SECRET_NAME}={VALUES_KEY}"));
@@ -188,7 +188,7 @@ fn remove_flux_resources(namespace: &str) {
     cmd.timeout(Duration::from_secs(60));
     cmd.arg("remove-cd-resources");
     cmd.arg("--namespace").arg(namespace);
-    cmd.arg("--release-name").arg(CD_RELEASE_NAME);
+    cmd.arg("--release-name").arg(TEST_RELEASE_NAME);
     let assert = cmd.assert();
     print_cli_output(&assert);
     assert.success();
@@ -210,7 +210,7 @@ fn flux_bootstrap_via_helm_command(k8s_client: Client, namespace: &str) {
     let mut cmd = assert_cmd::Command::new("helm");
     cmd.timeout(Duration::from_secs(90)); // to fail fast in case unrecoverable error.
     cmd.arg("install")
-        .arg(CD_RELEASE_NAME)
+        .arg(TEST_RELEASE_NAME)
         .arg(CHART_VERSION_UPSTREAM_1_PKG)
         .arg("--wait")
         .arg("--namespace")

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
-const HELM_RELEASE_NAME: &str = "agent-control-cd";
+const CD_RELEASE_NAME: &str = "agent-control-cd";
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -131,7 +131,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         block_on(check_helmrelease_chart_version(
             k8s.client.clone(),
             &namespace,
-            HELM_RELEASE_NAME,
+            CD_RELEASE_NAME,
             CHART_VERSION_UPSTREAM_2,
         ))?;
         let health = health_checker.check_health()?;
@@ -148,7 +148,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
         block_on(check_helmrelease_chart_version(
             k8s.client.clone(),
             &namespace,
-            HELM_RELEASE_NAME,
+            CD_RELEASE_NAME,
             CHART_VERSION_UPSTREAM_2,
         ))?;
         let health = health_checker.check_health()?;
@@ -174,6 +174,7 @@ fn create_flux_resources(namespace: &str, chart_version: &str) {
     cmd.arg("--repository-url").arg(LOCAL_CHART_REPOSITORY);
     cmd.arg("--chart-version").arg(chart_version);
     cmd.arg("--chart-name").arg(HELM_REPOSITORY_NAME);
+    cmd.arg("--release-name").arg(CD_RELEASE_NAME);
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets")
         .arg(format!("{SECRET_NAME}={VALUES_KEY}"));
@@ -187,6 +188,7 @@ fn remove_flux_resources(namespace: &str) {
     cmd.timeout(Duration::from_secs(60));
     cmd.arg("remove-cd-resources");
     cmd.arg("--namespace").arg(namespace);
+    cmd.arg("--release-name").arg(CD_RELEASE_NAME);
     let assert = cmd.assert();
     print_cli_output(&assert);
     assert.success();
@@ -208,7 +210,7 @@ fn flux_bootstrap_via_helm_command(k8s_client: Client, namespace: &str) {
     let mut cmd = assert_cmd::Command::new("helm");
     cmd.timeout(Duration::from_secs(90)); // to fail fast in case unrecoverable error.
     cmd.arg("install")
-        .arg(HELM_RELEASE_NAME)
+        .arg(CD_RELEASE_NAME)
         .arg(CHART_VERSION_UPSTREAM_1_PKG)
         .arg("--wait")
         .arg("--namespace")

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -172,6 +172,7 @@ agents:
                 kind: "Secret".to_string(),
             },
         ],
+        cd_release_name: "test-cd-release-name".to_string(),
     };
 
     // Expects the GC to keep the agent cr and secret from the config, event if looking for multiple kinds or that
@@ -242,6 +243,7 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![missing_kind, foo_type_meta()],
+        cd_release_name: "test-cd-release-name".to_string(),
     };
 
     let agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>("agents: {}")
@@ -284,6 +286,7 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: default_group_version_kinds(),
+        cd_release_name: "test-cd-release-name".to_string(),
     };
 
     // Expects the GC do not clean any resource related to the SA.
@@ -364,6 +367,7 @@ agents:
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![foo_type_meta()],
+        cd_release_name: "test-cd-release-name".to_string(),
     };
 
     // Expects the GC do not clean any resource related to the SA, running SubAgents or unmanaged resources.

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -376,6 +376,7 @@ fn install_ac_with_cli(namespace: &str, chart_version: &str) {
     cmd.arg("--repository-url").arg(LOCAL_CHART_REPOSITORY);
     cmd.arg("--chart-name").arg("agent-control-deployment");
     cmd.arg("--chart-version").arg(chart_version);
+    cmd.arg("--release-name").arg("agent-control-deployment");
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets")
         .arg(format!("{SECRET_NAME}={VALUES_KEY}"));

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -10,7 +10,6 @@ use newrelic_agent_control::agent_control::config::{
 use newrelic_agent_control::agent_control::version_updater::k8s::K8sACUpdater;
 use newrelic_agent_control::agent_control::version_updater::updater::VersionUpdater;
 use newrelic_agent_control::cli::install::agent_control::AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME;
-use newrelic_agent_control::cli::install::flux::AGENT_CONTROL_CD_RELEASE_NAME;
 use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL};
 use std::collections::BTreeMap;
@@ -21,6 +20,7 @@ const CURRENT_AC_VERSION: &str = "1.2.3-beta";
 const NEW_AC_VERSION: &str = "1.2.3";
 const CURRENT_CD_VERSION: &str = "1.2.5-beta";
 const NEW_CD_VERSION: &str = "1.2.5";
+const AGENT_CONTROL_CD_RELEASE_NAME: &str = "test-cd-release-name";
 
 #[test]
 #[ignore = "needs k8s cluster"]

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -20,7 +20,7 @@ const CURRENT_AC_VERSION: &str = "1.2.3-beta";
 const NEW_AC_VERSION: &str = "1.2.3";
 const CURRENT_CD_VERSION: &str = "1.2.5-beta";
 const NEW_CD_VERSION: &str = "1.2.5";
-const AGENT_CONTROL_CD_RELEASE_NAME: &str = "test-cd-release-name";
+const TEST_RELEASE_NAME: &str = "test-cd-release-name";
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -36,7 +36,7 @@ fn k8s_run_updater_for_cd_and_ac() {
         k8s_client.clone(),
         test_ns.clone(),
         CURRENT_AC_VERSION.to_string(),
-        AGENT_CONTROL_CD_RELEASE_NAME.to_string(),
+        TEST_RELEASE_NAME.to_string(),
     );
 
     let config_to_update = &AgentControlDynamicConfig {
@@ -57,7 +57,7 @@ fn k8s_run_updater_for_cd_and_ac() {
 
     let cd_dynamic_object = create_helm_release(
         test_ns.clone(),
-        AGENT_CONTROL_CD_RELEASE_NAME.to_string(),
+        TEST_RELEASE_NAME.to_string(),
         CURRENT_CD_VERSION.to_string(),
         AGENT_CONTROL_VERSION_SET_FROM.to_string(),
     );
@@ -81,7 +81,7 @@ fn k8s_run_updater_for_cd_and_ac() {
         verify_helm_release_state(
             &k8s_client,
             &test_ns,
-            AGENT_CONTROL_CD_RELEASE_NAME,
+            TEST_RELEASE_NAME,
             NEW_CD_VERSION,
             AGENT_CONTROL_VERSION_SET_FROM,
         )?;


### PR DESCRIPTION
# What this PR does / why we need it

Makes the flux release name configurable. Feature for clients and might help with testing.
Side-effect -> we had to update the k8s garbage collector to not remove resources created by the "cd" chart.

## Which issue this PR fixes

- fixes #NR-449397

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
