### PR TITLE
refactor: remove map[string]string

### DIFF
--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -89,7 +89,6 @@ In terms of variable types, we currently support the following types listed in [
 * `string`: A string value, such as "Hello, world!"
 * `number`: An numeric value, such as 42 or 0.25
 * `boolean`: A boolean value, which can be either *true* or *false*
-* `map[string]string`: A dictionary of key-value pairs, associating keys(string) and values(string).
 * `yaml`: The YAML type variable is used to handle multi-line strings that will be parsed as YAML such as Helm Charts values.
 * `map[string]yaml`: Handles YAML values that guarantee their top-level fields are strings. Useful for defining file system entries for on-host.
 

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -349,7 +349,7 @@ variables:
   common:
     config3:
       description: "Newrelic infra configuration yaml"
-      type: map[string]string
+      type: map[string]yaml
       required: true
     status_server_port:
       description: "Newrelic infra health status port"
@@ -388,9 +388,9 @@ status_server_port: 8004
             input_agent_type.fill_variables(GIVEN_NEWRELIC_INFRA_USER_CONFIG_YAML);
 
         // Then, we expect the corresponding final values.
-        let expected_config_3 = TrivialValue::MapStringString(HashMap::from([
-            ("log_level".to_string(), "trace".to_string()),
-            ("forward".to_string(), "true".to_string()),
+        let expected_config_3 = TrivialValue::MapStringYaml(HashMap::from([
+            ("log_level".to_string(), "trace".into()),
+            ("forward".to_string(), "true".into()),
         ]));
         // Number
         let expected_status_server = TrivialValue::Number(Number::from(8004));

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -26,8 +26,6 @@ pub enum VariableTypeDefinition {
     Bool(FieldsDefinition<bool>),
     #[serde(rename = "number")]
     Number(FieldsDefinition<serde_yaml::Number>),
-    #[serde(rename = "map[string]string")]
-    MapStringString(FieldsDefinition<HashMap<String, String>>),
     #[serde(rename = "map[string]yaml")]
     MapStringYaml(FieldsDefinition<HashMap<String, serde_yaml::Value>>),
     #[serde(rename = "yaml")]
@@ -40,7 +38,6 @@ pub enum VariableType {
     String(StringFields),
     Bool(Fields<bool>),
     Number(Fields<serde_yaml::Number>),
-    MapStringString(Fields<HashMap<String, String>>),
     MapStringYaml(Fields<HashMap<String, serde_yaml::Value>>),
     Yaml(Fields<serde_yaml::Value>),
 }
@@ -52,9 +49,6 @@ impl VariableTypeDefinition {
             VariableTypeDefinition::String(v) => VariableType::String(v.with_config(constraints)),
             VariableTypeDefinition::Bool(v) => VariableType::Bool(v.with_config(constraints)),
             VariableTypeDefinition::Number(v) => VariableType::Number(v.with_config(constraints)),
-            VariableTypeDefinition::MapStringString(v) => {
-                VariableType::MapStringString(v.with_config(constraints))
-            }
             VariableTypeDefinition::MapStringYaml(v) => {
                 VariableType::MapStringYaml(v.with_config(constraints))
             }
@@ -71,7 +65,6 @@ impl VariableType {
             VariableType::String(f) => f.inner.required,
             VariableType::Bool(f) => f.required,
             VariableType::Number(f) => f.required,
-            VariableType::MapStringString(f) => f.required,
             VariableType::MapStringYaml(f) => f.required,
             VariableType::Yaml(f) => f.required,
         }
@@ -85,7 +78,6 @@ impl VariableType {
             VariableType::String(f) => f.set_final_value(serde_yaml::from_value(value)?),
             VariableType::Bool(f) => f.set_final_value(serde_yaml::from_value(value)?),
             VariableType::Number(f) => f.set_final_value(serde_yaml::from_value(value)?),
-            VariableType::MapStringString(f) => f.set_final_value(serde_yaml::from_value(value)?),
             VariableType::MapStringYaml(f) => f.set_final_value(serde_yaml::from_value(value)?),
             VariableType::Yaml(f) => f.set_final_value(value),
         }?;
@@ -108,12 +100,6 @@ impl VariableType {
                 .or(f.default.as_ref())
                 .cloned()
                 .map(TrivialValue::Number),
-            VariableType::MapStringString(f) => f
-                .final_value
-                .as_ref()
-                .or(f.default.as_ref())
-                .cloned()
-                .map(TrivialValue::MapStringString),
             VariableType::MapStringYaml(f) => f
                 .final_value
                 .as_ref()

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -91,7 +91,6 @@ The value type that is accepted for this variable. As of now, the following type
 - `string`.
 - `bool`.
 - `number`: Integer or floating point are supported.
-- `map[string]string`: i.e. key-value pairs.
 - `yaml`: An arbitrary YAML value, like an array, an object or even a scalar.
 - `map[string]yaml`: A YAML value where the top-level is guaranteed to consist on string keys for other values.
 


### PR DESCRIPTION
Removes unused `map[string]string`. We already have a `map[string]yaml` and `serde_yaml::Value` support strings.

```
/// Represents any valid YAML value.
#[derive(Clone, PartialEq, PartialOrd)]
pub enum Value {
    /// Represents a YAML null value.
    Null,
    /// Represents a YAML boolean.
    Bool(bool),
    /// Represents a YAML numerical value, whether integer or floating point.
    Number(Number),
    /// Represents a YAML string.
    String(String),
    /// Represents a YAML sequence in which the elements are
    /// `serde_yaml::Value`.
    Sequence(Sequence),
    /// Represents a YAML mapping in which the keys and values are both
    /// `serde_yaml::Value`.
    Mapping(Mapping),
    /// A representation of YAML's `!Tag` syntax, used for enums.
    Tagged(Box<TaggedValue>),
}
```

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
