### PR TITLE
chore(unix): explicity targeting os family in code

### DIFF
--- a/agent-control/src/agent_control/pid_cache.rs
+++ b/agent-control/src/agent_control/pid_cache.rs
@@ -3,6 +3,7 @@ use fs::directory_manager::{DirectoryManagementError, DirectoryManager, Director
 use fs::file_reader::FileReader;
 use fs::writer_file::{FileWriter, WriteError};
 use std::fs::Permissions;
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/agent-control/src/opamp/instance_id/on_host/storer.rs
+++ b/agent-control/src/opamp/instance_id/on_host/storer.rs
@@ -9,6 +9,7 @@ use fs::utils::FsError;
 use fs::writer_file::{FileWriter, WriteError};
 use std::fs::Permissions;
 use std::io;
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use tracing::debug;
@@ -165,6 +166,7 @@ mod tests {
     use mockall::predicate;
     use std::fs::Permissions;
     use std::io;
+    #[cfg(target_family = "unix")]
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -27,6 +27,7 @@ use crate::utils::thread_context::{
 use crate::utils::threads::spawn_named_thread;
 use crate::version_checker::onhost::OnHostAgentVersionChecker;
 use crate::version_checker::spawn_version_checker;
+#[cfg(target_family = "unix")]
 use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 use std::process::ExitStatus;

--- a/fs/src/writer_file.rs
+++ b/fs/src/writer_file.rs
@@ -5,6 +5,7 @@ use std::fs::Permissions;
 use std::io::Write;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::OpenOptionsExt;
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::{fs, io};
@@ -123,13 +124,12 @@ pub mod mock {
 ////////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 pub mod tests {
+    use super::*;
     use std::fs;
     use std::fs::Permissions;
     #[cfg(target_family = "unix")]
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
-
-    use super::*;
 
     #[cfg(target_family = "unix")]
     #[test]


### PR DESCRIPTION
# What this PR does / why we need it
In some places we were missing `#[cfg(target_family = "unix")]`

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
