### PR TITLE
chore: fix repository endpoint on pre-release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -106,7 +106,7 @@ jobs:
     needs: [ upload ]
     with:
       scenarios: '["migration.yaml", "remote_config.yaml", "ebpf_agent.yaml"]'
-      repository_endpoint: "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/preview"
+      repository_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
       package_version: ${{ github.event.inputs.tag || github.event.release.tag_name }}
     secrets:
       NR_SYSTEM_IDENTITY_CLIENT_ID: ${{ secrets.AC_PROD_E2E_NR_SYSTEM_IDENTITY_CLIENT_ID }}


### PR DESCRIPTION
Saw them failing on [last release ](https://github.com/newrelic/newrelic-agent-control/actions/runs/17671371577/job/50225587282). But a [manual](https://github.com/newrelic/newrelic-agent-control/actions/runs/17672312194) dispatch worked with the right endpoint 
