### PR TITLE
style: uniform target family conditional compilation

### DIFF
--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -72,11 +72,8 @@ opentelemetry-appender-tracing = { version = "0.31.1", features = [
 ] }
 async-trait = "0.1.89"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_family = "unix")'.dependencies]
 nix = { workspace = true, features = ["signal", "user", "hostname"] }
-
-[target.'cfg(windows)'.dependencies]
-
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/agent-control/src/sub_agent/on_host/command/command_os.rs
+++ b/agent-control/src/sub_agent/on_host/command/command_os.rs
@@ -124,7 +124,7 @@ impl CommandOSStarted {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 mod unix {
     use crate::sub_agent::on_host::command::{command_os::CommandOSStarted, error::CommandError};
 
@@ -163,7 +163,7 @@ mod unix {
 }
 
 //TODO Properly design unix/windows shutdown when Windows support is added
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use crate::sub_agent::on_host::command::{command_os::CommandOSStarted, error::CommandError};
 

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -45,7 +45,7 @@ fn print_debug_info() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 #[test]
 fn does_not_run_if_no_root() -> Result<(), Box<dyn std::error::Error>> {
     let dir = TempDir::new()?;
@@ -58,7 +58,7 @@ fn does_not_run_if_no_root() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 #[test]
 fn basic_startup() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Duration;
@@ -108,7 +108,7 @@ logs:
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 #[test]
 fn custom_logging_format() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Duration;
@@ -158,7 +158,7 @@ server:
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 #[test]
 #[ignore = "requires root"]
 fn custom_directory_overrides_as_root() -> Result<(), Box<dyn std::error::Error>> {
@@ -234,7 +234,7 @@ server:
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 #[test]
 fn runs_with_no_config() -> Result<(), Box<dyn std::error::Error>> {
     use std::{env, time::Duration};


### PR DESCRIPTION
# What this PR does / why we need it

`#[cfg(unix)]` and `#[cfg(target_family = "unix")]` are equivalent per the [docs](https://doc.rust-lang.org/reference/conditional-compilation.html#unix-and-windows). Let's stick to the most explicit of them.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
