### PR TITLE
feat: update signature on OpAMP integration tests

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -77,7 +77,6 @@ pub fn build_signature_validator(
     let cert_verifier_store = VerifierStore::try_new(certificate_fetcher)
         .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
 
-<<<<<<< HEAD
     let maybe_pubkey_verifier_store =
         if let Some(public_key_server_url) = config.public_key_server_url {
             let http_config = HttpConfig::new(
@@ -100,23 +99,6 @@ pub fn build_signature_validator(
 
     Ok(SignatureValidator::Composite(
         CompositeSignatureValidator::new(cert_verifier_store, maybe_pubkey_verifier_store),
-=======
-    let http_config = HttpConfig::new(
-        DEFAULT_HTTPS_CLIENT_TIMEOUT,
-        DEFAULT_HTTPS_CLIENT_TIMEOUT,
-        proxy_config,
-    );
-    let http_client = HttpClient::new(http_config)
-        .map_err(|e| SignatureValidatorError::BuildingValidator(e.to_string()))?;
-
-    let public_key_fetcher = PublicKeyFetcher::new(http_client, config.public_key_server_url);
-
-    let pubkey_verifier_store = VerifierStore::try_new(public_key_fetcher)
-        .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
-
-    Ok(SignatureValidator::Composite(
-        CompositeSignatureValidator::new(cert_verifier_store, pubkey_verifier_store),
->>>>>>> 29d00c38 (feat: add public key signature validation)
     ))
 }
 
@@ -185,21 +167,13 @@ impl RemoteConfigValidator for SignatureValidator {
 /// can be removed.
 pub struct CompositeSignatureValidator {
     certificate_store: VerifierStore<Certificate, CertificateFetcher>,
-<<<<<<< HEAD
     public_key_store: Option<VerifierStore<PublicKey, PublicKeyFetcher>>,
-=======
-    public_key_store: VerifierStore<PublicKey, PublicKeyFetcher>,
->>>>>>> 29d00c38 (feat: add public key signature validation)
 }
 
 impl CompositeSignatureValidator {
     pub fn new(
         certificate_store: VerifierStore<Certificate, CertificateFetcher>,
-<<<<<<< HEAD
         public_key_store: Option<VerifierStore<PublicKey, PublicKeyFetcher>>,
-=======
-        public_key_store: VerifierStore<PublicKey, PublicKeyFetcher>,
->>>>>>> 29d00c38 (feat: add public key signature validation)
     ) -> Self {
         Self {
             certificate_store,
@@ -241,7 +215,6 @@ impl RemoteConfigValidator for CompositeSignatureValidator {
         // and falls back to cert based in case of failure.
         // This fallback mechanism makes errors misleading in case the platform is migrated and the validation fails
         // since the showed error is from the cert validation.
-<<<<<<< HEAD
         if let Some(public_key_store) = &self.public_key_store {
             match public_key_store.verify_signature(
                 signature.signature_algorithm(),
@@ -269,30 +242,6 @@ impl RemoteConfigValidator for CompositeSignatureValidator {
                 signature.signature(),
             )
             .map_err(|e| SignatureValidatorError::VerifySignature(e.to_string()))
-=======
-        if let Err(err) = self.public_key_store.verify_signature(
-            signature.signature_algorithm(),
-            signature.key_id(),
-            config_content,
-            signature.signature(),
-        ) {
-            debug!(
-                "Failed to verify signature using the Configurations Public Key: {}",
-                err
-            );
-
-            return self
-                .certificate_store
-                .verify_signature(
-                    signature.signature_algorithm(),
-                    signature.key_id(),
-                    config_content,
-                    signature.signature(),
-                )
-                .map_err(|e| SignatureValidatorError::VerifySignature(e.to_string()));
-        }
-        Ok(())
->>>>>>> 29d00c38 (feat: add public key signature validation)
     }
 }
 
@@ -592,7 +541,6 @@ pub mod tests {
                         test_signer.cert_pem_path(),
                     ))
                     .unwrap(),
-<<<<<<< HEAD
                     Some(
                         VerifierStore::try_new(PublicKeyFetcher::new(
                             HttpClient::new(HttpConfig::default()).unwrap(),
@@ -600,13 +548,6 @@ pub mod tests {
                         ))
                         .unwrap(),
                     ),
-=======
-                    VerifierStore::try_new(PublicKeyFetcher::new(
-                        HttpClient::new(HttpConfig::default()).unwrap(),
-                        pub_key_server.url,
-                    ))
-                    .unwrap(),
->>>>>>> 29d00c38 (feat: add public key signature validation)
                 );
 
                 let result =
@@ -683,7 +624,6 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
-<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -691,13 +631,6 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
-=======
-            VerifierStore::try_new(PublicKeyFetcher::new(
-                HttpClient::new(HttpConfig::default()).unwrap(),
-                pub_key_server.url,
-            ))
-            .unwrap(),
->>>>>>> 29d00c38 (feat: add public key signature validation)
         );
         let rc = OpampRemoteConfig::new(
             AgentID::AgentControl,
@@ -721,7 +654,6 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
-<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -729,13 +661,6 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
-=======
-            VerifierStore::try_new(PublicKeyFetcher::new(
-                HttpClient::new(HttpConfig::default()).unwrap(),
-                pub_key_server.url,
-            ))
-            .unwrap(),
->>>>>>> 29d00c38 (feat: add public key signature validation)
         );
 
         let config = "value";
@@ -768,7 +693,6 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
-<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -776,13 +700,6 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
-=======
-            VerifierStore::try_new(PublicKeyFetcher::new(
-                HttpClient::new(HttpConfig::default()).unwrap(),
-                pub_key_server.url.clone(),
-            ))
-            .unwrap(),
->>>>>>> 29d00c38 (feat: add public key signature validation)
         );
 
         let config = "value";

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -77,6 +77,7 @@ pub fn build_signature_validator(
     let cert_verifier_store = VerifierStore::try_new(certificate_fetcher)
         .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
 
+<<<<<<< HEAD
     let maybe_pubkey_verifier_store =
         if let Some(public_key_server_url) = config.public_key_server_url {
             let http_config = HttpConfig::new(
@@ -99,6 +100,23 @@ pub fn build_signature_validator(
 
     Ok(SignatureValidator::Composite(
         CompositeSignatureValidator::new(cert_verifier_store, maybe_pubkey_verifier_store),
+=======
+    let http_config = HttpConfig::new(
+        DEFAULT_HTTPS_CLIENT_TIMEOUT,
+        DEFAULT_HTTPS_CLIENT_TIMEOUT,
+        proxy_config,
+    );
+    let http_client = HttpClient::new(http_config)
+        .map_err(|e| SignatureValidatorError::BuildingValidator(e.to_string()))?;
+
+    let public_key_fetcher = PublicKeyFetcher::new(http_client, config.public_key_server_url);
+
+    let pubkey_verifier_store = VerifierStore::try_new(public_key_fetcher)
+        .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
+
+    Ok(SignatureValidator::Composite(
+        CompositeSignatureValidator::new(cert_verifier_store, pubkey_verifier_store),
+>>>>>>> 29d00c38 (feat: add public key signature validation)
     ))
 }
 
@@ -167,13 +185,21 @@ impl RemoteConfigValidator for SignatureValidator {
 /// can be removed.
 pub struct CompositeSignatureValidator {
     certificate_store: VerifierStore<Certificate, CertificateFetcher>,
+<<<<<<< HEAD
     public_key_store: Option<VerifierStore<PublicKey, PublicKeyFetcher>>,
+=======
+    public_key_store: VerifierStore<PublicKey, PublicKeyFetcher>,
+>>>>>>> 29d00c38 (feat: add public key signature validation)
 }
 
 impl CompositeSignatureValidator {
     pub fn new(
         certificate_store: VerifierStore<Certificate, CertificateFetcher>,
+<<<<<<< HEAD
         public_key_store: Option<VerifierStore<PublicKey, PublicKeyFetcher>>,
+=======
+        public_key_store: VerifierStore<PublicKey, PublicKeyFetcher>,
+>>>>>>> 29d00c38 (feat: add public key signature validation)
     ) -> Self {
         Self {
             certificate_store,
@@ -215,6 +241,7 @@ impl RemoteConfigValidator for CompositeSignatureValidator {
         // and falls back to cert based in case of failure.
         // This fallback mechanism makes errors misleading in case the platform is migrated and the validation fails
         // since the showed error is from the cert validation.
+<<<<<<< HEAD
         if let Some(public_key_store) = &self.public_key_store {
             match public_key_store.verify_signature(
                 signature.signature_algorithm(),
@@ -242,6 +269,30 @@ impl RemoteConfigValidator for CompositeSignatureValidator {
                 signature.signature(),
             )
             .map_err(|e| SignatureValidatorError::VerifySignature(e.to_string()))
+=======
+        if let Err(err) = self.public_key_store.verify_signature(
+            signature.signature_algorithm(),
+            signature.key_id(),
+            config_content,
+            signature.signature(),
+        ) {
+            debug!(
+                "Failed to verify signature using the Configurations Public Key: {}",
+                err
+            );
+
+            return self
+                .certificate_store
+                .verify_signature(
+                    signature.signature_algorithm(),
+                    signature.key_id(),
+                    config_content,
+                    signature.signature(),
+                )
+                .map_err(|e| SignatureValidatorError::VerifySignature(e.to_string()));
+        }
+        Ok(())
+>>>>>>> 29d00c38 (feat: add public key signature validation)
     }
 }
 
@@ -541,6 +592,7 @@ pub mod tests {
                         test_signer.cert_pem_path(),
                     ))
                     .unwrap(),
+<<<<<<< HEAD
                     Some(
                         VerifierStore::try_new(PublicKeyFetcher::new(
                             HttpClient::new(HttpConfig::default()).unwrap(),
@@ -548,6 +600,13 @@ pub mod tests {
                         ))
                         .unwrap(),
                     ),
+=======
+                    VerifierStore::try_new(PublicKeyFetcher::new(
+                        HttpClient::new(HttpConfig::default()).unwrap(),
+                        pub_key_server.url,
+                    ))
+                    .unwrap(),
+>>>>>>> 29d00c38 (feat: add public key signature validation)
                 );
 
                 let result =
@@ -624,6 +683,7 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
+<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -631,6 +691,13 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
+=======
+            VerifierStore::try_new(PublicKeyFetcher::new(
+                HttpClient::new(HttpConfig::default()).unwrap(),
+                pub_key_server.url,
+            ))
+            .unwrap(),
+>>>>>>> 29d00c38 (feat: add public key signature validation)
         );
         let rc = OpampRemoteConfig::new(
             AgentID::AgentControl,
@@ -654,6 +721,7 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
+<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -661,6 +729,13 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
+=======
+            VerifierStore::try_new(PublicKeyFetcher::new(
+                HttpClient::new(HttpConfig::default()).unwrap(),
+                pub_key_server.url,
+            ))
+            .unwrap(),
+>>>>>>> 29d00c38 (feat: add public key signature validation)
         );
 
         let config = "value";
@@ -693,6 +768,7 @@ pub mod tests {
         let signature_validator = CompositeSignatureValidator::new(
             VerifierStore::try_new(CertificateFetcher::PemFile(test_signer.cert_pem_path()))
                 .unwrap(),
+<<<<<<< HEAD
             Some(
                 VerifierStore::try_new(PublicKeyFetcher::new(
                     HttpClient::new(HttpConfig::default()).unwrap(),
@@ -700,6 +776,13 @@ pub mod tests {
                 ))
                 .unwrap(),
             ),
+=======
+            VerifierStore::try_new(PublicKeyFetcher::new(
+                HttpClient::new(HttpConfig::default()).unwrap(),
+                pub_key_server.url.clone(),
+            ))
+            .unwrap(),
+>>>>>>> 29d00c38 (feat: add public key signature validation)
         );
 
         let config = "value";

--- a/agent-control/tests/common/opamp.rs
+++ b/agent-control/tests/common/opamp.rs
@@ -275,7 +275,6 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
         (&server_state.key_pair, public_key_fingerprint(&public_key))
     };
 
-    // TODO: use the sing_with_cert bool and switch to sing with public-key when false
     let server_to_agent = build_response(identifier, remote_config, key_pair, key_id, flags);
     HttpResponse::Ok().body(server_to_agent)
 }

--- a/agent-control/tests/common/opamp.rs
+++ b/agent-control/tests/common/opamp.rs
@@ -1,7 +1,7 @@
 use super::runtime::tokio_runtime;
 use actix_web::{App, HttpResponse, HttpServer, web};
 use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
+use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD};
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 use newrelic_agent_control::opamp::remote_config::signature::{
     ED25519, SIGNATURE_CUSTOM_CAPABILITY, SIGNATURE_CUSTOM_MESSAGE_TYPE, SignatureFields,
@@ -15,6 +15,9 @@ use opamp_client::opamp::proto::{
 use opamp_client::operation::instance_uid::InstanceUid;
 use prost::Message;
 use rcgen::{CertificateParams, KeyPair, PKCS_ED25519, PublicKeyData};
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair as _};
+use serde_json::json;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -23,13 +26,17 @@ use tempfile::TempDir;
 use tokio::task::JoinHandle;
 
 const FAKE_SERVER_PATH: &str = "/opamp-fake-server";
+const JWKS_SERVER_PATH: &str = "/jwks";
 const CERT_FILE: &str = "server.crt";
 
 /// Represents the state of the FakeServer.
 struct ServerState {
     agent_state: HashMap<InstanceID, AgentState>,
-    // Server private key to sign the remote config
-    key_pair: KeyPair,
+    // Key pair to sign remote configuration
+    key_pair: Ed25519KeyPair,
+    // Use legacy system to sign remote configuration
+    use_legacy_signatures: bool,
+    cert_key_pair: KeyPair, // TODO: cleanup when no longer used
 }
 
 #[derive(Default)]
@@ -43,10 +50,12 @@ struct AgentState {
 }
 
 impl ServerState {
-    fn new(key_pair: KeyPair) -> Self {
+    fn new(cert_key_pair: KeyPair, use_legacy_signatures: bool) -> Self {
         Self {
             agent_state: HashMap::new(),
-            key_pair,
+            key_pair: generate_key_pair(),
+            use_legacy_signatures,
+            cert_key_pair,
         }
     }
 }
@@ -85,12 +94,21 @@ impl FakeServer {
         format!("http://localhost:{}{}", self.port, self.path)
     }
 
+    pub fn jwks_endpoint(&self) -> String {
+        format!("http://localhost:{}{}", self.port, JWKS_SERVER_PATH)
+    }
+
     /// Starts and returns new FakeServer in a random port.
     pub fn start_new() -> Self {
+        Self::start_new_with_legacy_signatures(false)
+    }
+
+    pub fn start_new_with_legacy_signatures(use_legacy_signatures: bool) -> Self {
         // While binding to port 0, the kernel gives you a free ephemeral port.
         let listener = net::TcpListener::bind("0.0.0.0:0").unwrap();
         let port = listener.local_addr().unwrap().port();
 
+        // Legacy certificate-based key pair
         let key_pair = KeyPair::generate_for(&PKCS_ED25519).unwrap();
         let cert = CertificateParams::new(vec!["localhost".to_string()])
             .unwrap()
@@ -100,7 +118,10 @@ impl FakeServer {
         let tmp_dir = tempfile::tempdir().unwrap();
         std::fs::write(tmp_dir.path().join(CERT_FILE), cert.pem()).unwrap();
 
-        let state = Arc::new(Mutex::new(ServerState::new(key_pair)));
+        let state = Arc::new(Mutex::new(ServerState::new(
+            key_pair,
+            use_legacy_signatures,
+        )));
 
         let handle = tokio_runtime().spawn(Self::run_http_server(listener, state.clone()));
 
@@ -118,6 +139,7 @@ impl FakeServer {
             App::new()
                 .app_data(web::Data::new(state.clone()))
                 .service(web::resource(FAKE_SERVER_PATH).to(opamp_handler))
+                .service(web::resource(JWKS_SERVER_PATH).to(jwks_handler))
         })
         .listen(listener)
         .unwrap_or_else(|err| panic!("Could not bind the HTTP server to the listener: {err}"))
@@ -193,61 +215,97 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
 
     let mut server_state = state.lock().unwrap();
 
-    let state = server_state
+    let agent_state = server_state
         .agent_state
         .entry(identifier.clone())
         .or_default();
 
     // Check sequence number
     let mut flags = ServerToAgentFlags::Unspecified as u64;
-    if message.sequence_num == (state.sequence_number + 1) {
+    if message.sequence_num == (agent_state.sequence_number + 1) {
         // case 1: first opamp connection start with seq number 1
         // case 2: Any valid new sequence number
-        state.sequence_number += 1;
+        agent_state.sequence_number += 1;
     } else {
         flags = ServerToAgentFlags::ReportFullState as u64;
         // upon report full state the opamp client will send a new AgentToServer
         // increasing the seq number so current should be the valid
-        state.sequence_number = message.sequence_num;
+        agent_state.sequence_number = message.sequence_num;
     }
 
     if let Some(health) = message.health {
-        state.health_status = Some(health);
+        agent_state.health_status = Some(health);
     }
 
     if let Some(attributes) = message.agent_description {
-        state.attributes = attributes;
+        agent_state.attributes = attributes;
     }
 
     if let Some(effective_cfg) = message.effective_config {
-        state.effective_config = effective_cfg;
+        agent_state.effective_config = effective_cfg;
     }
 
     // Process config status:
     // Stop sending the RemoteConfig once we got a RemoteConfigStatus response associated with the hash.
     // emulating what FC currently does.
     if let Some(cfg_status) = message.remote_config_status {
-        if state.remote_config.as_ref().is_some_and(|config_response| {
-            config_response.hash.encode_to_vec() == cfg_status.last_remote_config_hash
-        }) {
-            state.remote_config = None;
+        if agent_state
+            .remote_config
+            .as_ref()
+            .is_some_and(|config_response| {
+                config_response.hash.encode_to_vec() == cfg_status.last_remote_config_hash
+            })
+        {
+            agent_state.remote_config = None;
         }
-        state.config_status = cfg_status;
+        agent_state.config_status = cfg_status;
     }
 
-    let server_to_agent = build_response(
-        identifier,
-        state.remote_config.clone(),
-        &server_state.key_pair,
-        flags,
-    );
+    let remote_config = agent_state.remote_config.clone();
+
+    let _ = agent_state; // We need to get rid of the mutable reference before leveraging another immutable.
+
+    let (key_pair, key_id) = if server_state.use_legacy_signatures {
+        (
+            &Ed25519KeyPair::from_pkcs8(&server_state.cert_key_pair.serialize_der()).unwrap(),
+            public_key_fingerprint(&server_state.cert_key_pair.subject_public_key_info()),
+        )
+    } else {
+        let public_key = server_state.key_pair.public_key().as_ref().to_vec();
+        (&server_state.key_pair, public_key_fingerprint(&public_key))
+    };
+
+    // TODO: use the sing_with_cert bool and switch to sing with public-key when false
+    let server_to_agent = build_response(identifier, remote_config, key_pair, key_id, flags);
     HttpResponse::Ok().body(server_to_agent)
+}
+
+async fn jwks_handler(state: web::Data<Arc<Mutex<ServerState>>>, _req: web::Bytes) -> HttpResponse {
+    let server_state = state.lock().unwrap();
+    let public_key = server_state.key_pair.public_key().as_ref().to_vec();
+    let enc_public_key = BASE64_URL_SAFE_NO_PAD.encode(&public_key);
+    let payload = json!({
+        "keys": [
+            {
+                "kty": "OKP",
+                "alg": null,
+                "use": "sig",
+                "kid": public_key_fingerprint(&public_key),
+                "n": null,
+                "x": enc_public_key,
+                "y": null,
+                "crv": "Ed25519"
+            }
+        ]
+    });
+    HttpResponse::Ok().json(payload)
 }
 
 fn build_response(
     instance_id: InstanceID,
     agent_remote_config: Option<RemoteConfig>,
-    key_pair: &KeyPair,
+    key_pair: &Ed25519KeyPair,
+    key_id: String,
     flags: u64,
 ) -> Vec<u8> {
     let mut remote_config = None;
@@ -267,16 +325,14 @@ fn build_response(
             }),
         });
 
-        let key_pair_ring =
-            ring::signature::Ed25519KeyPair::from_pkcs8(&key_pair.serialize_der()).unwrap();
-        let signature = key_pair_ring.sign(config.raw_body.as_bytes());
+        let signature = key_pair.sign(config.raw_body.as_bytes());
 
         let custom_message_data = HashMap::from([(
             "fakeCRC".to_string(), //AC is not using the CRC.
             vec![SignatureFields {
                 signature: BASE64_STANDARD.encode(signature.as_ref()),
                 signing_algorithm: ED25519,
-                key_id: public_key_fingerprint(&key_pair.subject_public_key_info()),
+                key_id,
             }],
         )]);
 
@@ -294,4 +350,9 @@ fn build_response(
         ..Default::default()
     }
     .encode_to_vec()
+}
+
+fn generate_key_pair() -> Ed25519KeyPair {
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+    Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
 }

--- a/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_garbage_collector_triggers_on_ac_startup/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_garbage_collector_triggers_on_ac_startup/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_add_sub_agent/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_add_sub_agent/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_attributes_existing_agent_type/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_attributes_existing_agent_type/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_cr_subagent_installed_before_crd/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_cr_subagent_installed_before_crd/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_foo_cr_subagent/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_foo_cr_subagent/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_modify_subagent_config/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_modify_subagent_config/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_remove_subagent/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_remove_subagent/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_opamp_subagent_configuration_change_after_ac_restarts/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_opamp_subagent_configuration_change_after_ac_restarts/local-data-agent-control.template
@@ -3,6 +3,7 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 k8s:
   namespace: <ns>
   namespace_agents: <agents-ns>

--- a/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_remote_flux_update/local-data-agent-control.template
@@ -11,4 +11,5 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     certificate_pem_file_path: <cert-path>
+    public_key_server_url: <jwks-endpoint>
 agents: {}

--- a/agent-control/tests/k8s/data/k8s_signature_disabled/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_signature_disabled/local-data-agent-control.template
@@ -10,4 +10,3 @@ k8s:
 agents:
   hello-world:
     agent_type: "newrelic/com.newrelic.custom_agent:0.0.1"
-

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -93,6 +93,7 @@ fn k8s_remote_flux_update() {
         &namespace,
         Some(opamp_server.cert_file_path()),
         Some(&opamp_server.endpoint()),
+        Some(&opamp_server.jwks_endpoint()),
         vec![],
         tmp_dir.path(),
     );
@@ -177,6 +178,7 @@ fn k8s_remote_flux_update_with_wrong_version_causes_unhealthy() {
         &namespace,
         Some(opamp_server.cert_file_path()),
         Some(&opamp_server.endpoint()),
+        Some(&opamp_server.jwks_endpoint()),
         vec![],
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/ac_restarts.rs
+++ b/agent-control/tests/k8s/scenarios/ac_restarts.rs
@@ -42,6 +42,7 @@ fn k8s_opamp_subagent_configuration_change_after_ac_restarts() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         // This config is intended to be empty
         vec!["local-data-hello-world"],
         tmp_dir.path(),
@@ -99,6 +100,7 @@ valid: true
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         // This config is intended to be empty
         vec!["local-data-hello-world"],
         tmp_dir.path(),

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -44,6 +44,7 @@ fn k8s_test_attributes_from_existing_agent_type() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         vec!["local-data-hello-world"],
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/config_signature.rs
+++ b/agent-control/tests/k8s/scenarios/config_signature.rs
@@ -34,6 +34,7 @@ fn k8s_signature_disabled() {
         &namespace,
         None,
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         // This config is intended to be empty
         vec!["local-data-hello-world"],
         tmp_dir.path(),

--- a/agent-control/tests/k8s/scenarios/cr_based_agents.rs
+++ b/agent-control/tests/k8s/scenarios/cr_based_agents.rs
@@ -42,6 +42,7 @@ fn k8s_opamp_foo_cr_subagent() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         Vec::new(),
         tmp_dir.path(),
     );
@@ -123,6 +124,7 @@ fn k8s_opamp_cr_subagent_installed_before_crd() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         Vec::new(),
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/fail_remote_config.rs
+++ b/agent-control/tests/k8s/scenarios/fail_remote_config.rs
@@ -32,6 +32,7 @@ fn k8s_fail_remote_config_missing_required_values() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         vec!["local-data-fake-agent"],
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/garbage_collector.rs
+++ b/agent-control/tests/k8s/scenarios/garbage_collector.rs
@@ -45,6 +45,7 @@ fn k8s_garbage_collector_triggers_on_ac_startup() {
         &test_ns,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         // This config is intended to be empty
         vec![],
         tmp_dir.path(),

--- a/agent-control/tests/k8s/scenarios/no_opamp.rs
+++ b/agent-control/tests/k8s/scenarios/no_opamp.rs
@@ -26,6 +26,7 @@ fn k8s_sub_agent_started_with_no_opamp() {
         &namespace,
         None,
         None,
+        None,
         vec!["local-data-hello-world"],
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/opamp.rs
+++ b/agent-control/tests/k8s/scenarios/opamp.rs
@@ -44,6 +44,7 @@ fn k8s_opamp_remove_subagent() {
         &agents_ns,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         vec!["local-data-hello-world"],
         tmp_dir.path(),
     );
@@ -149,6 +150,7 @@ fn k8s_opamp_add_subagent() {
         &agents_ns,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         vec!["local-data-hello-world"],
         tmp_dir.path(),
     );
@@ -210,6 +212,7 @@ fn k8s_opamp_modify_subagent_config() {
         &namespace,
         Some(server.cert_file_path()),
         Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
         vec!["local-data-hello-world"],
         tmp_dir.path(),
     );

--- a/agent-control/tests/k8s/scenarios/secrets_providers.rs
+++ b/agent-control/tests/k8s/scenarios/secrets_providers.rs
@@ -31,6 +31,7 @@ fn k8s_template_secrets() {
         &namespace,
         None,
         None,
+        None,
         // This config is intended to be empty
         vec!["local-data-hello-world"],
         tmp_dir.path(),

--- a/agent-control/tests/k8s/tools/agent_control.rs
+++ b/agent-control/tests/k8s/tools/agent_control.rs
@@ -42,6 +42,7 @@ pub fn start_agent_control_with_testdata_config(
     agents_ns: &str,
     remote_config_sign_cert: Option<PathBuf>,
     opamp_endpoint: Option<&str>,
+    jwks_endpoint: Option<&str>,
     subagent_file_names: Vec<&str>,
     local_dir: &Path,
 ) -> StartedAgentControl {
@@ -59,6 +60,7 @@ pub fn start_agent_control_with_testdata_config(
         ac_ns,
         agents_ns,
         opamp_endpoint,
+        jwks_endpoint,
         remote_config_sign_cert,
         folder_name,
         local_dir,
@@ -129,11 +131,13 @@ pub async fn create_config_map(client: Client, ns: &str, name: &str, content: St
 
 /// Templates the namespace and the endpoint in `local-data-agent-control.template` file in the corresponding `folder_name`
 /// and returns the resulting file path.
+#[allow(clippy::too_many_arguments)]
 pub fn create_local_agent_control_config(
     client: Client,
     ac_ns: &str,
     agents_ns: &str,
     opamp_endpoint: Option<&str>,
+    jwk_endpoint: Option<&str>,
     remote_config_sign_cert: Option<PathBuf>,
     folder_name: &str,
     tmp_dir: &Path,
@@ -153,6 +157,9 @@ pub fn create_local_agent_control_config(
 
     if let Some(endpoint) = opamp_endpoint {
         content = content.replace("<opamp-endpoint>", endpoint);
+    }
+    if let Some(endpoint) = jwk_endpoint {
+        content = content.replace("<jwks-endpoint>", endpoint);
     }
     if let Some(cert_path) = remote_config_sign_cert {
         content = content.replace("<cert-path>", cert_path.to_str().unwrap());

--- a/agent-control/tests/on_host/proxy.rs
+++ b/agent-control/tests/on_host/proxy.rs
@@ -45,10 +45,15 @@ fn proxy_onhost_opamp_agent_control_local_effective_config() {
         .endpoint()
         .replace("localhost", host_gateway.as_str());
 
+    let jwks_endpoint = opamp_server
+        .jwks_endpoint()
+        .replace("localhost", host_gateway.as_str());
+
     let agents = "{}";
 
     create_agent_control_config_with_proxy(
         opamp_server_endpoint,
+        jwks_endpoint,
         agents.to_string(),
         local_dir.path().to_path_buf(),
         Some(format!(

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -46,6 +46,7 @@ fn test_attributes_from_non_existing_agent_type() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -131,6 +132,7 @@ agents:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -40,6 +40,7 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -118,6 +119,7 @@ fn onhost_opamp_sub_agent_with_no_local_config() {
     let agent_id = "nr-sleep-agent";
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -57,6 +57,7 @@ deployment:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.to_path_buf(),
         opamp_server.cert_file_path(),
@@ -149,6 +150,7 @@ deployment:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -50,6 +50,7 @@ file:
     create_sub_agent_values(sub_agent_id.to_string(), "".into(), local_dir.path().into());
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -156,6 +157,7 @@ http:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
@@ -40,6 +40,7 @@ fn onhost_opamp_sub_agent_invalid_remote_config() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -129,6 +130,7 @@ fn test_invalid_config_executable_less_supervisor() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -206,6 +208,7 @@ fn onhost_opamp_sub_agent_invalid_remote_config_rollback_previous_remote() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/multiple_executables.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_executables.rs
@@ -44,6 +44,7 @@ agents:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents,
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -102,6 +103,7 @@ agents:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents,
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -555,6 +555,8 @@ status_time_unix_nano: 1725444001
     });
 }
 
+/// Test that if AC signature validation fails using the public key obtained from the JWKS endpoint, it falls back
+/// to the previous certificate validation (useful while transitioning).
 #[test]
 fn test_opamp_with_legacy_signatures() {
     let mut opamp_server = FakeServer::start_new_with_legacy_signatures(true);

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -547,3 +547,15 @@ status_time_unix_nano: 1725444001
         check_latest_health_status_was_healthy(&opamp_server, &sub_agent_instance_id)
     });
 }
+
+#[test]
+fn test_opamp_with_legacy_signatures() {
+    // TODO: actual implementation setting up the endpoint but using `FakeServer::start_new_with_legacy_signatures(true)`
+    //let mut opamp_server = FakeServer::start_new();
+    //println!("{}", opamp_server.jwks_endpoint());
+    //let mut x = String::new();
+    //std::io::stdin().read_line(&mut x).unwrap();
+    //
+    // cargo test -- on_host::scenarios::opamp::test_jwks_endpoint --exact --no-capture
+    // and curl the shown endpoint
+}

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -36,6 +36,7 @@ fn onhost_opamp_agent_control_local_effective_config() {
     let agents = "{}";
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -83,6 +84,7 @@ fn onhost_opamp_agent_control_remote_effective_config() {
     let agents = "{}";
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -170,6 +172,7 @@ fn onhost_opamp_agent_control_remote_config_with_unknown_field() {
     let agents = "{}";
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -253,6 +256,7 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -325,6 +329,7 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -394,6 +399,7 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -479,6 +485,7 @@ agents:
 
     create_agent_control_config(
         opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
         agents.to_string(),
         local_dir.path().to_path_buf(),
         opamp_server.cert_file_path(),
@@ -550,12 +557,84 @@ status_time_unix_nano: 1725444001
 
 #[test]
 fn test_opamp_with_legacy_signatures() {
-    // TODO: actual implementation setting up the endpoint but using `FakeServer::start_new_with_legacy_signatures(true)`
-    //let mut opamp_server = FakeServer::start_new();
-    //println!("{}", opamp_server.jwks_endpoint());
-    //let mut x = String::new();
-    //std::io::stdin().read_line(&mut x).unwrap();
-    //
-    // cargo test -- on_host::scenarios::opamp::test_jwks_endpoint --exact --no-capture
-    // and curl the shown endpoint
+    let mut opamp_server = FakeServer::start_new_with_legacy_signatures(true);
+
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    let agents = "{}";
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        agents.to_string(),
+        local_dir.path().to_path_buf(),
+        opamp_server.cert_file_path(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+
+    // Add custom agent_type to registry
+    let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
+
+    let _agent_control =
+        start_agent_control_with_custom_config(base_paths.clone(), Environment::OnHost);
+
+    let agent_control_instance_id = get_instance_id(&AgentID::AgentControl, base_paths.clone());
+
+    let agents = format!(
+        r#"
+agents:
+  nr-sleep-agent:
+    agent_type: "{sleep_agent_type}"
+"#
+    );
+
+    // When a new config with an agent is received from OpAMP
+    opamp_server.set_config_response(agent_control_instance_id.clone(), agents.as_str());
+
+    // Then the config should be updated in the remote filesystem.
+    let expected_config = format!(
+        r#"agents:
+  nr-sleep-agent:
+    agent_type: "{sleep_agent_type}"
+"#
+    );
+    let expected_config_parsed =
+        serde_yaml::from_str::<YAMLConfig>(expected_config.as_str()).unwrap();
+
+    retry(60, Duration::from_secs(1), || {
+        let remote_file = remote_dir.path().join(AGENT_CONTROL_CONFIG_FILENAME);
+        let remote_config = std::fs::read_to_string(remote_file.as_path())
+            .unwrap_or("config: \nhash: a-hash\nstate: applying\n".to_string());
+        let content_parsed = serde_yaml::from_str::<RemoteConfig>(remote_config.as_str()).unwrap();
+        if content_parsed.config != expected_config_parsed {
+            return Err(format!(
+                "Agent Control config not as expected, Expected: {expected_config:?}, Found: {remote_config:?}",
+            )
+            .into());
+        }
+
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &agent_control_instance_id,
+            serde_yaml::to_string(&content_parsed.config).unwrap(),
+        )?;
+        check_latest_health_status_was_healthy(&opamp_server, &agent_control_instance_id)
+    });
+
+    let subagent_instance_id = get_instance_id(
+        &AgentID::try_from("nr-sleep-agent").unwrap(),
+        base_paths.clone(),
+    );
+
+    // The sub-agent waits for the remote config to be set, it cannot be empty since it would default to local
+    // which does not exist.
+    opamp_server.set_config_response(subagent_instance_id.clone(), "fake_variable: value");
+    retry(60, Duration::from_secs(1), || {
+        check_latest_health_status_was_healthy(&opamp_server, &subagent_instance_id)
+    });
 }

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -14,12 +14,14 @@ use newrelic_agent_control::values::file::ConfigRepositoryFile;
 /// and a list of agents on the specified local_dir.
 pub fn create_agent_control_config(
     opamp_server_endpoint: String,
+    jwks_endpoint: String,
     agents: String,
     local_dir: PathBuf,
     remote_config_sign_cert: PathBuf,
 ) {
     create_agent_control_config_with_proxy(
         opamp_server_endpoint,
+        jwks_endpoint,
         agents,
         local_dir,
         None,
@@ -30,6 +32,7 @@ pub fn create_agent_control_config(
 /// Extends [create_agent_control_config] with a proxy configuration parameter.
 pub fn create_agent_control_config_with_proxy(
     opamp_server_endpoint: String,
+    jwks_endpoint: String,
     agents: String,
     local_dir: PathBuf,
     proxy: Option<String>,
@@ -45,12 +48,14 @@ host_id: integration-test
 fleet_control:
   endpoint: {}
   poll_interval: 5s
-  signature_validation: 
+  signature_validation:
+    public_key_server_url: {}
     certificate_pem_file_path: {}
 agents: {}
 {}
 "#,
         opamp_server_endpoint,
+        jwks_endpoint,
         remote_config_sign_cert.to_str().unwrap(),
         agents,
         proxy_config,


### PR DESCRIPTION
This PR extends the OpAMP's mock server in the integration tests to sign the remote configuration with a self-generated private key and expose the public key using JWKS. It also updates on-host and k8s integration tests to leverage this new feature.

Additionally, it includes an additional integration test to check that 'falling back to certificate validation' works as expected. In case that the configured JWKS serves a public key but the signatures are still signed using the legacy system.