### PR TITLE
chore: remove Limited Preview from package description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 publish = false
 rust-version = "1.89.0"
 license-file = "./LICENSE.md"
+repository = "https://github.com/newrelic/newrelic-agent-control"
 
 [workspace.dependencies]
 serde_json = "1.0.145"
@@ -20,7 +21,7 @@ regex = "1.12.2"
 mockall = "0.13.1"
 clap = "4.5.50"
 nix = "0.30.1"
-tracing-subscriber = { version = "0.3.20", features = [ "json" ] }
+tracing-subscriber = { version = "0.3.20", features = ["json"] }
 tracing-test = "0.2.5"
 assert_cmd = "2.0.17"
 assert_matches = "1.5.0"

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "newrelic_agent_control"
-description = "New Relic Agent Control Limited Preview"
+description = "New Relic Agent Control"
 version = "1.2.0"
 authors.workspace = true
 edition.workspace = true
@@ -105,11 +105,12 @@ glob = "0.3.3"
 name = "newrelic-agent-control-k8s"
 path = "src/bin/main_k8s.rs"
 
-[[bin]] # on-host binary
+# On-host binary
 # Due to a GoReleaser limitation, the generated binary here must have the same name as the final
 # name we want to use in the generated and packaged assets.
 # As our K8s build is more manual and does not have this problem, we can name the on-host binary
 # just `newrelic-agent-control` while the K8s one is kept as `newrelic-agent-control-k8s`.
+[[bin]]
 name = "newrelic-agent-control"
 path = "src/bin/main_onhost.rs"
 


### PR DESCRIPTION
This will be reflected in the CLI output, for example when doing `newrelic-agent-control --help`. We could have a better description than this in any case.

Also, as `agent_control` is our main package in this repository, I think we should consider revisiting the workspace manifest to see if we want to have a [root package](https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package) or keep this a [virtual workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace)
