### PR TITLE
fix(ci/cd): tag packages in a deterministic way

### DIFF
--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -85,6 +85,7 @@ jobs:
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
           GPG_MAIL: 'infrastructure-eng@newrelic.com'
           NR_RELEASE_TAG: ${{ inputs.tag_name }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag_name }}
 
       - name: Upload assets to pipeline
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# What this PR does / why we need it
Fix for https://github.com/newrelic/newrelic-agent-control/actions/runs/18737145503/job/53446154703

it avoid this
```
• git command result                             args=[-c log.showSignature=false tag --points-at HEAD --sort -version:refname]
      stdout=
      │ 1.2.0
      │ 0.100.18737145503
```

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
