### PR TITLE
feat!: support instrumentation version v1beta2 (NR-478546)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -3,13 +3,13 @@ name: com.newrelic.apm_dotnet
 version: 0.1.0
 variables:
   k8s:
-    version:
-      description: "Dotnet Agent init container version"
-      type: string
-      default: "latest"
-      required: false
     podLabelSelector:
       description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
       type: yaml
       default: { }
       required: false
@@ -18,11 +18,33 @@ variables:
       type: yaml
       default: { }
       required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "Dotnet Agent init container version"
+      type: string
+      default: "latest"
+      required: false
     env:
       description: "environment variables to pass to Dotnet agent"
       type: yaml
       default: [ ]
       required: false
+    imagePullPolicy:
+      description: "image pull policy for the Dotnet agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the Dotnet agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the Dotnet agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
     health_env:
       description: "environment variables to pass to health sidecar"
       type: yaml
@@ -33,6 +55,21 @@ variables:
       type: string
       default: "latest"
       required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
 deployment:
   k8s:
     health:
@@ -40,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta1
+        apiVersion: newrelic.com/v1beta2
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -54,8 +91,15 @@ deployment:
             language: dotnet
             image: newrelic/newrelic-dotnet-init:${nr-var:version}
             env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
           podLabelSelector: ${nr-var:podLabelSelector}
           namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -3,26 +3,53 @@ name: com.newrelic.apm_java
 version: 0.1.0
 variables:
   k8s:
-    version:
-      description: "Java Agent init container version"
-      type: string
-      default: "latest"
-      required: false
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
       default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
+      type: yaml
+      default: { }
+      required: false
+    agentConfigMap:
+      description: "Java agent configMap name containing agent configuration"
+      type: string
+      default: ""
       required: false
     namespaceLabelSelector:
       description: "Namespace label selector"
       type: yaml
       default: { }
       required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "Java Agent init container version"
+      type: string
+      default: "latest"
+      required: false
     env:
       description: "environment variables to pass to Java agent"
       type: yaml
       default: [ ]
       required: false
+    imagePullPolicy:
+      description: "image pull policy for the Java agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the Java agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the Java agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
     health_env:
       description: "environment variables to pass to health sidecar"
       type: yaml
@@ -33,6 +60,21 @@ variables:
       type: string
       default: "latest"
       required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
 deployment:
   k8s:
     health:
@@ -40,7 +82,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta1
+        apiVersion: newrelic.com/v1beta2
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -54,8 +96,16 @@ deployment:
             language: java
             image: newrelic/newrelic-java-init:${nr-var:version}
             env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
           podLabelSelector: ${nr-var:podLabelSelector}
           namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}
+          agentConfigMap: ${nr-var:agentConfigMap}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -3,13 +3,13 @@ name: com.newrelic.apm_node
 version: 0.1.0
 variables:
   k8s:
-    version:
-      description: "NodeJS Agent init container version"
-      type: string
-      default: "latest"
-      required: false
     podLabelSelector:
       description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
       type: yaml
       default: { }
       required: false
@@ -18,11 +18,33 @@ variables:
       type: yaml
       default: { }
       required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "NodeJS Agent init container version"
+      type: string
+      default: "latest"
+      required: false
     env:
       description: "environment variables to pass to nodejs agent"
       type: yaml
       default: [ ]
       required: false
+    imagePullPolicy:
+      description: "image pull policy for the NodeJS agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the NodeJS agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the NodeJS agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
     health_env:
       description: "environment variables to pass to health sidecar"
       type: yaml
@@ -33,6 +55,21 @@ variables:
       type: string
       default: "latest"
       required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
 deployment:
   k8s:
     health:
@@ -40,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta1
+        apiVersion: newrelic.com/v1beta2
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -54,8 +91,15 @@ deployment:
             language: nodejs
             image: newrelic/newrelic-node-init:${nr-var:version}
             env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
           podLabelSelector: ${nr-var:podLabelSelector}
           namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -3,13 +3,13 @@ name: com.newrelic.apm_python
 version: 0.1.0
 variables:
   k8s:
-    version:
-      description: "Python Agent init container version"
-      type: string
-      default: "latest"
-      required: false
     podLabelSelector:
       description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
       type: yaml
       default: { }
       required: false
@@ -18,11 +18,33 @@ variables:
       type: yaml
       default: { }
       required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "Python Agent init container version"
+      type: string
+      default: "latest"
+      required: false
     env:
       description: "environment variables to pass to Python agent"
       type: yaml
       default: [ ]
       required: false
