### PR TITLE
feat: administrator permissions for created files on windows

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -279,8 +279,8 @@ jobs:
         run: |
           cargo install --locked cargo-zigbuild --force
 
-      - name: Run workspace tests excluding the agent control package
-        run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
+      - name: Run workspace tests excluding the agent control pkg (includes -winAdmin- ignored because it doesn't apply)
+        run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets -- --include-ignored
 
       - name: Run tests agent control lib excluding root-required tests (on-host)
         run: make -C agent-control test/onhost
@@ -451,9 +451,9 @@ jobs:
         if: '!cancelled()'
         run: cargo build --all --release
 
-      - name: Run workspace tests excluding the agent control package
+      - name: Run workspace tests excluding the agent control pkg (includes -winAdmin- ignored because user is elevated)
         if: '!cancelled()'
-        run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
+        run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets -- --include-ignored
 
       - name: Run tests agent control lib
         if: '!cancelled()'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -232,6 +232,12 @@ $ curl localhost:51200/status | jq
 cargo test --workspace --exclude 'newrelic_agent_control' --all-targets
 ```
 
+On Windows some of the tests need elevated permissions and are ignored by default but can be executed by adding:
+
+```sh
+cargo test --workspace --exclude 'newrelic_agent_control' --all-targets -- --include-ignored
+```
+
 We have `Makefile`s containing targets for testing. [Inspect them](../agent-control/Makefile) for more details.
 
 ### Feature `onhost`

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -14,6 +14,12 @@ mockall = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = "0.1.41"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Security",
+    "Win32_Security_Authorization",
+] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod directory_manager;
 pub mod file_reader;
 pub mod file_renamer;
 pub mod utils;
+pub mod win_permissions;
 pub mod writer_file;
 
 #[derive(Debug)]

--- a/fs/src/win_permissions.rs
+++ b/fs/src/win_permissions.rs
@@ -1,0 +1,118 @@
+#![cfg(target_family = "windows")]
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, GetLastError};
+use windows_sys::Win32::Security::Authorization::{
+    EXPLICIT_ACCESS_W, SE_FILE_OBJECT, SET_ACCESS, SetEntriesInAclW, SetNamedSecurityInfoW,
+    TRUSTEE_IS_SID, TRUSTEE_W,
+};
+use windows_sys::Win32::Security::{
+    ACL, CreateWellKnownSid, DACL_SECURITY_INFORMATION, NO_INHERITANCE,
+    PROTECTED_DACL_SECURITY_INFORMATION, WinBuiltinAdministratorsSid,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct PermissionError(String);
+
+fn get_administrator_sid() -> Result<Vec<u8>, PermissionError> {
+    unsafe {
+        let mut sid_size = 0;
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-createwellknownsid
+        // A Security Identifier (SID) is used to identify a security principal or group.
+        // CreateWellKnownSid allow creating a SID for predefined aliases, in this case administrators.
+        // This first call is done to get the size of the buffer to be used on the next call.
+        CreateWellKnownSid(
+            WinBuiltinAdministratorsSid,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut sid_size,
+        );
+
+        if sid_size == 0 {
+            return Err(PermissionError(format!(
+                "Failed to determine SID size. Error: {}",
+                GetLastError()
+            )));
+        }
+
+        // We define the buffer with the right size to be retrieved avoiding an error 122 (ERROR_INSUFICIENT_BUFFER)
+        let mut sid: Vec<u8> = vec![0; sid_size as usize];
+        if CreateWellKnownSid(
+            WinBuiltinAdministratorsSid,
+            ptr::null_mut(),
+            sid.as_mut_ptr() as *mut _,
+            &mut sid_size,
+        ) == 0
+        {
+            return Err(PermissionError(format!(
+                "Failed to create administrator SID. Error: {}",
+                GetLastError()
+            )));
+        }
+
+        Ok(sid)
+    }
+}
+
+/// set_file_permissions_for_administrator removes any other ACL from a file only granting
+/// read and write to Administrators.
+pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), PermissionError> {
+    // Conversion to UTF-16 format (native string representation in Windows OS)
+    let path_wstr: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+
+    let admin_sid = get_administrator_sid()
+        .map_err(|e| PermissionError(format!("Failed to get administrator sid: {}", e)))?;
+
+    // Define the trustee (windows ACL entity) with the current user SID
+    let trustee = TRUSTEE_W {
+        TrusteeForm: TRUSTEE_IS_SID,
+        ptstrName: admin_sid.as_ptr() as *mut _,
+        ..Default::default()
+    };
+
+    // Define the access entry to allow read and write for the trustee
+    let access_entry = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE,
+        grfAccessMode: SET_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: trustee,
+    };
+
+    // Create a new ACL with the access entry
+    let mut acl: *mut ACL = ptr::null_mut();
+    unsafe {
+        // https://learn.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setentriesinaclw
+        // creates a new ACL by merging new ACL into the AC provided in the 3rd parameter
+        // we set it to null because we overwrite the old ACL
+        let result = SetEntriesInAclW(1, &access_entry, ptr::null_mut(), &mut acl);
+
+        if result != 0 {
+            return Err(PermissionError("Failed to set entries in ACL".to_string()));
+        }
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setnamedsecurityinfow
+        // Set the security descriptor with the new ACL.
+        // PROTECTED_DACL_SECURITY_INFORMATION is removing inheritance so the ACL will only
+        // apply to administrators.
+        let result = SetNamedSecurityInfoW(
+            path_wstr.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            acl,
+            ptr::null_mut(),
+        );
+
+        if result != 0 {
+            return Err(PermissionError(
+                "Failed to set security descriptor".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Add a detailed description here. -->
Add administrator permissions for created files on windows revoking any other rights.
It uses windows-sys.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
