### PR TITLE
fix: permissions write for prerelease updalod

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,8 @@ jobs:
   build-packages:
     name: Build packages
     uses: ./.github/workflows/component_packages.yml
+    permissions:
+      contents: write
     with:
       pre-release: true
       tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
We need to be able to push packages to the pre-release
https://github.com/marketplace/actions/upload-files-to-a-github-release#permissions

Example of failure: https://github.com/newrelic/newrelic-agent-control/actions/runs/20072007882/job/57576446525#logs

## Checklist

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
