### PR TITLE
feat: Oci downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1872,6 +1878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2328,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2743,7 @@ dependencies = [
  "mockall_double",
  "nix",
  "nr-auth",
+ "oci-client",
  "oci-spec",
  "opamp-client",
  "opentelemetry",
@@ -2730,6 +2761,7 @@ dependencies = [
  "ring",
  "rstest",
  "rustls",
+ "rustls-pki-types",
  "schemars",
  "semver",
  "serde",
@@ -2863,6 +2895,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.4.0",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
 name = "oci-spec"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2944,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3577,12 +3646,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -4772,10 +4843,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4959,6 +5045,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1059,6 +1059,13 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
+## http-auth <https://crates.io/crates/http-auth>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
 ## http-body <https://crates.io/crates/http-body>
 
 Distributed under the following license(s):
@@ -1300,6 +1307,12 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## jsonwebtoken <https://crates.io/crates/jsonwebtoken>
+
+Distributed under the following license(s):
+
+* MIT
+
+## jwt <https://crates.io/crates/jwt>
 
 Distributed under the following license(s):
 
@@ -1585,6 +1598,12 @@ Distributed under the following license(s):
 
 * MIT
 
+## oci-client <https://crates.io/crates/oci-client>
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
 ## oci-spec <https://crates.io/crates/oci-spec>
 
 Distributed under the following license(s):
@@ -1592,6 +1611,13 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## oid-registry <https://crates.io/crates/oid-registry>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## olpc-cjson <https://crates.io/crates/olpc-cjson>
 
 Distributed under the following license(s):
 
@@ -2373,6 +2399,22 @@ Distributed under the following license(s):
 
 * Unicode-3.0
 
+## tinyvec <https://crates.io/crates/tinyvec>
+
+Distributed under the following license(s):
+
+* Zlib
+* Apache-2.0
+* MIT
+
+## tinyvec_macros <https://crates.io/crates/tinyvec_macros>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+* Zlib
+
 ## tokio <https://crates.io/crates/tokio>
 
 Distributed under the following license(s):
@@ -2555,6 +2597,13 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
+## unicase <https://crates.io/crates/unicase>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
 ## unicode-ident <https://crates.io/crates/unicode-ident>
 
 Distributed under the following license(s):
@@ -2562,6 +2611,13 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 * Unicode-3.0
+
+## unicode-normalization <https://crates.io/crates/unicode-normalization>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
 
 ## unicode-segmentation <https://crates.io/crates/unicode-segmentation>
 
@@ -2682,6 +2738,13 @@ Distributed under the following license(s):
 * Apache-2.0
 
 ## wasm-bindgen-shared <https://crates.io/crates/wasm-bindgen-shared>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
+## wasm-streams <https://crates.io/crates/wasm-streams>
 
 Distributed under the following license(s):
 

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -75,6 +75,8 @@ oci-spec = "0.8.3"
 flate2 = "1.1.5"
 tar = "0.4.44"
 zip = "6.0.0"
+oci-client = { version = "0.15.0", features = ["rustls-tls"], default-features = false }
+rustls-pki-types = { version = "1.13.1", features = ["std"] }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { workspace = true, features = ["signal", "user", "hostname"] }

--- a/agent-control/src/http/client.rs
+++ b/agent-control/src/http/client.rs
@@ -287,7 +287,7 @@ fn certs_from_file(path: &Path) -> Result<Vec<Certificate>, HttpBuildError> {
 }
 
 /// Returns all paths to be considered to load certificates under the provided directory path.
-fn cert_paths_from_dir(dir_path: &Path) -> Result<Vec<PathBuf>, HttpBuildError> {
+pub fn cert_paths_from_dir(dir_path: &Path) -> Result<Vec<PathBuf>, HttpBuildError> {
     if dir_path.as_os_str().is_empty() {
         return Ok(Vec::new());
     }
@@ -308,7 +308,7 @@ fn cert_paths_from_dir(dir_path: &Path) -> Result<Vec<PathBuf>, HttpBuildError> 
 }
 
 /// Helper to build a [HttpBuildError::CertificateError] more concisely.
-fn certificate_error<E: Display>(path: &Path, err: E) -> HttpBuildError {
+pub fn certificate_error<E: Display>(path: &Path, err: E) -> HttpBuildError {
     HttpBuildError::CertificateError {
         path: path.to_string_lossy().into(),
         err: err.to_string(),

--- a/agent-control/src/packages.rs
+++ b/agent-control/src/packages.rs
@@ -1,1 +1,3 @@
 pub mod extract;
+
+pub mod oci;

--- a/agent-control/src/packages/oci.rs
+++ b/agent-control/src/packages/oci.rs
@@ -1,0 +1,1 @@
+pub mod downloader;

--- a/agent-control/src/packages/oci/downloader.rs
+++ b/agent-control/src/packages/oci/downloader.rs
@@ -1,0 +1,355 @@
+use crate::http::client::{cert_paths_from_dir, certificate_error};
+use crate::http::config::ProxyConfig;
+use oci_client::client::{Certificate, CertificateEncoding, ClientConfig};
+use oci_client::{Client, secrets::RegistryAuth};
+use oci_spec::distribution::Reference;
+use rustls_pki_types::pem::PemObject;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tokio;
+use tracing::debug;
+use url::Url;
+
+#[derive(Debug, Error)]
+pub enum OCIDownloaderError {
+    #[error("donwnloading OCI artifact: {0}")]
+    DownloadingArtifactError(String),
+    #[error("certificate error: {0}")]
+    CertificateError(String),
+}
+
+pub struct OCIDownloader {
+    client: Client,
+    auth: RegistryAuth,
+}
+
+#[allow(dead_code, reason = "still unused")]
+impl OCIDownloader {
+    /// try_new requires a package dir where the artifacts will be downloaded and a proxy_config
+    /// that if url is empty will be ignored. By default, Auth is set to Anonymous, but it can be
+    /// modified with the with_auth method.
+    pub fn try_new(proxy_config: ProxyConfig) -> Result<Self, OCIDownloaderError> {
+        let mut client_config = ClientConfig::default();
+        Self::proxy_setup(proxy_config, &mut client_config)?;
+
+        Ok(OCIDownloader {
+            client: Client::new(client_config),
+            auth: RegistryAuth::Anonymous,
+        })
+    }
+
+    fn proxy_setup(
+        proxy_config: ProxyConfig,
+        client_config: &mut ClientConfig,
+    ) -> Result<(), OCIDownloaderError> {
+        let proxy_url = proxy_config.url_as_string();
+        if !proxy_url.is_empty() {
+            let scheme = Url::parse(&proxy_url)
+                .map(|url| match url.scheme() {
+                    "http" | "https" => url.scheme().to_string(),
+                    _ => "https".to_string(),
+                })
+                .unwrap_or_else(|_| "https".to_string());
+
+            if scheme == "http" {
+                client_config.http_proxy = Some(proxy_url);
+            } else {
+                client_config.https_proxy = Some(proxy_url);
+            }
+
+            client_config.extra_root_certificates =
+                certs_from_paths(proxy_config.ca_bundle_file(), proxy_config.ca_bundle_dir())
+                    .map_err(|err| {
+                        OCIDownloaderError::CertificateError(format!("invalid cert file: {err}"))
+                    })?;
+        }
+        Ok(())
+    }
+
+    pub fn with_auth(self, auth: RegistryAuth) -> Self {
+        Self { auth, ..self }
+    }
+
+    /// download_artifact downloads an artifact from the oci registry using a reference containing
+    /// all the required data to first pull the image manifest if it exists and then iterate all the
+    /// layers downloading each one and downloading the found package into a file where the name
+    /// is the digest. Tokio file is used for async_write so the blob can be read in chunks.
+    pub async fn download_artifact(
+        &self,
+        reference: Reference,
+        package_dir: PathBuf,
+    ) -> Result<(), OCIDownloaderError> {
+        let (image_manifest, _) = self
+            .client
+            .pull_image_manifest(&reference, &self.auth)
+            .await
+            .map_err(|err| {
+                OCIDownloaderError::DownloadingArtifactError(format!(
+                    "Failed to download OCI manifest: {}",
+                    err
+                ))
+            })?;
+        for layer in image_manifest.layers.iter() {
+            let layer_path = package_dir.join(layer.digest.clone());
+            let mut file = tokio::fs::File::create(&layer_path).await.map_err(|err| {
+                OCIDownloaderError::DownloadingArtifactError(format!(
+                    "Failed to create OCI artifact file: {}",
+                    err
+                ))
+            })?;
+            self.client
+                .pull_blob(&reference, &layer, &mut file)
+                .await
+                .map_err(|err| {
+                    OCIDownloaderError::DownloadingArtifactError(format!(
+                        "Failed pulling OCI blob into artifact file: {}",
+                        err
+                    ))
+                })?;
+            debug!("Artifact written to {}", layer_path.to_string_lossy());
+        }
+
+        Ok(())
+    }
+}
+
+/// Tries to extract certificates from the provided `ca_bundle_file` and `ca_bundle_dir` paths.
+#[allow(dead_code, reason = "still unused")]
+fn certs_from_paths(
+    ca_bundle_file: &Path,
+    ca_bundle_dir: &Path,
+) -> Result<Vec<Certificate>, OCIDownloaderError> {
+    let mut certs = Vec::new();
+    // Certs from bundle file
+    certs.extend(certs_from_file(ca_bundle_file)?);
+    // Certs from bundle dir
+    for path in cert_paths_from_dir(ca_bundle_dir)
+        .map_err(|err| OCIDownloaderError::CertificateError(err.to_string()))?
+    {
+        certs.extend(certs_from_file(&path)?)
+    }
+    Ok(certs)
+}
+
+/// Returns all certs bundled in the file corresponding to the provided path.
+#[allow(dead_code, reason = "still unused")]
+fn certs_from_file(path: &Path) -> Result<Vec<Certificate>, OCIDownloaderError> {
+    if path.as_os_str().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let file = File::open(path).map_err(|err| {
+        OCIDownloaderError::CertificateError(certificate_error(path, err).to_string())
+    })?;
+    let reader = BufReader::new(file);
+
+    let certificates: Result<Vec<Vec<u8>>, OCIDownloaderError> =
+        rustls_pki_types::CertificateDer::pem_reader_iter(reader)
+            .map(|result| {
+                result.map(|cert| cert.as_ref().to_vec()).map_err(|_| {
+                    OCIDownloaderError::CertificateError("invalid certificate encoding".to_string())
+                })
+            })
+            .collect();
+
+    let certs: Vec<Certificate> = certificates?
+        .into_iter()
+        .map(|data| Certificate {
+            encoding: CertificateEncoding::Pem,
+            data,
+        })
+        .collect();
+
+    Ok(certs)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    const INVALID_TESTING_CERT: &str =
+        "-----BEGIN CERTIFICATE-----\ninvalid!\n-----END CERTIFICATE-----";
+
+    fn valid_testing_cert() -> String {
+        let subject_alt_names = vec!["localhost".to_string()];
+        let rcgen::CertifiedKey {
+            cert,
+            signing_key: _,
+        } = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
+        cert.pem()
+    }
+
+    #[test]
+    fn test_with_empty_proxy_url() {
+        let proxy_config = ProxyConfig::from_url("".to_string()); // Assuming ProxyConfig::new method exists
+
+        let mut client_config = ClientConfig::default();
+        let proxy_result = OCIDownloader::proxy_setup(proxy_config, &mut client_config);
+        assert!(proxy_result.is_ok());
+
+        assert_eq!(client_config.https_proxy, None);
+        assert_eq!(client_config.http_proxy, None);
+    }
+
+    #[test]
+    fn test_valid_http_proxy_url() {
+        let proxy_config = ProxyConfig::from_url("http://valid.proxy.url".to_string());
+
+        let mut client_config = ClientConfig::default();
+        let proxy_result = OCIDownloader::proxy_setup(proxy_config, &mut client_config);
+        assert!(proxy_result.is_ok());
+
+        assert_eq!(client_config.https_proxy, None);
+        assert_eq!(
+            client_config.http_proxy,
+            Some("http://valid.proxy.url/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_proxy_url_without_scheme_with_certs() {
+        let dir = tempdir().unwrap();
+        let ca_bundle_dir = dir.path();
+
+        // Valid cert file
+        let file_path = dir.path().join("valid_cert.pem");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "{}", valid_testing_cert()).unwrap();
+        // Empty cert file
+        let file_path = dir.path().join("empty_cert.pem");
+        let _ = File::create(&file_path).unwrap();
+        // Unrelated file
+        let file_path = dir.path().join("other-file.txt");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "some content").unwrap();
+        // Invalid cert in no cert-file
+        let file_path = dir.path().join("invalid-cert.bk");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "{INVALID_TESTING_CERT}").unwrap();
+
+        let proxy_config = crate::cli::on_host::config_gen::config::ProxyConfig {
+            proxy_url: Some("valid.proxy.url".to_string()),
+            proxy_ca_bundle_dir: Some(ca_bundle_dir.to_str().unwrap().to_string()),
+            proxy_ca_bundle_file: None,
+            ignore_system_proxy: false,
+        };
+
+        let proxy_config_parsed = ProxyConfig::try_from(proxy_config).unwrap();
+
+        let mut client_config = ClientConfig::default();
+        let proxy_result = OCIDownloader::proxy_setup(proxy_config_parsed, &mut client_config);
+        assert!(proxy_result.is_ok());
+
+        assert_eq!(
+            client_config.https_proxy,
+            Some("valid.proxy.url".to_string())
+        );
+        assert_eq!(client_config.http_proxy, None);
+        assert_eq!(client_config.extra_root_certificates.len(), 1);
+    }
+
+    #[test]
+    fn test_try_new_with_https_proxy_url() {
+        let proxy_config = ProxyConfig::from_url("https://valid.proxy.url".to_string());
+
+        let mut client_config = ClientConfig::default();
+        let proxy_result = OCIDownloader::proxy_setup(proxy_config, &mut client_config);
+        assert!(proxy_result.is_ok());
+
+        assert_eq!(
+            client_config.https_proxy,
+            Some("https://valid.proxy.url/".to_string())
+        );
+        assert_eq!(client_config.http_proxy, None);
+    }
+
+    #[test]
+    fn test_certs_from_paths_no_certificates() {
+        let ca_bundle_file = PathBuf::default();
+        let ca_bundle_dir = PathBuf::default();
+        let certificates = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap();
+        assert_eq!(certificates.len(), 0);
+    }
+
+    #[test]
+    fn test_certs_from_paths_non_existing_certificate_path() {
+        let ca_bundle_file = PathBuf::from("non-existing.pem");
+        let ca_bundle_dir = PathBuf::default();
+        let err = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap_err();
+        assert_matches!(err, OCIDownloaderError::CertificateError { .. });
+
+        let ca_bundle_file = PathBuf::default();
+        let ca_bundle_dir = PathBuf::from("non-existing-dir.pem");
+        let err = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap_err();
+        assert_matches!(err, OCIDownloaderError::CertificateError { .. });
+    }
+
+    #[test]
+    fn test_certs_from_paths_invalid_certificate_file() {
+        let dir = tempdir().unwrap();
+        let ca_bundle_file = dir.path().join("invalid_cert.pem");
+        let mut file = File::create(&ca_bundle_file).unwrap();
+        writeln!(file, "{INVALID_TESTING_CERT}").unwrap();
+
+        let ca_bundle_dir = PathBuf::default();
+        let err = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap_err();
+        assert_matches!(err, OCIDownloaderError::CertificateError { .. });
+    }
+
+    #[test]
+    fn test_certs_from_paths_valid_certificate_file() {
+        let dir = tempdir().unwrap();
+        let ca_bundle_file = dir.path().join("valid_cert.pem");
+        let mut file = File::create(&ca_bundle_file).unwrap();
+        writeln!(file, "{}", valid_testing_cert()).unwrap();
+
+        let ca_bundle_dir = PathBuf::default();
+        let certificates = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap();
+        assert_eq!(certificates.len(), 1);
+    }
+
+    #[test]
+    fn test_certs_from_paths_dir_pointing_to_file() {
+        let dir = tempdir().unwrap();
+        let ca_bundle_dir = dir.path().join("valid_cert.pem");
+        let mut file = File::create(&ca_bundle_dir).unwrap();
+        writeln!(file, "{}", valid_testing_cert()).unwrap();
+
+        let ca_bundle_file = PathBuf::default();
+        let err = certs_from_paths(&ca_bundle_file, &ca_bundle_dir).unwrap_err();
+        assert_matches!(err, OCIDownloaderError::CertificateError { .. });
+    }
+
+    #[test]
+    fn test_certs_from_paths_valid_certificate_dir() {
+        let dir = tempdir().unwrap();
+        let ca_bundle_dir = dir.path();
+
+        // Valid cert file
+        let file_path = dir.path().join("valid_cert.pem");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "{}", valid_testing_cert()).unwrap();
+        // Empty cert file
+        let file_path = dir.path().join("empty_cert.pem");
+        let _ = File::create(&file_path).unwrap();
+        // Unrelated file
+        let file_path = dir.path().join("other-file.txt");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "some content").unwrap();
+        // Invalid cert in no cert-file
+        let file_path = dir.path().join("invalid-cert.bk");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "{INVALID_TESTING_CERT}").unwrap();
+
+        let ca_bundle_file = PathBuf::default();
+        let certificates = certs_from_paths(&ca_bundle_file, ca_bundle_dir).unwrap();
+        assert_eq!(certificates.len(), 1);
+    }
+}


### PR DESCRIPTION
<!-- Add a detailed description here. -->

Adds the oci downloader with proxy support, it has unit tests but integration tests are required for the full testing of the component and will be coming in a following PR together with a retry mechanism.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
