### PR TITLE
chore: add rust toolchain version to renovate shared config

### DIFF
--- a/.github/renovate-shared-base.json
+++ b/.github/renovate-shared-base.json
@@ -64,6 +64,19 @@
         "major"
       ],
       "groupName": "go major updates"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/Cargo.toml"
+      ],
+      "matchStrings": [
+        "rust-version\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
Add a renovate shared rule to update the rust toolchain version