### PR TITLE
feat: dynamic version check

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -113,7 +113,8 @@ deployment:
         path: "/v1/status/health"
         port: ${nr-var:health_port}
     version:
-      command: /usr/bin/newrelic-infra --version
+      path: /usr/bin/newrelic-infra
+      args: --version
       regex: \d+\.\d+\.\d+
       interval: 60s
     executables:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -116,7 +116,6 @@ deployment:
       path: /usr/bin/newrelic-infra
       args: --version
       regex: \d+\.\d+\.\d+
-      interval: 60s
     executables:
       - path: /usr/bin/newrelic-infra
         args: >-

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -112,6 +112,10 @@ deployment:
       http:
         path: "/v1/status/health"
         port: ${nr-var:health_port}
+    version:
+      command: /usr/bin/newrelic-infra --version
+      regex: \d+\.\d+\.\d+
+      interval: 60s
     executables:
       - path: /usr/bin/newrelic-infra
         args: >-

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -78,7 +78,8 @@ deployment:
         path: "${nr-var:health_check.path}"
         port: ${nr-var:health_check.port}
     version:
-      command: /usr/bin/nrdot-collector-host -v
+      path: /usr/bin/nrdot-collector-host
+      args: -v
       regex: \d+\.\d+\.\d+
       interval: 60s
     executables:

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -81,7 +81,6 @@ deployment:
       path: /usr/bin/nrdot-collector-host
       args: -v
       regex: \d+\.\d+\.\d+
-      interval: 60s
     executables:
       - # Important to note the binary name is nrdot-collector-host matching the new nrdot binary
         path: /usr/bin/nrdot-collector-host

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -77,6 +77,10 @@ deployment:
       http:
         path: "${nr-var:health_check.path}"
         port: ${nr-var:health_check.port}
+    version:
+      command: /usr/bin/nrdot-collector-host -v
+      regex: \d+\.\d+\.\d+
+      interval: 60s
     executables:
       - # Important to note the binary name is nrdot-collector-host matching the new nrdot binary
         path: /usr/bin/nrdot-collector-host

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -33,8 +33,8 @@ use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::k8s::builder::SupervisorBuilderK8s;
 use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
 use crate::utils::thread_context::StartedThreadContext;
+use crate::version_checker::k8s::checkers::spawn_version_checker;
 use crate::version_checker::k8s::helmrelease::HelmReleaseVersionChecker;
