### PR TITLE
chore(renovate): use bump rangeStratage

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,7 +82,7 @@
       packageNameTemplate: 'newrelic/newrelic-opamp-rs',
     },
   ],
-  rangeStrategy: 'auto',
+  rangeStrategy: 'bump',
   prConcurrentLimit: 0,
   printConfig: true,
   prHourlyLimit: 0,


### PR DESCRIPTION
I've noticed that PRs such as #1652 were updating `Cargo.lock` only and not `Cargo.toml`.  If I got the info from [renovate docs](https://docs.renovatebot.com/configuration-options/#rangestrategy) right, the proposed configuration change should update it accordingly.

Additional context in [this discussion](https://github.com/renovatebot/renovate/discussions/28280)