### PR TITLE
feat: support agentConfig override [NR-508104]

### DIFF
--- a/agent-control/src/opamp/remote_config.rs
+++ b/agent-control/src/opamp/remote_config.rs
@@ -17,6 +17,11 @@ pub mod validators;
 /// for each case.
 pub const AGENT_CONFIG_PREFIX: &str = "agentConfig";
 
+/// Prefix that identifies an agent configuration that should override the values considered part of the configuration.
+/// See the parsing implementation at [extract_remote_config_values](crate::sub_agent::remote_config_parser::extract_remote_config_values)
+/// for details.
+pub const AGENT_CONFIG_OVERRIDE_PREFIX: &str = "override.agentConfig";
+
 /// This structure represents the remote configuration that we would retrieve from a server via OpAMP.
 /// Contains identifying metadata and the actual configuration values
 #[derive(Debug, PartialEq, Clone)]
@@ -68,9 +73,7 @@ impl OpampRemoteConfig {
 
     /// Returns an iterator over the configuration key-value pairs that start with [AGENT_CONFIG_PREFIX].
     pub fn agent_configs_iter(&self) -> impl Iterator<Item = (&String, &String)> {
-        self.config_map
-            .0
-            .iter()
+        self.configs_iter()
             .filter(|(k, _)| k.starts_with(AGENT_CONFIG_PREFIX))
     }
 
@@ -82,6 +85,27 @@ impl OpampRemoteConfig {
             .0
             .iter()
             .any(|(k, v)| k.starts_with(AGENT_CONFIG_PREFIX) && !v.is_empty())
+    }
+
+    /// Returns the configuration override identified by [AGENT_CONFIG_OVERRIDE_PREFIX] if any. Only one configuration
+    /// override is supported, therefore any remote configuration with more than one entry starting
+    /// by [AGENT_CONFIG_OVERRIDE_PREFIX] will be invalid.
+    pub fn agent_config_override(&self) -> Result<Option<&String>, OpampRemoteConfigError> {
+        let mut override_configs = self
+            .configs_iter()
+            .filter_map(|(k, v)| k.starts_with(AGENT_CONFIG_OVERRIDE_PREFIX).then_some(v));
+
+        let override_config = override_configs.next(); // Keep the first item if any
+
+        // fail if there are multiple items
+        if override_configs.next().is_some() {
+            return Err(OpampRemoteConfigError::InvalidConfig(
+                self.hash.to_string(),
+                format!("multiple configurations with '{AGENT_CONFIG_OVERRIDE_PREFIX}' prefix"),
+            ));
+        }
+
+        Ok(override_config)
     }
 
     /// Get the signature data for a config key
@@ -154,36 +178,46 @@ impl From<ConfigurationMap> for EffectiveConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use rstest::rstest;
+    use serde_json::json;
 
-    #[rstest]
-    #[case::single_agent_config(
-        r#"{"agentConfig": "key: value"}"#,
-        r#"{"agentConfig": "key: value"}"#
-    )]
-    #[case::multiple_agent_configs(
-        r#"{"agentConfig": "key1: value1", "agentConfig2": "key2: value2"}"#,
-        r#"{"agentConfig": "key1: value1", "agentConfig2": "key2: value2"}"#
-    )]
-    #[case::mixed_configs_filters_non_agent(
-        r#"{"agentConfig": "key1: value1", "otherConfig": "key2: value2", "agentConfig3": "key3: value3"}"#,
-        r#"{"agentConfig": "key1: value1", "agentConfig3": "key3: value3"}"#
-    )]
-    #[case::no_agent_configs(
-        r#"{"otherConfig": "key1: value1", "someConfig": "key2: value2"}"#,
-        r#"{}"#
-    )]
-    fn test_agent_configs_iter(#[case] config_json: &str, #[case] expected_json: &str) {
+    /// Helper to build a [OpampRemoteConfig] for testing.
+    fn testing_agent_config(config_map: serde_json::Value) -> OpampRemoteConfig {
         let agent_id = AgentID::try_from("test-agent").unwrap();
         let hash = Hash::from("some-hash");
         let state = ConfigState::Applying;
         let config_map = ConfigurationMap::new(
-            serde_json::from_str::<HashMap<String, String>>(config_json).unwrap(),
+            serde_json::from_value::<HashMap<String, String>>(config_map).unwrap(),
         );
-        let opamp_config = OpampRemoteConfig::new(agent_id, hash, state, config_map);
+        OpampRemoteConfig::new(agent_id, hash, state, config_map)
+    }
+
+    #[rstest]
+    #[case::single_agent_config(
+        json!({"agentConfig": "key: value"}),
+        json!({"agentConfig": "key: value"})
+    )]
+    #[case::multiple_agent_configs(
+        json!({"agentConfig": "key1: value1", "agentConfig2": "key2: value2"}),
+        json!({"agentConfig": "key1: value1", "agentConfig2": "key2: value2"})
+    )]
+    #[case::mixed_configs_filters_non_agent(
+        json!({"agentConfig": "key1: value1", "otherConfig": "key2: value2", "agentConfig3": "key3: value3"}),
+        json!({"agentConfig": "key1: value1", "agentConfig3": "key3: value3"})
+    )]
+    #[case::no_agent_configs(
+        json!({"otherConfig": "key1: value1", "someConfig": "key2: value2"}),
+        json!({})
+    )]
+    fn test_agent_configs_iter(
+        #[case] config_map: serde_json::Value,
+        #[case] expected: serde_json::Value,
+    ) {
+        let opamp_config = testing_agent_config(config_map);
 
         let result: HashMap<&String, &String> = opamp_config.agent_configs_iter().collect();
-        let expected: HashMap<String, String> = serde_json::from_str(expected_json).unwrap();
+        let expected: HashMap<String, String> = serde_json::from_value(expected).unwrap();
 
         assert_eq!(result.len(), expected.len());
         for (expected_key, expected_value) in &expected {
@@ -192,5 +226,33 @@ mod tests {
                 Some(expected_value.as_str())
             );
         }
+    }
+
+    #[rstest]
+    #[case::no_override(json!({"agentConfig": "key: value"}), None)]
+    #[case::no_suffix(json!({"agentConfig": "key: value", "override.agentConfig": "key: value2"}), Some("key: value2"))]
+    #[case::suffix(json!({"agentConfig": "key: value", "override.agentConfig-1": "key: value2"}), Some("key: value2"))]
+    fn test_agent_config_override(
+        #[case] config_map: serde_json::Value,
+        #[case] expected: Option<&str>,
+    ) {
+        let opamp_config = testing_agent_config(config_map);
+        assert_eq!(
+            opamp_config
+                .agent_config_override()
+                .expect("no error expected")
+                .map(|k| k.as_str()),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_agent_config_override_error() {
+        let opamp_config = testing_agent_config(
+            json!({"override.agentConfig": "key: value", "override.agentConfig-1": "key: value1"}),
+        );
+        assert_matches!(opamp_config.agent_config_override(), Err(OpampRemoteConfigError::InvalidConfig(_, s)) => {
+            assert!(s.contains("multiple configurations with 'override.agentConfig' prefix"));
+        });
     }
 }


### PR DESCRIPTION
## Summary

This PR implements support for overriding agent configuration values received via OpAMP remote configuration. A new configuration prefix `override.agentConfig` has been introduced that allows specific configuration keys to be overridden without triggering duplicate key errors.

⚠️ The `override.` prefix applies to `agentConfig` entries only, there is no support for the same prefix in other entries: `override.whatever` doesn't have any special meaning.

⚠️ Multiple configurations with `override.agentConfig` prefix are not supported and any configuration containing them is considered an **invalid remote configuration** 💥.

## Changes

- Apply the described configuration override if the corresponding configuration is set in the remote config.
- Refactor some unit test to use `serde_json::json!` instead of play string in order to improve readability.

## Behavior

### Configuration Merging Rules

1. **Base Configuration Merging**: (previous behavior maintained) All configurations with keys starting with `agentConfig` are merged together. Duplicate keys in base configurations result in errors.

2. **Override Configuration**: A single configuration with key starting with `override.agentConfig` can be provided. This configuration is merged last and takes precedence over any conflicting keys.

3. **Final Output**: If the merged configuration is empty, `None` is returned. Otherwise, the merged configuration is returned with its hash and state.

### Expected behavior

<details>
<summary>Examples </summary>

### ✅ Valid remote config cases

#### Single agent config
**Input:**
```json
{
  "agentConfig": "key: value"
}
```
**Output:**
```yaml
key: value
```

#### Multiple agent configs (merged)
**Input:**
```json
{
  "agentConfig": "key1: value1",
  "agentConfig-2": "key2: value2"
}
```
**Output:**
```yaml
key1: value1
key2: value2
```

#### Override single key
**Input:**
```json
{
  "agentConfig": "key1: value1\nkey2: value2",
  "override.agentConfig": "key2: overridden"
}
```
**Output:**
```yaml
key1: value1
key2: overridden
```

#### Override adds new key
**Input:**
```json
{
  "agentConfig": "key1: value1",
  "override.agentConfig": "key2: value2"
}
```
**Output:**
```yaml
key1: value1
key2: value2
```

#### Override multiple keys
**Input:**
```json
{
  "agentConfig": "key1: value1\nkey2: value2\nkey3: value3",
  "override.agentConfig": "key2: overridden2\nkey3: overridden3"
}
```
**Output:**
```yaml
key1: value1
key2: overridden2
key3: overridden3
```

#### Override with multiple agent configs
**Input:**
```json
{
  "agentConfig": "key1: value1",
  "agentConfig-2": "key2: value2",
  "override.agentConfig": "key1: overridden"
}
```
**Output:**
```yaml
key1: overridden
key2: value2
```

#### Override with suffix
**Input:**
```json
{
  "agentConfig": "key1: value1\nkey2: value2",
  "override.agentConfig-1": "key2: overridden"
}
```
**Output:**
```yaml
key1: value1
key2: overridden
```

#### Override empty (no-op)
**Input:**
```json
{
  "agentConfig": "key: value",
  "override.agentConfig": ""
}
```
**Output:**
```yaml
key: value
```

#### Override only (no base config)
**Input:**
```json
{
  "override.agentConfig": "key1: overridden"
}
```
**Output:**
```yaml
key1: overridden
```

#### Override with null value (null is preserved)
**Input:**
```json
{
  "agentConfig": "key1: value1\nkey2: value2",
  "override.agentConfig": "key2: null"
}
```
**Output:**
```yaml
key1: value1
key2: null
```

#### Override with empty value (empty is preserved)
**Input:**
```json
{
  "agentConfig": "key1: value1\nkey2: value2",
  "override.agentConfig": "key2:\n"
}
```
**Output:**
```yaml
key1: value1
key2:

```

#### Nested objects are not merged (override replaces completely)
**Input:**
```json
{
  "agentConfig": "key1: {\"key1_1\": \"value_1_1\"}",
  "override.agentConfig": "key1: {\"overridden_key\": \"overridden_value\"}"
}
```
**Output:**
```yaml
key1: {"overridden_key": "overridden_value"}
```

### 💥  Error Cases

The following scenarios result in errors:

#### Invalid YAML map in base config (single value)
**Input:**
```json
{
  "agentConfig": "single-value"
}
```
**Error:** `InvalidValues`

#### Invalid YAML map in base config (array)
**Input:**
```json
{
  "agentConfig": "[1, 2, 3]"
}
```
**Error:** `InvalidValues`

#### Duplicate keys in multiple base configs
**Input:**
```json
{
  "agentConfig-1": "key: value",
  "agentConfig-2": "key: value2"
}
```
**Error:** `InvalidValues`

#### Invalid YAML map in override config
**Input:**
```json
{
  "agentConfig": "key: value",
  "override.agentConfig": "single-value"
}
```
**Error:** `InvalidValues`

#### Multiple override configurations
**Input:**
```json
{
  "agentConfig": "key: value",
  "override.agentConfig": "key: value2",
  "override.agentConfig-2": "key: value3"
}
```
**Error:** `InvalidValues - multiple configurations with 'override.agentConfig' prefix`
</details>


## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
