### PR TITLE
feat: make deployment release name configurable

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -231,6 +231,9 @@ pub struct K8sConfig {
     /// ac_remote_update enables or disables remote update for agent-control-deployment chart
     #[serde(default)]
     pub ac_remote_update: bool,
+    /// agent_control_deployment release name
+    #[serde(default)]
+    pub ac_release_name: String,
     /// cd_remote_update enables or disables remote update for the agent-control-cd chart
     #[serde(default)]
     pub cd_remote_update: bool,
@@ -315,6 +318,7 @@ impl Default for K8sConfig {
             current_chart_version: Default::default(),
             cr_type_meta: default_group_version_kinds(),
             ac_remote_update: Default::default(),
+            ac_release_name: Default::default(),
             cd_remote_update: Default::default(),
             cd_release_name: Default::default(),
         }

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -1,5 +1,4 @@
 use crate::agent_type::agent_type_id::AgentTypeID;
-use crate::cli::install::agent_control::AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME;
 use crate::opamp::remote_config::signature::SIGNATURE_CUSTOM_CAPABILITY;
 use crate::sub_agent::identity::AgentIdentity;
 use opamp_client::capabilities;
@@ -8,7 +7,7 @@ use opamp_client::operation::capabilities::Capabilities;
 
 pub const AGENT_CONTROL_ID: &str = "agent-control";
 
-pub const RESERVED_AGENT_IDS: [&str; 2] = [AGENT_CONTROL_ID, AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME];
+pub const RESERVED_AGENT_IDS: [&str; 1] = [AGENT_CONTROL_ID];
 
 pub const AGENT_CONTROL_TYPE: &str = "com.newrelic.agent_control";
 pub const AGENT_CONTROL_NAMESPACE: &str = "newrelic";

--- a/agent-control/src/agent_control/health_checker/k8s.rs
+++ b/agent-control/src/agent_control/health_checker/k8s.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, time::SystemTime};
 
