### PR TITLE
chore(e2e): improve logs

### DIFF
--- a/test/e2e-runner/src/linux/bash.rs
+++ b/test/e2e-runner/src/linux/bash.rs
@@ -19,5 +19,7 @@ pub fn exec_bash_command(command: &str) -> TestResult<String> {
         );
     }
 
-    Ok(stdout)
+    Ok(format!(
+        "command\n{command}\nsuccess\nStdout: {stdout}\nStderr: {stderr}"
+    ))
 }

--- a/test/e2e-runner/src/linux/install.rs
+++ b/test/e2e-runner/src/linux/install.rs
@@ -155,6 +155,7 @@ curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh |
   HTTPS_PROXY={} \
   /usr/local/bin/newrelic install \
   -y \
+  --debug \
   --localRecipes {}\
   -n {}
 "#,


### PR DESCRIPTION
- improve e2e runner logs as the recipe cmd will not exit with failure status when it fails
