### PR TITLE
refactor: type-safe sub-agent ID

### DIFF
--- a/agent-control/src/agent_control/agent_id.rs
+++ b/agent-control/src/agent_control/agent_id.rs
@@ -15,52 +15,30 @@ const AGENT_ID_MAX_LENGTH: usize = 32;
 /// following [RFC 1035 Label names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names).
 pub enum AgentID {
     AgentControl,
-    SubAgent(String),
-}
-
-#[derive(Error, Debug)]
-pub enum AgentIDError {
-    #[error(
-        "AgentID must contain 32 characters at most, contain lowercase alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric"
-    )]
-    InvalidFormat,
-    #[error("AgentID '{0}' is reserved")]
-    Reserved(String),
+    SubAgent(SubAgentID),
 }
 
 impl AgentID {
     pub fn as_str(&self) -> &str {
         match self {
             Self::AgentControl => AGENT_CONTROL_ID,
-            Self::SubAgent(id) => id,
+            Self::SubAgent(id) => id.as_str(),
         }
     }
 
     /// Checks if a string reference has valid format to build an [AgentID].
     /// It follows [RFC 1035 Label names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names),
     /// and sets a shorter maximum length to avoid issues when the agent-id is used to compose names.
-    fn is_valid_format(s: &str) -> bool {
-        s.len() <= AGENT_ID_MAX_LENGTH
-            && s.starts_with(|c: char| c.is_ascii_alphabetic())
-            && s.ends_with(|c: char| c.is_ascii_alphanumeric())
-            && s.chars()
-                .all(|c| c.eq(&'-') || c.is_ascii_digit() || c.is_ascii_lowercase())
+    pub fn is_valid_format(s: &str) -> Result<(), AgentIDError> {
+        agent_id_not_reserved_and_valid(s)
     }
 }
 
 impl TryFrom<String> for AgentID {
     type Error = AgentIDError;
     fn try_from(input: String) -> Result<Self, Self::Error> {
-        if RESERVED_AGENT_IDS
-            .iter()
-            .any(|id| input.eq_ignore_ascii_case(id))
-        {
-            Err(AgentIDError::Reserved(input))
-        } else if AgentID::is_valid_format(&input) {
-            Ok(AgentID::SubAgent(input))
-        } else {
-            Err(AgentIDError::InvalidFormat)
-        }
+        agent_id_not_reserved_and_valid(&input)?;
+        Ok(Self::SubAgent(SubAgentID::new_unchecked(input)))
     }
 }
 
@@ -75,7 +53,7 @@ impl From<AgentID> for String {
     fn from(val: AgentID) -> Self {
         match val {
             AgentID::AgentControl => AGENT_CONTROL_ID.to_string(),
-            AgentID::SubAgent(id) => id,
+            AgentID::SubAgent(id) => String::from(id),
         }
     }
 }
@@ -91,6 +69,91 @@ impl AsRef<Path> for AgentID {
         // TODO: define how AgentID should be converted to a Path here.
         Path::new(self.as_str())
     }
+}
+
+/// Type with the same API as [`AgentID`], but used to represent only sub-agent IDs.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Hash, Eq)]
+pub struct SubAgentID(String);
+
+impl SubAgentID {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Useful when creating this from an [`AgentID`] input, as the validations were already made.
+    fn new_unchecked(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl TryFrom<String> for SubAgentID {
+    type Error = AgentIDError;
+    fn try_from(input: String) -> Result<Self, Self::Error> {
+        agent_id_not_reserved_and_valid(&input)?;
+        Ok(Self(input))
+    }
+}
+
+impl TryFrom<&str> for SubAgentID {
+    type Error = AgentIDError;
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        Self::try_from(input.to_string())
+    }
+}
+
+impl From<SubAgentID> for String {
+    fn from(val: SubAgentID) -> Self {
+        val.0
+    }
+}
+
+impl Display for SubAgentID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl AsRef<Path> for SubAgentID {
+    fn as_ref(&self) -> &Path {
+        // TODO: define how SubAgentID should be converted to a Path here.
+        Path::new(self.as_str())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum AgentIDError {
+    #[error(
+        "AgentID must contain 32 characters at most, contain lowercase alphanumeric characters or dashes only, start with alphabetic, and end with alphanumeric"
+    )]
+    InvalidFormat,
+    #[error("AgentID '{0}' is reserved")]
+    Reserved(String),
+}
+
+/// Checks if a string reference has valid format to build an [`AgentID`] or [`SubAgentID`].
+/// It follows [RFC 1035 Label names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names),
+/// and sets a shorter maximum length to avoid issues when the agent-id is used to compose names.
+fn agent_id_not_reserved_and_valid(s: impl AsRef<str>) -> Result<(), AgentIDError> {
+    let s = s.as_ref();
+    if RESERVED_AGENT_IDS
+        .iter()
+        .any(|id| s.eq_ignore_ascii_case(id))
+    {
+        Err(AgentIDError::Reserved(s.to_string()))
+    } else if agent_id_str_validation(s) {
+        Ok(())
+    } else {
+        Err(AgentIDError::InvalidFormat)
+    }
+}
+
+fn agent_id_str_validation(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref();
+    s.len() <= AGENT_ID_MAX_LENGTH
+        && s.starts_with(|c: char| c.is_ascii_alphabetic())
+        && s.ends_with(|c: char| c.is_ascii_alphanumeric())
+        && s.chars()
+            .all(|c| c.eq(&'-') || c.is_ascii_digit() || c.is_ascii_lowercase())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# What this PR does / why we need it

There are (or will be) functions around that are intended to operate with a SubAgentID and should not **ever** receive the AC AgentID or any other reserved AgentID that we add in the future. With this we can be a bit more sure that we are using the correct IDs.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
