### PR TITLE
chore: simplify Agent Control error

### DIFF
--- a/agent-control/src/agent_control/error.rs
+++ b/agent-control/src/agent_control/error.rs
@@ -2,61 +2,24 @@ use super::config::AgentControlConfigError;
 use super::resource_cleaner::ResourceCleanerError;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::version_updater::updater::UpdaterError;
-use crate::agent_type::agent_type_registry::AgentRepositoryError;
-use crate::agent_type::error::AgentTypeError;
-use crate::event::channel::EventPublisherError;
-use crate::opamp::client_builder::OpAMPClientBuilderError;
-use crate::opamp::instance_id;
 
-use crate::opamp::instance_id::on_host::getter::IdentifiersProviderError;
 use crate::opamp::remote_config::OpampRemoteConfigError;
-use crate::sub_agent::effective_agents_assembler::EffectiveAgentsAssemblerError;
-use crate::sub_agent::error::{SubAgentBuilderError, SubAgentCollectionError, SubAgentError};
-use crate::values::config_repository::ConfigRepositoryError;
+use crate::sub_agent::error::{SubAgentBuilderError, SubAgentCollectionError};
 use crate::values::yaml_config::YAMLConfigError;
-use fs::file_reader::FileReaderError;
-use opamp_client::{ClientError, NotStartedClientError, StartedClientError};
+use opamp_client::{ClientError, StartedClientError};
 use std::fmt::{Debug, Display};
-use std::time::SystemTimeError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum AgentError {
+pub enum AgentControlError {
     #[error("could not resolve config: {0}")]
     ConfigResolve(#[from] AgentControlConfigError),
-
-    #[error("agent repository error: {0}")]
-    AgentRepository(#[from] AgentRepositoryError),
-
-    #[error("filesystem error: {0}")]
-    FileSystem(#[from] std::io::Error),
-
-    #[error("error deserializing YAML: {0}")]
-    SerdeYaml(#[from] serde_yaml::Error),
-
-    #[error("agent type error {0}")]
-    AgentType(#[from] AgentTypeError),
-
-    #[error("{0}")]
-    OpAMPBuilder(#[from] OpAMPClientBuilderError),
-
-    #[error("file reader error: {0}")]
-    FileReader(#[from] FileReaderError),
 
     #[error("{0}")]
     OpAMPClient(#[from] ClientError),
 
     #[error("{0}")]
-    OpAMPNotStartedClient(#[from] NotStartedClientError),
-
-    #[error("{0}")]
     OpAMPStartedClient(#[from] StartedClientError),
-
-    #[error("error getting agent instance id: {0}")]
-    GetInstanceID(#[from] instance_id::getter::GetterError),
-
-    #[error("Sub Agent error: {0}")]
-    SubAgent(#[from] SubAgentError),
 
     #[error("{0}")]
     SubAgentBuilder(#[from] SubAgentBuilderError),
@@ -64,35 +27,11 @@ pub enum AgentError {
     #[error("{0}")]
     SubAgentCollection(#[from] SubAgentCollectionError),
 
-    #[error("system time error: {0}")]
-    SystemTime(#[from] SystemTimeError),
-
-    #[error("effective agents assembler error: {0}")]
-    EffectiveAgentsAssembler(#[from] EffectiveAgentsAssemblerError),
-
     #[error("remote config error: {0}")]
     RemoteConfig(#[from] OpampRemoteConfigError),
 
-    #[error("sub agent remote config error: {0}")]
-    SubAgentRemoteConfig(#[from] ConfigRepositoryError),
-
-    #[error("external module error: {0}")]
-    ExternalError(String),
-
-    #[error("error from http client: {0}")]
-    Http(String),
-
-    #[error("required identifiers error: {0}")]
-    Identifiers(String),
-
-    #[error("error publishing event: {0}")]
-    EventPublisher(#[from] EventPublisherError),
-
     #[error("parsing remote config into YAMLConfig: {0}")]
     YAMLConfig(#[from] YAMLConfigError),
-
-    #[error("failed to initialize the identifiers provider: {0}")]
-    InitializeIdentifiersProvider(#[from] IdentifiersProviderError),
 
     #[error("agent control remote config validation error: {0}")]
     RemoteConfigValidator(String),
@@ -108,9 +47,9 @@ pub enum AgentError {
 }
 
 #[derive(Debug, Default)]
-pub struct BuildingSubagentErrors(Vec<(AgentID, AgentError)>);
+pub struct BuildingSubagentErrors(Vec<(AgentID, AgentControlError)>);
 impl BuildingSubagentErrors {
-    pub fn push(&mut self, agent_id: AgentID, error: AgentError) {
+    pub fn push(&mut self, agent_id: AgentID, error: AgentControlError) {
         self.0.push((agent_id, error));
     }
     pub fn is_empty(&self) -> bool {

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -3,7 +3,6 @@ use super::defaults::{
     AGENT_CONTROL_DATA_DIR, AGENT_CONTROL_LOCAL_DATA_DIR, AGENT_CONTROL_LOG_DIR,
     DYNAMIC_AGENT_TYPE_DIR,
 };
-use super::error::AgentError;
 use super::http_server::config::ServerConfig;
 use crate::agent_control::http_server::runner::Runner;
 use crate::agent_type::embedded_registry::EmbeddedRegistry;
@@ -21,6 +20,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error};
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct RunError(String);
 
 // k8s and on_host need to be public to allow integration tests to access the fn run_agent_control.
 
@@ -178,7 +181,7 @@ impl AgentControlRunner {
         })
     }
 
-    pub fn run(self, mode: Environment) -> Result<(), AgentError> {
+    pub fn run(self, mode: Environment) -> Result<(), RunError> {
         match mode {
             Environment::OnHost => self.run_onhost(),
             Environment::K8s => self.run_k8s(),


### PR DESCRIPTION
This PR refactors the error enum representing failures on Agent Control execution:
* It renames the error from `AgentError` to `AgentControlError`.
* It removes all variants handling errors _outside_ the `AgentControl::run()` method and replaces them by a simple error with string representation only, it also removes the unused variants.