### PR TITLE
ci: fix k8s canaries

### DIFF
--- a/test/k8s-canaries/helm/agent-control.yml
+++ b/test/k8s-canaries/helm/agent-control.yml
@@ -5,7 +5,7 @@ agentControlDeployment:
       pullPolicy: Always
     config:
       authSecret:
-        secretName: "agent-control-auth"
+        secretName: "sys-identity"
         secretKeyName: "private_key"
       log:
         level: debug


### PR DESCRIPTION
We were using the default `secretName` for k8s canaries. That is `agent-control-auth`. However, we use `sys-identity` in the makefile.

```
@kubectl get secret sys-identity --namespace newrelic || \
```

This PR updates the values file.