### PR TITLE
test: add default image tags to k8s e2e

### DIFF
--- a/test/k8s-e2e/apm/ac-values-apm.yml
+++ b/test/k8s-e2e/apm/ac-values-apm.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     config:
       fleet_control:

--- a/test/k8s-e2e/collector/ac-values-collector.yml
+++ b/test/k8s-e2e/collector/ac-values-collector.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     config:
       log:

--- a/test/k8s-e2e/custom-repo/ac-values-custom-repo.yml
+++ b/test/k8s-e2e/custom-repo/ac-values-custom-repo.yml
@@ -1,6 +1,10 @@
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   repositorySecretReferenceName: chartmuseum-auth
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     verboseLog: true
     config:

--- a/test/k8s-e2e/dynamic/ac-values-dynamic.yml
+++ b/test/k8s-e2e/dynamic/ac-values-dynamic.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     verboseLog: true # It is propagated to some agents (same as licenseKey and cluster)
     config:

--- a/test/k8s-e2e/ebpf/ac-values-ebpf.yml
+++ b/test/k8s-e2e/ebpf/ac-values-ebpf.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     config:
       log:

--- a/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
+++ b/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     systemIdentity:
       create: false

--- a/test/k8s-e2e/infra/ac-values-infra.yml
+++ b/test/k8s-e2e/infra/ac-values-infra.yml
@@ -1,6 +1,10 @@
 # Cluster and License info is set with "--set" in the e2e-spec file
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     verboseLog: true # It is propagated to some agents (same as licenseKey and cluster)
     config:

--- a/test/k8s-e2e/proxy/ac-values-proxy.yml
+++ b/test/k8s-e2e/proxy/ac-values-proxy.yml
@@ -43,8 +43,12 @@ agentControlCd:
               claimName: mitm-ca-pvc
 
 
+toolkitImage:
+  tag: failIfNotReplaced
 agentControlDeployment:
   chartValues:
+    image:
+      tag: failIfNotReplaced
     subAgentsNamespace: "newrelic-agents"
     # Mount a CA certificate bundle to the source-controller Trust root store.
     # It should contain the proxy CA certificates on it.


### PR DESCRIPTION
- Sets non-existing tags on e2e test yaml values. In case Tilt is not able to inject the generated image the tests will fail.