### PR TITLE
feat: package onhost agent-control-cli [NR-475245]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,12 +43,26 @@ builds:
       - --bin=newrelic-config-migrate
     env:
       - AGENT_CONTROL_VERSION={{ .Version }}
+  - id: newrelic-agent-control-cli
+    builder: rust
+    binary: newrelic-agent-control-cli
+    targets:
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-musl
+    flags:
+      - --release
+      - --package=newrelic_agent_control
+      - --bin=newrelic-agent-control-cli
+    env:
+      - AGENT_CONTROL_VERSION={{ .Version }}
+
 archives:
   - formats: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     ids:
       - newrelic-agent-control
       - newrelic-config-migrate
+      - newrelic-agent-control-cli
 
 nfpms:
   - package_name: newrelic-agent-control
@@ -178,6 +192,7 @@ nfpms:
     ids:
       - newrelic-agent-control
       - newrelic-config-migrate
+      - newrelic-agent-control-cli
     formats:
       - deb
       - rpm

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -121,8 +121,8 @@ path = "src/bin/main_config_migrate.rs"
 name = "newrelic-agent-control-k8s-cli"
 path = "src/bin/main_agent_control_k8s_cli.rs"
 
-[[bin]] # TODO: add to package when ready, check goreleaser limitations as in the on-host binary
-name = "newrelic-agent-control-onhost-cli"
+[[bin]] # Same GoReleaser limitations as "newrelic-agent-control" apply here.
+name = "newrelic-agent-control-cli"
 path = "src/bin/main_agent_control_onhost_cli.rs"
 
 [features]


### PR DESCRIPTION
This PR includes the `agent-control-cli` in the onhost packages so it can be used to generate the configuration in the installation steps.

### Out of scope

- Cleaning up other binaries or examples from the package (this needs to be addressed **after** the installation steps are updated).