### PR TITLE
fix: isolate build package artifacts

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: built-binaries
+          name: built-binaries-0.900.${{ github.run_id }}
           path: ./
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         required: false
         default: false
+      skip_upload_artifact:
+        description: 'skip uploading the artifact'
+        type: boolean
+        required: false
+        default: false
       tag_name:
         description: 'tag name for the packages'
         type: string
@@ -98,10 +103,11 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ inputs.tag_name }}
 
       - name: Upload assets to pipeline
+        if: ${{ !inputs.skip_upload_artifact }}
         uses: actions/upload-artifact@v4
         with:
           retention-days: 1
-          name: built-binaries
+          name: built-binaries-${{ inputs.tag_name }}
           path: |
             ./bin/*
             ./dist/*

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: built-binaries
+          name: built-binaries-0.100.${{ github.run_id }}
           path: ./
 
       - name: Publish deb to S3 action
@@ -135,7 +135,6 @@ jobs:
       - build-image
       - build-packages
       - k8s-e2e-tests
-      # - k8s-e2e-tests-proxy
     runs-on: ubuntu-latest
     steps:
       - name: Notify failure via Slack

--- a/.github/workflows/push_pr_package.yml
+++ b/.github/workflows/push_pr_package.yml
@@ -19,8 +19,9 @@ jobs:
     uses: ./.github/workflows/component_packages.yml
     with:
       pre-release: false
+      skip_upload_artifact: true
+      skip_sign: true
       tag_name: 0.100.0
-    secrets: inherit
 
   build-image:
     name: Build image


### PR DESCRIPTION
- Makes every artifact upload to have a unique name to avoid [collisions](https://github.com/newrelic/newrelic-agent-control/actions/runs/18896757554/job/53935864479). 
- Skips the upload in for the PR case which is not necessary 
