### PR TITLE
feat: package parsing on agent types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "const_panic"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1070,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn",
 ]
 
@@ -1122,6 +1143,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1569,6 +1621,18 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2563,6 +2627,7 @@ dependencies = [
  "mockall_double",
  "nix",
  "nr-auth",
+ "oci-spec",
  "opamp-client",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -2707,6 +2772,23 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "oci-spec"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb4684653aeaba48dea019caa17b2773e1212e281d50b6fa759f36fe032239d"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.17",
+]
 
 [[package]]
 name = "oid-registry"
@@ -3082,6 +3164,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3940,6 +4044,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -468,6 +468,18 @@ Distributed under the following license(s):
 
 * MIT
 
+## const_format <https://crates.io/crates/const_format>
+
+Distributed under the following license(s):
+
+* Zlib
+
+## const_format_proc_macros <https://crates.io/crates/const_format_proc_macros>
+
+Distributed under the following license(s):
+
+* Zlib
+
 ## const_panic <https://crates.io/crates/const_panic>
 
 Distributed under the following license(s):
@@ -617,6 +629,27 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## deranged <https://crates.io/crates/deranged>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## derive_builder <https://crates.io/crates/derive_builder>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## derive_builder_core <https://crates.io/crates/derive_builder_core>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## derive_builder_macro <https://crates.io/crates/derive_builder_macro>
 
 Distributed under the following license(s):
 
@@ -893,6 +926,12 @@ Distributed under the following license(s):
 
 * MIT
 * Apache-2.0
+
+## getset <https://crates.io/crates/getset>
+
+Distributed under the following license(s):
+
+* MIT
 
 ## glob <https://crates.io/crates/glob>
 
@@ -1463,6 +1502,12 @@ Distributed under the following license(s):
 
 * MIT
 
+## oci-spec <https://crates.io/crates/oci-spec>
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
 ## oid-registry <https://crates.io/crates/oid-registry>
 
 Distributed under the following license(s):
@@ -1692,6 +1737,20 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## prettyplease <https://crates.io/crates/prettyplease>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## proc-macro-error-attr2 <https://crates.io/crates/proc-macro-error-attr2>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## proc-macro-error2 <https://crates.io/crates/proc-macro-error2>
 
 Distributed under the following license(s):
 
@@ -2115,6 +2174,18 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## strsim <https://crates.io/crates/strsim>
+
+Distributed under the following license(s):
+
+* MIT
+
+## strum <https://crates.io/crates/strum>
+
+Distributed under the following license(s):
+
+* MIT
+
+## strum_macros <https://crates.io/crates/strum_macros>
 
 Distributed under the following license(s):
 

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -71,6 +71,7 @@ opentelemetry-appender-tracing = { version = "0.31.1", features = [
   "experimental_use_tracing_span_context",
 ] }
 async-trait = "0.1.89"
+oci-spec = "0.8.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { workspace = true, features = ["signal", "user", "hostname"] }

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -369,6 +369,14 @@ deployment:
       - id: newrelic-infra
         path: /usr/bin/newrelic-infra
         args: "--config ${nr-var:config} --config2 ${nr-var:config2}"