+    imagePullPolicy:
+      description: "image pull policy for the Python agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the Python agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the Python agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
     health_env:
       description: "environment variables to pass to health sidecar"
       type: yaml
@@ -33,6 +55,21 @@ variables:
       type: string
       default: "latest"
       required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
 deployment:
   k8s:
     health:
@@ -40,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta1
+        apiVersion: newrelic.com/v1beta2
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -54,8 +91,15 @@ deployment:
             language: python
             image: newrelic/newrelic-python-init:${nr-var:version}
             env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
           podLabelSelector: ${nr-var:podLabelSelector}
           namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -3,13 +3,13 @@ name: com.newrelic.apm_ruby
 version: 0.1.0
 variables:
   k8s:
-    version:
-      description: "Ruby Agent init container version"
-      type: string
-      default: "latest"
-      required: false
     podLabelSelector:
       description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
       type: yaml
       default: { }
       required: false
@@ -18,11 +18,33 @@ variables:
       type: yaml
       default: { }
       required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "Ruby Agent init container version"
+      type: string
+      default: "latest"
+      required: false
     env:
       description: "environment variables to pass to Ruby agent"
       type: yaml
       default: [ ]
       required: false
+    imagePullPolicy:
+      description: "image pull policy for the Ruby agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the Ruby agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the Ruby agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
     health_env:
       description: "environment variables to pass to health sidecar"
       type: yaml
@@ -33,6 +55,21 @@ variables:
       type: string
       default: "latest"
       required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
 deployment:
   k8s:
     health:
@@ -40,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta1
+        apiVersion: newrelic.com/v1beta2
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}
@@ -54,8 +91,15 @@ deployment:
             language: ruby
             image: newrelic/newrelic-ruby-init:${nr-var:version}
             env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
           healthAgent:
             image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
             env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
           podLabelSelector: ${nr-var:podLabelSelector}
           namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -315,9 +315,9 @@ pub fn helmrelease_v2_type_meta() -> TypeMeta {
     }
 }
 
-pub fn instrumentation_v1beta1_type_meta() -> TypeMeta {
+pub fn instrumentation_v1beta2_type_meta() -> TypeMeta {
     TypeMeta {
-        api_version: "newrelic.com/v1beta1".to_string(),
+        api_version: "newrelic.com/v1beta2".to_string(),
         kind: "Instrumentation".to_string(),
     }
 }
@@ -363,7 +363,7 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // A dynamic object reflector will be created for each of these types, since the GC lists them.
     vec![
         // Agent Operator CRD
-        instrumentation_v1beta1_type_meta(),
+        instrumentation_v1beta2_type_meta(),
         // This allows Secrets created as dynamic objects to be cleaned up by the GC
         // This should not be needed anymore whenever the GC detection logic doesn't rely on this list.
         TypeMeta {

--- a/agent-control/src/health/k8s/health_checker.rs
+++ b/agent-control/src/health/k8s/health_checker.rs
@@ -1,4 +1,4 @@
-use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta};
+use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta};
 use crate::health::health_checker::{HealthChecker, HealthCheckerError, Healthy};
 use crate::health::with_start_time::{HealthWithStartTime, StartTime};
 #[cfg_attr(test, mockall_double::double)]
@@ -84,7 +84,7 @@ pub fn health_checkers_for_type_meta(
             )),
         ]
     // Instrumentation (Newrelic CR)
