### PR TITLE
test: use port 5001 for OCI registry

### DIFF
--- a/agent-control/tests/on_host/oci_registry.rs
+++ b/agent-control/tests/on_host/oci_registry.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 // Registry created in the make target executing oci-registry.sh
-const REGISTRY_URL: &str = "localhost:5000";
+const REGISTRY_URL: &str = "localhost:5001";
 
 #[test]
 #[ignore = "needs oci registry"]
@@ -61,7 +61,7 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
     // Proxy to the oci server only after 4 retries, the client makes 2 calls per time.
     proxy_server.proxy(|rule| {
         rule.filter(|when| {
-            when.host("localhost").port(5000).and(|when| -> When {
+            when.host("localhost").port(5001).and(|when| -> When {
                 when.is_true(move |_| {
                     let mut attempts = attempts_clone.lock().unwrap();
                     *attempts += 1;

--- a/tools/oci-registry.sh
+++ b/tools/oci-registry.sh
@@ -35,8 +35,10 @@ readonly CONFIG_FILE="$CONFIG_FOLDER/config.json"
 readonly BINARY="$CONFIG_FOLDER/zot"
 
 if [ "$OS" = "windows" ]; then
-    readonly STORAGE_PATH=$(cygpath -m "$CONFIG_FOLDER/storage")
-    readonly LOG_FILE=$(cygpath -m "$CONFIG_FOLDER/zot.log")
+    STORAGE_PATH=$(cygpath -m "$CONFIG_FOLDER/storage")
+    readonly STORAGE_PATH
+    LOG_FILE=$(cygpath -m "$CONFIG_FOLDER/zot.log")
+    readonly LOG_FILE
 else
     readonly STORAGE_PATH="$CONFIG_FOLDER/storage"
     readonly LOG_FILE="$CONFIG_FOLDER/zot.log"
@@ -46,7 +48,7 @@ fi
 # ----- ARGUMENTS -----
 OPTION="${1:-empty}"
 VERSION="${VERSION:-v2.1.11}"
-PORT="${PORT:-5000}"
+PORT="${PORT:-5001}"
 
 
 # ----- HELPER FUNCTIONS -----
@@ -70,8 +72,8 @@ function install() {
         if [ "$OS" = "windows" ]; then
             DOWNLOAD_URL="${DOWNLOAD_URL}.exe"
         fi
-        curl -L $DOWNLOAD_URL --output $BINARY
-        chmod +x $BINARY
+        curl -L "$DOWNLOAD_URL" --output "$BINARY"
+        chmod +x "$BINARY"
     else
         echo "zot binary already exists, skipping download"
     fi
@@ -79,7 +81,7 @@ function install() {
 
 function create_zot_configuration() {
     echo "Creating zot configuration at $CONFIG_FILE..."
-    touch $LOG_FILE
+    touch "$LOG_FILE"
     cat > "$CONFIG_FILE" << EOF
 {
     "distSpecVersion": "1.0.1",


### PR DESCRIPTION
It is clashing on my local setup (macOS) which has the used port allocated for AirPort activity ([ref](https://stackoverflow.com/questions/72369320/why-always-something-is-running-at-port-5000-on-my-mac)). 

<!-- Add a detailed description here. -->

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
