### PR TITLE
fix(canaries): update bad threshold value

### DIFF
--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -174,7 +174,7 @@ module "alerts" {
       metric        = "max(ioReadBytesPerSecond) OR 0"
       sample        = "ProcessSample"
       threshold     = 500000
-      duration      = 500
+      duration      = 300
       operator      = "above"
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
     },
@@ -183,7 +183,7 @@ module "alerts" {
       metric        = "max(ioWriteBytesPerSecond) OR 0"
       sample        = "ProcessSample"
       threshold     = 20000
-      duration      = 500
+      duration      = 300
       operator      = "above"
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
     },


### PR DESCRIPTION
The value introduced in #1924 was invalid. It was failing with:

```
2025-12-05T10:30:09Z    │ Error: Validation Error: BAD_USER_INPUT
2025-12-05T10:30:09Z    │
2025-12-05T10:30:09Z    │   with module.alerts["onhost-canary-staging-amd64-ubuntu22-04"].newrelic_nrql_alert_condition.condition_nrql_canary[4],
2025-12-05T10:30:09Z    │   on ../../terraform/modules/nr_alerts/main.tf line 62, in resource "newrelic_nrql_alert_condition" "condition_nrql_canary":
2025-12-05T10:30:09Z    │   62: resource "newrelic_nrql_alert_condition" "condition_nrql_canary" {
2025-12-05T10:30:09Z    │
2025-12-05T10:30:09Z    │ terms[].thresholdDuration: Term duration must be a multiple of the
2025-12-05T10:30:09Z    │ aggregation window (60 seconds) but was 500 seconds
2025-12-05T10:30:09Z    ╵
```

This PR fixes it