### PR TITLE
test(flux-upgrade): check cd-chart-version is updated

### DIFF
--- a/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
@@ -5,6 +5,7 @@ k8s:
   cd_remote_update: true
   ac_remote_update: false
   cd_release_name: test-agent-control-cd
+  current_chart_version: 0.0.1000
 fleet_control:
   endpoint: <opamp-endpoint>
   poll_interval: 5s


### PR DESCRIPTION
When putting together a demo I noticed we are not testing that the agent-description is properly updated after an update of agent-control-cd.

This PR adds a test to extend the corresponding test and check we are reporting it as expected.
