### PR TITLE
feat: extract admin rights check and do it also for windows

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -455,15 +455,20 @@ jobs:
         if: '!cancelled()'
         run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
 
-      - name: Run tests agent control lib excluding root-required tests (on-host)
+      - name: Run tests agent control lib
         if: '!cancelled()'
         shell: bash
         run: make -C agent-control test/onhost
 
-      - name: Run integration tests
+      - name: Run integration tests excluding non root-required tests only available for unix (on-host)
         if: '!cancelled()'
         shell: bash
         run: make -C agent-control test/onhost/integration
+
+      - name: Run onHost root-required integration-tests only (windows runner has elevated permissions)
+        if: '!cancelled()'
+        shell: bash
+        run: make -C agent-control test/onhost/root/integration
 
       - name: Run documentation tests
         if: '!cancelled()'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "tracing-test",
  "url",
  "windows",
+ "windows-sys 0.61.2",
  "wrapper_with_default",
  "x509-parser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ reqwest = { version = "0.12.24", default-features = false, features = [
 ] }
 rstest = "0.26.1"
 windows = "0.62.2"
+windows-sys = "0.61.2"
 
 [profile.release]
 # remove debug symbols from the release binary

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -81,6 +81,9 @@ windows = { workspace = true, features = [
   "Win32_System_Threading",
 ] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }

--- a/agent-control/src/utils.rs
+++ b/agent-control/src/utils.rs
@@ -1,4 +1,5 @@
 pub mod binary_metadata;
+pub mod is_elevated;
 pub mod retry;
 pub mod thread_context;
 pub mod threads;

--- a/agent-control/src/utils/is_elevated.rs
+++ b/agent-control/src/utils/is_elevated.rs
@@ -1,0 +1,59 @@
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::Security::{
+    GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation,
+};
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct IsElevatedError(String);
+
+pub fn is_elevated() -> Result<bool, IsElevatedError> {
+    #[cfg(target_family = "unix")]
+    return Ok(nix::unistd::Uid::effective().is_root());
+
+    #[cfg(target_family = "windows")]
+    is_elevated_windows()
+}
+
+#[cfg(target_family = "windows")]
+fn is_elevated_windows() -> Result<bool, IsElevatedError> {
+    unsafe {
+        let mut token_handle: HANDLE = std::ptr::null_mut();
+        let process = GetCurrentProcess();
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken
+        // An access token contains the security information for a logon session and every process
+        // executed on behalf of the user has a copy of the token. Here we get that token.
+        if OpenProcessToken(process, TOKEN_QUERY, &mut token_handle) == 0 {
+            return Err(IsElevatedError("Failed to open process token.".to_string()));
+        }
+
+        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+        let mut return_length = 0;
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation
+        // GetTokenInformation requires a pointer to a buffer (elevation) the function fills with the requested information.
+        // The second parameter is the class (TokenElevation) we want to get information from the Token.
+        let result = GetTokenInformation(
+            token_handle,
+            TokenElevation,
+            &mut elevation as *mut _ as *mut _,
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut return_length,
+        );
+
+        CloseHandle(token_handle);
+
+        if result == 0 {
+            return Err(IsElevatedError(
+                "Failed to get token information to check user rights.".to_string(),
+            ));
+        }
+
+        Ok(elevation.TokenIsElevated != 0)
+    }
+}

--- a/agent-control/tests/on_host/cli.rs
+++ b/agent-control/tests/on_host/cli.rs
@@ -67,9 +67,9 @@ fn does_not_run_if_no_root() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     let mut cmd = cargo_bin_cmd!("newrelic-agent-control");
     cmd.arg("--local-dir").arg(dir.path());
-    cmd.assert()
-        .failure()
-        .stdout(predicate::str::contains("Program must run as root"));
+    cmd.assert().failure().stdout(predicate::str::contains(
+        "Program must run with elevated permissions",
+    ));
     Ok(())
 }
 

--- a/agent-control/tests/on_host/logging/file_logging.rs
+++ b/agent-control/tests/on_host/logging/file_logging.rs
@@ -48,8 +48,10 @@ fn default_log_level_no_root() {
     // Expecting to fail as non_root
     // Asserting content is logged to stdout as well
     cmd.assert().failure().stdout(
-        predicate::str::is_match(TIME_FORMAT.to_owned() + "ERROR.*Program must run as root")
-            .unwrap(),
+        predicate::str::is_match(
+            TIME_FORMAT.to_owned() + "ERROR.*Program must run with elevated permissions",
+        )
+        .unwrap(),
     );
 
     // The behavior of the appender functionality is already unit tested as part of the sub-agent

--- a/agent-control/tests/on_host/logging/level.rs
+++ b/agent-control/tests/on_host/logging/level.rs
@@ -46,8 +46,10 @@ fn default_log_level_no_root() {
             .unwrap(),
         )
         .stdout(
-            predicate::str::is_match(TIME_FORMAT.to_owned() + "ERROR.*Program must run as root")
-                .unwrap(),
+            predicate::str::is_match(
+                TIME_FORMAT.to_owned() + "ERROR.*Program must run with elevated permissions",
+            )
+            .unwrap(),
         );
 }
 
@@ -122,8 +124,10 @@ fn debug_log_level_no_root() {
             .unwrap(),
         )
         .stdout(
-            predicate::str::is_match(TIME_FORMAT.to_owned() + "ERROR.*Program must run as root")
-                .unwrap(),
+            predicate::str::is_match(
+                TIME_FORMAT.to_owned() + "ERROR.*Program must run with elevated permissions",
+            )
+            .unwrap(),
         );
 }
 


### PR DESCRIPTION
# What this PR does / why we need it

Adds check for elevation rights on the user executing agent-control both for linux or windows.

It's done with windows-sys crate, I tried using windows crate but couldn't manage to make it work. We are using the crate windows in another part of the project, we can think in the future if we unify all in the same crate.

## Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged. You can also add Jira ticket references if appropriate.)*

- fixes #

## Special notes for your reviewer

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
