### PR TITLE
chore(logs): improve log messages [NR-457551]

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -122,8 +122,8 @@ where
     }
 
     pub fn run(self) -> Result<(), AgentError> {
-        let span = info_span!("start_agent_control", id = AGENT_CONTROL_ID);
-        let _span_guard = span.enter();
+        let ac_startup_span = info_span!("start_agent_control", id = AGENT_CONTROL_ID);
+        let _ac_startup_span_guard = ac_startup_span.enter();
         info!("Starting the agents supervisor runtime");
         // This is a first-time run and we already read the config earlier, the `initial_config` contains
         // the result as read by the `AgentControlConfigLoader`.
@@ -181,7 +181,7 @@ where
             .inspect_err(|err| error!("Error executing Agent Control updater: {err}"));
 
         info!("Agents supervisor runtime successfully started");
-        drop(_span_guard); // The span representing agent start finishes before entering in the `process_events` loop. Otherwise the span would be open while Agent Control runs.
+        drop(_ac_startup_span_guard); // The span representing agent start finishes before entering in the `process_events` loop. Otherwise the span would be open while Agent Control runs.
 
         self.process_events(running_sub_agents);
 

--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -181,7 +181,7 @@ where
             .inspect_err(|err| error!("Error executing Agent Control updater: {err}"));
 
         info!("Agents supervisor runtime successfully started");
-        drop(_span_guard);
+        drop(_span_guard); // The span representing agent start finishes before entering in the `process_events` loop. Otherwise the span would be open while Agent Control runs.
 
         self.process_events(running_sub_agents);
 

--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -12,6 +12,7 @@ pub mod run;
 pub mod uptime_report;
 pub mod version_updater;
 
+use crate::agent_control::defaults::AGENT_CONTROL_ID;
 use crate::event::AgentControlInternalEvent;
 use crate::event::channel::EventPublisher;
 use crate::event::{
@@ -39,7 +40,7 @@ use opamp_client::StartedClient;
 use resource_cleaner::ResourceCleaner;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, info_span, instrument, trace, warn};
 use uptime_report::UptimeReporter;
 use version_updater::updater::VersionUpdater;
 
@@ -121,6 +122,8 @@ where
     }
 
     pub fn run(self) -> Result<(), AgentError> {
+        let span = info_span!("start_agent_control", id = AGENT_CONTROL_ID);
+        let _span_guard = span.enter();
         info!("Starting the agents supervisor runtime");
         // This is a first-time run and we already read the config earlier, the `initial_config` contains
         // the result as read by the `AgentControlConfigLoader`.
@@ -178,6 +181,8 @@ where
             .inspect_err(|err| error!("Error executing Agent Control updater: {err}"));
 
         info!("Agents supervisor runtime successfully started");
+        drop(_span_guard);
+
         self.process_events(running_sub_agents);
 
         if let Some(opamp_client) = self.opamp_client {
@@ -287,6 +292,8 @@ where
         loop {
             select! {
                 recv(&opamp_receiver.as_ref()) -> opamp_event_res => {
+                    let span = info_span!("process_fleet_event", id=AGENT_CONTROL_ID);
+                    let _span_guard = span.enter();
                     match opamp_event_res {
                         Err(_) => {
                             debug!("channel closed");
@@ -316,6 +323,8 @@ where
                     }
                 },
                 recv(&self.agent_control_internal_consumer.as_ref()) -> internal_event_res => {
+                    let span = info_span!("process_event", id=AGENT_CONTROL_ID);
+                    let _span_guard = span.enter();
                     match internal_event_res {
                         Err(err) => {
                             debug!("Error receiving Agent Control internal event {err}");
@@ -337,6 +346,8 @@ where
                     }
                 }
                 recv(self.application_event_consumer.as_ref()) -> _agent_control_event => {
+                    let span = info_span!("process_application_event", id=AGENT_CONTROL_ID);
+                    let _span_guard = span.enter();
                     debug!("stopping Agent Control event processor");
                     self.agent_control_publisher.broadcast(AgentControlEvent::AgentControlStopped);
                     break sub_agents.stop();
@@ -402,7 +413,6 @@ where
         }
     }
 
-    #[instrument(skip_all)]
     pub(super) fn validate_apply_store_remote_config(
         &self,
         opamp_remote_config: &OpampRemoteConfig,
@@ -488,7 +498,7 @@ where
 
             let apply_result = match current_dynamic_config.agents.get(agent_id) {
                 Some(old_sub_agent_config) if old_sub_agent_config == agent_config => {
-                    debug!(%agent_id, "Retaining the existing running SubAgent as its configuration remains unchanged");
+                    debug!(%agent_id, "Retaining the existing running SubAgent as its type remains unchanged");
                     Ok(())
                 }
                 Some(old_sub_agent_config) => {

--- a/agent-control/src/opamp/instance_id/getter.rs
+++ b/agent-control/src/opamp/instance_id/getter.rs
@@ -63,7 +63,7 @@ where
 {
     fn get(&self, agent_id: &AgentID) -> Result<InstanceID, GetterError> {
         let storer = self.storer.lock().expect("failed to acquire the lock");
-        debug!("retrieving instance id");
+        debug!(target_agent_id = %agent_id, "retrieving instance id");
         let data = storer.get(agent_id)?;
 
         match data {
@@ -72,8 +72,8 @@ where
             }
             Some(d) if d.identifiers == self.identifiers => return Ok(d.instance_id),
             Some(d) => debug!(
-                "stored data had different identifiers {:?}!={:?}",
-                d.identifiers, self.identifiers
+                target_agent_id = %agent_id,
+                "stored data had different identifiers {:?}!={:?}", d.identifiers, self.identifiers
             ),
         }
 
@@ -82,7 +82,7 @@ where
             identifiers: self.identifiers.clone(),
         };
 
-        debug!("persisting instance id {}", new_data.instance_id);
+        debug!(target_agent_id = %agent_id, "persisting instance id {}", new_data.instance_id);
         storer.set(agent_id, &new_data)?;
 
         Ok(new_data.instance_id)


### PR DESCRIPTION
This PR improves some log messages. Specifically:
* Includes **spans** in the Agent Control's startup and event-processor.
* Removes redundant fields from some logs
* Includes missing fields in some other logs
* Add the error message in some errors as stated in the guidelines.

Some Examples:

<details>
<summary>Creating a sub-agent</summary>

Before: 

```
2025-09-03T15:34:29  INFO validate_apply_store_remote_config: Creating SubAgent, agent_id: nr-sleep-agent
2025-09-03T15:34:29 DEBUG validate_apply_store_remote_config:build_agent{id: nr-sleep-agent}: building subAgent
2025-09-03T15:34:29 DEBUG validate_apply_store_remote_config:build_agent{id: nr-sleep-agent}: retrieving instance id
2025-09-03T15:34:29 DEBUG validate_apply_store_remote_config:build_agent{id: nr-sleep-agent}: retrieving instance id
```

After:

```
2025-09-03T15:32:05  INFO process_fleet_event{id: "agent-control"}: Creating SubAgent, agent_id: nr-sleep-agent
2025-09-03T15:32:05 DEBUG process_fleet_event{id: "agent-control"}:build_agent{id: nr-sleep-agent}: building subAgent
2025-09-03T15:32:05 DEBUG process_fleet_event{id: "agent-control"}:build_agent{id: nr-sleep-agent}: retrieving instance id, target_agent_id: agent-control
2025-09-03T15:32:05 DEBUG process_fleet_event{id: "agent-control"}:build_agent{id: nr-sleep-agent}: retrieving instance id, target_agent_id: nr-sleep-agent

```
</details>

<details>
<summary>Starting the sub-agent</summary>

Before:

```
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: loading config
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: remote config not found, loading local
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: No configuration found for sub-agent
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: OpAMP get effective config, agent_id: nr-sleep-agent
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: loading config
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: remote config not found, loading local
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: OpAMP effective config loaded, agent_id: nr-sleep-agent
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: sending AgentToServer with fetched effective config, instance_uid: "01990FC938247683B46DE15A40B78988"
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: No supervisor found, but the runtime will continue to run waiting for remote configs
2025-09-03T15:34:29 DEBUG start_agent{id: nr-sleep-agent}: runtime started
```

After:

```
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: loading config
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: remote config not found, loading local
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: No configuration found for sub-agent
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: OpAMP get effective config
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: loading config
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: remote config not found, loading local
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: OpAMP effective config loaded
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: sending AgentToServer with fetched effective config, instance_uid: "01990FC707A27BC1A8BD9AE896EBD84B"
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: No supervisor found, but the runtime will continue to run waiting for remote configs
2025-09-03T15:32:06 DEBUG start_agent{id: nr-sleep-agent}: runtime started
```
</details>
