### PR TITLE
feat: kill process if graceful shutdown fails

### DIFF
--- a/agent-control/src/sub_agent/on_host/command/command_os.rs
+++ b/agent-control/src/sub_agent/on_host/command/command_os.rs
@@ -126,6 +126,8 @@ impl CommandOSStarted {
 
 #[cfg(target_family = "unix")]
 mod unix {
+    use tracing::warn;
+
     use crate::sub_agent::on_host::command::{command_os::CommandOSStarted, error::CommandError};
 
     use std::time::Duration;
@@ -137,7 +139,7 @@ mod unix {
 
             use nix::{sys::signal, unistd::Pid};
             let graceful_shutdown_result = signal::kill(Pid::from_raw(pid), signal::SIGTERM)
-                .map_err(|err| CommandError::NixError(err.to_string()));
+                .inspect_err(|err| warn!(agent_id = %self.agent_id, "Failed to gracefully exit process {pid}: {err}. Attempting forceful shutdown"));
 
             if graceful_shutdown_result.is_err()
                 || self.is_running_after_timeout(self.shutdown_timeout)


### PR DESCRIPTION
# What this PR does / why we need it

The graceful shutdown attempt might fail for whatever reason and if this happens we just propagate the error without further checking the process. I think we should attempt to kill the process instead.

Added a log line indicating the failure to gracefully exit.

If this is merged, I can also attempt to unify the calls to `shutdown` in https://github.com/newrelic/newrelic-agent-control/pull/1838
## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
