### PR TITLE
fix: align remote config digest signature

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
@@ -68,10 +68,12 @@ impl Verifier for PublicKey {
                 "The only supported algorithm is Ed25519".to_string(),
             ));
         }
-
-        self.public_key.verify(msg, signature).map_err(|_| {
-            PubKeyError::ValidatingSignature("signature verification failed".to_string())
-        })
+        let msg = ring::digest::digest(&ring::digest::SHA256, msg);
+        self.public_key
+            .verify(msg.as_ref(), signature)
+            .map_err(|_| {
+                PubKeyError::ValidatingSignature("signature verification failed".to_string())
+            })
     }
 
     fn key_id(&self) -> &str {

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
@@ -1,8 +1,8 @@
 use crate::opamp::remote_config::signature::SigningAlgorithm;
 use crate::opamp::remote_config::validators::signature::public_key_fetcher::KeyData;
 use crate::opamp::remote_config::validators::signature::verifier::Verifier;
-use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::{Engine, prelude::BASE64_STANDARD};
 use ring::signature::{ED25519, UnparsedPublicKey};
 use thiserror::Error;
 
@@ -68,7 +68,14 @@ impl Verifier for PublicKey {
                 "The only supported algorithm is Ed25519".to_string(),
             ));
         }
+
+        // Actual implementation from FC side signs the Base64 representation of the SHA256 digest
+        // of the message (i.e. the remote configs). Hence, to verify the signature, we need to
+        // compute the SHA256 digest of the message, then Base64 encode it, and finally verify
+        // the signature against that.
         let msg = ring::digest::digest(&ring::digest::SHA256, msg);
+        let msg = BASE64_STANDARD.encode(msg);
+
         self.public_key
             .verify(msg.as_ref(), signature)
             .map_err(|_| {

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key_fetcher.rs
@@ -131,7 +131,13 @@ pub mod tests {
             }
         }
         pub fn sign(&self, msg: &[u8]) -> String {
-            BASE64_STANDARD.encode(self.key_pair.sign(msg).as_ref())
+            // Actual implementation from FC side signs the Base64 representation of the SHA256 digest
+            // of the message (i.e. the remote configs). Hence, to verify the signature, we need to
+            // compute the SHA256 digest of the message, then Base64 encode it, and finally verify
+            // the signature against that.
+            let digest = ring::digest::digest(&ring::digest::SHA256, msg);
+            let msg = BASE64_STANDARD.encode(digest);
+            BASE64_STANDARD.encode(self.key_pair.sign(msg.as_bytes()).as_ref())
         }
     }
 

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -677,8 +677,14 @@ pub mod tests {
         );
 
         let config = "value";
+        // Actual implementation from FC side signs the Base64 representation of the SHA256 digest
+        // of the message (i.e. the remote configs). Hence, to verify the signature, we need to
+        // compute the SHA256 digest of the message, then Base64 encode it, and finally verify
+        // the signature against that.
+        let digest = ring::digest::digest(&ring::digest::SHA256, config.as_bytes());
+        let msg = BASE64_STANDARD.encode(digest);
 
-        let encoded_signature = test_signer.encoded_signature(config);
+        let encoded_signature = test_signer.encoded_signature(&msg);
         let remote_config = OpampRemoteConfig::new(
             AgentID::AgentControl,
             Hash::from("test"),

--- a/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/verifier.rs
@@ -94,7 +94,7 @@ where
                 .fetch()
                 .map_err(|err| VerifierStoreError::Fetch(err.to_string()))?;
 
-            if !verifier.key_id().eq(key_id) {
+            if !verifier.key_id().eq_ignore_ascii_case(key_id) {
                 return Err(VerifierStoreError::KeyMismatch {
                     signature_key_id: key_id.to_string(),
                     certificate_key_id: verifier.key_id().to_string(),

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -124,7 +124,7 @@ impl CustomAgentType {
 
     pub fn with_version(self, version: Option<&str>) -> Self {
         Self {
-            version: version.map(|v| (serde_yaml::from_str(v).unwrap())),
+            version: version.map(|v| serde_yaml::from_str(v).unwrap()),
             ..self
         }
     }

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -117,7 +117,7 @@ impl CustomAgentType {
 
     pub fn with_health(self, health: Option<&str>) -> Self {
         Self {
-            health: health.map(|h| (serde_yaml::from_str(h).unwrap())),
+            health: health.map(|h| serde_yaml::from_str(h).unwrap()),
             ..self
         }
     }


### PR DESCRIPTION
# What this PR does / why we need it

Performs signing of remote configs the same way FC does. From the remote config as input:
1. Compute Sha256 digest
2. Encode to base 64
3. Sign that

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