+    packages:
+      infra-agent:
+        type: tar.gz
+        download:
+          oci:
+            registry: ${nr-var:registry}
+            repository: ${nr-var:repository}
+            version: ${nr-var:version}
 "#;
 
     const GIVEN_NEWRELIC_INFRA_USER_CONFIG_YAML: &str = r#"

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -25,4 +25,8 @@ pub enum AgentTypeError {
     RenderingTemplate(String),
     #[error("conflicting variable definition: {0}")]
     ConflictingVariableDefinition(String),
+    #[error("unsupported package type: {0}")]
+    UnsupportedPackageType(String),
+    #[error("error parsing oci reference: {0}")]
+    OCIReferenceParsingError(String),
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -1,0 +1,159 @@
+use crate::agent_type::definition::Variables;
+use crate::agent_type::error::AgentTypeError;
+use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
+use crate::agent_type::templates::Templateable;
+use oci_spec::distribution::Reference;
+use serde::Deserialize;
+use std::str::FromStr;
+
+pub mod rendered;
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Default)]
+pub enum PackageType {
+    #[default]
+    Tar,
+    Zip,
+}
+
+impl FromStr for PackageType {
+    type Err = AgentTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tar" => Ok(Self::Tar),
+            "tar.gz" => Ok(Self::Tar),
+            "zip" => Ok(Self::Zip),
+            _ => Err(AgentTypeError::UnsupportedPackageType(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub(super) struct Package {
+    #[serde(rename = "type")]
+    pub(super) package_type: TemplateableValue<PackageType>, // Using `r#type` to avoid keyword conflict
+
+    /// Download defines the supported repository sources for the packages.
+    pub(super) download: Download,
+    //TODO: implement signature, install and uninstall fields when defined.
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct Download {
+    /// OCI repository definition
+    pub oci: Oci,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct Oci {
+    /// OCI registry url.
+    pub registry: TemplateableValue<String>,
+    /// Repository name.
+    pub repository: TemplateableValue<String>,
+    /// Package version including tag, digest or tag + digest.
+    #[serde(default)]
+    pub version: TemplateableValue<String>,
+}
+
+impl Templateable for Package {
+    type Output = rendered::Package;
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        Ok(Self::Output {
+            package_type: self.package_type.template_with(variables)?,
+            download: self.download.template_with(variables)?,
+        })
+    }
+}
+
+impl Templateable for Download {
+    type Output = rendered::Download;
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        Ok(Self::Output {
+            oci: self.oci.template_with(variables)?,
+        })
+    }
+}
+
+impl Templateable for Oci {
+    type Output = rendered::Oci;
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        let registry = self.registry.template_with(variables)?;
+        let repository = self.repository.template_with(variables)?;
+        let mut version = self.version.template_with(variables)?;
+
+        if !version.is_empty() && !version.starts_with('@') {
+            version = format!(":{}", version);
+        }
+
+        let reference =
+            Reference::from_str(format!("{}/{}{}", registry, repository, version).as_str())
+                .map_err(|err| AgentTypeError::OCIReferenceParsingError(err.to_string()))?;
+
+        Ok(Self::Output { reference })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::definition::Variables;
+    use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
+    use crate::agent_type::variable::Variable;
+    use rstest::rstest;
+
+    #[test]
+    fn test_package_type_from_str() {
+        assert_eq!(PackageType::from_str("tar").unwrap(), PackageType::Tar);
+        assert_eq!(PackageType::from_str("tar.gz").unwrap(), PackageType::Tar);
+        assert_eq!(PackageType::from_str("zip").unwrap(), PackageType::Zip);
+        assert!(PackageType::from_str("unsupported").is_err());
+    }
+
+    #[rstest]
+    #[case::only_digest(
+        "@sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723",
+        None,
+        Some("sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723")
+    )]
+    #[case::tag_and_digest(
+        "a-tag@sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723",
+        Some("a-tag"),
+        Some("sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723")
+    )]
+    #[case::empty_version("", Some("latest"), None)]
+    fn oci_template(
+        #[case] version: &str,
+        #[case] tag: Option<&str>,
+        #[case] digest: Option<&str>,
+    ) {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:registry".to_string(),
+            Variable::new_final_string_variable("registry.com".to_string()),
+        );
+        variables.insert(
+            "nr-var:repository".to_string(),
+            Variable::new_final_string_variable("repo".to_string()),
+        );
+        variables.insert(
+            "nr-var:version".to_string(),
+            Variable::new_final_string_variable(version.to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("${nr-var:registry}".to_string()),
+            repository: TemplateableValue::from_template("${nr-var:repository}".to_string()),
+            version: TemplateableValue::from_template("${nr-var:version}".to_string()),
+        };
+
+        let rendered_oci = oci.template_with(&variables);
+        assert!(rendered_oci.is_ok());
+
+        let rendered_oci = rendered_oci.unwrap();
+
+        assert_eq!(rendered_oci.reference.registry(), "registry.com");
+        assert_eq!(rendered_oci.reference.repository(), "repo");
+        assert_eq!(rendered_oci.reference.tag(), tag);
+        assert_eq!(rendered_oci.reference.digest(), digest);
+    }
+}

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -1,0 +1,23 @@
+use crate::agent_type::runtime_config::on_host::package::PackageType;
+use oci_spec::distribution::Reference;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Package {
+    /// Package type (tar.gz, zip).
+    pub(super) package_type: PackageType,
+
+    /// Download defines the supported repository sources for the packages.
+    pub(super) download: Download,
+    //TODO: implement signature, install and uninstall fields when defined.
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Download {
+    /// OCI repository definition
+    pub(super) oci: Oci,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Oci {
+    pub(super) reference: Reference,
+}

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -1,8 +1,10 @@
+use crate::agent_type::runtime_config::on_host::package::rendered::Package;
 use crate::agent_type::runtime_config::{
     health_config::rendered::OnHostHealthConfig,
     on_host::{executable::rendered::Executable, filesystem::rendered::FileSystem},
     version_config::rendered::OnHostVersionConfig,
 };
+use std::collections::HashMap;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct OnHost {
@@ -12,4 +14,5 @@ pub struct OnHost {
     pub health: OnHostHealthConfig,
     pub version: Option<OnHostVersionConfig>,
     pub filesystem: FileSystem,
+    pub packages: HashMap<String, Package>,
 }


### PR DESCRIPTION
<!-- Add a detailed description here. -->

Package parsing for agent types.

Now Agent Type can have a packages section:

```yaml
    packages:
      infra-agent:
        type: tar.gz
        download:
          oci:
            registry: ${nr-var:registry}
            repository: ${nr-var:repository}
            version: ${nr-var:version}
```

the version is going to be parsed prepending : if it's not starting by @. This is because it can be:
- tag 
- tag@digest
- digest

So once parsed it can be appended at the end of a registry url to get the wanted package.


- I have not updated the Readme or docs because this packages section is still not doing anything and prone to change with new additions.


## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
