### PR TITLE
fix(comment): the label is not useless

### DIFF
--- a/agent-control/src/cli/k8s/install/agent_control.rs
+++ b/agent-control/src/cli/k8s/install/agent_control.rs
@@ -56,7 +56,8 @@ impl DynamicObjectListBuilder for InstallAgentControl {
             labels.clone(),
             annotations.clone(),
         );
-        // This is not strictly necessary, but it helps to ensure that the labels are consistent
+        // This is needed whenever the version is managed remotely (otherwise we would lose such info)
+        // Moreover, we add it also when it is local to be consistent.
         let mut helm_release_labels = labels;
         helm_release_labels.insert(AGENT_CONTROL_VERSION_SET_FROM.to_string(), source);
 

--- a/agent-control/src/cli/k8s/install/flux.rs
+++ b/agent-control/src/cli/k8s/install/flux.rs
@@ -47,7 +47,8 @@ impl DynamicObjectListBuilder for InstallFlux {
             BTreeMap::default(),
         );
 
-        // This is not strictly necessary, but it helps to ensure that the labels are consistent
+        // This is needed whenever the version is managed remotely (otherwise we would lose such info)
+        // Moreover, we add it also when it is local to be consistent.
         let mut helm_release_labels = labels;
         helm_release_labels.insert(AGENT_CONTROL_VERSION_SET_FROM.to_string(), source);
 


### PR DESCRIPTION
# What this PR does / why we need it
it fixes a misleading comment.

if the release version is managed remotely, without adding it to the HelmObject two subsequent local installation would "steal" the control of the helmRelease object 

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
