### PR TITLE
fix: add more logs to http client

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/certificate_fetcher.rs
@@ -22,8 +22,8 @@ pub enum CertificateFetcher {
 }
 
 impl VerifierFetcher for CertificateFetcher {
-    type Verifier = Certificate;
     type Error = CertificateFetcherError;
+    type Verifier = Certificate;
 
     fn fetch(&self) -> Result<Self::Verifier, Self::Error> {
         let cert = match self {

--- a/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/public_key.rs
@@ -17,7 +17,7 @@ pub enum PubKeyError {
     #[error("validating signature: {0}")]
     ValidatingSignature(String),
 }
-
+#[derive(Debug)]
 pub struct PublicKey {
     pub public_key: UnparsedPublicKey<Vec<u8>>,
     pub key_id: String,


### PR DESCRIPTION
# What this PR does / why we need it

We need more info the http logs for oauth opamp etc eveything comming from the single http client.

## Which issue this PR fixes

Fix the errors coming from common http client to be more clear whats happens with connections.

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
