### PR TITLE
feat: improve wrong version error message

### DIFF
--- a/agent-control/src/cli/install.rs
+++ b/agent-control/src/cli/install.rs
@@ -126,11 +126,11 @@ pub fn apply_resources(
             // Specifying an invalid version of `agent-control-cd` throws an error showing that something is wrong with the api.
             // It can be hard to understand without prior knowledge, thus we simplify the error message for that specific variant.
             K8sError::MissingAPIResource(_) => CliError::ApplyResource(format!(
-                "could not get helmRelease with name {release_name} and version {}",
+                "could not get HelmRelease with name {release_name} and version {}",
                 install_data.chart_version
             )),
             _ => CliError::ApplyResource(format!(
-                "could not get helmRelease with name {release_name}: {err}",
+                "could not get HelmRelease with name {release_name}: {err}",
             )),
         })?;
 


### PR DESCRIPTION
# What this PR does / why we need it

Improves the error message when we use an invalid version for `agent-control-cd` a bit.

Original error:
```
│ {"timestamp":"2025-09-29T15:36:00","level":"ERROR","message":"Operation failed: failed to apply resource: could not get helmRelease with name agent-control-deployment: api resource kind n │
│ ot present in the cluster: apiVersion: helm.toolkit.fluxcd.io/v2 kind: HelmRelease"}
```

New error:
```
{"timestamp":"2025-09-30T07:55:18","level":"ERROR","message":"Operation failed: failed to apply resource: could not get helmRelease with name agent-control-cd and version 10.0.0"}
```

## Which issue this PR fixes

- related to #NR-464888

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
