### PR TITLE
feat: change remote configmap name from fleet to remote

### DIFF
--- a/agent-control/src/agent_control/config_repository/store.rs
+++ b/agent-control/src/agent_control/config_repository/store.rs
@@ -131,7 +131,7 @@ where
     }
 }
 
-/// Removes an configuration from local values that is only supported on remote configs.
+/// Removes a configuration from local values that is only supported on remote configs.
 fn sanitize_local_dynamic_config(
     dynamic_config: AgentControlDynamicConfig,
 ) -> AgentControlDynamicConfig {

--- a/agent-control/src/k8s/store.rs
+++ b/agent-control/src/k8s/store.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 pub const CM_NAME_LOCAL_DATA_PREFIX: &str = "local-data-";
 /// The cm having CM_NAME_OPAMP_DATA_PREFIX as prefix stores all the data related with opamp:
 /// Instance IDs, hashes, and remote configs. The Sa reads and writes those CMs.
-pub const CM_NAME_OPAMP_DATA_PREFIX: &str = "fleet-data-";
+pub const CM_NAME_OPAMP_DATA_PREFIX: &str = "remote-data-";
 
 /// The key used to identify the data in the Store.
 pub type StoreKey = str;

--- a/agent-control/tests/k8s/scenarios/cr_based_agents.rs
+++ b/agent-control/tests/k8s/scenarios/cr_based_agents.rs
@@ -148,7 +148,7 @@ agents:
     retry(120, Duration::from_secs(1), || {
         block_on(check_config_map_exist(
             k8s.client.clone(),
-            "fleet-data-bar-agent",
+            "remote-data-bar-agent",
             &namespace,
         ))?;
         Ok(())

--- a/agent-control/tests/k8s/tools/agent_control.rs
+++ b/agent-control/tests/k8s/tools/agent_control.rs
@@ -184,7 +184,7 @@ pub fn wait_until_agent_control_with_opamp_is_started(k8s_client: Client, namesp
     retry(30, Duration::from_secs(1), || {
         block_on(check_config_map_exist(
             k8s_client.clone(),
-            "fleet-data-agent-control",
+            "remote-data-agent-control",
             namespace,
         ))
     });


### PR DESCRIPTION
# What this PR does / why we need it

Rename remote configmaps from fleet to remote to be align with onhost naming

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
