### PR TITLE
chore: use new fleets for onhost and k8s e2e

### DIFF
--- a/test/e2e/ansible/sub_agent_remote_config.yaml
+++ b/test/e2e/ansible/sub_agent_remote_config.yaml
@@ -16,8 +16,8 @@
   gather_facts: yes
 
   vars:
-    # ac-e2e-onhost-1 fleet on canaries account
-    fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTVmZmIzLTdlODItN2U2Zi05MThlLTcwMjc4YjEzMjU4Zg
+    # ac-e2e-onhost-2 fleet on canaries account
+    fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyOGQyLTg3OTAtNzJlNC05ODgwLTJhYzE0NTRlZDUyZg
 
   tasks:
     - name: Install AC and assert a remote config is applied.

--- a/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
+++ b/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
@@ -9,8 +9,8 @@ agentControlDeployment:
     config:
       fleet_control:
         enabled: true
-        # Fleet with name 'ac-e2e-2'. The sub-agent reports data to the 'Agent Control Canaries' account.
-        fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTVjOGJkLTc3ZjYtN2Y2Ni05ZDQ4LTgxMzFlYTJlNWRkMw
+        # Fleet with name 'ac-e2e-3'. The sub-agent reports data to the 'Agent Control Canaries' account.
+        fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyODk4LTg0OWMtNzdmZC1iN2Y1LWMwYjNiNDRmNzlkNw
       log:
         level: debug
       agents:


### PR DESCRIPTION
This PR updates the fleet_id for k8s ohost e2e tests.