### PR TITLE
fix(tests): improve wording

### DIFF
--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -247,8 +247,8 @@ deployment:
     const EXAMPLE_CONFIG_REPLACE_WRONG_TYPE: &str = r#"
     config: |
       test
-    deployment:
-      whatever:
+    whatever:
+      test:
         path: true
         args: --verbose true
     integrations: {}


### PR DESCRIPTION
The tests was using a variable "deployment" that was leading to confusion. Moreover, it had a useless "deployment" section