### PR TITLE
ci(e2e): parameterize fleet id

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -18,6 +18,9 @@ feature_branch = os.getenv('FEATURE_BRANCH', "master")
 enable_ac_remote_update = os.getenv('ENABLE_AC_REMOTE_UPDATE', "false")
 enable_cd_remote_update = os.getenv('ENABLE_CD_REMOTE_UPDATE', "false")
 
+# Fleet with name 'ac-e2e-3'. The sub-agent reports data to the 'Agent Control Canaries' account.
+fleet_id = os.getenv('FLEET_ID', "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyODk4LTg0OWMtNzdmZC1iN2Y1LWMwYjNiNDRmNzlkNw")
+
 # Enables basic auth in chartmuseum (for testing reasons)
 # 
 chartmuseum_basic_auth = os.getenv('CHARTMUSEUM_BASIC_AUTH', "")
@@ -115,6 +118,7 @@ ac_flags = [
   '--set=agentControlDeployment.chartVersion=0.0.1',
   '--set=agentControlDeployment.chartValues.config.acRemoteUpdate=' + enable_ac_remote_update,
   '--set=agentControlDeployment.chartValues.config.cdRemoteUpdate=' + enable_cd_remote_update,
+  '--set=agentControlDeployment.chartValues.config.fleet_control.fleet_id=' + fleet_id,
   '--version=>=0.0.0-beta',
   '--set=agentControlDeployment.chartValues.image.imagePullPolicy=Always',
   '--values=' + sa_chart_values_file,

--- a/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
+++ b/test/k8s-e2e/fleet-control/ac-values-fleet-control.yml
@@ -13,8 +13,7 @@ agentControlDeployment:
     config:
       fleet_control:
         enabled: true
-        # Fleet with name 'ac-e2e-3'. The sub-agent reports data to the 'Agent Control Canaries' account.
-        fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyODk4LTg0OWMtNzdmZC1iN2Y1LWMwYjNiNDRmNzlkNw
+        # Fleet ID passed via Tiltfile
       log:
         level: debug
       agents:

--- a/test/onhost-e2e/Makefile
+++ b/test/onhost-e2e/Makefile
@@ -7,6 +7,8 @@ RECIPE_BRANCH ?= main
 # Variables dependent on the New Relic platform region.
 OPAMP_ENDPOINT = "https://opamp.staging-service.newrelic.com/v1/opamp"
 NEW_RELIC_API_ENDPOINT = "https://staging-api.newrelic.com"
+# ac-e2e-onhost-2 fleet on canaries account
+FLEET_ID ?= "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyOGQyLTg3OTAtNzJlNC05ODgwLTJhYzE0NTRlZDUyZ"
 ifeq ($(ENVIRONMENT), production)
 	OPAMP_ENDPOINT = "https://opamp.service.newrelic.com/v1/opamp"
 	NEW_RELIC_API_ENDPOINT = "https://api.newrelic.com"
@@ -70,6 +72,7 @@ e2e:
 		-e local_package_path=$(LOCAL_PACKAGE_PATH) \
 		-e agent_control_version=${PACKAGE_VERSION} \
 		-e system_identity_client_id=${NR_SYSTEM_IDENTITY_CLIENT_ID} \
+		-e fleet_id=${FLEET_ID} \
 		$(ANSIBLE_FOLDER)/$(ANSIBLE_PLAYBOOK)
 
 .PHONY: clean

--- a/test/onhost-e2e/ansible/remote_config.yaml
+++ b/test/onhost-e2e/ansible/remote_config.yaml
@@ -41,8 +41,7 @@
             name: install_ac_recipe
           vars:
             monitoring_source: "infra-agent"
-            # ac-e2e-onhost-2 fleet on canaries account
-            fleet_id: NjQyNTg2NXxOR0VQfEZMRUVUfDAxOTkyOGQyLTg3OTAtNzJlNC05ODgwLTJhYzE0NTRlZDUyZg
+            fleet_id: "{{ fleet_id }}"
             agent_control_private_key: "/etc/newrelic-agent-control/priv.key"
 
         - name: Setup AC config


### PR DESCRIPTION
<!-- Add a detailed description here. -->

I plan to call the E2E test infrastructure defined in this repo from https://github.com/newrelic/nr-control-e2e-testing/, and I would create a new Fleet ID for these, hence the ability to parameterize it here.

Once the estimations and the larger runners are available, tasks would be created to set up the E2E tests in that new repo and possibly removing them from this one.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
