### PR TITLE
feat(on-host-cli): support empty proxy on config generation

### DIFF
--- a/agent-control/src/cli/on_host/config_gen/config.rs
+++ b/agent-control/src/cli/on_host/config_gen/config.rs
@@ -1,10 +1,8 @@
 //! Contains the definition of the configuration to be generated
 
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
 use serde::Serialize;
-
-use crate::http::config::ProxyConfig;
 
 /// Represents the set of agents to be included in the AC configuration.
 #[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum)]
@@ -33,6 +31,46 @@ impl From<AgentSet> for HashMap<String, Agent> {
             .into(),
             AgentSet::NoAgents => HashMap::new(),
         }
+    }
+}
+
+/// Holds the proxy configuration.
+/// Cannot use [crate::http::config::ProxyConfig] directly due lack of support for defaults in clap.
+/// See <https://github.com/clap-rs/clap/issues/4746> for details.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, clap::Args)]
+pub struct ProxyConfig {
+    #[serde(skip_serializing_if = "is_none_or_empty_string", rename = "url")]
+    #[arg(long, required = false)]
+    pub proxy_url: Option<String>,
+
+    #[serde(
+        skip_serializing_if = "is_none_or_empty_string",
+        rename = "ca_bundle_dir"
+    )]
+    #[arg(long, required = false)]
+    pub proxy_ca_bundle_dir: Option<String>,
+
+    #[serde(
+        skip_serializing_if = "is_none_or_empty_string",
+        rename = "ca_bundle_file"
+    )]
+    #[arg(long, required = false)]
+    pub proxy_ca_bundle_file: Option<String>,
+
+    #[arg(long, default_value_t = false, value_parser = ignore_system_proxy_parser, action = clap::ArgAction::Set)]
+    pub ignore_system_proxy: bool,
+}
+
+// Helper to avoid serializing empty values
+fn is_none_or_empty_string(v: &Option<String>) -> bool {
+    v.as_ref().map(|s| s.is_empty()).unwrap_or(true)
+}
+
+// Custom parser to allow empty values as false booleans
+fn ignore_system_proxy_parser(s: &str) -> Result<bool, Infallible> {
+    match s.to_lowercase().as_str() {
+        "" | "false" => Ok(false),
+        _ => Ok(true),
     }
 }
 
@@ -84,6 +122,7 @@ pub struct Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::{Args, FromArgMatches};
     use rstest::rstest;
 
     #[rstest]
@@ -108,5 +147,55 @@ mod tests {
             .collect();
 
         assert_eq!(result, expected_map);
+    }
+
+    #[test]
+    fn test_serialize_proxy_config_all_empty_options() {
+        let proxy_config = ProxyConfig {
+            proxy_url: Some(String::new()),
+            proxy_ca_bundle_dir: Some(String::new()),
+            proxy_ca_bundle_file: Some(String::new()),
+            ignore_system_proxy: false,
+        };
+
+        let serialized = serde_yaml::to_string(&proxy_config).unwrap();
+        // Only ignore_system_proxy should be present
+        assert_eq!(serialized.trim(), "ignore_system_proxy: false");
+    }
+
+    #[test]
+    fn test_serialize_proxy_config_none_options() {
+        let proxy_config = ProxyConfig {
+            proxy_url: None,
+            proxy_ca_bundle_dir: None,
+            proxy_ca_bundle_file: None,
+            ignore_system_proxy: true,
+        };
+
+        let serialized = serde_yaml::to_string(&proxy_config).unwrap();
+        // Only ignore_system_proxy should be present
+        assert_eq!(serialized.trim(), "ignore_system_proxy: true");
+    }
+
+    #[rstest]
+    #[case("", ProxyConfig::default())]
+    #[case(
+        "--proxy-url https://proxy.url --proxy-ca-bundle-dir=/bundle/dir --proxy-ca-bundle-file=/bundle/file --ignore-system-proxy true",
+        ProxyConfig{proxy_url: Some("https://proxy.url".into()), proxy_ca_bundle_dir: Some("/bundle/dir".into()), proxy_ca_bundle_file: Some("/bundle/file".into()), ignore_system_proxy: true},
+    )]
+    #[case("--proxy-url= --proxy-ca-bundle-dir= --proxy-ca-bundle-file= --ignore-system-proxy=", ProxyConfig{proxy_url: Some("".into()), proxy_ca_bundle_dir: Some("".into()), proxy_ca_bundle_file: Some("".into()), ignore_system_proxy: false})]
+    #[case(" --ignore-system-proxy=", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=false", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=true", ProxyConfig{ignore_system_proxy: true, ..Default::default()})]
+    #[case(" --ignore-system-proxy=False", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=True", ProxyConfig{ignore_system_proxy: true, ..Default::default()})]
+    fn test_proxy_args(#[case] args: &str, #[case] expected: ProxyConfig) {
+        let cmd = clap::Command::new("test").no_binary_name(true);
+        let cmd = ProxyConfig::augment_args(cmd);
+        let matches = cmd
+            .try_get_matches_from(args.split_ascii_whitespace())
+            .expect("arguments should be valid");
+        let value = ProxyConfig::from_arg_matches(&matches).expect("should create the struct back");
+        assert_eq!(value, expected)
     }
 }

