### PR TITLE
chore(delete): restart_exit_codes feature

### DIFF
--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -172,7 +172,6 @@ restart_policy:
                         "${nr-var:backoff.interval}".to_string(),
                     ),
                 },
-                restart_exit_codes: Vec::default(),
             },
         };
 
@@ -251,7 +250,6 @@ restart_policy:
                     max_retries: 30.into(),
                     last_retry_interval: BackoffLastRetryInterval::from_secs(300),
                 },
-                restart_exit_codes: vec![],
             },
         };
 
@@ -284,7 +282,6 @@ restart_policy:
                             .to_string(),
                     ),
                 },
-                restart_exit_codes: vec![],
             },
         };
 
@@ -354,7 +351,6 @@ restart_policy:
                     max_retries: 30.into(),
                     last_retry_interval: BackoffLastRetryInterval::from_secs(300),
                 },
-                restart_exit_codes: vec![],
             },
         };
 
@@ -427,7 +423,6 @@ restart_policy:
                         "${nr-var:backoff.interval}".to_string(),
                     ),
                 },
-                restart_exit_codes: vec![],
             },
         };
         let expected_output = executable::rendered::Executable {
@@ -445,7 +440,6 @@ restart_policy:
                     max_retries: 30.into(),
                     last_retry_interval: BackoffLastRetryInterval::from_secs(300),
                 },
-                restart_exit_codes: vec![],
             },
         };
         let actual_output = input.template_with(&variables).unwrap();
@@ -492,7 +486,6 @@ executables:
                         max_retries: TemplateableValue::from_template("3".to_string()),
                         last_retry_interval: TemplateableValue::from_template("30s".to_string()),
                     },
-                    restart_exit_codes: vec![],
                 },
                 env: Env::default(),
             }],

--- a/agent-control/src/agent_type/runtime_config/restart_policy.rs
+++ b/agent-control/src/agent_type/runtime_config/restart_policy.rs
@@ -17,9 +17,6 @@ pub struct RestartPolicyConfig {
     /// Strategy configuration to retry in case of failure.
     #[serde(default)]
     pub backoff_strategy: BackoffStrategyConfig,
-    /// List of exit codes that triggers a restart.
-    #[serde(default)]
-    pub restart_exit_codes: Vec<i32>,
 }
 
 impl Templateable for RestartPolicyConfig {
@@ -28,7 +25,6 @@ impl Templateable for RestartPolicyConfig {
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         Ok(Self::Output {
             backoff_strategy: self.backoff_strategy.template_with(variables)?,
-            restart_exit_codes: self.restart_exit_codes, // TODO Not templating this for now!
         })
     }
 }

--- a/agent-control/src/agent_type/runtime_config/restart_policy/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/restart_policy/rendered.rs
@@ -6,8 +6,6 @@ use crate::agent_type::runtime_config::restart_policy::{
 pub struct RestartPolicyConfig {
     /// Strategy configuration to retry in case of failure.
     pub backoff_strategy: BackoffStrategyConfig,
-    /// List of exit codes that triggers a restart.
-    pub restart_exit_codes: Vec<i32>,
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -253,7 +253,6 @@ Instructions to actually run the sub-agent process. It is composed of the follow
 - `args`: Command line arguments passed to the executable. This is a string.
 - `env`: A key-value mapping of environment variables and their respective values. Strings.
 - `restart_policy`: How the sub-agent should behave if it ends execution. If this policy limits are exceeded the sub-agent will be marked as unhealthy (see [Health status](#health-status) below) and not restarted anymore. Accepts the following fields:
-  - `restart_exit_codes`: An array of numbers matching the exit codes where the restart policy will be applied. Any exit code not on this list won't trigger a restart. If not provided, the process will be restarted on non-successful codes.
   - `backoff_strategy`: Timing-related configuration for the restart, to prevent wasteful crash-loops. Accepts the following values:
     - `type`: either `fixed`, `linear` or `exponential`.
     - `backoff_delay`: Time between restarts. This is a time string in the form of `10s`, `1h`, etc.


### PR DESCRIPTION
# What this PR does / why we need it
IMO this feature is quite complex to be used and it should not be there unless required.
Moreover, it creates issues with windows since the implementation is currently unix dependent

Removing it it will simplify as well the process management

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
