### PR TITLE
fix(canaries): do not append content to service conf file

### DIFF
--- a/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
+++ b/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
@@ -82,7 +82,7 @@
         {% endraw %}
 
   - name: Add license to service
-    shell: echo 'NEW_RELIC_LICENSE_KEY="{{ nr_license_key }}"' >> {{ agent_control_service_conf }}
+    shell: echo 'NEW_RELIC_LICENSE_KEY="{{ nr_license_key }}"' > {{ agent_control_service_conf }}
 
   - name: Restart Agent Control
     include_role:


### PR DESCRIPTION
# What this PR does / why we need it

Each release appends the same environment variable to the `EnvironmentFile` for AC's `systemd` service over and over again. This should fix that.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
