### PR TITLE
chore: move recipes branch to main

### DIFF
--- a/test/onhost-e2e/Makefile
+++ b/test/onhost-e2e/Makefile
@@ -2,7 +2,7 @@
 include ../Ansible.common
 
 LOCAL_PACKAGE_PATH ?= $(CURDIR)/../../dist
-RECIPE_BRANCH ?= feat/agent-control-use-ac-cli
+RECIPE_BRANCH ?= main
 
 # Variables dependent on the New Relic platform region.
 OPAMP_ENDPOINT = "https://opamp.staging-service.newrelic.com/v1/opamp"


### PR DESCRIPTION
This PR moves the recipe's branch to main for on-host e2e. Check #1794 for details