### PR TITLE
fix(renovate): remove wrong versioningTemplate field

### DIFF
--- a/.github/renovate-shared-base.json
+++ b/.github/renovate-shared-base.json
@@ -14,7 +14,8 @@
   "enabledManagers": [
     "cargo",
     "custom.regex",
-    "gomod"
+    "gomod",
+    "github-actions"
   ],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 0,


### PR DESCRIPTION
Hopefully fixes the rule introduced in #1926 and makes renovate open PRs with new rust toolchain versions.