### PR TITLE
feat: set windows directory permissions

### DIFF
--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -215,7 +215,7 @@ pub mod tests {
         }
 
         #[cfg(target_family = "windows")]
-        crate::win_permissions::tests::verify_windows_permissions(&path);
+        crate::win_permissions::tests::assert_windows_permissions(&path);
 
         assert!(path.exists());
     }

--- a/fs/src/win_permissions.rs
+++ b/fs/src/win_permissions.rs
@@ -113,7 +113,13 @@ pub mod tests {
 
     use super::*;
 
-    pub fn verify_windows_permissions(path: &Path) {
+    /// Asserts directory permissions are set to only allow Administrators read and write access on Windows.
+    ///
+    /// This is a helper function that checks the following:
+    /// 1. The DACL of the file contains exactly one ACE.
+    /// 2. The ACE is for the Administrators SID.
+    /// 3. The ACE grants FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions.
+    pub fn assert_windows_permissions(path: &Path) {
         let mut admin_sid_size = SECURITY_MAX_SID_SIZE;
         let mut admin_sid: Vec<u8> = vec![0; admin_sid_size as usize];
 

--- a/fs/src/writer_file.rs
+++ b/fs/src/writer_file.rs
@@ -149,7 +149,7 @@ pub mod tests {
         }
 
         #[cfg(target_family = "windows")]
-        crate::win_permissions::tests::verify_windows_permissions(&path);
+        crate::win_permissions::tests::assert_windows_permissions(&path);
 
         assert!(path.exists());
     }


### PR DESCRIPTION
Add administrator permissions for created directories on windows revoking any other rights.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
