### PR TITLE
fix: grant admin permissions in windows install script

### DIFF
--- a/build/package/windows/install.ps1
+++ b/build/package/windows/install.ps1
@@ -62,8 +62,15 @@ function Set-RestrictedAcl {
     if (-not (Test-Path -Path $Path)) { return }
     # Remove inheritance and replace explicit grants with Administrators members only
     # Giving Full Control Access (F) and making it apply to all child objects (OI)(CI)
+    #
+    # Use SID instead of group name to avoid localization issues. The group name changes
+    # based on the configured language.
+    # For example, BUILTIN\Administrators (english) vs BUILTIN\Administradores (spanish).
+    # 
+    # S-1-5-32-544 is the well-known SID for BUILTIN\Administrators.
+    # Reference: https://learn.microsoft.com/es-es/windows-server/identity/ad-ds/manage/understand-security-identifiers
     & icacls $Path /inheritance:r | Out-Null
-    & icacls $Path /grant "BUILTIN\Administrators:(OI)(CI)F"| Out-Null 
+    & icacls $Path /grant "*S-1-5-32-544:(OI)(CI)F" | Out-Null 
 }
 
 # Check for administrator privileges


### PR DESCRIPTION
The current windows install script assumes it's running on a system configured with english. Running it on a windows with spanish breaks the installation. This PR makes the script language agnostic.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
