### PR TITLE
test: verify no orphan processes remain after killing AC

### DIFF
--- a/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
+++ b/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
@@ -194,6 +194,7 @@ log:
   level: debug
   file:
     enabled: true
+host_id: "no-orphan-processes-integration-test"
 agents:
   test-agent:
     agent_type: newrelic/com.newrelic.test-agent:0.0.1


### PR DESCRIPTION
<!-- Add a detailed description here. -->

Add a new test scenario:

- Start AC as a process, configured to spawn a sub-agent with a long-running process (a "sleep" command or script).
- Kill the AC process.
- Verify the sub-agent's long-running process has also stopped.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
