### PR TITLE
chore: stop packaging newrelic-authr-rs-cli for linux [NR-475245]

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,17 +49,6 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/^.goreleaser.yml$/',
-      ],
-      depNameTemplate: 'newrelic/newrelic-auth-rs',
-      datasourceTemplate: 'github-releases',
-      matchStrings: [
-        ' *- NR_AUTH_CLIENT_VERSION=(?<currentValue>.+)',
-      ],
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
         '**/Cargo.toml',
       ],
       matchStrings: [

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ env:
   # Currently the only way to update the sub-agent versions is rebuild the binary of the agent-control
   - NEWRELIC_INFRA_AGENT_VERSION=1.70.0
   - NR_OTEL_COLLECTOR_VERSION=1.5.0
-  - NR_AUTH_CLIENT_VERSION=0.1.1
 builds:
   - id: newrelic-agent-control
     builder: rust
@@ -21,13 +20,12 @@ builds:
       - AGENT_CONTROL_VERSION={{ .Version }}
       - NEWRELIC_INFRA_AGENT_VERSION={{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}
       - NR_OTEL_COLLECTOR_VERSION={{ .Env.NR_OTEL_COLLECTOR_VERSION }}
-      - NR_AUTH_CLIENT_VERSION={{ .Env.NR_AUTH_CLIENT_VERSION }}
     hooks:
       post:
         - cmd: ./build/scripts/download_embedded.sh
           env:
             - ARCH={{ .Arch }}
-            - ARTIFACTS_VERSIONS={"newrelic-infra":"{{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}","nr-otel-collector":"{{ .Env.NR_OTEL_COLLECTOR_VERSION }}","newrelic-auth-cli":"{{ .Env.NR_AUTH_CLIENT_VERSION }}"}
+            - ARTIFACTS_VERSIONS={"newrelic-infra":"{{ .Env.NEWRELIC_INFRA_AGENT_VERSION }}","nr-otel-collector":"{{ .Env.NR_OTEL_COLLECTOR_VERSION }}"}
         - cmd: ./build/scripts/download_collector_config.sh
           env:
             - NR_OTEL_COLLECTOR_VERSION={{ .Env.NR_OTEL_COLLECTOR_VERSION }}
@@ -164,8 +162,6 @@ nfpms:
       # NR Otel Collector - Important to note the binary name is nrdot-collector-host matching nrdot binary
       - src: build/embedded/artifacts/{{- .Arch }}/nr-otel-collector/nrdot-collector-host
         dst: /usr/bin/nrdot-collector-host
-      - src: build/embedded/artifacts/{{- .Arch }}/newrelic-auth-cli/newrelic-auth-cli
-        dst: /usr/bin/newrelic-auth-cli
       - src: build/examples/
         dst: /etc/newrelic-agent-control/examples
 

--- a/build/embedded/embedded.yaml
+++ b/build/embedded/embedded.yaml
@@ -63,11 +63,3 @@ artifacts:
   # installed via its newrelic-cli recipe with services disabled, allowing
   # agent-control to manage its orchestration.
   # name: nr-ebpf-agent
-
-  - name: newrelic-auth-cli
-    # Version now should be added in goreleaser.yaml global envs
-    url: https://github.com/newrelic/newrelic-auth-rs/releases/download/{{.Version | trimv}}/newrelic-auth-cli_{{.Arch}}.tar.gz
-    files:
-      - name: newrelic-auth-cli binary
-        src: newrelic-auth-cli
-        dest: artifacts/{{.Arch}}/newrelic-auth-cli


### PR DESCRIPTION
This PR removes the `newrelic-auth-rs-cli` from the linux packages, the tool is it not needed anymore after these changes in the recipe: https://github.com/newrelic/open-install-library/pull/1277

### Additional context

The folder `build/examples` is kept for now because it is still including some files needed to set up the local configuration for the `nr-dot` agent.