--- a/agent-control/src/cli/on_host/config_gen/identity.rs
+++ b/agent-control/src/cli/on_host/config_gen/identity.rs
@@ -23,7 +23,7 @@ use nr_auth::{
 };
 use tracing::info;
 
-use crate::{cli::error::CliError, http::config::ProxyConfig};
+use crate::cli::{error::CliError, on_host::config_gen::config::ProxyConfig};
 
 use super::Args;
 
@@ -142,13 +142,13 @@ fn build_nr_auth_proxy_config(
     ac_cfg: ProxyConfig,
 ) -> Result<nr_auth::http::config::ProxyConfig, CliError> {
     let auth_cfg = nr_auth::http::config::ProxyConfig::new(
-        ac_cfg.url_as_string(),
-        ac_cfg.ca_bundle_dir().to_owned(),
-        ac_cfg.ca_bundle_file().to_owned(),
+        ac_cfg.proxy_url.unwrap_or_default(),
+        PathBuf::from(ac_cfg.proxy_ca_bundle_dir.unwrap_or_default()),
+        PathBuf::from(ac_cfg.proxy_ca_bundle_file.unwrap_or_default()),
     )
     .map_err(|err| CliError::Command(format!("invalid proxy configuration: {err}")))?;
 
-    if ac_cfg.ignore_system_proxy() {
+    if ac_cfg.ignore_system_proxy {
         Ok(auth_cfg)
     } else {
         auth_cfg


### PR DESCRIPTION
The changes extend the support of the `generate-config` on-hots command for allowing empty values. Basically we can move from:

```
    # Proxy configuration
          if [ ! -z "{{.NEW_RELIC_AGENT_CONTROL_PROXY_URL}}" ] ; then
            AC_PROXY_ARGS="--proxy-url {{.NEW_RELIC_AGENT_CONTROL_PROXY_URL}}"
            if [ ! -z "{{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_FILE}}" ] ; then
              AC_PROXY_ARGS="$AC_PROXY_ARGS --proxy-ca-bundle-file {{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_FILE}}"
            fi
            if [ ! -z "{{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_DIR}}" ] ; then
              AC_PROXY_ARGS="$AC_PROXY_ARGS --proxy-ca-bundle-dir {{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_DIR}}"
            fi
            if [ "{{.NEW_RELIC_AGENT_CONTROL_PROXY_IGNORE_SYSTEM}}" == "true" ] ; then
              AC_PROXY_ARGS="$AC_PROXY_ARGS --ignore-system-proxy"
            fi
          else
            AC_PROXY_ARGS=""
          fi
          # Config generation
          newrelic-agent-control-cli generate-config \
            <OTHER-ARGS> \
            $AC_PROXY_ARGS
```

to:

```
newrelic-agent-control-cli generate-config \
  <OTHER-ARGS> \
  --proxy-url "{{.NEW_RELIC_AGENT_CONTROL_PROXY_URL}}" \
  --proxy-ca-bundle-file "{{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_FILE}}" \
  --proxy-ca-bundle-dir "{{.NEW_RELIC_AGENT_CONTROL_PROXY_CA_BUNDLE_DIR}}" \
  --ignore-system-proxy "{{.NEW_RELIC_AGENT_CONTROL_PROXY_IGNORE_SYSTEM}}" 
```