### PR TITLE
test: command shutdown when sigterm is ignored

### DIFF
--- a/agent-control/src/sub_agent/on_host/command/executable_data.rs
+++ b/agent-control/src/sub_agent/on_host/command/executable_data.rs
@@ -1,5 +1,7 @@
 use crate::sub_agent::on_host::command::restart_policy::RestartPolicy;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
+
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct ExecutableData {
@@ -8,6 +10,7 @@ pub struct ExecutableData {
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
     pub restart_policy: RestartPolicy,
+    pub shutdown_timeout: Duration,
 }
 
 impl ExecutableData {
@@ -18,6 +21,7 @@ impl ExecutableData {
             args: Vec::default(),
             env: HashMap::default(),
             restart_policy: RestartPolicy::default(),
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
 

--- a/agent-control/tests/on_host/command/mod.rs
+++ b/agent-control/tests/on_host/command/mod.rs
@@ -1,1 +1,1 @@
-mod non_blocking_runner;
+mod shutdown;

--- a/agent-control/tests/on_host/command/shutdown.rs
+++ b/agent-control/tests/on_host/command/shutdown.rs
@@ -5,6 +5,7 @@ use newrelic_agent_control::sub_agent::on_host::command::restart_policy::Restart
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
+use std::{thread::sleep, time::Duration};
 
 #[test]
 fn non_blocking_runner() {
@@ -20,12 +21,39 @@ fn non_blocking_runner() {
             args: vec!["5".to_string()],
             env: HashMap::from([("TEST".to_string(), "TEST".to_string())]),
             restart_policy: RestartPolicy::default(),
+            shutdown_timeout: Default::default(),
         },
         false,
         PathBuf::default(),
     );
 
     let mut started_cmd = cmd.start().unwrap();
+    sleep(Duration::from_millis(500)); // Give the process some room to start
+
     let terminated = started_cmd.shutdown();
     assert!(terminated.is_ok());
+}
+
+#[test]
+fn command_shutdown_when_sigterm_is_ignored() {
+    let agent_id = "test".to_string().try_into().unwrap();
+    let mut cmd = CommandOSNotStarted::new(
+        agent_id,
+        &ExecutableData {
+            id: "test".to_string(),
+            bin: "tests/on_host/data/ignore_sigterm.sh".to_string(),
+            args: Default::default(),
+            env: Default::default(),
+            restart_policy: Default::default(),
+            shutdown_timeout: Duration::from_secs(1),
+        },
+        false,
+        Default::default(),
+    )
+    .start()
+    .unwrap();
+    sleep(Duration::from_millis(500)); // Give the process some room to start
+
+    let terminated = cmd.shutdown();
+    assert!(terminated.is_ok())
 }

--- a/agent-control/tests/on_host/data/ignore_sigterm.sh
+++ b/agent-control/tests/on_host/data/ignore_sigterm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Trap SIGTERM (Signal 15) and set its action to ignore.
+trap '' SIGTERM
+
+echo "Script started. PID: $$"
+echo "Waiting forever. Send SIGTERM (kill \$PID) to see it ignored."
+echo "Send SIGKILL (kill -9 \$PID) to stop forcefully."
+
+while true; do
+    sleep 5
+done


### PR DESCRIPTION
This PR add a test to check that the command shutdown is working as expected when the corresponding process handles sigterm by itself (this may happen when the agent handles graceful shutdown). It also adds a configuration field to allow setting up the _shutdown timeout_ which is useful for the test itself and will help use making this value configurable in the agent type.