### PR TITLE
feat(validator): first implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1801,7 +1801,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1820,7 +1820,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -2364,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
 dependencies = [
  "jsonptr",
  "serde",
@@ -3211,7 +3211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
 ]
 
 [[package]]
@@ -3343,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -3895,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4102,11 +4102,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "itoa",
  "ryu",
  "serde",
@@ -4556,40 +4556,35 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.0",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
 dependencies = [
- "indexmap 2.11.1",
- "toml_datetime 0.6.11",
+ "indexmap 2.11.3",
+ "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
 
@@ -5042,18 +5037,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -5410,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wrapper_with_default"

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -76,7 +76,6 @@ opentelemetry-appender-tracing = { version = "0.30.1", features = [
 ] }
 async-trait = "0.1.89"
 
-
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -44,8 +44,7 @@ where
         let id = executable.id.clone();
         if !ids.insert(id.clone()) {
             return Err(serde::de::Error::custom(format!(
-                "Duplicate executable ID found: {}",
-                id
+                "Duplicate executable ID found: {id}",
             )));
         }
     }

--- a/agent-control/src/opamp/remote_config/signature.rs
+++ b/agent-control/src/opamp/remote_config/signature.rs
@@ -94,21 +94,6 @@ impl TryFrom<&SigningAlgorithm> for &webpki::SignatureAlgorithm {
     }
 }
 
-// TODO: when removing support for certificate signature validation we can move this to a `From` implementation
-// and keep only the variant(s) supported here in the `SigningAlgorithm` definition. We would fail earlier if an
-// unsupported algorithm was set in signatures.
-impl TryFrom<&SigningAlgorithm> for &'static dyn ring::signature::VerificationAlgorithm {
-    type Error = SignatureError;
-    fn try_from(value: &SigningAlgorithm) -> Result<Self, Self::Error> {
-        match value {
-            SigningAlgorithm::ED25519 => Ok(&ring::signature::ED25519),
-            _ => Err(SignatureError::UnsupportedAlgorithm(
-                value.as_ref().to_string(),
-            )),
-        }
-    }
-}
-
 // parses the RSA algorithm string coming from the server into a supported signature algorithm
 // example: "RSA_PKCS1_2048_SHA256" -> RSA_PKCS1_2048_8192_SHA256
 // example: "RSA_PKCS1_4444_SHA256" -> RSA_PKCS1_2048_8192_SHA256

--- a/agent-control/src/opamp/remote_config/validators/signature.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature.rs
@@ -1,5 +1,8 @@
 mod certificate;
 mod certificate_fetcher;
+pub mod public_key;
+mod public_key_fetcher;
 pub mod validator;
 mod verifier;
