### PR TITLE
fix(regex): block hexadecimals as well

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/regexes.rs
+++ b/agent-control/src/opamp/remote_config/validators/regexes.rs
@@ -465,7 +465,7 @@ config:
                 config: CONFIG_WITH_EXEC,
             },
             TestCase {
-                _name: "infra-agent config with exec exadecimal should be invalid",
+                _name: "infra-agent config with exec hexadecimal should be invalid",
                 agent_identity: infra_agent(),
                 config: CONFIG_WITH_EXEC_HEXADECIMAL,
             },


### PR DESCRIPTION
Covering hexadcimals as well, exposing which is the regex matching

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
