### PR TITLE
chore: avoid winreg dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,7 +3474,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "windows-link 0.2.1",
- "winreg",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4946,15 +4946,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -5107,16 +5098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2659,12 +2659,6 @@ Distributed under the following license(s):
 
 * MIT
 
-## winreg <https://crates.io/crates/winreg>
-
-Distributed under the following license(s):
-
-* MIT
-
 ## wit-bindgen <https://crates.io/crates/wit-bindgen>
 
 Distributed under the following license(s):

--- a/resource-detection/Cargo.toml
+++ b/resource-detection/Cargo.toml
@@ -20,7 +20,7 @@ konst = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-link = "0.2.1"
-winreg = "0.55"
+windows-sys = { version = "0.61.2", features = ["Win32_System_Registry"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/resource-detection/src/system/machine_identifier/windows.rs
+++ b/resource-detection/src/system/machine_identifier/windows.rs
@@ -1,7 +1,7 @@
 use crate::system::detector::SystemDetectorError;
-use winreg::{
-    RegKey,
-    enums::{HKEY_LOCAL_MACHINE, KEY_READ},
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::System::Registry::{
+    HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
 };
 
 const CRYPTOGRAPHY_KEY_PATH: &str = "SOFTWARE\\Microsoft\\Cryptography";
@@ -11,17 +11,114 @@ const MACHINE_GUID_KEY_NAME: &str = "MachineGuid";
 pub struct MachineIdentityProvider {}
 
 impl MachineIdentityProvider {
-    /// Reads the _MachineGuid_ from the Windows registry using [winreg].
+    /// Reads the _MachineGuid_ from the Windows registry.
     pub fn provide(&self) -> Result<String, SystemDetectorError> {
-        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE); // Open the local machine root key.
-        // Open the Cryptography reg key with read permissions
-        let cryptography_key = hklm
-            .open_subkey_with_flags(CRYPTOGRAPHY_KEY_PATH, KEY_READ)
-            .map_err(|err| SystemDetectorError::MachineIDError(err.to_string()))?;
-        // Get the value from the registry
-        cryptography_key
-            .get_value(MACHINE_GUID_KEY_NAME)
-            .map_err(|err| SystemDetectorError::MachineIDError(err.to_string()))
+        // Convert the value names to wide strings (UTF-16)
+        let key_path: Vec<u16> = CRYPTOGRAPHY_KEY_PATH
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let key_name: Vec<u16> = MACHINE_GUID_KEY_NAME
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+
+        Self::read_string_from_registry(key_path, key_name)
+    }
+
+    /// Helper to read a string from the registry
+    pub fn read_string_from_registry(
+        key_path: Vec<u16>,
+        key_name: Vec<u16>,
+    ) -> Result<String, SystemDetectorError> {
+        unsafe {
+            // Open the registry key
+            let mut registry_key: *mut std::ffi::c_void = std::ptr::null_mut();
+            let result = RegOpenKeyExW(
+                HKEY_LOCAL_MACHINE,
+                key_path.as_ptr(),
+                0,
+                KEY_READ,
+                &mut registry_key,
+            );
+
+            if result != ERROR_SUCCESS {
+                return Err(SystemDetectorError::MachineIDError(format!(
+                    "failed to open registry key: error code {}",
+                    result
+                )));
+            }
+
+            // Query the type and size of the value
+            let mut value_type = 0u32;
+            let mut data_size = 0u32;
+
+            let result = RegQueryValueExW(
+                registry_key,
+                key_name.as_ptr(),
+                std::ptr::null(),
+                &mut value_type,
+                std::ptr::null_mut(),
+                &mut data_size,
+            );
+
+            if result != ERROR_SUCCESS {
+                Self::close_registry_key(registry_key)?;
+                return Err(SystemDetectorError::MachineIDError(format!(
+                    "failed to query registry value size: error code {}",
+                    result
+                )));
+            }
+
+            // Allocate buffer and read the actual value
+            let mut buffer: Vec<u16> = vec![0; (data_size / 2) as usize];
+
+            let result = RegQueryValueExW(
+                registry_key,
+                key_name.as_ptr(),
+                std::ptr::null(),
+                &mut value_type,
+                buffer.as_mut_ptr() as *mut u8,
+                &mut data_size,
+            );
+
+            Self::close_registry_key(registry_key)?;
+
+            if result != ERROR_SUCCESS {
+                return Err(SystemDetectorError::MachineIDError(format!(
+                    "failed to read registry value: error code {}",
+                    result
+                )));
+            }
+
+            // Verify it's a string type
+            if value_type != REG_SZ {
+                return Err(SystemDetectorError::MachineIDError(format!(
+                    "unexpected registry value type: {}",
+                    value_type
+                )));
+            }
+
+            // Convert from UTF-16 to String, removing the null terminator
+            let string_value = String::from_utf16_lossy(&buffer)
+                .trim_end_matches('\0')
+                .to_string();
+
+            Ok(string_value)
+        }
+    }
+
+    /// Helper to close the registry key returning the corresponding error on failure
+    unsafe fn close_registry_key(hkey: *mut std::ffi::c_void) -> Result<(), SystemDetectorError> {
+        unsafe {
+            let result = RegCloseKey(hkey);
+            if result != ERROR_SUCCESS {
+                return Err(SystemDetectorError::MachineIDError(format!(
+                    "failed to close the registry key: error code {result}"
+                )));
+            }
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
On top of #1809 

As pointed out by @paologallinaharbur, `winreg` dependency hasn't been updated in several months. This PR avoids its usage when reading the MachineGuid from the registry.