+
 pub use certificate::public_key_fingerprint;

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
@@ -1,0 +1,108 @@
+use crate::opamp::remote_config::signature::SigningAlgorithm;
+use crate::opamp::remote_config::validators::signature::public_key_fetcher::{
+    KeyData, PubKeyError,
+};
+use crate::opamp::remote_config::validators::signature::verifier::Verifier;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ring::signature::{ED25519, UnparsedPublicKey};
+
+pub struct PublicKey {
+    pub public_key: UnparsedPublicKey<Vec<u8>>,
+    pub key_id: String,
+}
+
+impl PublicKey {
+    pub fn try_new(data: &KeyData) -> Result<Self, PubKeyError> {
+        if data.use_ != "sig" {
+            return Err(PubKeyError::ParsePubKey("Key use is not 'sig'".to_string()));
+        }
+        if data.kty != "OKP" {
+            return Err(PubKeyError::ParsePubKey(
+                "The only supported algorithm is Okp".to_string(),
+            ));
+        }
+
+        if data.crv != "Ed25519" {
+            return Err(PubKeyError::ParsePubKey(
+                "The only supported crv is Ed25519".to_string(),
+            ));
+        }
+
+        // JWKs make use of the base64url encoding as defined in RFC 4648 [RFC4648]. As allowed by Section 3.2 of the RFC,
+        // this specification mandates that base64url encoding when used with JWKs MUST NOT use padding.
+        let decoded_key = URL_SAFE_NO_PAD
+            .decode(data.x.clone())
+            .map_err(|e| PubKeyError::ParsePubKey(e.to_string()))?;
+
+        Ok(PublicKey {
+            key_id: data.kid.to_string(),
+            public_key: UnparsedPublicKey::new(&ED25519, decoded_key),
+        })
+    }
+}
+
+impl Verifier for PublicKey {
+    type Error = PubKeyError;
+
+    fn verify_signature(
+        &self,
+        signing_algorithm: &SigningAlgorithm,
+        msg: &[u8],
+        signature: &[u8],
+    ) -> Result<(), Self::Error> {
+        if signing_algorithm != &SigningAlgorithm::ED25519 {
+            return Err(PubKeyError::ValidatingSignature(
+                "The only supported algorithm is Ed25519".to_string(),
+            ));
+        }
+
+        self.public_key
+            .verify(msg, signature)
+            .map_err(|e| PubKeyError::ValidatingSignature(e.to_string()))
+    }
+
+    fn key_id(&self) -> &str {
+        self.key_id.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::opamp::remote_config::signature::SigningAlgorithm::ED25519;
+    use crate::opamp::remote_config::validators::signature::public_key::PublicKey;
+    use crate::opamp::remote_config::validators::signature::public_key_fetcher::PubKeyPayload;
+    use crate::opamp::remote_config::validators::signature::verifier::Verifier;
+    use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
+    use serde_json::json;
+    use x509_parser::nom::AsBytes;
+
+    #[test]
+    fn test_certificate_validation() {
+        let payload = serde_json::from_value::<PubKeyPayload>(json!({"keys":[{"kty":"OKP","alg":null,"use":"sig","kid":"869003544/1","n":null,"e":null,"x":"TpT81pA8z0vYiSK2LLhXzkWYJwrL-kxoNt93lzAb1_Q","y":null,"crv":"Ed25519"}]}))
+            .unwrap();
+
+        assert_eq!(payload.keys.len(), 1);
+        let first_key = payload.keys.first().unwrap();
+
+        let sign = BASE64_STANDARD.decode("6l3Jv23SUClwCRzWuFHkZn21laEJiNUu7GXwWK+kDaVCMenLJt9Us+r7LyIqEnfRq/Z5PPJoWaalta6mn/wrDw==").unwrap();
+
+        let a = PublicKey::try_new(first_key).unwrap();
+        a.verify_signature(
+            &ED25519,
+            "my-message-to-be-signed this can be anything".as_bytes(),
+            sign.as_bytes(),
+        )
+        .unwrap();
+
+        a.verify_signature(&ED25519, "wrong_message".as_bytes(), sign.as_bytes())
+            .unwrap_err();
+        a.verify_signature(
+            &ED25519,
+            "my-message-to-be-signed this can be anything".as_bytes(),
+            "wrong_signature".as_bytes(),
+        )
+        .unwrap_err();
+    }
+}

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
@@ -12,18 +12,22 @@ pub struct PublicKey {
     pub key_id: String,
 }
 
+const SUPPORTED_USE: &str = "sig";
+const SUPPORTED_KTY: &str = "OKP";
+const SUPPORTED_CRV: &str = "Ed25519";
+
 impl PublicKey {
     pub fn try_new(data: &KeyData) -> Result<Self, PubKeyError> {
-        if data.use_ != "sig" {
+        if data.use_ != SUPPORTED_USE {
             return Err(PubKeyError::ParsePubKey("Key use is not 'sig'".to_string()));
         }
-        if data.kty != "OKP" {
+        if data.kty != SUPPORTED_KTY {
             return Err(PubKeyError::ParsePubKey(
                 "The only supported algorithm is Okp".to_string(),
             ));
         }
 
-        if data.crv != "Ed25519" {
+        if data.crv != SUPPORTED_CRV {
             return Err(PubKeyError::ParsePubKey(
                 "The only supported crv is Ed25519".to_string(),
             ));
@@ -75,34 +79,57 @@ mod tests {
     use crate::opamp::remote_config::validators::signature::verifier::Verifier;
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
+    use ring::rand::SystemRandom;
+    use ring::signature::{Ed25519KeyPair, KeyPair, UnparsedPublicKey};
     use serde_json::json;
     use x509_parser::nom::AsBytes;
 
     #[test]
-    fn test_certificate_validation() {
+    fn test_real_example() {
+        // This payload was returned by a real staging endpoint
+        let signature = BASE64_STANDARD.decode("6l3Jv23SUClwCRzWuFHkZn21laEJiNUu7GXwWK+kDaVCMenLJt9Us+r7LyIqEnfRq/Z5PPJoWaalta6mn/wrDw==").unwrap();
+        let message = "my-message-to-be-signed this can be anything";
         let payload = serde_json::from_value::<PubKeyPayload>(json!({"keys":[{"kty":"OKP","alg":null,"use":"sig","kid":"869003544/1","n":null,"e":null,"x":"TpT81pA8z0vYiSK2LLhXzkWYJwrL-kxoNt93lzAb1_Q","y":null,"crv":"Ed25519"}]}))
             .unwrap();
 
         assert_eq!(payload.keys.len(), 1);
         let first_key = payload.keys.first().unwrap();
 
-        let sign = BASE64_STANDARD.decode("6l3Jv23SUClwCRzWuFHkZn21laEJiNUu7GXwWK+kDaVCMenLJt9Us+r7LyIqEnfRq/Z5PPJoWaalta6mn/wrDw==").unwrap();
+        let pub_key = PublicKey::try_new(first_key).unwrap();
+        pub_key
+            .verify_signature(&ED25519, message.as_bytes(), signature.as_bytes())
+            .unwrap();
+    }
 
-        let a = PublicKey::try_new(first_key).unwrap();
-        a.verify_signature(
-            &ED25519,
-            "my-message-to-be-signed this can be anything".as_bytes(),
-            sign.as_bytes(),
-        )
-        .unwrap();
+    #[test]
+    fn test_generating_signature() {
+        let pkcs8_bytes = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+        let key_pair = Ed25519KeyPair::from_pkcs8(pkcs8_bytes.as_ref()).unwrap();
 
-        a.verify_signature(&ED25519, "wrong_message".as_bytes(), sign.as_bytes())
+        const MESSAGE: &[u8] = b"hello, world";
+        let signature = key_pair.sign(MESSAGE);
+
+        let pub_key = PublicKey {
+            key_id: "my-signing-key-test/0".to_string(),
+            public_key: UnparsedPublicKey::new(
+                &ring::signature::ED25519,
+                key_pair.public_key().as_ref().to_vec(),
+            ),
+        };
+        pub_key
+            .verify_signature(&ED25519, MESSAGE, signature.as_ref().as_bytes())
+            .unwrap();
+
+        pub_key
+            .verify_signature(
+                &ED25519,
+                "wrong_message".as_bytes(),
+                signature.as_ref().as_bytes(),
+            )
             .unwrap_err();
-        a.verify_signature(
-            &ED25519,
-            "my-message-to-be-signed this can be anything".as_bytes(),
-            "wrong_signature".as_bytes(),
-        )
-        .unwrap_err();
+
+        pub_key
+            .verify_signature(&ED25519, MESSAGE, "wrong_signature".as_bytes())
+            .unwrap_err();
     }
 }

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PubKeyPayload {
+    pub keys: Vec<KeyData>,
+}
+
+#[derive(Error, Debug)]
+pub enum PubKeyError {
+    #[error("parsing PubKey: `{0}`")]
+    ParsePubKey(String),
+
+    #[error("validating signature: `{0}`")]
+    ValidatingSignature(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KeyData {
+    pub kty: String,
+    pub alg: Option<String>,
+    #[serde(rename = "use")]
+    pub use_: String,
+    pub kid: String,
+    pub x: String,
+    pub crv: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::opamp::remote_config::validators::signature::public_key_fetcher::PubKeyPayload;
+    use serde_json::json;
+
+    #[test]
+    fn test_certificate_key_id() {
+        let payload = serde_json::from_value::<PubKeyPayload>(json!({
+          "keys": [
+            {
+              "kty": "OKP",
+              "alg": null,
+              "use": "sig",
+              "kid": "my-signing-key-test/1",
+              "n": null,
+              "e": null,
+              "x": "l5FbLTPxv4TxhYTanUwdxFxoh_X2UYIbQYKyRr-0xnw",
+              "y": null,
+              "crv": "Ed25519"
+            },
+            {
+              "kty": "OKP",
+              "alg": null,
+              "use": "sig",
+              "kid": "my-signing-key-test/0",
+              "n": null,
+              "e": null,
+              "x": "rA2BPHW1vkVpdX6s8Bp9WKXUZJb7W1oYHJeDFfhxNVw",
+              "y": null,
+              "crv": "Ed25519"
+            }
+          ]
+        }))
+        .unwrap();
+
+        assert_eq!(payload.keys.len(), 2);
+        let first_key = payload.keys.first().unwrap();
+        assert_eq!(first_key.kid, "my-signing-key-test/1")
+    }
+}

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
@@ -8,10 +8,10 @@ pub struct PubKeyPayload {
 
 #[derive(Error, Debug)]
 pub enum PubKeyError {
-    #[error("parsing PubKey: `{0}`")]
+    #[error("parsing PubKey: {0}")]
     ParsePubKey(String),
 
-    #[error("validating signature: `{0}`")]
+    #[error("validating signature: {0}")]
     ValidatingSignature(String),
 }
 

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -19,7 +19,7 @@ use url::Url;
 
 const DEFAULT_CERTIFICATE_SERVER_URL: &str = "https://newrelic.com/";
 const DEFAULT_PUBLIC_KEY_SERVER_URL: &str =
-    "https://staging-publickeys.newrelic.com/r/blob-management/GLOBAL/AgentConfiguration";
+    "https://publickeys.newrelic.com/r/blob-management/GLOBAL/AgentConfiguration";
 const DEFAULT_HTTPS_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_SIGNATURE_VALIDATOR_ENABLED: bool = true;
 

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -19,7 +19,7 @@ use url::Url;
 
 const DEFAULT_CERTIFICATE_SERVER_URL: &str = "https://newrelic.com/";
 const DEFAULT_PUBLIC_KEY_SERVER_URL: &str =
-    "https://publickeys.newrelic.com/signing/blob-management/GLOBAL/AgentConfiguration";
+    "https://staging-publickeys.newrelic.com/r/blob-management/GLOBAL/AgentConfiguration";
 const DEFAULT_HTTPS_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_SIGNATURE_VALIDATOR_ENABLED: bool = true;
 
@@ -204,9 +204,6 @@ impl RemoteConfigValidator for CertificateSignatureValidator {
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::HashMap;
-    use std::str::FromStr;
-
     use super::*;
     use crate::agent_control::agent_id::AgentID;
     use crate::http::tls::install_rustls_default_crypto_provider;
@@ -223,6 +220,8 @@ pub mod tests {
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
     use rcgen::{CertificateParams, PKCS_ED25519};
+    use std::collections::HashMap;
+    use std::str::FromStr;
     use tempfile::TempDir;
 
     // A test signer util that generates a key pair and a self-signed certificate, and can be used to sign messages,
@@ -307,7 +306,6 @@ pub mod tests {
             .unwrap();
     }
     #[test]
-
     fn test_certificate_signature_content_missmatch() {
         install_rustls_default_crypto_provider();
         let test_signer = TestCertificateSigner::new();

--- a/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
@@ -1,9 +1,8 @@
+use crate::opamp::remote_config::signature::SigningAlgorithm;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use std::sync::Mutex;
 use thiserror::Error;
 use tracing::debug;
-
-use crate::opamp::remote_config::signature::SigningAlgorithm;
 
 /// Represents any struct that is able to verify signatures and it is identified by a key.
 pub trait Verifier {


### PR DESCRIPTION
# What this PR does / why we need it
This Pr introduces the first iteration of the verifier. 

This PR assumes:
> Consequently, an EdDSA public key is represented by a single parameter though it represents a point with two coordinates. This becomes clearly visible in the JWK format of an EdDSA public key, where the parameter x holds the encoded public key:
```
"kty": "OKP",
"kid": "-1909572257",
"alg":	"EdDSA",
"crv":	"Ed25519",
"x":	"XWxGtApfcqmKI7p0OKnF5JSEWMVoLsytFXLEP7xZ_l8"
```

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
