### PR TITLE
fix: use latest ebpf version

### DIFF
--- a/test/k8s-e2e/ebpf/ac-values-ebpf.yml
+++ b/test/k8s-e2e/ebpf/ac-values-ebpf.yml
@@ -17,4 +17,4 @@ agentControlDeployment:
     agentsConfig:
       nr-ebpf:
         # Testing the latest released version of the chart
-        chart_version: "0.2.6" # TODO: move back to latest when issues are fixed
+        chart_version: "*"


### PR DESCRIPTION
# What this PR does / why we need it

Version 0.2.6 of the ebpf agent isn't available anymore in docker. At least I can't find it.
Issues with init containers might be solved. Let's try to use the latest version again.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
