### PR TITLE
test: activate win integration tests

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -438,6 +438,10 @@ jobs:
         shell: bash
         run: make -C agent-control test/onhost
 
+      - name: Run integration tests
+        shell: bash
+        run: make -C agent-control test/onhost/integration
+
   check-all-green:
     name: 🟢 All required checks and tests pass
     if: always()

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -1,4 +1,5 @@
 use crate::common::retry::retry;
+#[cfg(target_family = "unix")]
 use crate::on_host::logging::level::TIME_FORMAT;
 use assert_cmd::Command;
 use assert_cmd::assert::OutputAssertExt;

--- a/agent-control/tests/on_host/id.rs
+++ b/agent-control/tests/on_host/id.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 use super::tools::config::{create_file, create_local_config};
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::retry::retry;
@@ -174,6 +173,7 @@ fn test_gcp_cloud_id() {
 }
 
 /// tests that nr-ac:host_id and nr-sub:agent_id are correctly replaced in the agent type.
+#[cfg(target_family = "unix")]
 #[test]
 fn test_sub_sa_vars() {
     use newrelic_agent_control::agent_control::run::Environment;

--- a/agent-control/tests/on_host/logging/file_logging.rs
+++ b/agent-control/tests/on_host/logging/file_logging.rs
@@ -1,3 +1,4 @@
+#![cfg(target_family = "unix")]
 use super::level::TIME_FORMAT;
 use crate::on_host::cli::cmd_with_config_file;
 use newrelic_agent_control::{

--- a/agent-control/tests/on_host/logging/level.rs
+++ b/agent-control/tests/on_host/logging/level.rs
@@ -1,3 +1,4 @@
+#![cfg(target_family = "unix")]
 use crate::on_host::cli::cmd_with_config_file;
 use newrelic_agent_control::{
     agent_control::defaults::{

--- a/agent-control/tests/on_host/opamp_auth.rs
+++ b/agent-control/tests/on_host/opamp_auth.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use http::header::{AUTHORIZATION, CONTENT_TYPE};

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 use crate::on_host::tools::config::create_remote_config;
 use crate::{
     common::{
@@ -99,6 +98,7 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 
 /// The agent-control is configured with local configuration containing a sub-agent, but there is no local configuration
 /// for the sub-agent. The corresponding sub-agent supervisor will not start until a remote configuration is received.
+#[cfg(target_family = "unix")]
 #[test]
 fn onhost_opamp_sub_agent_with_no_local_config() {
     // Given a agent-control with a custom-agent with opamp configured.

--- a/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
@@ -102,6 +101,7 @@ fn onhost_opamp_sub_agent_invalid_remote_config() {
 /// - That the latest remote config status is failed.
 /// - The failed remote config should not be persisted.
 /// - That latest effective configuration reported is the local one (which is valid).
+#[cfg(target_family = "unix")]
 #[test]
 fn test_invalid_config_executable_less_supervisor() {
     let mut opamp_server = FakeServer::start_new();
@@ -184,6 +184,7 @@ fn test_invalid_config_executable_less_supervisor() {
 /// - That the latest remote config status is failed.
 /// - The failed remote config should not be persisted.
 /// - That latest effective configuration reported is the latest applied valid remote config.
+#[cfg(target_family = "unix")]
 #[test]
 fn onhost_opamp_sub_agent_invalid_remote_config_rollback_previous_remote() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::check_latest_health_status_was_healthy;
@@ -245,6 +244,7 @@ non-existing: {}
 /// The agent control is configured with one agent whose local configuration contains an environment variable
 /// placeholder. This test checks that the effective config is reported as expected (and it does not included
 /// the environment variable expanded).
+#[cfg(target_family = "unix")]
 #[test]
 fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
@@ -317,6 +317,7 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
 
 /// The agent-control is configured with on agent with local configuration and a remote configuration was also set for the
 /// corresponding sub-agent. This test checks that the latest effective config reported corresponds to the remote.
+#[cfg(target_family = "unix")]
 #[test]
 fn onhost_opamp_sub_agent_remote_effective_config() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
@@ -452,6 +453,7 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
 /// - Effective configuration updates to remote config
 /// - Stored retrieves latest applied remote config
 /// - Healthy status is reported
+#[cfg(target_family = "unix")]
 #[test]
 fn onhost_executable_less_reports_local_effective_config() {
     // Given a agent-control without agents and opamp configured.


### PR DESCRIPTION
- add windows integration test to CI
- Enables the tests that are platform independent ( mostly because they are not asserting on anything related to the process of the sub-agent)

Once the windows feature is more stable we can work on the tests. 
