### PR TITLE
feat: add on-host cli scaffolding [NR-475245]

### DIFF
--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -122,6 +122,10 @@ path = "src/bin/main_config_migrate.rs"
 name = "newrelic-agent-control-k8s-cli"
 path = "src/bin/main_agent_control_k8s_cli.rs"
 
+[[bin]] # TODO: add to package when ready, check goreleaser limitations as in the on-host binary
+name = "newrelic-agent-control-onhost-cli"
+path = "src/bin/main_agent_control_onhost_cli.rs"
+
 [features]
 # feature tokio-console allows debugging tokio tasks using tokio-console
 tokio-console = ["tokio/full", "tokio/tracing", "dep:console-subscriber"]

--- a/agent-control/src/bin/main_agent_control_onhost_cli.rs
+++ b/agent-control/src/bin/main_agent_control_onhost_cli.rs
@@ -1,0 +1,44 @@
+use std::process::ExitCode;
+
+use clap::Parser;
+use newrelic_agent_control::cli::{
+    logs,
+    on_host::config_gen::{ConfigInputs, generate_config},
+};
+use tracing::Level;
+
+#[derive(Debug, clap::Parser)]
+#[command()]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+    #[arg(long, global = true, default_value = "info")]
+    log_level: Level,
+}
+
+/// Commands supported by the cli
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    // Generate Agent Control configuration according to the provided configuration data.
+    GenerateConfig(ConfigInputs),
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let tracer = logs::init(cli.log_level);
+    if let Err(err) = tracer {
+        eprintln!("Failed to initialize tracing: {err}");
+        return err.into();
+    }
+
+    let result = match cli.command {
+        Commands::GenerateConfig(inputs) => generate_config(inputs),
+    };
+
+    if let Err(err) = result {
+        return err.into();
+    }
+
+    ExitCode::SUCCESS
+}

--- a/agent-control/src/cli.rs
+++ b/agent-control/src/cli.rs
@@ -1,1 +1,4 @@
+pub mod error;
 pub mod k8s;
+pub mod logs;
+pub mod on_host;

--- a/agent-control/src/cli/error.rs
+++ b/agent-control/src/cli/error.rs
@@ -1,0 +1,34 @@
+use std::process::ExitCode;
+
+use thiserror::Error;
+
+use crate::instrumentation::tracing::TracingError;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("failed to initialize logs: {0}")]
+    Tracing(#[from] TracingError),
+
+    #[error("failed to start the command: {0}")]
+    Precondition(String),
+
+    #[error("{0}")]
+    Command(String),
+}
+
+impl From<CliError> for ExitCode {
+    /// Converts the error to an exit code.
+    ///
+    /// We comply with the [Advanced Bash Scripting Guide] and
+    /// [BSD guidelines] for the exit codes.
+    ///
+    /// [Advanced Bash Scripting Guide]: https://tldp.org/LDP/abs/html/exitcodes.html
+    /// [BSD exit codes]: https://man.freebsd.org/cgi/man.cgi?query=sysexits&manpath=FreeBSD+4.3-RELEASE
+    fn from(value: CliError) -> Self {
+        match value {
+            CliError::Precondition(_) => Self::from(69),
+            CliError::Tracing(_) => Self::from(70),
+            CliError::Command(_) => Self::from(1),
+        }
+    }
+}

--- a/agent-control/src/cli/k8s/errors.rs
+++ b/agent-control/src/cli/k8s/errors.rs
@@ -1,14 +1,11 @@
-use std::process::ExitCode;
-
 use thiserror::Error;
 
+use crate::cli::error::CliError;
+
 #[derive(Debug, Error)]
