### PR TITLE
feat(on-hots-cli): support empty proxy on config generation

### DIFF
--- a/agent-control/src/cli/on_host/config_gen/config.rs
+++ b/agent-control/src/cli/on_host/config_gen/config.rs
@@ -1,10 +1,8 @@
 //! Contains the definition of the configuration to be generated
 
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
 use serde::Serialize;
-
-use crate::http::config::ProxyConfig;
 
 /// Represents the set of agents to be included in the AC configuration.
 #[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum)]
@@ -33,6 +31,46 @@ impl From<AgentSet> for HashMap<String, Agent> {
             .into(),
             AgentSet::NoAgents => HashMap::new(),
         }
+    }
+}
+
+/// Holds the proxy configuration.
+/// Cannot use [crate::http::config::ProxyConfig] directly due lack of support for defaults in clap.
+/// See <https://github.com/clap-rs/clap/issues/4746> for details.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, clap::Args)]
+pub struct ProxyConfig {
+    #[serde(skip_serializing_if = "is_none_or_empty_string", rename = "url")]
+    #[arg(long, required = false)]
+    pub proxy_url: Option<String>,
+
+    #[serde(
+        skip_serializing_if = "is_none_or_empty_string",
+        rename = "ca_bundle_dir"
+    )]
+    #[arg(long, required = false)]
+    pub proxy_ca_bundle_dir: Option<String>,
+
+    #[serde(
+        skip_serializing_if = "is_none_or_empty_string",
+        rename = "ca_bundle_file"
+    )]
+    #[arg(long, required = false)]
+    pub proxy_ca_bundle_file: Option<String>,
+
+    #[arg(long, default_value_t = false, value_parser = ignore_system_proxy_parser, action = clap::ArgAction::Set)]
+    pub ignore_system_proxy: bool,
+}
+
+// Helper to avoid serializing empty values
+fn is_none_or_empty_string(v: &Option<String>) -> bool {
+    v.as_ref().map(|s| s.is_empty()).unwrap_or(true)
+}
+
+// Custom parser to allow empty values as false booleans
+fn ignore_system_proxy_parser(s: &str) -> Result<bool, Infallible> {
+    match s.to_lowercase().as_str() {
+        "" | "false" => Ok(false),
+        _ => Ok(true),
     }
 }
 
@@ -84,6 +122,7 @@ pub struct Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::{Args, FromArgMatches};
     use rstest::rstest;
 
     #[rstest]
@@ -108,5 +147,55 @@ mod tests {
             .collect();
 
         assert_eq!(result, expected_map);
+    }
+
+    #[test]
+    fn test_serialize_proxy_config_all_empty_options() {
+        let proxy_config = ProxyConfig {
+            proxy_url: Some(String::new()),
+            proxy_ca_bundle_dir: Some(String::new()),
+            proxy_ca_bundle_file: Some(String::new()),
+            ignore_system_proxy: false,
+        };
+
+        let serialized = serde_yaml::to_string(&proxy_config).unwrap();
+        // Only ignore_system_proxy should be present
+        assert_eq!(serialized.trim(), "ignore_system_proxy: false");
+    }
+
+    #[test]
+    fn test_serialize_proxy_config_none_options() {
+        let proxy_config = ProxyConfig {
+            proxy_url: None,
+            proxy_ca_bundle_dir: None,
+            proxy_ca_bundle_file: None,
+            ignore_system_proxy: true,
+        };
+
+        let serialized = serde_yaml::to_string(&proxy_config).unwrap();
+        // Only ignore_system_proxy should be present
+        assert_eq!(serialized.trim(), "ignore_system_proxy: true");
+    }
+
+    #[rstest]
+    #[case("", ProxyConfig::default())]
+    #[case(
+        "--proxy-url https://proxy.url --proxy-ca-bundle-dir=/bundle/dir --proxy-ca-bundle-file=/bundle/file --ignore-system-proxy true",
+        ProxyConfig{proxy_url: Some("https://proxy.url".into()), proxy_ca_bundle_dir: Some("/bundle/dir".into()), proxy_ca_bundle_file: Some("/bundle/file".into()), ignore_system_proxy: true},
+    )]
+    #[case("--proxy-url= --proxy-ca-bundle-dir= --proxy-ca-bundle-file= --ignore-system-proxy=", ProxyConfig{proxy_url: Some("".into()), proxy_ca_bundle_dir: Some("".into()), proxy_ca_bundle_file: Some("".into()), ignore_system_proxy: false})]
+    #[case(" --ignore-system-proxy=", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=false", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=true", ProxyConfig{ignore_system_proxy: true, ..Default::default()})]
+    #[case(" --ignore-system-proxy=False", ProxyConfig{ignore_system_proxy: false, ..Default::default()})]
+    #[case(" --ignore-system-proxy=True", ProxyConfig{ignore_system_proxy: true, ..Default::default()})]
+    fn test_proxy_args(#[case] args: &str, #[case] expected: ProxyConfig) {
+        let cmd = clap::Command::new("test").no_binary_name(true);
+        let cmd = ProxyConfig::augment_args(cmd);
+        let matches = cmd
+            .try_get_matches_from(args.split_ascii_whitespace())
+            .expect("arguments should be valid");
+        let value = ProxyConfig::from_arg_matches(&matches).expect("should create the struct back");
+        assert_eq!(value, expected)
     }
 }