-    } else if type_meta == instrumentation_v1beta1_type_meta() {
+    } else if type_meta == instrumentation_v1beta2_type_meta() {
         vec![K8sResourceHealthChecker::NewRelic(
             K8sHealthNRInstrumentation::new(k8s_client, type_meta, name, namespace, start_time),
         )]
@@ -168,7 +168,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use crate::agent_control::config::{
-        helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta,
+        helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta,
     };
     use crate::health::health_checker::HealthChecker;
     use crate::health::health_checker::HealthCheckerError::K8sError;
@@ -321,7 +321,7 @@ pub mod tests {
         let start_time = StartTime::now();
 
         let test_object = DynamicObject {
-            types: Some(instrumentation_v1beta1_type_meta()),
+            types: Some(instrumentation_v1beta2_type_meta()),
             metadata: kube::core::ObjectMeta {
                 name: Some("test-instrumentation".to_string()),
                 namespace: Some("test-namespace".to_string()),

--- a/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use std::fmt::Display;
 use std::sync::Arc;
 
-/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1beta1.
+/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1beta2.
 ///
 /// The `Instrumentation` CR structure which contains this `status` field in K8s also contains a
 /// field `Instrumentation.status.lastUpdated`, this represents when the statuses were written

--- a/agent-control/src/version_checker/k8s/checkers.rs
+++ b/agent-control/src/version_checker/k8s/checkers.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta};
+use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta};
 use crate::agent_type::version_config::{VersionCheckerInitialDelay, VersionCheckerInterval};
 use crate::event::cancellation::CancellationMessage;
 use crate::event::channel::{EventConsumer, EventPublisher};
@@ -37,7 +37,7 @@ impl TryFrom<&TypeMeta> for SupportedResourceType {
         if type_meta == &helmrelease_v2_type_meta() {
             return Ok(Self::HelmRelease);
         }
-        if type_meta == &instrumentation_v1beta1_type_meta() {
+        if type_meta == &instrumentation_v1beta2_type_meta() {
             return Ok(Self::Instrumentation);
         }
         Err(UnsupportedResourceType)
@@ -167,7 +167,7 @@ mod tests {
     use crate::version_checker::k8s::checkers::tests::SubAgentInternalEvent::AgentVersionInfo;
     use crate::{
         agent_control::{
-            config::{helmrelease_v2_type_meta, instrumentation_v1beta1_type_meta},
+            config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta},
             defaults::OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY,
         },
         event::{SubAgentInternalEvent, channel::pub_sub},
@@ -305,7 +305,7 @@ mod tests {
     }
 
     fn instrumentation_dyn_obj() -> DynamicObject {
-        empty_dynamic_object(instrumentation_v1beta1_type_meta())
+        empty_dynamic_object(instrumentation_v1beta2_type_meta())
     }
 
     fn secret_dyn_obj() -> DynamicObject {

--- a/agent-control/src/version_checker/k8s/instrumentation.rs
+++ b/agent-control/src/version_checker/k8s/instrumentation.rs
@@ -78,7 +78,7 @@ impl VersionChecker for NewrelicInstrumentationVersionChecker {
     }
 }
 
-/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1beta1, Instrumentation) object.
+/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1beta2, Instrumentation) object.
 /// Specifically it gets it from `spec.agent.image`, where the image's tag is considered the version.
 fn version_from_newrelic_instrumentation_image(
     data: &serde_json::Map<String, serde_json::Value>,

--- a/test/k8s-e2e/apm/ac-values-apm.yml
+++ b/test/k8s-e2e/apm/ac-values-apm.yml
@@ -10,7 +10,7 @@ agentControlDeployment:
       fleet_control:
         enabled: false
       log:
-        level: trace
+        level: debug
       agents:
         operator:
           agent_type: newrelic/com.newrelic.k8s_agent_operator:0.1.0
@@ -35,6 +35,11 @@ agentControlDeployment:
             - key: "app"
               operator: "In"
               values: [ "javaapp" ]
+        containerSelector:
+          envSelector:
+            matchExpressions:
+              - key: NRI
+                operator: Exists
       python-agent:
         podLabelSelector:
           matchExpressions:

--- a/test/k8s-e2e/apm/dotnetapp.yaml
+++ b/test/k8s-e2e/apm/dotnetapp.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  labels:
+    app: dotneteapp
+spec:
+  containers:
+    - name: placeholder
+      image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-dotnet@sha256:def752e3e4f9b1f40b6f943c376dc8cb7f0f8a204be9ef810448ea1de7b52419
+      ports:
+        - containerPort: 8080
+    - name: trafficgen
+      image: alpine/curl:latest
+      command: ["/bin/sh","-c"]
+      args:
+        - |
+          until curl -sS -o /dev/null 127.0.0.1:8080/rolldice; do echo "Dotnet app not ready yet"; sleep 5; done;
+          while true; do curl -sS -o /dev/null 127.0.0.1:8080/rolldice; sleep 1; done
+  restartPolicy: Always

--- a/test/k8s-e2e/apm/e2e-apm.yml
+++ b/test/k8s-e2e/apm/e2e-apm.yml
@@ -3,44 +3,29 @@ description: E2E Test
 custom_test_key: appName
 
 scenarios:
+    # This test spawns AC along with the APM operator and five sample apps (Java, Python, Node.js, Ruby and .NET).
+    # Each app is instrumented with its corresponding APM agent via an Instrumentation CR created by AC.
+    # The test validates that each agent is healthy via the AC /status endpoint and that data is being reported to New Relic.
+    # Sample apps are basic web servers that respond to HTTP requests. Each Pod includes a lightweight sidecar that waits for 
+    # readiness and continuously generates local traffic to help validate agent instrumentation.
   - description: Deploy SA with APM operator and Java, Python and Node.js agents
     before:
       - echo The cluster name of the test is ${SCENARIO_TAG}
       - cd ../../../ && SA_CHART_VALUES_FILE="test/k8s-e2e/apm/ac-values-apm.yml" CLUSTER=${SCENARIO_TAG} USE_LATEST_FLUX=${USE_LATEST_FLUX} tilt ci
-      # we need wait and retry since the resource might me not created yet
-      - timeout 600s bash -c "until kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 deploy/operator-k8s-agents-operator -n newrelic-agents; do sleep 5; echo waiting on operator ; done"
-      - sleep 60
-      # Pinned digest to the 'main' tag at 2025/12/02
-      - kubectl run ${SCENARIO_TAG}-python --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python@sha256:bed9586c6ad919365ce165026717c2eaa81a439fdf5fb1d24872a58aeeaf45a1 -o yaml | kubectl label app=pythonapp -f - --local -o yaml | kubectl create -f -
-      - kubectl run ${SCENARIO_TAG}-java --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java@sha256:c7dd7b82a124ed358fac83fb609ccd9346bee32c1f4de7863cf810b80f0c8f18 -o yaml | kubectl label app=javaapp -f - --local -o yaml | kubectl create -f -
-      - kubectl run ${SCENARIO_TAG}-dotnet --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-dotnet@sha256:def752e3e4f9b1f40b6f943c376dc8cb7f0f8a204be9ef810448ea1de7b52419 -o yaml | kubectl label app=dotneteapp -f - --local -o yaml | kubectl create -f -
-      - kubectl run ${SCENARIO_TAG}-node --dry-run=client --image=ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-nodejs@sha256:5a07647c580c8fc49c0173b00d9c159c05451ca1fa122a81036648832546e7bf -o yaml | kubectl label app=nodeapp -f - --local -o yaml | kubectl create -f -
+      # Before spawn the apps, wait for the operator and the Instrumentation CRs to be created.
+      - kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 deploy/operator-k8s-agents-operator -n newrelic-agents --timeout=600s
+      - kubectl wait --for=create instrumentation/python-agent instrumentation/java-agent instrumentation/node-agent instrumentation/ruby-agent instrumentation/dotnet-agent --timeout=60s -n newrelic-agents
+      # At this point the operator should be ready and AC should have created the Instrumentation resources.
+      - kubectl create -f ./pythonapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-python/ | kubectl create -f -
+      - kubectl create -f ./javaapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-java/ | kubectl create -f -
+      - kubectl create -f ./nodeapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-node/ | kubectl create -f -
       - kubectl create -f ./rubyapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-ruby/ | kubectl create -f -
-
-      # Generate some traffic
-      - kubectl wait --for=condition=Ready --all pods --timeout 5m
-      - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-python -c ${SCENARIO_TAG}-python -- wget -qO /dev/null 127.0.0.1:8080; do echo 'Python not ready yet. Retrying...';sleep 5;done"
-      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-python -c ${SCENARIO_TAG}-python -- wget -qO /dev/null 127.0.0.1:8080
-      - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-node -c ${SCENARIO_TAG}-node -- wget -qO /dev/null 127.0.0.1:3000/rolldice; do echo 'Node not ready yet. Retrying...';sleep 5;done"
-      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-node -c ${SCENARIO_TAG}-node -- wget -qO /dev/null 127.0.0.1:3000/rolldice
-      - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null 127.0.0.1:9292; do echo 'Ruby not ready yet. Retrying...';sleep 5;done"
-      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null 127.0.0.1:9292
-      # dotnet image does not have wget available, we use one from a different pod
-      - timeout 60s bash -c "until kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`:8080/rolldice; do echo 'Dotnet not ready yet. Retrying...';sleep 5;done"
-      - seq 100 | xargs -I{} kubectl exec ${SCENARIO_TAG}-ruby -c ${SCENARIO_TAG}-ruby -- wget -qO /dev/null `kubectl get pod ${SCENARIO_TAG}-dotnet -o json | jq -r .status.podIP`:8080/rolldice
-
-      # Show app logs
-      - kubectl logs --tail=-1 -l app=pythonapp --all-containers --prefix=true -n newrelic-agents
-      - kubectl logs --tail=-1 -l app=javaapp --all-containers --prefix=true -n newrelic-agents
-      - kubectl logs --tail=-1 -l app=dotneteapp --all-containers --prefix=true -n newrelic-agents
-      - kubectl logs --tail=-1 -l app=nodeapp --all-containers --prefix=true -n newrelic-agents
-      - kubectl logs --tail=-1 -l app=rubyapp --all-containers --prefix=true -n newrelic-agents
-
+        # the dotnet container for linux/arm64 is broken, it doesn't have the binary. Do not expect this to work in Mac MX minikube.
+      - kubectl create -f ./dotnetapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-dotnet/ | kubectl create -f -
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=operator --all-containers --prefix=true -n newrelic-agents
       - kubectl get all -o wide --all-namespaces --show-labels
-      - cd ../../../ && tilt down
     tests:
       nrqls:
         # Checks that the metric exist for the test scenario, an extra where testKey=$SCENARIO_TAG is always added.

--- a/test/k8s-e2e/apm/javaapp.yaml
+++ b/test/k8s-e2e/apm/javaapp.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  labels:
+    app: javaapp
+spec:
+  containers:
+    - name: placeholder
+      image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java@sha256:c7dd7b82a124ed358fac83fb609ccd9346bee32c1f4de7863cf810b80f0c8f18
+      ports:
+        - containerPort: 8080
+      env:
+        - name: NRI
+          value: "true"
+    - name: trafficgen
+      image: alpine/curl:latest
+      command: ["/bin/sh","-c"]
+      args:
+        - |
+          until curl -sS 127.0.0.1:8080; do echo "Java app not ready yet"; sleep 5; done;
+          while true; do curl -sS 127.0.0.1:8080; sleep 1; done
+  restartPolicy: Always

--- a/test/k8s-e2e/apm/nodeapp.yaml
+++ b/test/k8s-e2e/apm/nodeapp.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  labels:
+    app: nodeapp
+spec:
+  containers:
+    - name: placeholder
+      image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-nodejs@sha256:5a07647c580c8fc49c0173b00d9c159c05451ca1fa122a81036648832546e7bf
+      ports:
+        - containerPort: 3000
+    - name: trafficgen
+      image: alpine/curl:latest
+      command: ["/bin/sh","-c"]
+      args:
+        - |
+          until curl -sS 127.0.0.1:3000/rolldice; do echo "Node app not ready yet"; sleep 5; done;
+          while true; do curl -sS 127.0.0.1:3000/rolldice; sleep 1; done
+  restartPolicy: Always

--- a/test/k8s-e2e/apm/pythonapp.yaml
+++ b/test/k8s-e2e/apm/pythonapp.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  labels:
+    app: pythonapp
+spec:
+  containers:
+    - name: placeholder
+      image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python@sha256:bed9586c6ad919365ce165026717c2eaa81a439fdf5fb1d24872a58aeeaf45a1
+      ports:
+        - containerPort: 8080
+    - name: trafficgen
+      image: alpine/curl:latest
+      command: ["/bin/sh","-c"]
+      args:
+        - |
+          until curl -sS 127.0.0.1:8080; do echo "Python app not ready yet"; sleep 5; done;
+          while true; do curl -sS 127.0.0.1:8080; sleep 1; done
+  restartPolicy: Always

--- a/test/k8s-e2e/apm/rubyapp.yaml
+++ b/test/k8s-e2e/apm/rubyapp.yaml
@@ -48,6 +48,13 @@ spec:
         - mountPath: /app/main.rb
           name: code
           subPath: main.rb
+    - name: trafficgen
+      image: alpine/curl:latest
+      command: ["/bin/sh","-c"]
+      args:
+        - |
+          until curl -sS 127.0.0.1:9292; do echo "Ruby app not ready yet"; sleep 5; done;
+          while true; do curl -sS 127.0.0.1:9292; sleep 1; done
   volumes:
     - name: code
       configMap:

--- a/test/k8s-e2e/dynamic/ac-values-dynamic.yml
+++ b/test/k8s-e2e/dynamic/ac-values-dynamic.yml
@@ -23,8 +23,6 @@ agentControlDeployment:
               kind: "GitRepository"
             - apiVersion: "v1"
               kind: "Secret"
-            - apiVersion: "newrelic.com/v1beta1"
-              kind: "Instrumentation"
       agents:
         logs:
           agent_type: newrelic/io.fluentbit:0.1.0 # these agent-types are overwritten yb the e2e test


### PR DESCRIPTION
Replaces Instrumentation v1beta1 to v1beta2 adding support to:
- `containerSelector`
- Java agent `agentConfigMap`

Improves apm e2e 

# Breaking Notice

Cluster running k8s-agent-operator version < [v0.28.0](https://github.com/newrelic/k8s-agents-operator/releases/tag/v0.28.0) will not have v1beta2 CRD version