### PR TITLE
test: fix tls timeout host e2e

### DIFF
--- a/test/ac-ansible-roles/install_ac_recipe/tasks/debian.yaml
+++ b/test/ac-ansible-roles/install_ac_recipe/tasks/debian.yaml
@@ -61,6 +61,9 @@
       --localRecipes {{ tmp_recipes.path }}\
       -n {{ recipe_list }}
   register: install_logs
+  retries: 3
+  delay: 30
+  until: "'TLS handshake timeout' not in install_logs.stderr"
 
 - name: Install logs
   debug:

--- a/test/onhost-e2e/ansible/migration.yaml
+++ b/test/onhost-e2e/ansible/migration.yaml
@@ -26,6 +26,9 @@
             NEW_RELIC_REGION=US \
             /usr/local/bin/newrelic install -n infrastructure-agent-installer
         register: out
+        retries: 3
+        delay: 30
+        until: "'TLS handshake timeout' not in out.stderr"
       - debug:
           var: out.stdout_lines
 


### PR DESCRIPTION
Retries whenever the recipe fails testing the endpoints due to tls timeout
https://github.com/newrelic/newrelic-agent-control/actions/runs/18929474020/job/54043857131#step:6:113