### PR TITLE
feat: cleanup err messages [NR-369541]

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -67,23 +67,23 @@ pub struct AgentControlConfig {
 
 #[derive(Error, Debug)]
 pub enum AgentControlConfigError {
-    #[error("deleting agent control config: `{0}`")]
+    #[error("deleting agent control config: {0}")]
     Delete(String),
-    #[error("loading agent control config: `{0}`")]
+    #[error("loading agent control config: {0}")]
     Load(String),
-    #[error("storing agent control config: `{0}`")]
+    #[error("storing agent control config: {0}")]
     Store(String),
-    #[error("updating agent control config: `{0}`")]
+    #[error("updating agent control config: {0}")]
     Update(String),
-    #[error("building source to parse environment variables: `{0}`")]
+    #[error("building source to parse environment variables: {0}")]
     ConfigError(#[from] config::ConfigError),
-    #[error("sub agent configuration `{0}` not found")]
+    #[error("sub agent configuration '{0}' not found")]
     SubAgentNotFound(String),
-    #[error("configuration is not valid YAML: `{0}`")]
+    #[error("configuration is not valid YAML: {0}")]
     InvalidYamlConfiguration(#[from] serde_yaml::Error),
-    #[error("remote config error: `{0}`")]
+    #[error("remote config error: {0}")]
     RemoteConfigError(#[from] OpampRemoteConfigError),
-    #[error("remote config error: `{0}`")]
+    #[error("remote config error: {0}")]
     IOError(#[from] std::io::Error),
 }
 

--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DynamicConfigValidatorError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     AgentRepositoryError(#[from] AgentRepositoryError),
 }
 

--- a/agent-control/src/agent_control/error.rs
+++ b/agent-control/src/agent_control/error.rs
@@ -24,91 +24,91 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AgentError {
-    #[error("could not resolve config: `{0}`")]
+    #[error("could not resolve config: {0}")]
     ConfigResolve(#[from] AgentControlConfigError),
 
-    #[error("agent repository error: `{0}`")]
+    #[error("agent repository error: {0}")]
     AgentRepository(#[from] AgentRepositoryError),
 
-    #[error("filesystem error: `{0}`")]
+    #[error("filesystem error: {0}")]
     FileSystem(#[from] std::io::Error),
 
-    #[error("error deserializing YAML: `{0}`")]
+    #[error("error deserializing YAML: {0}")]
     SerdeYaml(#[from] serde_yaml::Error),
 
-    #[error("agent type error `{0}`")]
+    #[error("agent type error {0}")]
     AgentType(#[from] AgentTypeError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     OpAMPBuilder(#[from] OpAMPClientBuilderError),
 
-    #[error("file reader error: `{0}`")]
+    #[error("file reader error: {0}")]
     FileReader(#[from] FileReaderError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     OpAMPClient(#[from] ClientError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     OpAMPNotStartedClient(#[from] NotStartedClientError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     OpAMPStartedClient(#[from] StartedClientError),
 
-    #[error("error persisting agent config: `{0}`")]
+    #[error("error persisting agent config: {0}")]
     Persistence(#[from] PersistError),
 
-    #[error("error getting agent instance id: `{0}`")]
+    #[error("error getting agent instance id: {0}")]
     GetInstanceID(#[from] instance_id::getter::GetterError),
 
-    #[error("`Sub Agent error: {0}`")]
+    #[error("Sub Agent error: {0}")]
     SubAgent(#[from] SubAgentError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     SubAgentBuilder(#[from] SubAgentBuilderError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     SubAgentCollection(#[from] SubAgentCollectionError),
 
-    #[error("system time error: `{0}`")]
+    #[error("system time error: {0}")]
     SystemTime(#[from] SystemTimeError),
 
-    #[error("effective agents assembler error: `{0}`")]
+    #[error("effective agents assembler error: {0}")]
     EffectiveAgentsAssembler(#[from] EffectiveAgentsAssemblerError),
 
-    #[error("remote config error: `{0}`")]
+    #[error("remote config error: {0}")]
     RemoteConfig(#[from] OpampRemoteConfigError),
 
-    #[error("sub agent remote config error: `{0}`")]
+    #[error("sub agent remote config error: {0}")]
     SubAgentRemoteConfig(#[from] ConfigRepositoryError),
 
-    #[error("external module error: `{0}`")]
+    #[error("external module error: {0}")]
     ExternalError(String),
 
-    #[error("error from http client: `{0}`")]
+    #[error("error from http client: {0}")]
     Http(String),
 
-    #[error("required identifiers error: `{0}`")]
+    #[error("required identifiers error: {0}")]
     Identifiers(String),
 
-    #[error("error publishing event: `{0}`")]
+    #[error("error publishing event: {0}")]
     EventPublisher(#[from] EventPublisherError),
 
-    #[error("parsing remote config into YAMLConfig: `{0}`")]
+    #[error("parsing remote config into YAMLConfig: {0}")]
     YAMLConfig(#[from] YAMLConfigError),
 
-    #[error("failed to initialize the identifiers provider: `{0}`")]
+    #[error("failed to initialize the identifiers provider: {0}")]
     InitializeIdentifiersProvider(#[from] IdentifiersProviderError),
 
-    #[error("agent control remote config validation error: `{0}`")]
+    #[error("agent control remote config validation error: {0}")]
     RemoteConfigValidator(#[from] DynamicConfigValidatorError),
 
-    #[error("resource cleaner error: `{0}`")]
+    #[error("resource cleaner error: {0}")]
     ResourceCleaner(#[from] ResourceCleanerError),
 
-    #[error("updater error: `{0}`")]
+    #[error("updater error: {0}")]
     Updater(#[from] UpdaterError),
 
-    #[error("failed to build agents: `{0}`")]
+    #[error("failed to build agents: {0}")]
     BuildingSubagents(BuildingSubagentErrors),
 }
 

--- a/agent-control/src/agent_control/http_server.rs
+++ b/agent-control/src/agent_control/http_server.rs
@@ -12,12 +12,12 @@ mod status_updater;
 
 #[derive(Error, Debug)]
 pub enum StatusServerError {
-    #[error("status server error `{0}`")]
+    #[error("status server error {0}")]
     StatusServerError(String),
-    #[error("error building the server `{0}`")]
+    #[error("error building the server {0}")]
     BuildingServerError(String),
-    #[error("error receiving server handle `{0}`")]
+    #[error("error receiving server handle {0}")]
     ServerConsumerError(#[from] RecvError),
-    #[error("error waiting for async join handle `{0}`")]
+    #[error("error waiting for async join handle {0}")]
     JoinHandleError(#[from] JoinError),
 }

--- a/agent-control/src/agent_control/pid_cache.rs
+++ b/agent-control/src/agent_control/pid_cache.rs
@@ -13,10 +13,10 @@ pub enum PIDCacheError {
     #[error("invalid PID file path")]
     InvalidFilePath,
 
-    #[error("directory error: `{0}`")]
+    #[error("directory error: {0}")]
     DirectoryError(#[from] DirectoryManagementError),
 
-    #[error("file error: `{0}`")]
+    #[error("file error: {0}")]
     SaveError(#[from] WriteError),
 
     #[error("pid-file already exists. Can't guarantee that no other agent-control is running.")]

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -242,10 +242,10 @@ impl K8sGarbageCollectorMode<'_> {
 
 #[derive(Error, Debug)]
 pub enum K8sGarbageCollectorError {
-    #[error("the kube client returned an error: `{0}`")]
+    #[error("the kube client returned an error: {0}")]
     Generic(#[from] K8sError),
 
-    #[error("garbage collector failed loading config store: `{0}`")]
+    #[error("garbage collector failed loading config store: {0}")]
     LoadingConfigStore(#[from] AgentControlConfigError),
 
     #[error("garbage collector fetched resources without required labels")]
@@ -254,10 +254,10 @@ pub enum K8sGarbageCollectorError {
     #[error("garbage collector fetched resources without required annotations")]
     MissingAnnotations,
 
-    #[error("unable to parse AgentTypeID: `{0}`")]
+    #[error("unable to parse AgentTypeID: {0}")]
     ParsingAgentType(#[from] AgentTypeIDError),
 
-    #[error("unable to parse AgentID: `{0}`")]
+    #[error("unable to parse AgentID: {0}")]
     ParsingAgentId(#[from] AgentIDError),
 
     #[error("attempted to clean up resources for Agent Control")]

--- a/agent-control/src/agent_type/agent_type_registry.rs
+++ b/agent-control/src/agent_type/agent_type_registry.rs
@@ -5,11 +5,11 @@ use super::definition::AgentTypeDefinition;
 
 #[derive(Error, Debug)]
 pub enum AgentRepositoryError {
-    #[error("agent type `{0}` not found")]
+    #[error("agent type {0} not found")]
     NotFound(String),
-    #[error("agent `{0}` already exists")]
+    #[error("agent {0} already exists")]
     AlreadyExists(String),
-    #[error("`{0}`")]
+    #[error("{0}")]
     SerdeYaml(#[from] serde_yaml::Error),
 }
 

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -4,28 +4,28 @@ use thiserror::Error;
 /// The different error types to be returned by operations involving the [`Agent`] type.
 #[derive(Error, Debug)]
 pub enum AgentTypeError {
-    #[error("error while parsing: `{0}`")]
+    #[error("error while parsing: {0}")]
     SerdeYaml(#[from] serde_yaml::Error),
-    #[error("missing value for key: `{0}`")]
+    #[error("missing value for key: {0}")]
     MissingValue(String),
     #[error("unexpected value for key: key({0}) val({1})")]
     UnexpectedValueForKey(String, String),
-    #[error("missing required template key: `{0}`")]
+    #[error("missing required template key: {0}")]
     MissingTemplateKey(String),
-    #[error("parsing AgentType variables: `{0}`")]
+    #[error("parsing AgentType variables: {0}")]
     Parse(String),
     #[error("not all values for this agent type have been populated: {0:?}")]
     ValuesNotPopulated(Vec<String>),
-    #[error("template value not parseable from the string `{0}")]
+    #[error("template value not parseable from the string {0}")]
     ValueNotParseableFromString(String),
-    #[error("unknown backoff strategy type: `{0}`")]
+    #[error("unknown backoff strategy type: {0}")]
     UnknownBackoffStrategyType(String),
     #[error("invalid value provided. Variants allowed: {0}")]
     InvalidVariant(String),
     #[error("rendering template: {0}")]
     RenderingTemplate(String),
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     ConfigurationPersisterError(#[from] PersistError),
-    #[error("conflicting variable definition: `{0}`")]
+    #[error("conflicting variable definition: {0}")]
     ConflictingVariableDefinition(String),
 }

--- a/agent-control/src/agent_type/render/persister/config_persister.rs
+++ b/agent-control/src/agent_type/render/persister/config_persister.rs
@@ -9,10 +9,10 @@ use fs::writer_file::WriteError;
 
 #[derive(Error, Debug)]
 pub enum PersistError {
-    #[error("directory error: `{0}`")]
+    #[error("directory error: {0}")]
     DirectoryError(#[from] DirectoryManagementError),
 
-    #[error("file error: `{0}`")]
+    #[error("file error: {0}")]
     FileError(#[from] WriteError),
 }
 

--- a/agent-control/src/agent_type/render/persister/config_persister_file.rs
+++ b/agent-control/src/agent_type/render/persister/config_persister_file.rs
@@ -404,7 +404,7 @@ mod tests {
         let result = persister.persist_agent_config(&agent_id, &filled_variables);
         assert!(result.is_err());
         assert_eq!(
-            "directory error: `cannot delete directory: `oh now...``".to_string(),
+            "directory error: cannot delete directory: oh now...".to_string(),
             result.unwrap_err().to_string()
         );
     }
@@ -442,7 +442,7 @@ mod tests {
         let persist_result = persister.persist_agent_config(&agent_id, &filled_variables);
         assert!(persist_result.is_err());
         assert_eq!(
-            "directory error: `cannot create directory `some/path/some-agent-id` : `oh now...``"
+            "directory error: cannot create directory 'some/path/some-agent-id' : oh now..."
                 .to_string(),
             persist_result.unwrap_err().to_string()
         );
@@ -479,7 +479,7 @@ mod tests {
         let persist_result = persister.persist_agent_config(&agent_id, &filled_variables);
         assert!(persist_result.is_err());
         assert_eq!(
-            "directory error: `cannot create directory `some/path/some-agent-id` : `oh now...``"
+            "directory error: cannot create directory 'some/path/some-agent-id' : oh now..."
                 .to_string(),
             persist_result.unwrap_err().to_string()
         );
@@ -518,7 +518,7 @@ mod tests {
         let persist_result = persister.persist_agent_config(&agent_id, &filled_variables);
         assert!(persist_result.is_err());
         assert_eq!(
-            "file error: `error creating file: `permission denied``".to_string(),
+            "file error: error creating file: permission denied".to_string(),
             persist_result.unwrap_err().to_string()
         );
     }
@@ -564,7 +564,7 @@ mod tests {
         let persist_result = persister.persist_agent_config(&agent_id.clone(), &filled_variables);
         assert!(persist_result.is_err());
         assert_eq!(
-            "file error: `error creating file: `entity already exists``".to_string(),
+            "file error: error creating file: entity already exists".to_string(),
             persist_result.unwrap_err().to_string()
         );
     }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(
             rendered_err.to_string(),
             format!(
-                "missing value for key: `{}`",
+                "missing value for key: {}",
                 Namespace::SubAgent.namespaced_name(AgentAttributes::GENERATED_DIR)
             )
         );

--- a/agent-control/src/config_migrate/migration/agent_config_getter.rs
+++ b/agent-control/src/config_migrate/migration/agent_config_getter.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ConversionError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     AgentControlConfigError(#[from] AgentControlConfigError),
-    #[error("error comparing versions `{0}`")]
+    #[error("error comparing versions {0}")]
     SemverError(#[from] semver::Error),
     #[error("no agents of type found on config")]
     NoAgentsFound,

--- a/agent-control/src/config_migrate/migration/config.rs
+++ b/agent-control/src/config_migrate/migration/config.rs
@@ -19,10 +19,10 @@ pub type DirPath = PathBuf;
 
 #[derive(Error, Debug)]
 pub enum MigrationConfigError {
-    #[error("error parsing yaml: `{0}`")]
+    #[error("error parsing yaml: {0}")]
     SerdeYaml(#[from] Error),
 
-    #[error("config mapping should not be empty`")]
+    #[error("config mapping should not be empty")]
     EmptyConfigMapping,
 }
 

--- a/agent-control/src/config_migrate/migration/converter.rs
+++ b/agent-control/src/config_migrate/migration/converter.rs
@@ -21,13 +21,13 @@ use tracing::{debug, error};
 
 #[derive(Error, Debug)]
 pub enum ConversionError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     RepositoryError(#[from] AgentRepositoryError),
-    #[error("`{0}`")]
+    #[error("{0}")]
     ConvertFileError(#[from] FileReaderError),
-    #[error("`{0}`")]
+    #[error("{0}")]
     AgentValueError(#[from] AgentValueError),
-    #[error("`{0}`")]
+    #[error("{0}")]
     AgentTypeDefinitionError(#[from] AgentTypeDefinitionError),
     #[error("cannot find required file map")]
     RequiredFileMappingNotFoundError,

--- a/agent-control/src/config_migrate/migration/migrator.rs
+++ b/agent-control/src/config_migrate/migration/migrator.rs
@@ -24,16 +24,16 @@ pub enum MigratorError {
     #[error("")]
     AgentTypeNotFoundOnConfig,
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     AgentControlConfigError(#[from] AgentControlConfigError),
 
-    #[error("configuration is not valid YAML: `{0}`")]
+    #[error("configuration is not valid YAML: {0}")]
     InvalidYamlConfiguration(#[from] serde_yaml::Error),
 
-    #[error("error persisting values file: `{0}`")]
+    #[error("error persisting values file: {0}")]
     PersistError(#[from] PersistError),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     ConversionError(#[from] ConversionError),
 }
 

--- a/agent-control/src/config_migrate/migration/persister/values_persister_file.rs
+++ b/agent-control/src/config_migrate/migration/persister/values_persister_file.rs
@@ -9,10 +9,10 @@ use tracing::debug;
 
 #[derive(Error, Debug)]
 pub enum PersistError {
-    #[error("directory error: `{0}`")]
+    #[error("directory error: {0}")]
     DirectoryError(#[from] DirectoryManagementError),
 
-    #[error("file error: `{0}`")]
+    #[error("file error: {0}")]
     FileError(#[from] WriteError),
 }
 

--- a/agent-control/src/health/health_checker.rs
+++ b/agent-control/src/health/health_checker.rs
@@ -38,10 +38,10 @@ pub enum Health {
 pub enum HealthCheckerError {
     #[error("{0}")]
     Generic(String),
-    #[error("system time error `{0}`")]
+    #[error("system time error {0}")]
     SystemTime(#[from] SystemTimeError),
 
-    #[error("{kind}/{name} misses field `{field}`")]
+    #[error("{kind}/{name} misses field '{field}'")]
     MissingK8sObjectField {
         kind: String,
         name: String,

--- a/agent-control/src/health/on_host/http.rs
+++ b/agent-control/src/health/on_host/http.rs
@@ -13,7 +13,7 @@ const DEFAULT_PROTOCOL: &str = "http://";
 /// An enumeration of potential errors related to the HTTP client.
 #[derive(Error, Debug)]
 pub enum HttpClientError {
-    #[error("internal HTTP client error: `{0}`")]
+    #[error("internal HTTP client error: {0}")]
     HttpClientError(String),
 }
 
@@ -175,7 +175,7 @@ pub(crate) mod tests {
 
         assert!(health_response.is_err());
         assert_eq!(
-            "internal HTTP client error: `Timeout`".to_string(),
+            "internal HTTP client error: Timeout".to_string(),
             health_response.unwrap_err().to_string()
         );
     }

--- a/agent-control/src/http/client.rs
+++ b/agent-control/src/http/client.rs
@@ -88,7 +88,7 @@ pub enum HttpResponseError {
     BuildingResponse(String),
     #[error("could build request: {0}")]
     BuildingRequest(String),
-    #[error("`{0}`")]
+    #[error("{0}")]
     TransportError(String),
 }
 

--- a/agent-control/src/http/config.rs
+++ b/agent-control/src/http/config.rs
@@ -46,7 +46,7 @@ const HTTPS_PROXY_ENV_NAME: &str = "HTTPS_PROXY";
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProxyError {
-    #[error("invalid proxy url `{0}`: `{1}`")]
+    #[error("invalid proxy url '{0}': {1}")]
     InvalidUrl(String, String),
 }
 

--- a/agent-control/src/instrumentation/config/logs/config.rs
+++ b/agent-control/src/instrumentation/config/logs/config.rs
@@ -18,14 +18,14 @@ const SPAN_ATTRIBUTES_MAX_LEVEL: &Level = &Level::INFO;
 /// An enum representing possible errors during the logging initialization.
 #[derive(Error, Debug)]
 pub enum LoggingConfigError {
-    #[error("invalid directive `{directive}` in `{field_name}`: {err}")]
+    #[error("invalid directive '{directive}' in '{field_name}': {err}")]
     InvalidDirective {
         directive: String,
         field_name: String,
         err: String,
     },
 
-    #[error("invalid logging file path: `{0}`")]
+    #[error("invalid logging file path: {0}")]
     InvalidFilePath(String),
 }
 
@@ -270,7 +270,7 @@ mod tests {
                     insecure_fine_grained_level: Some("newrelic_agent_control=lolwut".into()),
                     ..Default::default()
                 },
-                expected: "invalid directive `newrelic_agent_control=lolwut` in `insecure_fine_grained_level`: error parsing level filter: expected one of \"off\", \"error\", \"warn\", \"info\", \"debug\", \"trace\", or a number 0-5",
+                expected: "invalid directive 'newrelic_agent_control=lolwut' in 'insecure_fine_grained_level': error parsing level filter: expected one of \"off\", \"error\", \"warn\", \"info\", \"debug\", \"trace\", or a number 0-5",
             },
             TestCase {
                 name: "invalid insecure fine grained (level as integer)",
@@ -278,7 +278,7 @@ mod tests {
                     insecure_fine_grained_level: Some("newrelic_agent_control=11".into()),
                     ..Default::default()
                 },
-                expected: "invalid directive `newrelic_agent_control=11` in `insecure_fine_grained_level`: error parsing level filter: expected one of \"off\", \"error\", \"warn\", \"info\", \"debug\", \"trace\", or a number 0-5",
+                expected: "invalid directive 'newrelic_agent_control=11' in 'insecure_fine_grained_level': error parsing level filter: expected one of \"off\", \"error\", \"warn\", \"info\", \"debug\", \"trace\", or a number 0-5",
             },
         ];
 

--- a/agent-control/src/instrumentation/tracing_layers/otel.rs
+++ b/agent-control/src/instrumentation/tracing_layers/otel.rs
@@ -24,7 +24,7 @@ pub enum OtelBuildError {
     HttpClient(#[from] HttpBuildError),
     #[error("could not build the exporter: {0}")]
     ExporterBuild(#[from] ExporterBuildError),
-    #[error("invalid filtering directive `{directive}`: {err}")]
+    #[error("invalid filtering directive '{directive}': {err}")]
     FilteringDirective { directive: String, err: String },
 }
 

--- a/agent-control/src/k8s/error.rs
+++ b/agent-control/src/k8s/error.rs
@@ -9,20 +9,20 @@ pub enum K8sError {
     #[error("{0}")]
     Generic(String),
 
-    #[error("the kube client returned an error: `{0}`")]
+    #[error("the kube client returned an error: {0}")]
     KubeRs(Box<kube::Error>),
 
-    #[error("it is not possible to read kubeconfig: `{0}`")]
+    #[error("it is not possible to read kubeconfig: {0}")]
     UnableToSetupClientKubeconfig(#[from] KubeconfigError),
 
-    #[error("cannot start a k8s reader `{0}`")]
+    #[error("cannot start a k8s reader {0}")]
     ReflectorWriterDropped(#[from] kube::runtime::reflector::store::WriterDropped),
 
     // We need to add the debug info since the string representation of CommitError hide the source of the error
-    #[error("cannot post object `{0:?}`")]
+    #[error("cannot post object {0:?}")]
     CommitError(Box<api::entry::CommitError>),
 
-    #[error("cannot patch object {0} with `{1}`")]
+    #[error("cannot patch object {0} with {1}")]
     PatchError(String, String),
 
     #[error("the kind of the resource is missing")]
@@ -37,7 +37,7 @@ pub enum K8sError {
     #[error("{0} does not have .metadata.name")]
     MissingName(String),
 
-    #[error("error parsing GroupVersion: `{0}`")]
+    #[error("error parsing GroupVersion: {0}")]
     ParseGroupVersion(#[from] ParseGroupVersionError),
 
     #[error("while getting dynamic resource: {0}")]
@@ -73,10 +73,10 @@ impl From<api::entry::CommitError> for K8sError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum GarbageCollectorK8sError {
-    #[error("the kube client returned an error: `{0}`")]
+    #[error("the kube client returned an error: {0}")]
     Generic(#[from] K8sError),
 
-    #[error("garbage collector failed loading config store: `{0}`")]
+    #[error("garbage collector failed loading config store: {0}")]
     LoadingConfigStore(#[from] AgentControlConfigError),
 
     #[error("garbage collector executed with empty current agents list")]
@@ -88,9 +88,9 @@ pub enum GarbageCollectorK8sError {
     #[error("garbage collector fetched resources without required annotations")]
     MissingAnnotations(),
 
-    #[error("unable to parse AgentTypeID: `{0}`")]
+    #[error("unable to parse AgentTypeID: {0}")]
     ParsingAgentType(#[from] AgentTypeIDError),
 
-    #[error("unable to parse AgentID: `{0}`")]
+    #[error("unable to parse AgentID: {0}")]
     ParsingAgentId(#[from] AgentIDError),
 }

--- a/agent-control/src/opamp/auth/token_retriever.rs
+++ b/agent-control/src/opamp/auth/token_retriever.rs
@@ -19,10 +19,10 @@ const DEFAULT_AUTHENTICATOR_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Error, Debug)]
 pub enum TokenRetrieverImplError {
-    #[error("building JWT signer: `{0}`")]
+    #[error("building JWT signer: {0}")]
     JwtSignerBuildError(#[from] JwtSignerImplError),
 
-    #[error("error building http client: `{0}`")]
+    #[error("error building http client: {0}")]
     HTTPBuildingClientError(String),
 }
 

--- a/agent-control/src/opamp/callbacks.rs
+++ b/agent-control/src/opamp/callbacks.rs
@@ -29,16 +29,16 @@ use tracing::{debug, error, trace};
 
 #[derive(Debug, Error)]
 pub enum AgentCallbacksError {
-    #[error("deserialization error: `{0}`")]
+    #[error("deserialization error: {0}")]
     DeserializationError(#[from] OpampRemoteConfigError),
 
-    #[error("invalid UTF-8 sequence: `{0}`")]
+    #[error("invalid UTF-8 sequence: {0}")]
     UTF8(#[from] FromUtf8Error),
 
     #[error("unable to publish OpAMP event")]
     PublishEventError(#[from] EventPublisherError),
 
-    #[error("unable to get effective config: `{0}`")]
+    #[error("unable to get effective config: {0}")]
     EffectiveConfigError(#[from] EffectiveConfigError),
 }
 
@@ -430,7 +430,7 @@ pub(crate) mod tests {
                 expected_remote_config_config_map: ConfigurationMap::default(),
                 expected_remote_config_hash:  Hash::from(valid_hash),
                 expected_remote_config_state: ConfigState::Failed {
-                    error_message: "Invalid remote config format: invalid UTF-8 sequence: `invalid utf-8 sequence of 1 bytes from index 0`".into(),
+                    error_message: "Invalid remote config format: invalid UTF-8 sequence: invalid utf-8 sequence of 1 bytes from index 0".into(),
                 },
                 expected_signature: None,
             },

--- a/agent-control/src/opamp/client_builder.rs
+++ b/agent-control/src/opamp/client_builder.rs
@@ -24,13 +24,13 @@ pub struct PollInterval(#[serde(deserialize_with = "deserialize_duration")] Dura
 
 #[derive(Error, Debug)]
 pub enum OpAMPClientBuilderError {
-    #[error("OpAMP client: `{0}`")]
+    #[error("OpAMP client: {0}")]
     NotStartedClientError(#[from] NotStartedClientError),
 
-    #[error("error getting agent instance id: `{0}`")]
+    #[error("error getting agent instance id: {0}")]
     GetInstanceIDError(#[from] GetterError),
 
-    #[error("error building http client: `{0}`")]
+    #[error("error building http client: {0}")]
     HttpClientBuilderError(#[from] HttpClientBuilderError),
 }
 

--- a/agent-control/src/opamp/effective_config/agent_control.rs
+++ b/agent-control/src/opamp/effective_config/agent_control.rs
@@ -54,7 +54,7 @@ struct AgentControlEffectiveConfig {
 
 #[derive(Debug, Error)]
 pub enum AgentControlEffectiveConfigError {
-    #[error("processing agent-control effective config: `{0}`")]
+    #[error("processing agent-control effective config: {0}")]
     Conversion(String),
 }
 

--- a/agent-control/src/opamp/effective_config/error.rs
+++ b/agent-control/src/opamp/effective_config/error.rs
@@ -9,7 +9,7 @@ pub enum EffectiveConfigError {
 /// Error type for the effective configuration loader.
 /// This is implementation-dependent so it only encapsulates a String.
 #[derive(Debug, Error)]
-#[error("could not load effective configuration: `{0}`")]
+#[error("could not load effective configuration: {0}")]
 pub struct LoaderError(String);
 
 impl From<String> for LoaderError {

--- a/agent-control/src/opamp/http/client.rs
+++ b/agent-control/src/opamp/http/client.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 #[derive(thiserror::Error, Debug)]
 pub enum OpAMPHttpClientError {
-    #[error("could not build auth headers: `{0}`")]
+    #[error("could not build auth headers: {0}")]
     AuthorizationHeadersError(String),
 }
 

--- a/agent-control/src/opamp/instance_id/getter.rs
+++ b/agent-control/src/opamp/instance_id/getter.rs
@@ -13,13 +13,13 @@ pub trait InstanceIDGetter {
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetterError {
-    #[error("failed to persist data: `{0}`")]
+    #[error("failed to persist data: {0}")]
     OnHostPersisting(#[from] super::on_host::storer::StorerError),
 
-    #[error("failed to persist k8s data: `{0}`")]
+    #[error("failed to persist k8s data: {0}")]
     K8sPersisting(#[from] super::k8s::storer::StorerError),
 
-    #[error("initialising client: `{0}`")]
+    #[error("initialising client: {0}")]
     K8sClientInitialization(#[from] k8s::Error),
 
     #[cfg(test)]

--- a/agent-control/src/opamp/instance_id/on_host/getter.rs
+++ b/agent-control/src/opamp/instance_id/on_host/getter.rs
@@ -41,12 +41,12 @@ impl Display for Identifiers {
 #[derive(Error, Debug)]
 pub enum IdentifiersProviderError {
     #[error(
-        "generating host identification: adding a `host_id` in the agent-control config is required for this case`"
+        "generating host identification: adding a 'host_id' in the agent-control config is required for this case"
     )]
     MissingHostIDError,
-    #[error("detecting resources: `{0}`")]
+    #[error("detecting resources: {0}")]
     DetectError(#[from] DetectError),
-    #[error("building cloud detector: `{0}`")]
+    #[error("building cloud detector: {0}")]
     BuildError(#[from] HttpClientError),
 }
 

--- a/agent-control/src/opamp/instance_id/on_host/storer.rs
+++ b/agent-control/src/opamp/instance_id/on_host/storer.rs
@@ -27,15 +27,15 @@ where
 pub enum StorerError {
     #[error("generic error")]
     Generic,
-    #[error("error (de)serializing from/into an identifiers file: `{0}`")]
+    #[error("error (de)serializing from/into an identifiers file: {0}")]
     Serde(#[from] serde_yaml::Error),
-    #[error("directory management error: `{0}`")]
+    #[error("directory management error: {0}")]
     DirectoryManagement(#[from] DirectoryManagementError),
-    #[error("error writing file: `{0}`")]
+    #[error("error writing file: {0}")]
     WriteError(#[from] WriteError),
-    #[error("error creating file: `{0}`")]
+    #[error("error creating file: {0}")]
     IOError(#[from] io::Error),
-    #[error("error reading file: `{0}`")]
+    #[error("error reading file: {0}")]
     ReadError(#[from] FileReaderError),
 }
 

--- a/agent-control/src/opamp/remote_config.rs
+++ b/agent-control/src/opamp/remote_config.rs
@@ -28,10 +28,10 @@ pub struct OpampRemoteConfig {
 
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum OpampRemoteConfigError {
-    #[error("invalid UTF-8 sequence: `{0}`")]
+    #[error("invalid UTF-8 sequence: {0}")]
     UTF8(#[from] FromUtf8Error),
 
-    #[error("config hash: `{0}` config error: `{1}`")]
+    #[error("invalid config for hash '{0}': {1}")]
     InvalidConfig(String, String),
 }
 

--- a/agent-control/src/opamp/remote_config/validators/regexes.rs
+++ b/agent-control/src/opamp/remote_config/validators/regexes.rs
@@ -12,7 +12,7 @@ pub enum RegexValidatorError {
     #[error("invalid config: restricted values detected")]
     InvalidConfig,
 
-    #[error("error compiling regex: `{0}`")]
+    #[error("error compiling regex: {0}")]
     RegexError(#[from] regex::Error),
 }
 

--- a/agent-control/src/opamp/remote_config/validators/signature/certificate.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/certificate.rs
@@ -12,9 +12,9 @@ use crate::opamp::remote_config::{
 
 #[derive(Error, Debug)]
 pub enum CertificateError {
-    #[error("parsing certificate from bytes: `{0}`")]
+    #[error("parsing certificate from bytes: {0}")]
     ParseCertificate(String),
-    #[error("verifying signature: `{0}`")]
+    #[error("verifying signature: {0}")]
     VerifySignature(String),
 }
 #[derive(Debug, Clone)]

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -27,11 +27,11 @@ const DEFAULT_SIGNATURE_VALIDATOR_ENABLED: bool = true;
 type ErrorMessage = String;
 #[derive(Error, Debug)]
 pub enum SignatureValidatorError {
-    #[error("failed to fetch certificate: `{0}`")]
+    #[error("failed to fetch certificate: {0}")]
     FetchCertificate(ErrorMessage),
-    #[error("failed to build validator: `{0}`")]
+    #[error("failed to build validator: {0}")]
     BuildingValidator(ErrorMessage),
-    #[error("failed to verify signature: `{0}`")]
+    #[error("failed to verify signature: {0}")]
     VerifySignature(ErrorMessage),
 }
 

--- a/agent-control/src/secrets_provider/vault.rs
+++ b/agent-control/src/secrets_provider/vault.rs
@@ -32,13 +32,13 @@ pub enum VaultError {
     SerdeError(#[from] Error),
 
     /// Represents an error building the HttpClient
-    #[error("could not build the HTTP client: `{0}`")]
+    #[error("could not build the HTTP client: {0}")]
     BuildingError(String),
 
-    #[error("http transport error: `{0}`")]
+    #[error("http transport error: {0}")]
     HttpTransportError(String),
 
-    #[error("unable to deserialize body: `{0}`")]
+    #[error("unable to deserialize body: {0}")]
     DeserializeError(String),
 
     #[error("secret path '{0}' does not have a valid format 'source:mount:path:name'")]

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -935,7 +935,9 @@ deployment:
             RemoteConfigStatus {
                 status: RemoteConfigStatuses::Failed as i32,
                 last_remote_config_hash: Self::hash().to_string().into_bytes(),
-                error_message: "could not build the supervisor from an effective agent: ``no configuration found``".into(),
+                error_message:
+                    "could not build the supervisor from an effective agent: no configuration found"
+                        .into(),
             }
         }
 

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -24,23 +24,23 @@ use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum EffectiveAgentsAssemblerError {
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     EffectiveAgentsAssemblerError(String),
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     RepositoryError(#[from] AgentRepositoryError),
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     SerdeYamlError(#[from] serde_yaml::Error),
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     AgentTypeError(#[from] AgentTypeError),
-    #[error("error assembling agents: `{0}`")]
+    #[error("error assembling agents: {0}")]
     AgentTypeDefinitionError(#[from] AgentTypeDefinitionError),
-    #[error("error loading secrets: `{0}`")]
+    #[error("error loading secrets: {0}")]
     SecretVariablesError(#[from] SecretVariablesError),
 }
 
 #[derive(Error, Debug)]
 pub enum AgentTypeDefinitionError {
-    #[error("invalid agent-type for `{0}` environment: `{1}")]
+    #[error("invalid agent-type for '{0}' environment: {1}")]
     EnvironmentError(AgentTypeError, Environment),
 }
 
@@ -385,7 +385,7 @@ pub(crate) mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            "error assembling agents: `agent type `namespace/name:0.0.1` not found`",
+            "error assembling agents: agent type namespace/name:0.0.1 not found",
             result.unwrap_err().to_string()
         );
     }

--- a/agent-control/src/sub_agent/error.rs
+++ b/agent-control/src/sub_agent/error.rs
@@ -11,21 +11,21 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SubAgentError {
-    #[error("system time error: `{0}`")]
+    #[error("system time error: {0}")]
     SystemTimeError(#[from] SystemTimeError),
-    #[error("OpAMP client error: `{0}`")]
+    #[error("OpAMP client error: {0}")]
     OpampClientError(#[from] ClientError),
-    #[error("OpAMP client error: `{0}`")]
+    #[error("OpAMP client error: {0}")]
     OpampClientBuilderError(#[from] OpAMPClientBuilderError),
-    #[error("started opamp client error: `{0}`")]
+    #[error("started opamp client error: {0}")]
     StartedOpampClientError(#[from] StartedClientError),
-    #[error("not started opamp client error: `{0}`")]
+    #[error("not started opamp client error: {0}")]
     NotStartedOpampClientError(#[from] NotStartedClientError),
-    #[error("config assembler error: `{0}`")]
+    #[error("config assembler error: {0}")]
     ConfigAssemblerError(#[from] EffectiveAgentsAssemblerError),
-    #[error("sub agent yaml config repository error: `{0}`")]
+    #[error("sub agent yaml config repository error: {0}")]
     ConfigRepositoryError(#[from] ConfigRepositoryError),
-    #[error("error publishing event: `{0}`")]
+    #[error("error publishing event: {0}")]
     EventPublisherError(#[from] EventPublisherError),
     #[error("no configuration found")]
     NoConfiguration,
@@ -34,46 +34,46 @@ pub enum SubAgentError {
 /// Errors that can occur when creating a supervisor, including when receiving a remote config.
 #[derive(Error, Debug)]
 pub enum SupervisorCreationError {
-    #[error("failed remote config hash for remote config: `{0}`")]
+    #[error("failed remote config hash for remote config: {0}")]
     RemoteConfigHash(String),
-    #[error("could not parse the remote config: `{0}`")]
+    #[error("could not parse the remote config: {0}")]
     RemoteConfigParse(#[from] RemoteConfigParserError),
     #[error("no configuration found")]
     NoConfiguration,
-    #[error("could not assemble the effective agent from YAML config: `{0}`")]
+    #[error("could not assemble the effective agent from YAML config: {0}")]
     EffectiveAgentAssemble(#[from] EffectiveAgentsAssemblerError),
-    #[error("could not build the supervisor from an effective agent: `{0}`")]
+    #[error("could not build the supervisor from an effective agent: {0}")]
     SupervisorAssemble(#[from] SubAgentBuilderError),
-    #[error("could not start the supervisor: `{0}`")]
+    #[error("could not start the supervisor: {0}")]
     SupervisorStart(#[from] SupervisorStarterError),
 }
 
 #[derive(Error, Debug)]
 pub enum SubAgentBuilderError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     SubAgent(#[from] SubAgentError),
-    #[error("config assembler error: `{0}`")]
+    #[error("config assembler error: {0}")]
     ConfigAssemblerError(#[from] EffectiveAgentsAssemblerError),
-    #[error("OpAMP client error: `{0}`")]
+    #[error("OpAMP client error: {0}")]
     OpampClientBuilderError(String),
-    #[error("unsupported K8s object: `{0}`")]
+    #[error("unsupported K8s object: {0}")]
     UnsupportedK8sObject(String),
 }
 
 #[derive(Error, Debug)]
 pub enum SubAgentCollectionError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     SubAgent(#[from] SubAgentError),
-    #[error("sub agent `{0}` not found in the collection")]
+    #[error("sub agent {0} not found in the collection")]
     SubAgentNotFound(String),
 }
 
 #[derive(Error, Debug)]
 pub enum SubAgentStopError {
-    #[error("could not stop the sub agent event loop: `{0}`")]
+    #[error("could not stop the sub agent event loop: {0}")]
     SubAgentEventLoop(#[from] EventPublisherError),
-    #[error("failed to join the sub agent thread: `{0}")]
+    #[error("failed to join the sub agent thread: {0}")]
     SubAgentJoinHandle(String),
-    #[error("failed to stop the sub agent runtime: `{0}")]
+    #[error("failed to stop the sub agent runtime: {0}")]
     SubAgentRuntimeStop(#[from] SubAgentError),
 }

--- a/agent-control/src/sub_agent/on_host/command/error.rs
+++ b/agent-control/src/sub_agent/on_host/command/error.rs
@@ -3,12 +3,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum CommandError {
-    #[error("`{0}` not piped")]
+    #[error("{0} not piped")]
     StreamPipeError(String),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     IOError(#[from] std::io::Error),
 
-    #[error("Nix Error: `{0}`")]
+    #[error("Nix Error: {0}")]
     NixError(String),
 }

--- a/agent-control/src/values/config_repository.rs
+++ b/agent-control/src/values/config_repository.rs
@@ -8,13 +8,13 @@ use tracing::debug;
 
 #[derive(Error, Debug, Clone)]
 pub enum ConfigRepositoryError {
-    #[error("error loading values: `{0}`")]
+    #[error("error loading values: {0}")]
     LoadError(String),
-    #[error("error storing values: `{0}`")]
+    #[error("error storing values: {0}")]
     StoreError(String),
-    #[error("error deleting values: `{0}`")]
+    #[error("error deleting values: {0}")]
     DeleteError(String),
-    #[error("error updating hash, no remote config to update: `{0}`")]
+    #[error("error updating hash, no remote config to update: {0}")]
     UpdateHashStateError(String),
 }
 

--- a/agent-control/src/values/file.rs
+++ b/agent-control/src/values/file.rs
@@ -19,13 +19,13 @@ use tracing::{debug, error};
 
 #[derive(Error, Debug)]
 pub enum OnHostConfigRepositoryError {
-    #[error("serialize error loading SubAgentConfig: `{0}`")]
+    #[error("serialize error loading SubAgentConfig: {0}")]
     StoreSerializeError(#[from] serde_yaml::Error),
-    #[error("directory manager error: `{0}`")]
+    #[error("directory manager error: {0}")]
     DirectoryManagementError(#[from] DirectoryManagementError),
-    #[error("file write error: `{0}`")]
+    #[error("file write error: {0}")]
     WriteError(#[from] WriteError),
-    #[error("file read error: `{0}`")]
+    #[error("file read error: {0}")]
     ReadError(#[from] FileReaderError),
     #[cfg(test)]
     #[error("common variant for k8s and on-host implementations")]

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -14,7 +14,7 @@ pub struct YAMLConfig(HashMap<String, serde_yaml::Value>);
 
 #[derive(Error, Debug)]
 pub enum YAMLConfigError {
-    #[error("invalid agent values format: `{0}`")]
+    #[error("invalid agent values format: {0}")]
     FormatError(#[from] serde_yaml::Error),
 }
 
@@ -310,7 +310,7 @@ deployment:
         assert!(result.is_err());
         assert_eq!(
             format!("{}", result.unwrap_err()),
-            "error while parsing: `invalid type: boolean `true`, expected a string`"
+            "error while parsing: invalid type: boolean `true`, expected a string"
         );
     }
 }

--- a/agent-control/tests/k8s/tools/k8s_env.rs
+++ b/agent-control/tests/k8s/tools/k8s_env.rs
@@ -21,7 +21,7 @@ use tracing::{error, info};
 
 #[derive(Debug, Error)]
 enum PortForwardError {
-    #[error("kube wait error `{0}`")]
+    #[error("kube wait error {0}")]
     KubeWaitError(#[from] KubeWaitError),
 
     #[error("pod not found: {0}")]

--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -6,13 +6,13 @@ use tracing::instrument;
 
 #[derive(Error, Debug)]
 pub enum DirectoryManagementError {
-    #[error("cannot create directory `{0}` : `{1}`")]
+    #[error("cannot create directory '{0}' : {1}")]
     ErrorCreatingDirectory(String, String),
 
-    #[error("cannot delete directory: `{0}`")]
+    #[error("cannot delete directory: {0}")]
     ErrorDeletingDirectory(String),
 
-    #[error("invalid directory: `{0}`")]
+    #[error("invalid directory: {0}")]
     InvalidDirectory(#[from] FsError),
 }
 
@@ -172,7 +172,7 @@ pub mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            "invalid directory: `dots disallowed in path `some/path/../with/../dots``".to_string(),
+            "invalid directory: dots disallowed in path some/path/../with/../dots".to_string(),
             result.unwrap_err().to_string()
         );
     }
@@ -188,7 +188,7 @@ pub mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            "invalid directory: `dots disallowed in path `some/path/../with/../dots``".to_string(),
+            "invalid directory: dots disallowed in path some/path/../with/../dots".to_string(),
             result.unwrap_err().to_string()
         );
     }

--- a/fs/src/file_reader.rs
+++ b/fs/src/file_reader.rs
@@ -6,11 +6,11 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FileReaderError {
-    #[error("error reading contents: `{0}`")]
+    #[error("error reading contents: {0}")]
     Read(#[from] ioError),
-    #[error("file not found: `{0}`")]
+    #[error("file not found: {0}")]
     FileNotFound(String),
-    #[error("dir not found: `{0}`")]
+    #[error("dir not found: {0}")]
     DirNotFound(String),
 }
 
@@ -110,7 +110,7 @@ pub mod tests {
         let result = reader.read(Path::new("/a/path/that/does/not/exist"));
         assert!(result.is_err());
         assert_eq!(
-            String::from("file not found: `/a/path/that/does/not/exist`"),
+            String::from("file not found: /a/path/that/does/not/exist"),
             result.unwrap_err().to_string()
         );
     }
@@ -121,7 +121,7 @@ pub mod tests {
         let result = reader.dir_entries(Path::new("/a/path/that/does/not/exist"));
         assert!(result.is_err());
         assert_eq!(
-            String::from("dir not found: `/a/path/that/does/not/exist`"),
+            String::from("dir not found: /a/path/that/does/not/exist"),
             result.unwrap_err().to_string()
         );
     }

--- a/fs/src/file_renamer.rs
+++ b/fs/src/file_renamer.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FileRenamerError {
-    #[error("error renaming file or dir: `{0}`")]
+    #[error("error renaming file or dir: {0}")]
     Rename(#[from] ioError),
-    #[error("file or dir not found: `{0}`")]
+    #[error("file or dir not found: {0}")]
     FileDirNotFound(String),
 }
 
@@ -67,7 +67,7 @@ pub mod tests {
         );
         assert!(result.is_err());
         assert_eq!(
-            String::from("file or dir not found: `/a/path/that/does/not/exist`"),
+            String::from("file or dir not found: /a/path/that/does/not/exist"),
             result.unwrap_err().to_string()
         );
     }

--- a/fs/src/utils.rs
+++ b/fs/src/utils.rs
@@ -4,10 +4,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
 pub enum FsError {
-    #[error("invalid path: `{0}`")]
+    #[error("invalid path: {0}")]
     InvalidPath(String),
 
-    #[error("dots disallowed in path `{0}`")]
+    #[error("dots disallowed in path {0}")]
     DotsDisallowed(String),
 }
 

--- a/fs/src/writer_file.rs
+++ b/fs/src/writer_file.rs
@@ -14,13 +14,13 @@ use tracing::instrument;
 
 #[derive(Error, Debug)]
 pub enum WriteError {
-    #[error("directory error: `{0}`")]
+    #[error("directory error: {0}")]
     DirectoryError(#[from] DirectoryManagementError),
 
-    #[error("error creating file: `{0}`")]
+    #[error("error creating file: {0}")]
     ErrorCreatingFile(#[from] io::Error),
 
-    #[error("invalid path: `{0}`")]
+    #[error("invalid path: {0}")]
     InvalidPath(#[from] FsError),
 }
 
@@ -193,7 +193,7 @@ pub mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            "invalid path: `dots disallowed in path `some/path/../../etc/passwd``".to_string(),
+            "invalid path: dots disallowed in path some/path/../../etc/passwd".to_string(),
             result.unwrap_err().to_string()
         );
     }

--- a/resource-detection/src/cloud/aws/detector.rs
+++ b/resource-detection/src/cloud/aws/detector.rs
@@ -33,13 +33,13 @@ impl<C: HttpClient> AWSDetector<C> {
 #[derive(Error, Debug)]
 pub enum AWSDetectorError {
     /// Internal HTTP error
-    #[error("`{0}`")]
+    #[error("{0}")]
     HttpError(#[from] HttpClientError),
     /// Error while deserializing endpoint metadata
-    #[error("`{0}`")]
+    #[error("{0}")]
     JsonError(#[from] serde_json::Error),
     /// Unsuccessful HTTP response.
-    #[error("status code: `{0}` Canonical reason: `{1}`")]
+    #[error("status code: {0} Canonical reason: {1}")]
     UnsuccessfulResponse(u16, String),
 }
 impl<C> Detector for AWSDetector<C>

--- a/resource-detection/src/cloud/azure/detector.rs
+++ b/resource-detection/src/cloud/azure/detector.rs
@@ -41,13 +41,13 @@ impl<C: HttpClient> AzureDetector<C> {
 #[derive(Error, Debug)]
 pub enum AzureDetectorError {
     /// Internal HTTP error
-    #[error("`{0}`")]
+    #[error("{0}")]
     HttpError(#[from] HttpClientError),
     /// Error while deserializing endpoint metadata
-    #[error("error deserializing json: `{0}`")]
+    #[error("error deserializing json: {0}")]
     JsonError(#[from] serde_json::Error),
     /// Unsuccessful HTTP response.
-    #[error("status code: `{0}` Canonical reason: `{1}`")]
+    #[error("status code: {0} Canonical reason: {1}")]
     UnsuccessfulResponse(u16, String),
 }
 

--- a/resource-detection/src/cloud/gcp/detector.rs
+++ b/resource-detection/src/cloud/gcp/detector.rs
@@ -42,13 +42,13 @@ impl<C: HttpClient> GCPDetector<C> {
 #[derive(Error, Debug)]
 pub enum GCPDetectorError {
     /// Internal HTTP error
-    #[error("`{0}`")]
+    #[error("{0}")]
     HttpError(#[from] HttpClientError),
     /// Error while deserializing endpoint metadata
-    #[error("`{0}`")]
+    #[error("{0}")]
     JsonError(#[from] serde_json::Error),
     /// Unsuccessful HTTP response.
-    #[error("status code: `{0}` Canonical reason: `{1}`")]
+    #[error("status code: {0} Canonical reason: {1}")]
     UnsuccessfulResponse(u16, String),
 }
 

--- a/resource-detection/src/cloud/http_client.rs
+++ b/resource-detection/src/cloud/http_client.rs
@@ -10,16 +10,16 @@ pub const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Error, Debug)]
 pub enum HttpClientError {
     /// Represents an error building the HttpClient
-    #[error("could not build the HTTP client: `{0}`")]
+    #[error("could not build the HTTP client: {0}")]
     BuildingError(String),
     /// Represents an internal HTTP client error.
-    #[error("internal HTTP client error: `{0}`")]
+    #[error("internal HTTP client error: {0}")]
     InternalError(String),
     /// Represents HTTP Transport error.
-    #[error("transport HTTP client error: `{0}`")]
+    #[error("transport HTTP client error: {0}")]
     TransportError(String),
     /// Represents an error in the HTTP response.
-    #[error("status code: `{0}`, Reason: `{1}`")]
+    #[error("status code: {0}, Reason: {1}")]
     ResponseError(u16, String),
 }
 

--- a/resource-detection/src/lib.rs
+++ b/resource-detection/src/lib.rs
@@ -56,16 +56,16 @@ impl Resource {
 #[derive(thiserror::Error, Debug)]
 pub enum DetectError {
     /// Error for the system implementation
-    #[error("error detecting system resources `{0}`")]
+    #[error("error detecting system resources {0}")]
     SystemError(#[from] SystemDetectorError),
     /// Error for the AWS cloud implementation
-    #[error("error detecting aws resources `{0}`")]
+    #[error("error detecting aws resources {0}")]
     AWSError(#[from] AWSDetectorError),
     /// Error for the Azure cloud implementation
-    #[error("error detecting azure resources `{0}`")]
+    #[error("error detecting azure resources {0}")]
     AzureError(#[from] AzureDetectorError),
     /// Error for the GCP cloud implementation
-    #[error("error detecting gcp resources `{0}`")]
+    #[error("error detecting gcp resources {0}")]
     GCPError(#[from] GCPDetectorError),
     /// Unsuccessful cloud detection.
     #[error("non of the cloud API responded")]

--- a/resource-detection/src/system/detector.rs
+++ b/resource-detection/src/system/detector.rs
@@ -11,10 +11,10 @@ use tracing::{error, instrument};
 #[derive(thiserror::Error, Debug)]
 pub enum SystemDetectorError {
     /// Error while getting hostname
-    #[error("error getting hostname `{0}`")]
+    #[error("error getting hostname {0}")]
     HostnameError(String),
     /// Error while getting the machine-id
-    #[error("error getting machine-id: `{0}`")]
+    #[error("error getting machine-id: {0}")]
     MachineIDError(String),
 }
 

--- a/resource-detection/src/system/identifier_machine_id_unix.rs
+++ b/resource-detection/src/system/identifier_machine_id_unix.rs
@@ -130,7 +130,7 @@ mod tests {
         let result = provider.provide();
         assert!(result.is_err());
         assert_eq!(
-            String::from("error getting machine-id: `file not found: `some error message``"),
+            String::from("error getting machine-id: file not found: some error message"),
             result.unwrap_err().to_string()
         );
     }


### PR DESCRIPTION
This PR removes most '`' characters from error messages in order to avoid really convoluted with multiple nested quotes.