--- a/agent-control/src/cli/on_host/config_gen/identity.rs
+++ b/agent-control/src/cli/on_host/config_gen/identity.rs
@@ -23,7 +23,7 @@ use nr_auth::{
 };
 use tracing::info;
 
-use crate::{cli::error::CliError, http::config::ProxyConfig};
+use crate::cli::{error::CliError, on_host::config_gen::config::ProxyConfig};
 
 use super::Args;
 
@@ -142,13 +142,13 @@ fn build_nr_auth_proxy_config(
     ac_cfg: ProxyConfig,
 ) -> Result<nr_auth::http::config::ProxyConfig, CliError> {
     let auth_cfg = nr_auth::http::config::ProxyConfig::new(
-        ac_cfg.url_as_string(),
-        ac_cfg.ca_bundle_dir().to_owned(),
-        ac_cfg.ca_bundle_file().to_owned(),
+        ac_cfg.proxy_url.unwrap_or_default(),
+        PathBuf::from(ac_cfg.proxy_ca_bundle_dir.unwrap_or_default()),
+        PathBuf::from(ac_cfg.proxy_ca_bundle_file.unwrap_or_default()),
     )
     .map_err(|err| CliError::Command(format!("invalid proxy configuration: {err}")))?;
 
-    if ac_cfg.ignore_system_proxy() {
+    if ac_cfg.ignore_system_proxy {
         Ok(auth_cfg)
     } else {
         auth_cfg

--- a/agent-control/tests/on_host/agent_control_cli.rs
+++ b/agent-control/tests/on_host/agent_control_cli.rs
@@ -10,9 +10,9 @@ fn test_config_generator_fleet_disabled_proxy() {
 
     let mut cmd = cargo_bin_cmd!("newrelic-agent-control-cli");
     let args = format!(
-        "generate-config --fleet-disabled --agent-set infra-agent --region us --proxy-url https://some.proxy.url/ --proxy-ca-bundle-dir /test/bundle/dir --proxy-ca-bundle-file /test/bundle/file --ignore-system-proxy --output-path {path}",
+        "generate-config --fleet-disabled --agent-set infra-agent --region us --proxy-url https://some.proxy.url/ --proxy-ca-bundle-dir /test/bundle/dir --ignore-system-proxy true --output-path {path}",
     );
-    cmd.args(args.split(" "));
+    cmd.args(args.split_ascii_whitespace());
     cmd.assert().success();
 
     let expected_value: serde_yaml::Value = serde_yaml::from_str(
@@ -25,8 +25,36 @@ agents:
 proxy:
   url: https://some.proxy.url/
   ca_bundle_dir: /test/bundle/dir
-  ca_bundle_file: /test/bundle/file
   ignore_system_proxy: true
+    "#,
+    )
+    .unwrap();
+    let actual_content = std::fs::read_to_string(&path).unwrap();
+    let actual_value: serde_yaml::Value = serde_yaml::from_str(&actual_content).unwrap();
+    assert_eq!(actual_value, expected_value);
+}
+
+#[test]
+fn test_config_generator_fleet_disabled_proxy_empty_fields() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("output.yaml").to_string_lossy().to_string();
+
+    let mut cmd = cargo_bin_cmd!("newrelic-agent-control-cli");
+    let args = format!(
+        "generate-config --fleet-disabled --agent-set infra-agent --region us --proxy-url= --proxy-ca-bundle-dir= --proxy-ca-bundle-file= --ignore-system-proxy= --output-path {path}",
+    );
+    cmd.args(args.split_ascii_whitespace());
+    cmd.assert().success();
+
+    let expected_value: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+server:
+  enabled: true
+agents:
+  nr-infra:
+    agent_type: "newrelic/com.newrelic.infrastructure:0.1.0"
+proxy:
+  ignore_system_proxy: false
     "#,
     )
     .unwrap();
@@ -47,7 +75,7 @@ fn test_config_generator_fleet_enabled_identity_provisioned() {
     let args = format!(
         "generate-config --agent-set infra-agent --region us --fleet-id FLEET-ID --auth-client-id CLIENT-ID --auth-private-key-path {key_path} --output-path {path}",
     );
-    cmd.args(args.split(" "));
+    cmd.args(args.split_ascii_whitespace());
     cmd.assert().success();
 
     let expected_value: serde_yaml::Value = serde_yaml::from_str(


### PR DESCRIPTION
Includes the changes of #1805 that were omitted in a bad rebase.