### PR TITLE
chore(testingEnv): saving resources

### DIFF
--- a/test/k8s-canaries/terraform/testing/main.tf
+++ b/test/k8s-canaries/terraform/testing/main.tf
@@ -2,7 +2,7 @@
 module "eks_cluster" {
   source               = "../modules/eks_cluster"
   canary_name          = "Agent_Control_Testing"
-  cluster_desired_size = 2
-  cluster_max_size     = 3
-  cluster_min_size     = 2
+  cluster_desired_size = 0
+  cluster_max_size     = 1
+  cluster_min_size     = 0
 }


### PR DESCRIPTION
# What this PR does / why we need it

The testing cluster is not used often, there is no reason to run 3 machine there continuously
@gsanchezgavier I believe you added than, can we just remove them and enable them back when needed (from the UI or via PR is pretty easy)

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