-pub enum CliError {
+pub enum K8sCliError {
     #[error("failed to create k8s client: {0}")]
     K8sClient(String),
-
-    #[error("failed to create tracing: {0}")]
-    Tracing(String),
 
     #[error("failed to apply resource: {0}")]
     ApplyResource(String),
@@ -26,23 +23,11 @@ pub enum CliError {
     Generic(String),
 }
 
-impl CliError {
-    /// Converts the error to an exit code.
-    ///
-    /// We comply with the [Advanced Bash Scripting Guide] and
-    /// [BSD guidelines] for the exit codes.
-    ///
-    /// [Advanced Bash Scripting Guide]: https://tldp.org/LDP/abs/html/exitcodes.html
-    /// [BSD exit codes]: https://man.freebsd.org/cgi/man.cgi?query=sysexits&manpath=FreeBSD+4.3-RELEASE
-    pub fn to_exit_code(&self) -> ExitCode {
-        match self {
-            CliError::K8sClient(_) => ExitCode::from(69),
-            CliError::Tracing(_) => ExitCode::from(70),
-            CliError::DeleteResource(_)
-            | CliError::ApplyResource(_)
-            | CliError::GetResource(_)
-            | CliError::InstallationCheck(_)
-            | CliError::Generic(_) => ExitCode::from(1),
+impl From<K8sCliError> for CliError {
+    fn from(value: K8sCliError) -> Self {
+        match value {
+            K8sCliError::K8sClient(_) => CliError::Precondition(value.to_string()),
+            _ => CliError::Command(value.to_string()),
         }
     }
 }

--- a/agent-control/src/cli/k8s/uninstall/agent_control.rs
+++ b/agent-control/src/cli/k8s/uninstall/agent_control.rs
@@ -1,7 +1,7 @@
 use crate::agent_control::config::{
     default_group_version_kinds, helmrelease_v2_type_meta, helmrepository_type_meta,
 };
-use crate::cli::k8s::errors::CliError;
+use crate::cli::k8s::errors::K8sCliError;
 use crate::cli::k8s::install::agent_control::REPOSITORY_NAME;
 use crate::cli::k8s::uninstall::Deleter;
 use crate::cli::k8s::utils::try_new_k8s_client;
@@ -26,7 +26,7 @@ pub struct AgentControlUninstallData {
 pub fn uninstall_agent_control(
     namespace: &str,
     uninstall_data: &AgentControlUninstallData,
-) -> Result<(), CliError> {
+) -> Result<(), K8sCliError> {
     let k8s_client = try_new_k8s_client()?;
     let kinds_available = retrieve_api_resources(&k8s_client)?;
     let AgentControlUninstallData {
@@ -44,12 +44,12 @@ pub fn uninstall_agent_control(
     Ok(())
 }
 
-fn retrieve_api_resources(k8s_client: &SyncK8sClient) -> Result<HashSet<TypeMeta>, CliError> {
+fn retrieve_api_resources(k8s_client: &SyncK8sClient) -> Result<HashSet<TypeMeta>, K8sCliError> {
     let mut tm_available = HashSet::new();
 
     let all_api_resource_list = k8s_client
         .list_api_resources()
-        .map_err(|err| CliError::Generic(format!("failed to retrieve api_resources: {err}")))?;
+        .map_err(|err| K8sCliError::Generic(format!("failed to retrieve api_resources: {err}")))?;
 
     for api_resource_list in &all_api_resource_list {
         for resource in &api_resource_list.resources {
@@ -67,7 +67,7 @@ fn delete_owned_objects(
     k8s_client: &SyncK8sClient,
     kinds_available: &HashSet<TypeMeta>,
     namespace: &str,
-) -> Result<(), CliError> {
+) -> Result<(), K8sCliError> {
     let ac_owned_label_selector = Labels::default().selector();
     let deleter = Deleter::with_default_retry_setup(k8s_client);
     for tm in objects_to_delete(kinds_available) {
@@ -97,7 +97,7 @@ fn delete_agent_control_crs(
     kinds_available: &HashSet<TypeMeta>,
     namespace: &str,
     release_name: &str,
-) -> Result<(), CliError> {
+) -> Result<(), K8sCliError> {
     let mut crs_to_delete: Vec<(TypeMeta, &str)> = vec![
         (helmrelease_v2_type_meta(), release_name),
         (helmrepository_type_meta(), REPOSITORY_NAME),

--- a/agent-control/src/cli/k8s/utils.rs
+++ b/agent-control/src/cli/k8s/utils.rs
@@ -1,4 +1,4 @@
-use super::errors::CliError;
+use super::errors::K8sCliError;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use std::collections::BTreeMap;
@@ -34,7 +34,7 @@ pub fn parse_key_value_pairs(data: impl AsRef<str>) -> BTreeMap<String, String> 
         .collect()
 }
 
-pub fn try_new_k8s_client() -> Result<SyncK8sClient, CliError> {
+pub fn try_new_k8s_client() -> Result<SyncK8sClient, K8sCliError> {
     debug!("Starting the runtime");
     let runtime = Arc::new(
         tokio::runtime::Builder::new_multi_thread()
@@ -44,7 +44,7 @@ pub fn try_new_k8s_client() -> Result<SyncK8sClient, CliError> {
     );
 
     debug!("Starting the k8s client");
-    SyncK8sClient::try_new(runtime).map_err(|err| CliError::K8sClient(err.to_string()))
+    SyncK8sClient::try_new(runtime).map_err(|err| K8sCliError::K8sClient(err.to_string()))
 }
 
 #[cfg(test)]

--- a/agent-control/src/cli/logs.rs
+++ b/agent-control/src/cli/logs.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use tracing::Level;
+
+use crate::{
+    agent_control::defaults::AGENT_CONTROL_LOG_DIR,
+    cli::error::CliError,
+    instrumentation::{
+        config::logs::config::LoggingConfig,
+        tracing::{TracingConfig, TracingGuardBox, try_init_tracing},
+    },
+};
+
+/// Initializes logging (though the tracing crate) for the cli.
+pub fn init(log_level: Level) -> Result<Vec<TracingGuardBox>, CliError> {
+    let logging_config: LoggingConfig = serde_yaml::from_str(&format!("level: {}", log_level))
+        .expect("Logging config should be valid");
+    let tracing_config = TracingConfig::from_logging_path(PathBuf::from(AGENT_CONTROL_LOG_DIR))
+        .with_logging_config(logging_config);
+    try_init_tracing(tracing_config).map_err(CliError::from)
+}

--- a/agent-control/src/cli/on_host.rs
+++ b/agent-control/src/cli/on_host.rs
@@ -1,0 +1,1 @@
+pub mod config_gen;

--- a/agent-control/src/cli/on_host/config_gen.rs
+++ b/agent-control/src/cli/on_host/config_gen.rs
@@ -1,0 +1,14 @@
+use crate::cli::error::CliError;
+
+#[derive(Debug, clap::Parser)]
+pub struct ConfigInputs {
+    /// Fleet identifier
+    #[arg(long)]
+    fleet_id: Option<String>,
+    // TODO: add remaining inputs
+}
+
+/// Generates the Agent Control configuration and any requisite according to the provided inputs.
+pub fn generate_config(_inputs: ConfigInputs) -> Result<(), CliError> {
+    unimplemented!("TODO: implement config generation")
+}


### PR DESCRIPTION
On top of #1766 

This PR adds the scaffolding for the on-host cli: it adds the module structure and a base binary to generate such cli. When the implementation is completed, this binary will replace the current `nr-auth-cli` and will be in charge of generating the agent control configuration (including the required identities).