-use crate::version_checker::spawn_version_checker;
 use crate::{agent_control::error::AgentError, opamp::client_builder::DefaultOpAMPClientBuilder};
 use crate::{
     k8s::store::K8sStore, sub_agent::k8s::builder::K8sSubAgentBuilder,

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -242,7 +242,7 @@ In this configuration:
 
 * `path`: Specifies the binary to run. 
 * `args`: Specifies the arguments passed to the binary to get the version. 
-* `regex`: Optional field that specifies the regular expression to get the version from the ouput.
+* `regex`: Optional field that specifies the regular expression to get the version from the output.
 
 
 ### Kubernetes Deployment

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -137,6 +137,10 @@ deployment:
       http:
         path: "/v1/status"
         port: 8003
+    version:
+      path: /usr/bin/newrelic-infra
+      args: --version
+      regex: \d+\.\d+\.\d+
     executables:
       - path: /usr/bin/newrelic-infra
         args: "--config=${nr-var:config_agent}"
@@ -151,6 +155,7 @@ In this section:
 
 * `enable_file_logging`: This setting turns on logging for the agent supervisor
 * `health`: The measures used to check the health status of the agent.
+* `version`: The command used to check the version of the binary.
 * `executables`: This outlines the list of binaries the agent supervisor runs. Developers can define:
   - * `path`: The location of the binary required.
     * `args`: The command-line arguments needed by the binary.
@@ -221,6 +226,24 @@ health:
     should_be_present: true
     unhealthy_string: ".*(unhealthy|fatal|error).*"
 ```
+
+#### OnHost Version
+
+The `version` section in the deployment configuration is where you can specify how to obtain the version of the binary running. Here's how you can define it block:
+
+```yaml
+version:
+  path: /usr/bin/newrelic-infra
+  args: --version
+  regex: \d+\.\d+\.\d+
+```
+
+In this configuration:
+
+* `path`: Specifies the binary to run. 
+* `args`: Specifies the arguments passed to the binary to get the version. 
+* `regex`: Optional field that specifies the regular expression to get the version from the ouput.
+
 
 ### Kubernetes Deployment
 

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -242,7 +242,7 @@ In this configuration:
 
 * `path`: Specifies the binary to run. 
 * `args`: Specifies the arguments passed to the binary to get the version. 
-* `regex`: Optional field that specifies the regular expression to get the version from the output.
+* `regex`: Optional field that specifies the regular expression to get the version from the output. When not used, the whole output will be used as the version.
 
 
 ### Kubernetes Deployment

--- a/agent-control/src/agent_type/runtime_config.rs
+++ b/agent-control/src/agent_type/runtime_config.rs
@@ -9,6 +9,7 @@ pub mod k8s;
 pub mod onhost;
 pub mod restart_policy;
 pub mod templateable_value;
+pub mod version_config;
 
 use super::definition::Variables;
 use super::error::AgentTypeError;

--- a/agent-control/src/agent_type/runtime_config/onhost.rs
+++ b/agent-control/src/agent_type/runtime_config/onhost.rs
@@ -9,6 +9,7 @@ use crate::agent_type::templates::Templateable;
 use super::health_config::OnHostHealthConfig;
 use super::restart_policy::RestartPolicyConfig;
 use super::templateable_value::TemplateableValue;
+use super::version_config::OnHostVersionConfig;
 
 /// The definition for an on-host supervisor.
 ///
@@ -21,6 +22,8 @@ pub struct OnHost {
     pub enable_file_logging: TemplateableValue<bool>,
     /// Enables and define health checks configuration.
     pub health: Option<OnHostHealthConfig>,
+    /// Enables and define version checks configuration.
+    pub version: Option<OnHostVersionConfig>,
 }
 
 impl Templateable for OnHost {
@@ -35,6 +38,10 @@ impl Templateable for OnHost {
             health: self
                 .health
                 .map(|h| h.template_with(variables))
+                .transpose()?,
+            version: self
+                .version
+                .map(|v| v.template_with(variables))
                 .transpose()?,
         })
     }

--- a/agent-control/src/agent_type/runtime_config/version_config.rs
+++ b/agent-control/src/agent_type/runtime_config/version_config.rs
@@ -1,4 +1,5 @@
-use serde::Deserialize;
+use regex::Regex;
+use serde::{Deserialize, Deserializer};
 
 use crate::agent_type::{
     definition::Variables,
@@ -8,7 +9,7 @@ use crate::agent_type::{
 };
 
 /// Represents the configuration for version checks.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct OnHostVersionConfig {
     /// Path to the binary from which we want to check the version.
     pub path: String,
@@ -19,7 +20,47 @@ pub struct OnHostVersionConfig {
     /// The regex expression to get the version from the command output.
     ///
     /// If not provided, the entire output will be used.
-    pub(crate) regex: Option<String>,
+    pub(crate) regex: Option<Regex>,
+}
+
+impl<'de> Deserialize<'de> for OnHostVersionConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // intermediate serialization type to validate `default` and `required` fields
+        #[derive(Debug, Deserialize)]
+        pub struct IntermediateOnHostVersionConfig {
+            pub path: String,
+            pub args: TemplateableValue<Args>,
+            pub(crate) regex: Option<String>,
+        }
+
+        let intermediate_spec = IntermediateOnHostVersionConfig::deserialize(deserializer)?;
+
+        let regex = intermediate_spec
+            .regex
+            .as_ref()
+            .map(|r| {
+                Regex::new(r)
+                    .map_err(|e| serde::de::Error::custom(format!("error compiling regex: {e}")))
+            })
+            .transpose()?;
+
+        Ok(OnHostVersionConfig {
+            path: intermediate_spec.path,
+            args: intermediate_spec.args,
+            regex,
+        })
+    }
+}
+
+impl PartialEq for OnHostVersionConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
+            && self.args == other.args
+            && self.regex.as_ref().map(|r| r.as_str()) == other.regex.as_ref().map(|r| r.as_str())
+    }
 }
 
 impl Templateable for OnHostVersionConfig {

--- a/agent-control/src/agent_type/runtime_config/version_config.rs
+++ b/agent-control/src/agent_type/runtime_config/version_config.rs
@@ -1,9 +1,6 @@
 use serde::Deserialize;
 
-use crate::agent_type::{
-    definition::Variables, error::AgentTypeError, templates::Templateable,
-    version_config::VersionCheckerInterval,
-};
+use crate::agent_type::{definition::Variables, error::AgentTypeError, templates::Templateable};
 
 /// Represents the configuration for version checks.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -17,10 +14,6 @@ pub struct OnHostVersionConfig {
     /// If not provided, the entire output will be used.
     #[serde(default)]
     pub(crate) regex: Option<String>,
-
-    /// The duration to wait between version checks.
-    #[serde(default)]
-    pub(crate) interval: VersionCheckerInterval,
 }
 
 impl Templateable for OnHostVersionConfig {
@@ -28,7 +21,6 @@ impl Templateable for OnHostVersionConfig {
         Ok(Self {
             command: self.command.template_with(variables)?,
             regex: self.regex,
-            interval: self.interval,
         })
     }
 }

--- a/agent-control/src/agent_type/runtime_config/version_config.rs
+++ b/agent-control/src/agent_type/runtime_config/version_config.rs
@@ -12,7 +12,7 @@ use crate::agent_type::{
 #[derive(Debug, Clone)]
 pub struct OnHostVersionConfig {
     /// Path to the binary from which we want to check the version.
-    pub path: String,
+    pub path: TemplateableValue<String>,
 
     // Command arguments.
     pub args: TemplateableValue<Args>,
@@ -31,7 +31,7 @@ impl<'de> Deserialize<'de> for OnHostVersionConfig {
         // intermediate serialization type to validate `default` and `required` fields
         #[derive(Debug, Deserialize)]
         pub struct IntermediateOnHostVersionConfig {
-            pub path: String,
+            pub path: TemplateableValue<String>,
             pub args: TemplateableValue<Args>,
             pub(crate) regex: Option<String>,
         }

--- a/agent-control/src/agent_type/runtime_config/version_config.rs
+++ b/agent-control/src/agent_type/runtime_config/version_config.rs
@@ -1,0 +1,34 @@
+use serde::Deserialize;
+
+use crate::agent_type::{
+    definition::Variables, error::AgentTypeError, templates::Templateable,
+    version_config::VersionCheckerInterval,
+};
+
+/// Represents the configuration for version checks.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct OnHostVersionConfig {
+    /// The command to check the version.
+    #[serde(default)]
+    pub(crate) command: String,
+
+    /// The regex expression to get the version from the command output.
+    ///
+    /// If not provided, the entire output will be used.
+    #[serde(default)]
+    pub(crate) regex: Option<String>,
+
+    /// The duration to wait between version checks.
+    #[serde(default)]
+    pub(crate) interval: VersionCheckerInterval,
+}
+
+impl Templateable for OnHostVersionConfig {
+    fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
+        Ok(Self {
+            command: self.command.template_with(variables)?,
+            regex: self.regex,
+            interval: self.interval,
+        })
+    }
+}

--- a/agent-control/src/agent_type/runtime_config/version_config.rs
+++ b/agent-control/src/agent_type/runtime_config/version_config.rs
@@ -1,25 +1,32 @@
 use serde::Deserialize;
 
-use crate::agent_type::{definition::Variables, error::AgentTypeError, templates::Templateable};
+use crate::agent_type::{
+    definition::Variables,
+    error::AgentTypeError,
+    runtime_config::{onhost::Args, templateable_value::TemplateableValue},
+    templates::Templateable,
+};
 
 /// Represents the configuration for version checks.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct OnHostVersionConfig {
-    /// The command to check the version.
-    #[serde(default)]
-    pub(crate) command: String,
+    /// Path to the binary from which we want to check the version.
+    pub path: String,
+
+    // Command arguments.
+    pub args: TemplateableValue<Args>,
 
     /// The regex expression to get the version from the command output.
     ///
     /// If not provided, the entire output will be used.
-    #[serde(default)]
     pub(crate) regex: Option<String>,
 }
 
 impl Templateable for OnHostVersionConfig {
     fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
         Ok(Self {
-            command: self.command.template_with(variables)?,
+            path: self.path.template_with(variables)?,
+            args: self.args.template_with(variables)?,
             regex: self.regex,
         })
     }

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -19,8 +19,7 @@ use crate::sub_agent::supervisor::stopper::SupervisorStopper;
 use crate::utils::thread_context::{
     NotStartedThreadContext, StartedThreadContext, ThreadContextStopperError,
 };
-use crate::version_checker::k8s::checkers::K8sAgentVersionChecker;
-use crate::version_checker::spawn_version_checker;
+use crate::version_checker::k8s::checkers::{K8sAgentVersionChecker, spawn_version_checker};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::serde_json;
 use kube::{api::DynamicObject, core::TypeMeta};

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -175,6 +175,7 @@ impl SupervisorBuilder for SupervisortBuilderOnHost {
             executables,
             Context::new(),
             on_host.health,
+            on_host.version,
         )
         .with_file_logging(enable_file_logging, self.logging_path.to_path_buf());
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -160,7 +160,7 @@ impl NotStartedSupervisorOnHost {
             );
             return Ok(Some(started_thread_context));
         }
-        debug!("health checks are disabled for this agent");
+        info!(%self.agent_identity.agent_type_id, "health checks are disabled for this agent");
         Ok(None)
     }
 
@@ -169,7 +169,7 @@ impl NotStartedSupervisorOnHost {
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) {
         let Some(version_config) = &self.version_config else {
-            debug!("version checks are disabled for this agent");
+            info!(%self.agent_identity.agent_type_id, "version checks are disabled for this agent");
             return;
         };
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -174,7 +174,7 @@ impl NotStartedSupervisorOnHost {
         };
 
         let onhost_version_checker = OnHostAgentVersionChecker {
-            path: version_config.path.clone(),
+            path: version_config.path.clone().get(),
             args: version_config.args.clone().get(),
             regex: version_config.regex.clone(),
         };

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -174,7 +174,8 @@ impl NotStartedSupervisorOnHost {
         };
 
         let onhost_version_checker = OnHostAgentVersionChecker {
-            command: version_config.command.clone(),
+            path: version_config.path.clone(),
+            args: version_config.args.clone().get(),
             regex: version_config.regex.clone(),
         };
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -66,7 +66,7 @@ impl SupervisorStarter for NotStartedSupervisorOnHost {
             .iter()
             .map(|e| self.start_process_thread(sub_agent_internal_publisher.clone(), e));
 
-        self.start_version_checker(sub_agent_internal_publisher.clone());
+        self.check_subagent_version(sub_agent_internal_publisher.clone());
 
         let thread_contexts: Vec<StartedThreadContext> =
             vec![self.start_health_check(sub_agent_internal_publisher.clone())?]
@@ -160,16 +160,16 @@ impl NotStartedSupervisorOnHost {
             );
             return Ok(Some(started_thread_context));
         }
-        info!(%self.agent_identity.agent_type_id, "health checks are disabled for this agent");
+        info!(agent_type=%self.agent_identity.agent_type_id, "health checks are disabled for this agent");
         Ok(None)
     }
 
-    pub fn start_version_checker(
+    pub fn check_subagent_version(
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) {
         let Some(version_config) = &self.version_config else {
-            info!(%self.agent_identity.agent_type_id, "version checks are disabled for this agent");
+            info!(agent_type=%self.agent_identity.agent_type_id, "version checks are disabled for this agent");
             return;
         };
 

--- a/agent-control/src/version_checker.rs
+++ b/agent-control/src/version_checker.rs
@@ -2,13 +2,9 @@ pub mod handler;
 pub mod k8s;
 pub mod onhost;
 
-use crate::agent_type::version_config::VersionCheckerInterval;
-use crate::event::cancellation::CancellationMessage;
-use crate::event::channel::{EventConsumer, EventPublisher};
-use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
-use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
+use crate::event::channel::EventPublisher;
 use std::fmt::Debug;
-use tracing::{debug, error, info, info_span, warn};
+use tracing::error;
 const VERSION_CHECKER_THREAD_NAME: &str = "version_checker";
 
 pub trait VersionChecker {
@@ -31,56 +27,6 @@ pub enum VersionCheckError {
     Generic(String),
 }
 
-pub(crate) fn spawn_version_checker<V, T, F>(
-    version_checker_id: String,
-    version_checker: V,
-    version_event_publisher: EventPublisher<T>,
-    version_event_generator: F,
-    interval: VersionCheckerInterval,
-) -> StartedThreadContext
-where
-    V: VersionChecker + Send + Sync + 'static,
-    T: Debug + Send + Sync + 'static,
-    F: Fn(AgentVersion) -> T + Send + Sync + 'static,
-{
-    let thread_name = format!("{version_checker_id}_{VERSION_CHECKER_THREAD_NAME}");
-    // Stores if the version was retrieved in last iteration for logging purposes.
-    let mut version_retrieved = false;
-    let callback = move |stop_consumer: EventConsumer<CancellationMessage>| loop {
-        let span = info_span!(
-            "version_check",
-            { ID_ATTRIBUTE_NAME } = %version_checker_id
-        );
-        let _guard = span.enter();
-
-        debug!("starting to check version with the configured checker");
-
-        match version_checker.check_agent_version() {
-            Ok(agent_data) => {
-                if !version_retrieved {
-                    info!("agent version successfully checked");
-                    version_retrieved = true;
-                }
-
-                publish_version_event(
-                    &version_event_publisher,
-                    version_event_generator(agent_data),
-                );
-            }
-            Err(error) => {
-                warn!("failed to check agent version: {error}");
-                version_retrieved = false;
-            }
-        }
-
-        if stop_consumer.is_cancelled(interval.into()) {
-            break;
-        }
-    };
-
-    NotStartedThreadContext::new(thread_name, callback).start()
-}
-
 pub(crate) fn publish_version_event<T>(version_event_publisher: &EventPublisher<T>, event: T)
 where
     T: Debug + Send + Sync + 'static,
@@ -98,67 +44,12 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::agent_control::defaults::OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY;
-    use crate::event::SubAgentInternalEvent::AgentVersionInfo;
-    use crate::event::channel::pub_sub;
-    use crate::{agent_control::agent_id::AgentID, event::SubAgentInternalEvent};
-    use mockall::{Sequence, mock};
-    use std::time::Duration;
+    use mockall::mock;
 
     mock! {
         pub VersionChecker {}
         impl VersionChecker for VersionChecker {
             fn check_agent_version(&self) -> Result<AgentVersion, VersionCheckError>;
         }
-    }
-
-    #[test]
-    fn test_spawn_version_checker() {
-        let (version_publisher, version_consumer) = pub_sub();
-
-        let mut version_checker = MockVersionChecker::new();
-        let mut seq = Sequence::new();
-        version_checker
-            .expect_check_agent_version()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Err(VersionCheckError::Generic(
-                    "mocked version check error!".to_string(),
-                ))
-            });
-        version_checker
-            .expect_check_agent_version()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move || {
-                Ok(AgentVersion {
-                    version: "1.0.0".to_string(),
-                    opamp_field: OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
-                })
-            });
-
-        let started_thread_context = spawn_version_checker(
-            AgentID::default().to_string(),
-            version_checker,
-            version_publisher,
-            SubAgentInternalEvent::AgentVersionInfo,
-            Duration::from_millis(10).into(),
-        );
-
-        // Check that we received the expected version event
-        assert_eq!(
-            AgentVersionInfo(AgentVersion {
-                version: "1.0.0".to_string(),
-                opamp_field: OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
-            }),
-            version_consumer.as_ref().recv().unwrap()
-        );
-
-        // Check that the thread is finished
-        started_thread_context.stop_blocking().unwrap();
-
-        // Check there are no more events
-        assert!(version_consumer.as_ref().recv().is_err());
     }
 }

--- a/agent-control/src/version_checker.rs
+++ b/agent-control/src/version_checker.rs
@@ -22,10 +22,8 @@ pub struct AgentVersion {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum VersionCheckError {
-    #[error("generic error: {0}")]
-    Generic(String),
-}
+#[error("checking version: {0}")]
+pub struct VersionCheckError(pub String);
 
 pub(crate) fn publish_version_event<T>(version_event_publisher: &EventPublisher<T>, event: T)
 where

--- a/agent-control/src/version_checker/k8s/checkers.rs
+++ b/agent-control/src/version_checker/k8s/checkers.rs
@@ -321,11 +321,7 @@ mod tests {
             .expect_check_agent_version()
             .once()
             .in_sequence(&mut seq)
-            .returning(move || {
-                Err(VersionCheckError::Generic(
-                    "mocked version check error!".to_string(),
-                ))
-            });
+            .returning(move || Err(VersionCheckError("mocked version check error!".to_string())));
         version_checker
             .expect_check_agent_version()
             .once()

--- a/agent-control/src/version_checker/k8s/instrumentation.rs
+++ b/agent-control/src/version_checker/k8s/instrumentation.rs
@@ -36,13 +36,13 @@ impl NewrelicInstrumentationVersionChecker {
                 self.namespace.as_str(),
             )
             .map_err(|err| {
-                VersionCheckError::Generic(format!(
+                VersionCheckError(format!(
                     "Error fetching Instrumentation for agent_id '{}': {}",
                     &self.agent_id, err
                 ))
             })?
             .ok_or_else(|| {
-                VersionCheckError::Generic(format!(
+                VersionCheckError(format!(
                     "Instrumentation for agent_id '{}' not found",
                     &self.agent_id
                 ))
@@ -55,7 +55,7 @@ impl VersionChecker for NewrelicInstrumentationVersionChecker {
         let instrumentation = self.get_instrumentation()?;
 
         let instrumentation_data = instrumentation.data.as_object().ok_or_else(|| {
-            VersionCheckError::Generic(format!(
+            VersionCheckError(format!(
                 "Invalid Instrumentation for agent_id '{}'",
                 &self.agent_id
             ))
@@ -63,7 +63,7 @@ impl VersionChecker for NewrelicInstrumentationVersionChecker {
 
         let version = version_from_newrelic_instrumentation_image(instrumentation_data)
             .ok_or_else(|| {
-                VersionCheckError::Generic(format!(
+                VersionCheckError(format!(
                     "Could not extract version from 'spec.agent.image' in the Instrumentation object for '{}'",
                     &self.agent_id
                 ))

--- a/agent-control/src/version_checker/onhost.rs
+++ b/agent-control/src/version_checker/onhost.rs
@@ -23,13 +23,11 @@ impl VersionChecker for OnHostAgentVersionChecker {
         let output = Command::new(&self.path)
             .args(self.args.clone().into_vector())
             .output()
-            .map_err(|e| {
-                VersionCheckError::Generic(format!("error executing version command: {e}"))
-            })?;
+            .map_err(|e| VersionCheckError(format!("error executing version command: {e}")))?;
         let output = String::from_utf8_lossy(&output.stdout);
 
         let version = if let Some(regex) = &self.regex {
-            let version_match = regex.find(&output).ok_or(VersionCheckError::Generic(
+            let version_match = regex.find(&output).ok_or(VersionCheckError(
                 "error checking agent version: version not found".to_string(),
             ))?;
             version_match.as_str().to_string()

--- a/agent-control/src/version_checker/onhost.rs
+++ b/agent-control/src/version_checker/onhost.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, info_span, warn};
 pub struct OnHostAgentVersionChecker {
     pub(crate) path: String,
     pub(crate) args: Args,
-    pub(crate) regex: Option<String>,
+    pub(crate) regex: Option<Regex>,
 }
 
 impl VersionChecker for OnHostAgentVersionChecker {
@@ -28,10 +28,7 @@ impl VersionChecker for OnHostAgentVersionChecker {
             })?;
         let output = String::from_utf8_lossy(&output.stdout);
 
-        let version = if let Some(pattern) = &self.regex {
-            let regex = Regex::new(pattern)
-                .map_err(|e| VersionCheckError::Generic(format!("error compiling regex: {e}")))?;
-
+        let version = if let Some(regex) = &self.regex {
             let version_match = regex.find(&output).ok_or(VersionCheckError::Generic(
                 "error checking agent version: version not found".to_string(),
             ))?;
@@ -106,7 +103,7 @@ mod tests {
         let agent_version = OnHostAgentVersionChecker {
             path: path.to_string(),
             args: Args(args),
-            regex: regex.map(|r| r.to_string()),
+            regex: regex.map(|r| Regex::new(r).unwrap()),
         }
         .check_agent_version()
         .unwrap();

--- a/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
+++ b/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
@@ -140,7 +140,7 @@ chart_version: "{CHART_VERSION_LATEST_RELEASE}"
 
         let obj = k8s_client
             .get_dynamic_object(&helmrelease_v2_type_meta(), release_name, &ac_namespace)?
-            .ok_or(VersionCheckError::Generic(format!(
+            .ok_or(VersionCheckError(format!(
                 "helmRelease object not found: {release_name}",
             )))?;
 
@@ -170,7 +170,7 @@ pub fn check_version_and_source(
 ) -> Result<(), Box<dyn Error>> {
     let obj = k8s_client
         .get_dynamic_object(&helmrelease_v2_type_meta(), release_name, namespace)?
-        .ok_or(VersionCheckError::Generic(format!(
+        .ok_or(VersionCheckError(format!(
             "helmRelease object not found: {release_name}",
         )))?;
 

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -24,7 +24,8 @@ variables:
 deployment:
   on_host:
     version:
-      command: echo "Some data 1.0.0 Some data"
+      path: echo
+      args: "Some data 1.0.0 Some data"
       regex: \d+\.\d+\.\d+
       interval: 10s
     executables:
@@ -120,7 +121,8 @@ variables:
 deployment:
   on_host:
     version:
-      command: echo -n 1.0.0
+      path: echo
+      args: -n 1.0.0
       interval: 10s
     executables:
       - path: {path}


### PR DESCRIPTION
# What this PR does / why we need it

Dynamically check binaries versions.

## Which issue this PR fixes

- fixes #NR-458027

## Special notes for your reviewer

Why did we add the `version` field below `on_host` and not below each executable?

I thought it made sense to have `version` next to `health`, given that they represent a similar thing. Also, it makes things simpler for now. We have a single command to check the version.

It doesn't support checking the version of multiple binaries, but I don't know if this is wanted nor how the information should be displayed. Maybe we want different version checkers? Maybe we want a single version checker that returns every version?

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
