### PR TITLE
chore(ac): bump instrumentation CR version

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -77,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta2
+        apiVersion: newrelic.com/v1beta3
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -82,7 +82,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta2
+        apiVersion: newrelic.com/v1beta3
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -77,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta2
+        apiVersion: newrelic.com/v1beta3
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -77,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta2
+        apiVersion: newrelic.com/v1beta3
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -77,7 +77,7 @@ deployment:
       initial_delay: 30s
     objects:
       instrumentation:
-        apiVersion: newrelic.com/v1beta2
+        apiVersion: newrelic.com/v1beta3
         kind: Instrumentation
         metadata:
           name: ${nr-sub:agent_id}

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -315,9 +315,9 @@ pub fn helmrelease_v2_type_meta() -> TypeMeta {
     }
 }
 
-pub fn instrumentation_v1beta2_type_meta() -> TypeMeta {
+pub fn instrumentation_v1beta3_type_meta() -> TypeMeta {
     TypeMeta {
-        api_version: "newrelic.com/v1beta2".to_string(),
+        api_version: "newrelic.com/v1beta3".to_string(),
         kind: "Instrumentation".to_string(),
     }
 }
@@ -363,7 +363,7 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // A dynamic object reflector will be created for each of these types, since the GC lists them.
     vec![
         // Agent Operator CRD
-        instrumentation_v1beta2_type_meta(),
+        instrumentation_v1beta3_type_meta(),
         // This allows Secrets created as dynamic objects to be cleaned up by the GC
         // This should not be needed anymore whenever the GC detection logic doesn't rely on this list.
         TypeMeta {

--- a/agent-control/src/health/k8s/health_checker.rs
+++ b/agent-control/src/health/k8s/health_checker.rs
@@ -1,4 +1,4 @@
-use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta};
+use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta3_type_meta};
 use crate::health::health_checker::{HealthChecker, HealthCheckerError, Healthy};
 use crate::health::with_start_time::{HealthWithStartTime, StartTime};
 #[cfg_attr(test, mockall_double::double)]
@@ -84,7 +84,7 @@ pub fn health_checkers_for_type_meta(
             )),
         ]
     // Instrumentation (Newrelic CR)
-    } else if type_meta == instrumentation_v1beta2_type_meta() {
+    } else if type_meta == instrumentation_v1beta3_type_meta() {
         vec![K8sResourceHealthChecker::NewRelic(
             K8sHealthNRInstrumentation::new(k8s_client, type_meta, name, namespace, start_time),
         )]
@@ -168,7 +168,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use crate::agent_control::config::{
-        helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta,
+        helmrelease_v2_type_meta, instrumentation_v1beta3_type_meta,
     };
     use crate::health::health_checker::HealthChecker;
     use crate::health::health_checker::HealthCheckerError::K8sError;
@@ -321,7 +321,7 @@ pub mod tests {
         let start_time = StartTime::now();
 
         let test_object = DynamicObject {
-            types: Some(instrumentation_v1beta2_type_meta()),
+            types: Some(instrumentation_v1beta3_type_meta()),
             metadata: kube::core::ObjectMeta {
                 name: Some("test-instrumentation".to_string()),
                 namespace: Some("test-namespace".to_string()),

--- a/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
+++ b/agent-control/src/health/k8s/health_checker/resources/instrumentation.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use std::fmt::Display;
 use std::sync::Arc;
 
-/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1beta2.
+/// Represents the status of an Instrumentation CRD in K8s, as of apiVersion: newrelic.com/v1beta3.
 ///
 /// The `Instrumentation` CR structure which contains this `status` field in K8s also contains a
 /// field `Instrumentation.status.lastUpdated`, this represents when the statuses were written

--- a/agent-control/src/version_checker/k8s/checkers.rs
+++ b/agent-control/src/version_checker/k8s/checkers.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta};
+use crate::agent_control::config::{helmrelease_v2_type_meta, instrumentation_v1beta3_type_meta};
 use crate::agent_type::version_config::{VersionCheckerInitialDelay, VersionCheckerInterval};
 use crate::event::cancellation::CancellationMessage;
 use crate::event::channel::{EventConsumer, EventPublisher};
@@ -37,7 +37,7 @@ impl TryFrom<&TypeMeta> for SupportedResourceType {
         if type_meta == &helmrelease_v2_type_meta() {
             return Ok(Self::HelmRelease);
         }
-        if type_meta == &instrumentation_v1beta2_type_meta() {
+        if type_meta == &instrumentation_v1beta3_type_meta() {
             return Ok(Self::Instrumentation);
         }
         Err(UnsupportedResourceType)
@@ -167,7 +167,7 @@ mod tests {
     use crate::version_checker::k8s::checkers::tests::SubAgentInternalEvent::AgentVersionInfo;
     use crate::{
         agent_control::{
-            config::{helmrelease_v2_type_meta, instrumentation_v1beta2_type_meta},
+            config::{helmrelease_v2_type_meta, instrumentation_v1beta3_type_meta},
             defaults::OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY,
         },
         event::{SubAgentInternalEvent, channel::pub_sub},
@@ -305,7 +305,7 @@ mod tests {
     }
 
     fn instrumentation_dyn_obj() -> DynamicObject {
-        empty_dynamic_object(instrumentation_v1beta2_type_meta())
+        empty_dynamic_object(instrumentation_v1beta3_type_meta())
     }
 
     fn secret_dyn_obj() -> DynamicObject {

--- a/agent-control/src/version_checker/k8s/instrumentation.rs
+++ b/agent-control/src/version_checker/k8s/instrumentation.rs
@@ -78,7 +78,7 @@ impl VersionChecker for NewrelicInstrumentationVersionChecker {
     }
 }
 
-/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1beta2, Instrumentation) object.
+/// Obtains the version from the data of a 'newrelic instrumentation' (newrelic.com/v1beta3, Instrumentation) object.
 /// Specifically it gets it from `spec.agent.image`, where the image's tag is considered the version.
 fn version_from_newrelic_instrumentation_image(
     data: &serde_json::Map<String, serde_json::Value>,


### PR DESCRIPTION
Bumping the instrumentation version so that we can laverage the GUID status new feature

https://github.com/newrelic/k8s-agents-operator/blob/17563991b803c5aa604713e5765ecba437f2413f/api/v1beta3/instrumentation_types.go#L173

## Checklist

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
