### PR TITLE
feat: support initial-delay for k8s version checker [NR-465311]

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -17,7 +17,9 @@ use crate::agent_control::version_updater::k8s::K8sACUpdater;
 use crate::agent_type::render::persister::config_persister_file::ConfigurationPersisterFile;
 use crate::agent_type::render::renderer::TemplateRenderer;
 use crate::agent_type::variable::Variable;
-use crate::agent_type::version_config::VersionCheckerInterval;
+use crate::agent_type::version_config::{
+    AGENT_CONTROL_VERSION_CHECKER_INITIAL_DELAY, VersionCheckerInterval,
+};
 use crate::event::AgentControlInternalEvent;
 use crate::event::channel::{EventPublisher, pub_sub};
 #[cfg_attr(test, mockall_double::double)]
@@ -279,6 +281,7 @@ fn start_cd_version_checker(
         // Same as passing "|x| AgentControlInternalEvent::AgentControlCdVersionUpdated(x)"
         AgentControlInternalEvent::AgentControlCdVersionUpdated,
         VersionCheckerInterval::default(),
+        AGENT_CONTROL_VERSION_CHECKER_INITIAL_DELAY,
     )
 }
 

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -351,7 +351,7 @@ Any agent deployed in Kubernetes can be composed of several components and those
 
 That's why the Agent Control leverages the Kubernetes Rust SDK to retrieve the health of standard replication controllers (Deployment, DaemonSet, StatefulSet) of the Agent at a configurable interval.
 
-That's why the health section for a Kubernetes deployment is as simple as this:
+As a result, the health section for a Kubernetes deployment is as simple as this:
 
 ```yaml
 deployment:
@@ -363,6 +363,19 @@ deployment:
 ```
 
 Users can currently only configure the interval of those periodic health check, within the Agent Type. However, in the future, we could offer the end users the possibility of selecting what information should be retrieved.
+
+#### Kubernetes Version
+
+Version is checked periodically by querying the corresponding k8s object in the cluster. The Agent Type allows setting up the version
+check interval and initial delay:
+
+```yaml
+deployment:
+  k8s:
+    version:
+      interval: 120s # Defaults to 60s..
+      initial_delay: 10s # Defaults to 30s.
+```
 
 ## Development
 

--- a/agent-control/src/agent_type/version_config.rs
+++ b/agent-control/src/agent_type/version_config.rs
@@ -4,7 +4,14 @@ use std::time::Duration;
 use wrapper_with_default::WrapperWithDefault;
 
 const DEFAULT_VERSION_CHECKER_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_VERSION_CHECKER_INITIAL_DELAY: Duration = Duration::from_secs(30);
+pub const AGENT_CONTROL_VERSION_CHECKER_INITIAL_DELAY: VersionCheckerInitialDelay =
+    VersionCheckerInitialDelay(Duration::ZERO); // The Agent Control HelmRelease is supposed to exists when it starts.
 
 #[derive(Debug, Clone, Deserialize, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_VERSION_CHECKER_INTERVAL)]
 pub struct VersionCheckerInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_VERSION_CHECKER_INITIAL_DELAY)]
+pub struct VersionCheckerInitialDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -307,6 +307,7 @@ pub(crate) mod tests {
                         .into_iter()
                         .collect(),
                     health: Some(Default::default()),
+                    version: Default::default(),
                 }),
             },
         }

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -359,6 +359,7 @@ pub mod tests {
         K8s {
             objects,
             health: None,
+            version: Default::default(),
         }
     }
 

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -1,7 +1,6 @@
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY;
 use crate::agent_type::runtime_config::k8s::{K8s, K8sObject};
-use crate::agent_type::version_config::VersionCheckerInterval;
 use crate::event::SubAgentInternalEvent;
 use crate::event::cancellation::CancellationMessage;
 use crate::event::channel::{EventConsumer, EventPublisher};
@@ -204,7 +203,8 @@ impl NotStartedSupervisorK8s {
             k8s_version_checker,
             sub_agent_internal_publisher,
             SubAgentInternalEvent::AgentVersionInfo,
-            VersionCheckerInterval::default(),
+            self.k8s_config.version.interval,
+            self.k8s_config.version.initial_delay,
         ))
     }
 
@@ -333,6 +333,7 @@ pub mod tests {
                     ("mock_cr2".to_string(), k8s_object()),
                 ]),
                 health: None,
+                version: Default::default(),
             },
         );
 
@@ -381,9 +382,8 @@ pub mod tests {
         let (sub_agent_internal_publisher, _) = pub_sub();
         let config = K8s {
             objects: HashMap::from([("obj".to_string(), k8s_object())]),
-            health: Some(K8sHealthConfig {
-                ..Default::default()
-            }),
+            health: Some(Default::default()),
+            version: Default::default(),
         };
 
         let supervisor = not_started_supervisor(config, None);
@@ -408,6 +408,7 @@ pub mod tests {
         let config = K8s {
             objects: HashMap::from([("obj".to_string(), k8s_object())]),
             health: Some(Default::default()),
+            version: Default::default(),
         };
 
         let not_started = not_started_supervisor(config, None);
@@ -424,6 +425,7 @@ pub mod tests {
         let config = K8s {
             objects: HashMap::from([("obj".to_string(), k8s_object())]),
             health: None,
+            version: Default::default(),
         };
 
         let not_started = not_started_supervisor(config, None);

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -135,6 +135,7 @@ fn k8s_garbage_collector_cleans_removed_agent_resources() {
                 ),
             ]),
             health: None,
+            version: Default::default(),
         },
     );
 


### PR DESCRIPTION
This PR allows setting up the `interval` and `initial_delay` for the version checks in K8s in the AgentTypes. Such configuration is completely optional and sets the defaults as follows:

```yaml
deployment:
  k8s:
    version:
      interval: 120s # Defaults to 60s..
      initial_delay: 10s # Defaults to 30s.
```