### PR TITLE
chore: move e2e recipes branch back to main

### DIFF
--- a/test/ac-ansible-roles/install_ac_recipe/vars/main.yaml
+++ b/test/ac-ansible-roles/install_ac_recipe/vars/main.yaml
@@ -18,7 +18,7 @@ migrate_infra_config: "true"
 local_package_path: ""
 
 # Git branch name to use when fetching recipes from the repository
-recipe_repo_branch: "feat/infra-agent-config-proxy" # TODO: back to main when the feature is ready
+recipe_repo_branch: "main"
 
 # Specific version of the agent control software to install
 agent_control_version: ""


### PR DESCRIPTION
This PR changes the recipes' branch back to `main` after https://github.com/newrelic/open-install-library/pull/1287 has been merged.
