### PR TITLE
feat: remove duplicate logs

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
@@ -95,7 +95,6 @@ where
                 .map_err(|err| VerifierStoreError::Fetch(err.to_string()))?;
 
             if !verifier.key_id().eq(key_id) {
-                error!("keyId '{key_id}' doesn't match with newest key available");
                 return Err(VerifierStoreError::KeyMismatch {
                     signature_key_id: key_id.to_string(),
                     certificate_key_id: verifier.key_id().to_string(),

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -424,11 +424,7 @@ where
                 // If parsing was successful, call the function with Some(remote_config)
                 self.create_supervisor_from_remote_config(&remote_config)
             }
-            Err(error) => {
-                warn!("Failed to parse remote configuration: {}", error);
-
-                Err(error.into())
-            }
+            Err(error) => Err(error.into()),
         };
 
         // Now, we should have either a Supervisor or an error to handle later,


### PR DESCRIPTION
- Remove duplicated log entries
before:
```shell
INFO process_fleet_event{id: nr-infra}: Applying remote config, hash: "31decd7fb2b0ead41f02aae1bf7effee93d18d79ce31e02e058c4a5ff7c485ee"
2025-09-19T12:11:41 ERROR process_fleet_event{id: nr-infra}: keyId 'AgentConfiguration/0' doesn't match with newest key available
2025-09-19T12:11:41  WARN process_fleet_event{id: nr-infra}: Failed to parse remote configuration: remote configuration with validation errors: failed to verify signature: `signature key ID (AgentConfiguration/0) does not match the latest available key ID (5f03b81912560bc96e4727ce037097179e801381ac247c70b8031f7fdd32abb3)`
2025-09-19T12:11:41  WARN process_fleet_event{id: nr-infra}: Failed to build supervisor: could not parse the remote config: `remote configuration with validation errors: failed to verify signature: `signature key ID (AgentConfiguration/0) does not match the latest available key ID (5f03b81912560bc96e4727ce037097179e801381ac247c70b8031f7fdd32abb3)``
```
after:
```shell
2025-09-19T12:18:59  INFO process_fleet_event{id: nr-infra}: Applying remote config, hash: "31decd7fb2b0ead41f02aae1bf7effee93d18d79ce31e02e058c4a5ff7c485ee"
2025-09-19T12:18:59  WARN process_fleet_event{id: nr-infra}: Failed to build supervisor: could not parse the remote config: `remote configuration with validation errors: failed to verify signature: `signature key ID (AgentConfiguration/0) does not match the latest available key ID (5f03b81912560bc96e4727ce037097179e801381ac247c70b8031f7fdd32abb3)``
```