### PR TITLE
refactor: install rust toolchain composite action

### DIFF
--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -1,0 +1,24 @@
+name: 'Install Rust Toolchain'
+description: 'Installs the Rust toolchain version specified in Cargo.toml'
+inputs:
+  targets:
+    description: 'Comma-separated list of additional targets to install'
+    required: false
+  components:
+    description: 'Comma-separated list of additional components to install'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Obtain Rust version from project
+      shell: bash
+      run: |
+        RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
+        echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
+
+    - name: Install Rust ${{ env.RUST_VERSION }}
+      uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      with:
+        toolchain: ${{ env.RUST_VERSION }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}

--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -35,15 +35,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }} with targets
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             aarch64-unknown-linux-musl,
             x86_64-unknown-linux-musl

--- a/.github/workflows/component_k8s_e2e.yml
+++ b/.github/workflows/component_k8s_e2e.yml
@@ -63,15 +63,8 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             x86_64-unknown-linux-musl
 

--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -34,15 +34,8 @@ jobs:
           go-version-file: 'build/embedded/go.mod'
           check-latest: true
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }} with targets
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             aarch64-unknown-linux-musl,
             x86_64-unknown-linux-musl,

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -30,17 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
           components: rustfmt
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Check code formatting
         run: cargo fmt --check
@@ -54,16 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
       - uses: ./.github/actions/rust-cache
@@ -81,16 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
+      - uses: ./.github/actions/install-rust-toolchain
 
       - name: Create documentation
         run: cargo doc --no-deps --package newrelic_agent_control
@@ -103,15 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
+      - uses: ./.github/actions/install-rust-toolchain
 
       - name: Fetch dependencies
         run: cargo fetch
@@ -138,16 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
           components: llvm-tools-preview
-          toolchain: ${{ env.RUST_VERSION }}
+
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@71765c00dd3e08a5484a5b9e82a4c88b86520e0e # 71765c00dd3e08a5484a5b9e82a4c88b86520e0e
         # uses: taiki-e/install-action@cargo-llvm-cov
@@ -195,16 +156,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             x86_64-unknown-linux-musl
 
@@ -235,16 +188,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             aarch64-unknown-linux-musl,
             x86_64-unknown-linux-musl
@@ -290,15 +235,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
+      - uses: ./.github/actions/install-rust-toolchain
 
       - uses: ./.github/actions/rust-cache
         with:
@@ -346,15 +283,8 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
-      - name: Obtain Rust version from project
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: >-
             x86_64-unknown-linux-musl
 
@@ -392,16 +322,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Obtain Rust version from project
-        shell: bash
-        run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
-          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
-
-      - name: Install Rust ${{ env.RUST_VERSION }}
-        uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # master
+      - uses: ./.github/actions/install-rust-toolchain
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
       - uses: taiki-e/install-action@575f713d0233afba556737a7b85080563be14186 # 575f713d0233afba556737a7b85080563be14186


### PR DESCRIPTION
Improved pipelines a bit. Created composite action to install rust toolchain.

## Context

I noticed we don't create caches in the `nightly`. I wanted to fix it. It's not that "easy". We have to install different components in different OSes. I also noticed that Linux and Windows don't work the same. For example, in Windows we have a single `test-dev` cache for every step. In Linux we don't. I remember adding that distinction because it made it faster on Linux.

Anyway, instead of trying to fix all at once. I decided to start small and improve one thing at a time whenever I have a bit of time.

The idea is to end up with smaller more manageable units that we can easily mix and compose in the pipelines. Otherwise, it's "hard" to make modifications.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
