### PR TITLE
feat: report cd chart version in effective config

### DIFF
--- a/agent-control/src/opamp/effective_config/agent_control.rs
+++ b/agent-control/src/opamp/effective_config/agent_control.rs
@@ -48,6 +48,8 @@ struct AgentControlEffectiveConfig {
     agents: Option<serde_yaml::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     chart_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cd_chart_version: Option<String>,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
# What this PR does / why we need it

Adds the cd chart version in the effective config.

Original behaviour
<img width="684" height="214" alt="image" src="https://github.com/user-attachments/assets/da0a23cb-f33d-4d39-972b-7194fc7c5ec1" />

Resulting behaviour
<img width="528" height="209" alt="image" src="https://github.com/user-attachments/assets/3a5b6ff4-1dd3-4587-bbb2-9e55456a0a2b" />


## Which issue this PR fixes

- fixes #NR-467643

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
