### PR TITLE
fix: validate AC remote config signature

### DIFF
--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -1,7 +1,5 @@
-use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::data_store::StoreKey;
 use crate::opamp::remote_config::signature::SIGNATURE_CUSTOM_CAPABILITY;
-use crate::sub_agent::identity::AgentIdentity;
 use opamp_client::capabilities;
 use opamp_client::opamp::proto::{AgentCapabilities, CustomCapabilities};
 use opamp_client::operation::capabilities::Capabilities;
@@ -95,19 +93,10 @@ pub fn default_capabilities() -> Capabilities {
     )
 }
 
-pub fn default_sub_agent_custom_capabilities() -> CustomCapabilities {
+pub fn default_custom_capabilities() -> CustomCapabilities {
     CustomCapabilities {
         capabilities: vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
     }
-}
-
-pub(crate) fn get_custom_capabilities(agent_type_id: &AgentTypeID) -> Option<CustomCapabilities> {
-    if agent_type_id.eq(&AgentIdentity::new_agent_control_identity().agent_type_id) {
-        // Agent_Control does not have custom capabilities for now
-        return None;
-    }
-
-    Some(default_sub_agent_custom_capabilities())
 }
 
 pub const AGENT_TYPE_NAME_INFRA_AGENT: &str = "com.newrelic.infrastructure";

--- a/agent-control/src/opamp/operations.rs
+++ b/agent-control/src/opamp/operations.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::agent_control::defaults::{
     OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SUPERVISOR_KEY,
-    PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, get_custom_capabilities,
+    PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, default_custom_capabilities,
 };
 use crate::sub_agent::identity::AgentIdentity;
 use crate::{
@@ -105,7 +105,7 @@ pub fn start_settings(
     StartSettings {
         instance_uid: instance_id.into(),
         capabilities: default_capabilities(),
-        custom_capabilities: get_custom_capabilities(&agent_identity.agent_type_id),
+        custom_capabilities: Some(default_custom_capabilities()),
         agent_description: AgentDescription {
             identifying_attributes,
             non_identifying_attributes,

--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -1,9 +1,7 @@
-use crate::agent_control::defaults::get_custom_capabilities;
 use crate::http::client::HttpClient;
 use crate::http::config::HttpConfig;
 use crate::http::config::ProxyConfig;
 use crate::opamp::remote_config::OpampRemoteConfig;
-use crate::opamp::remote_config::signature::SIGNATURE_CUSTOM_CAPABILITY;
 use crate::opamp::remote_config::validators::RemoteConfigValidator;
 use crate::opamp::remote_config::validators::signature::public_key::PublicKey;
 use crate::opamp::remote_config::validators::signature::public_key_fetcher::PublicKeyFetcher;
@@ -104,22 +102,13 @@ impl RemoteConfigValidator for SignatureValidator {
 
     fn validate(
         &self,
-        agent_identity: &AgentIdentity,
+        _: &AgentIdentity,
         opamp_remote_config: &OpampRemoteConfig,
     ) -> Result<(), Self::Err> {
         // Noop validation
         let Some(public_key_store) = &self.public_key_store else {
             return Ok(());
         };
-
-        // custom capabilities are got from the agent-type (currently hard-coded)
-        // If the capability is not set, no validation is performed
-        if !get_custom_capabilities(&agent_identity.agent_type_id).is_some_and(|c| {
-            c.capabilities
-                .contains(&SIGNATURE_CUSTOM_CAPABILITY.to_string())
-        }) {
-            return Ok(());
-        }
 
         let signature = opamp_remote_config
             .get_default_signature()
@@ -170,10 +159,11 @@ pub mod tests {
         .unwrap();
 
         let config = "value";
-
         let encoded_signature = pub_key_server.sign(config.as_bytes());
+
+        // agent remote config
         let remote_config = OpampRemoteConfig::new(
-            AgentID::AgentControl,
+            AgentIdentity::default().id,
             Hash::from("test"),
             ConfigState::Applying,
             ConfigurationMap::new(HashMap::from([(
@@ -189,6 +179,26 @@ pub mod tests {
 
         signature_validator
             .validate(&AgentIdentity::default(), &remote_config)
+            .unwrap();
+
+        // agent-control remote config
+        let remote_config = OpampRemoteConfig::new(
+            AgentIdentity::new_agent_control_identity().id,
+            Hash::from("test"),
+            ConfigState::Applying,
+            ConfigurationMap::new(HashMap::from([(
+                DEFAULT_AGENT_CONFIG_IDENTIFIER.to_string(),
+                config.to_string(),
+            )])),
+        )
+        .with_signature(Signatures::new_default(
+            encoded_signature.as_str(),
+            ED25519,
+            pub_key_server.key_id.as_str(),
+        ));
+
+        signature_validator
+            .validate(&AgentIdentity::new_agent_control_identity(), &remote_config)
             .unwrap()
     }
 

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -165,7 +165,7 @@ mod tests {
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_control::defaults::{
         OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SUPERVISOR_KEY,
-        PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, default_sub_agent_custom_capabilities,
+        PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, default_custom_capabilities,
     };
     use crate::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
     use crate::agent_type::agent_type_id::AgentTypeID;
@@ -466,7 +466,7 @@ mod tests {
         StartSettings {
             instance_uid: sub_agent_instance_id.into(),
             capabilities: default_capabilities(),
-            custom_capabilities: Some(default_sub_agent_custom_capabilities()),
+            custom_capabilities: Some(default_custom_capabilities()),
             agent_description: AgentDescription {
                 identifying_attributes,
                 non_identifying_attributes: HashMap::from([


### PR DESCRIPTION
Issue:
We were currently skipping the validation of AC remote config signature due to capabilities check. 
Context:
This capabilities check was done on the first iteration when no AC signature was being sent by the server. Then the serverver start sending it and we did #1744 but without removing the capability check.
Fix:
This PR is removing the capability check as is not used anymore and not capabilities are not fully implemented yet.