### PR TITLE
fix(test): fix ebpf chart version for k8s e2e

### DIFF
--- a/test/k8s-e2e/ebpf/ac-values-ebpf.yml
+++ b/test/k8s-e2e/ebpf/ac-values-ebpf.yml
@@ -15,4 +15,4 @@ agentControlDeployment:
       # Currently ebpf agent only supports amd64 nodes. Testing this on a local minikube arm64 will not work.
       nr-ebpf:
         # Testing the latest released version of the chart
-        chart_version: "*"
+        chart_version: "0.2.6" # TODO: move back to latest when issues are fixed


### PR DESCRIPTION
We are fixing the chart version for ebpf on k8s e2e temporaly as [0.2.7](https://github.com/newrelic/helm-charts/pull/1916/files#diff-0975451adc8a29486af27c23861cfdfbcf1417c54057cf40fe79c8c11a33549aR48) presents some issues preventing the installation in our testing clusters.