-use crate::cli::install::agent_control::AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::{
@@ -12,13 +11,14 @@ use crate::{
 pub fn agent_control_health_checker_builder(
     k8s_client: Arc<SyncK8sClient>,
     namespace: String,
+    ac_release_name: String,
 ) -> impl Fn(SystemTime) -> Option<K8sHealthChecker> {
     move |start_time: SystemTime| {
         Some(K8sHealthChecker::new(
             health_checkers_for_type_meta(
                 helmrelease_v2_type_meta(),
                 k8s_client.clone(),
-                AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME.to_string(),
+                ac_release_name.clone(),
                 namespace.clone(),
                 Some(namespace.clone()),
                 start_time,

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -32,6 +32,7 @@ pub struct K8sGarbageCollector {
     /// The namespace where agents are running. We are garbage collecting resources here only due to Instrumentation
     pub namespace_agents: String,
     pub cr_type_meta: Vec<TypeMeta>,
+    pub ac_release_name: String,
     pub cd_release_name: String,
 }
 
@@ -141,7 +142,10 @@ impl K8sGarbageCollector {
             .ok_or(K8sGarbageCollectorError::MissingLabels)?
             .as_str();
 
-        if agent_id_from_labels == self.cd_release_name {
+        // TODO AgentId should be aware of the "ac" and "cd" release names.
+        if agent_id_from_labels == self.ac_release_name
+            || agent_id_from_labels == self.cd_release_name
+        {
             return Ok(false);
         }
 
@@ -273,7 +277,8 @@ mod tests {
 
     const TEST_NAMESPACE: &str = "test-namespace";
     const TEST_NAMESPACE_AGENTS: &str = "test-namespace-agents";
-    const TEST_RELEASE_NAME: &str = "test-release-name";
+    const TEST_AC_RELEASE_NAME: &str = "test-ac-release-name";
+    const TEST_CD_RELEASE_NAME: &str = "test-cd-release-name";
 
     #[test]
     fn errors_if_ac_id() {
@@ -288,7 +293,8 @@ mod tests {
             cr_type_meta: vec![],
             namespace: TEST_NAMESPACE.to_string(),
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
-            cd_release_name: TEST_RELEASE_NAME.to_string(),
+            ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+            cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
         };
         let ac_id = &AgentID::AgentControl;
         let ac_type_id =
@@ -333,7 +339,8 @@ mod tests {
             cr_type_meta: vec![type_meta],
             namespace: TEST_NAMESPACE.to_string(),
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
-            cd_release_name: TEST_RELEASE_NAME.to_string(),
+            ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+            cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
         };
         let ac_id = &AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = &AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -184,6 +184,7 @@ impl AgentControlRunner {
             namespace: self.k8s_config.namespace.clone(),
             namespace_agents: self.k8s_config.namespace_agents.clone(),
             cr_type_meta: self.k8s_config.cr_type_meta,
+            ac_release_name: self.k8s_config.ac_release_name.clone(),
             cd_release_name: self.k8s_config.cd_release_name.clone(),
         };
 
@@ -205,6 +206,7 @@ impl AgentControlRunner {
         let health_checker_builder = agent_control_health_checker_builder(
             k8s_client.clone(),
             self.k8s_config.namespace.to_string(),
+            self.k8s_config.ac_release_name.clone(),
         );
 
         let k8s_ac_updater = K8sACUpdater::new(
@@ -213,6 +215,7 @@ impl AgentControlRunner {
             k8s_client.clone(),
             self.k8s_config.namespace.clone(),
             self.k8s_config.current_chart_version.clone(),
+            self.k8s_config.ac_release_name,
             self.k8s_config.cd_release_name.clone(),
         );
         let (agent_control_internal_publisher, agent_control_internal_consumer) = pub_sub();

--- a/agent-control/src/cli/install/agent_control.rs
+++ b/agent-control/src/cli/install/agent_control.rs
@@ -22,7 +22,6 @@ use crate::{
 /// To be applied via [`install_or_upgrade`](super::install_or_upgrade).
 pub struct InstallAgentControl;
 
-pub const AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME: &str = "agent-control-deployment";
 pub const REPOSITORY_NAME: &str = AGENT_CONTROL_ID;
 
 impl DynamicObjectListBuilder for InstallAgentControl {

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -41,6 +41,9 @@ use newrelic_agent_control::{
 };
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+const TEST_AC_RELEASE_NAME: &str = "test-ac-release-name";
+const TEST_CD_RELEASE_NAME: &str = "test-cd-release-name";
+
 // Setup AgentControlConfigLoader mock
 mock! {
     pub AgentControlConfigLoader {}
@@ -172,7 +175,8 @@ agents:
                 kind: "Secret".to_string(),
             },
         ],
-        cd_release_name: "test-cd-release-name".to_string(),
+        ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+        cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
     };
 
     // Expects the GC to keep the agent cr and secret from the config, event if looking for multiple kinds or that
@@ -243,7 +247,8 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![missing_kind, foo_type_meta()],
-        cd_release_name: "test-cd-release-name".to_string(),
+        ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+        cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
     };
 
     let agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>("agents: {}")
@@ -286,7 +291,8 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: default_group_version_kinds(),
-        cd_release_name: "test-cd-release-name".to_string(),
+        ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+        cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
     };
 
     // Expects the GC do not clean any resource related to the SA.
@@ -367,7 +373,8 @@ agents:
         namespace: test_ns.clone(),
         namespace_agents: test_ns.clone(),
         cr_type_meta: vec![foo_type_meta()],
-        cd_release_name: "test-cd-release-name".to_string(),
+        ac_release_name: TEST_AC_RELEASE_NAME.to_string(),
+        cd_release_name: TEST_CD_RELEASE_NAME.to_string(),
     };
 
     // Expects the GC do not clean any resource related to the SA, running SubAgents or unmanaged resources.

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -42,6 +42,7 @@ fn k8s_self_update_bump_chart_version_from_last_release_to_local_new_config() {
         &opamp_server,
         &namespace,
         CHART_VERSION_LATEST_RELEASE,
+        "agent-control-deployment",
     );
 
     let ac_config = format!(
@@ -103,6 +104,7 @@ fn k8s_self_update_bump_chart_version() {
         &opamp_server,
         &namespace,
         CHART_VERSION_DEV_1,
+        "self-update-bump-chart-version",
     );
 
     opamp_server.set_config_response(
@@ -154,6 +156,7 @@ fn k8s_self_update_bump_chart_version_with_new_config() {
         &opamp_server,
         &namespace,
         CHART_VERSION_DEV_1,
+        "self-update-bump-chart-version-with-new-config",
     );
 
     // This agent will not actually be deployed since misses the chart_version config.
@@ -222,6 +225,7 @@ fn k8s_self_update_new_version_fails_to_start_next_receives_correct_version() {
         &opamp_server,
         &namespace,
         CHART_VERSION_DEV_1,
+        "self-update-new-version-fails-then-works",
     );
 
     opamp_server.set_config_response(
@@ -288,6 +292,7 @@ fn k8s_self_update_new_version_failing_image() {
         &opamp_server,
         &namespace,
         CHART_VERSION_DEV_2,
+        "self-update-new-version-failing-image",
     );
 
     opamp_server.set_config_response(
@@ -345,6 +350,7 @@ fn bootstrap_ac(
     opamp_server: &FakeServer,
     namespace: &str,
     chart_version: &str,
+    release_name: &str,
 ) -> InstanceID {
     let opamp_endpoint = get_minikube_opamp_url_from_fake_server(opamp_server.endpoint().as_str());
 
@@ -358,7 +364,7 @@ fn bootstrap_ac(
         ac_chart_values(opamp_endpoint, namespace),
     );
 
-    install_ac_with_cli(namespace, chart_version);
+    install_ac_with_cli(namespace, chart_version, release_name);
 
     // make some OpAMP seq number gap between old and new pod to avoid the fake server to
     // always send full-resend flag for each pod, and finally keep the new pod data once
@@ -368,7 +374,7 @@ fn bootstrap_ac(
     instance_id::get_instance_id(client.clone(), namespace, &AgentID::AgentControl)
 }
 
-fn install_ac_with_cli(namespace: &str, chart_version: &str) {
+fn install_ac_with_cli(namespace: &str, chart_version: &str, release_name: &str) {
     let mut cmd = Command::cargo_bin("newrelic-agent-control-cli").unwrap();
 
     cmd.arg("install-agent-control");
@@ -376,7 +382,7 @@ fn install_ac_with_cli(namespace: &str, chart_version: &str) {
     cmd.arg("--repository-url").arg(LOCAL_CHART_REPOSITORY);
     cmd.arg("--chart-name").arg("agent-control-deployment");
     cmd.arg("--chart-version").arg(chart_version);
-    cmd.arg("--release-name").arg("agent-control-deployment");
+    cmd.arg("--release-name").arg(release_name);
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets")
         .arg(format!("{SECRET_NAME}={VALUES_KEY}"));

--- a/agent-control/tests/k8s/tools/k8s_env.rs
+++ b/agent-control/tests/k8s/tools/k8s_env.rs
@@ -3,7 +3,6 @@ use crate::common::{global_logger::init_logger, runtime::tokio_runtime};
 use super::test_crd::create_foo_crd;
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::{Namespace, Pod};
-use k8s_openapi::api::rbac::v1::ClusterRole;
 use kube::runtime::conditions::is_pod_running;
 use kube::runtime::wait::Error as KubeWaitError;
 use kube::runtime::wait::await_condition;
@@ -189,8 +188,6 @@ impl Drop for K8sEnv {
 
         futures::executor::block_on(async move {
             let ns_api: Api<Namespace> = Api::all(self.client.clone());
-            let cr_api: Api<ClusterRole> = Api::all(self.client.clone());
-
             let generated_namespaces = self.generated_namespaces.clone();
             tokio_runtime()
                 .spawn(async move {
@@ -200,14 +197,6 @@ impl Drop for K8sEnv {
                             .await
                             .expect("fail to remove namespace");
                     }
-
-                    // TODO This is a workaround. As soon as we have a way to configure RELEASE_NAME in the tests, we can remove this.
-                    let _ = cr_api
-                        .delete(
-                            "agent-control-deployment-resources",
-                            &DeleteParams::default(),
-                        )
-                        .await;
                 })
                 .await
                 .unwrap();

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -9,7 +9,6 @@ use newrelic_agent_control::agent_control::config::{
 };
 use newrelic_agent_control::agent_control::version_updater::k8s::K8sACUpdater;
 use newrelic_agent_control::agent_control::version_updater::updater::VersionUpdater;
-use newrelic_agent_control::cli::install::agent_control::AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME;
 use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL};
 use std::collections::BTreeMap;
@@ -20,7 +19,8 @@ const CURRENT_AC_VERSION: &str = "1.2.3-beta";
 const NEW_AC_VERSION: &str = "1.2.3";
 const CURRENT_CD_VERSION: &str = "1.2.5-beta";
 const NEW_CD_VERSION: &str = "1.2.5";
-const TEST_RELEASE_NAME: &str = "test-cd-release-name";
+const TEST_CD_RELEASE_NAME: &str = "test-cd-release-name";
+const TEST_AC_RELEASE_NAME: &str = "test-deployment-release-name";
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -36,7 +36,8 @@ fn k8s_run_updater_for_cd_and_ac() {
         k8s_client.clone(),
         test_ns.clone(),
         CURRENT_AC_VERSION.to_string(),
-        TEST_RELEASE_NAME.to_string(),
+        TEST_AC_RELEASE_NAME.to_string(),
+        TEST_CD_RELEASE_NAME.to_string(),
     );
 
     let config_to_update = &AgentControlDynamicConfig {
@@ -47,7 +48,7 @@ fn k8s_run_updater_for_cd_and_ac() {
 
     let ac_dynamic_object = create_helm_release(
         test_ns.clone(),
-        AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME.to_string(),
+        TEST_AC_RELEASE_NAME.to_string(),
         CURRENT_AC_VERSION.to_string(),
         AGENT_CONTROL_VERSION_SET_FROM.to_string(),
     );
@@ -57,7 +58,7 @@ fn k8s_run_updater_for_cd_and_ac() {
 
     let cd_dynamic_object = create_helm_release(
         test_ns.clone(),
-        TEST_RELEASE_NAME.to_string(),
+        TEST_CD_RELEASE_NAME.to_string(),
         CURRENT_CD_VERSION.to_string(),
         AGENT_CONTROL_VERSION_SET_FROM.to_string(),
     );
@@ -73,7 +74,7 @@ fn k8s_run_updater_for_cd_and_ac() {
         verify_helm_release_state(
             &k8s_client,
             &test_ns,
-            AGENT_CONTROL_DEPLOYMENT_RELEASE_NAME,
+            TEST_AC_RELEASE_NAME,
             NEW_AC_VERSION,
             AGENT_CONTROL_VERSION_SET_FROM,
         )?;
@@ -81,7 +82,7 @@ fn k8s_run_updater_for_cd_and_ac() {
         verify_helm_release_state(
             &k8s_client,
             &test_ns,
-            TEST_RELEASE_NAME,
+            TEST_CD_RELEASE_NAME,
             NEW_CD_VERSION,
             AGENT_CONTROL_VERSION_SET_FROM,
         )?;


### PR DESCRIPTION
# What this PR does / why we need it

Makes `agent-control-deployment` release name configurable.

## Which issue this PR fixes

- fixes #NR-441446

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
