### PR TITLE
fix(test): add missing secret to installation test

### DIFF
--- a/agent-control/tests/k8s/agent_control_cli/installation.rs
+++ b/agent-control/tests/k8s/agent_control_cli/installation.rs
@@ -1,6 +1,6 @@
 use crate::common::opamp::FakeServer;
 use crate::common::runtime::block_on;
-use crate::k8s::tools::agent_control::{K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET};
+use crate::k8s::tools::agent_control::{DUMMY_PRIVATE_KEY, K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET};
 use crate::k8s::tools::cmd::{assert_stdout_contains, print_cli_output};
 use crate::k8s::tools::k8s_api::create_values_secret;
 use crate::k8s::tools::k8s_env::K8sEnv;
@@ -105,6 +105,14 @@ fn k8s_cli_install_agent_control_installation_failed_upgrade() {
         "test-secret",
         opamp_server.endpoint().as_str(),
         "values.yaml",
+    );
+
+    create_values_secret(
+        k8s_env.client.clone(),
+        &ac_namespace,
+        K8S_PRIVATE_KEY_SECRET,
+        K8S_KEY_SECRET,
+        DUMMY_PRIVATE_KEY.to_string(),
     );
 
     let release_name = "install-ac-installation-failed-upgrade";


### PR DESCRIPTION
Adds a missing Secret to an integration tests in order to fix failures.

<details>
<summary>Example</summary>

```
[job failure](https://github.com/newrelic/newrelic-agent-control/actions/runs/20923719485/job/60118012166?pr=2048)

```
thread 'k8s::agent_control_cli::installation::k8s_cli_install_agent_control_installation_failed_upgrade' (18535) panicked at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/ops/function.rs:250:5:
Unexpected failure.
code=1
stderr=```""```
command=`"/home/runner/work/newrelic-agent-control/newrelic-agent-control/target/debug/newrelic-agent-control-k8s-cli" "install-agent-control" "--log-level" "debug" "--chart-name" "agent-control-deployment" "--chart-version" "0.0.0-latest-released" "--release-name" "install-ac-installation-failed-upgrade" "--namespace" "ac-test-9zssx" "--secrets" "test-secret=values.yaml" "--repository-url" "http://chartmuseum.default.svc.cluster.local:8080/" "--installation-check-timeout" "1m"`
code=1
stdout=```
2026-01-12T15:19:26 DEBUG tracing_subscriber initialized successfully
2026-01-12T15:19:26 DEBUG Installing default rustls crypto provider
2026-01-12T15:19:26  INFO Installing release install-ac-installation-failed-upgrade
2026-01-12T15:19:26 DEBUG Starting the runtime
2026-01-12T15:19:26 DEBUG Starting the k8s client
2026-01-12T15:19:26 DEBUG trying inClusterConfig for k8s client
2026-01-12T15:19:26 DEBUG inClusterConfig failed to read an incluster environment variable: environment variable not found, trying kubeconfig for k8s client
2026-01-12T15:19:26 DEBUG k8s client initialization succeeded
2026-01-12T15:19:26 DEBUG Initializing dynamic object manager for type: TypeMetaNamespaced { type_meta: TypeMeta { api_version: \"helm.toolkit.fluxcd.io/v2\", kind: \"HelmRelease\" }, namespace: \"ac-test-9zssx\" }
2026-01-12T15:19:26 DEBUG Using local version: 0.0.0-latest-released
2026-01-12T15:19:26 DEBUG Parsed labels: {\"app.kubernetes.io/managed-by\": \"newrelic-agent-control\", \"newrelic.io/agent-id\": \"agent-control\"}
2026-01-12T15:19:26  INFO Applying release install-ac-installation-failed-upgrade resources
2026-01-12T15:19:26  INFO Applying HelmRepository with name \"agent-control\"
2026-01-12T15:19:26 DEBUG Initializing dynamic object manager for type: TypeMetaNamespaced { type_meta: TypeMeta { api_version: \"source.toolkit.fluxcd.io/v1\", kind: \"HelmRepository\" }, namespace: \"ac-test-9zssx\" }
2026-01-12T15:19:26  INFO HelmRepository with name agent-control applied successfully
2026-01-12T15:19:26  INFO Applying HelmRelease with name \"install-ac-installation-failed-upgrade\"
2026-01-12T15:19:26  INFO HelmRelease with name install-ac-installation-failed-upgrade applied successfully
2026-01-12T15:19:26  INFO Release install-ac-installation-failed-upgrade resources applied successfully
2026-01-12T15:19:26  INFO Checking release install-ac-installation-failed-upgrade installation
2026-01-12T15:19:26  INFO Waiting for installation check initial delay: 10s
2026-01-12T15:19:36  INFO Performing installation check with 20 attempts and 3s check interval
2026-01-12T15:19:36 DEBUG Checking health with retries 1/20
2026-01-12T15:19:36 DEBUG Initializing dynamic object manager for type: TypeMetaNamespaced { type_meta: TypeMeta { api_version: \"apps/v1\", kind: \"StatefulSet\" }, namespace: \"ac-test-9zssx\" }
2026-01-12T15:19:36 DEBUG Initializing dynamic object manager for type: TypeMetaNamespaced { type_meta: TypeMeta { api_version: \"apps/v1\", kind: \"DaemonSet\" }, namespace: \"ac-test-9zssx\" }
2026-01-12T15:19:36 DEBUG Initializing dynamic object manager for type: TypeMetaNamespaced { type_meta: TypeMeta { api_version: \"apps/v1\", kind: \"Deployment\" }, namespace: \"ac-test-9zssx\" }
2026-01-12T15:19:36 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:39 DEBUG Checking health with retries 2/20
2026-01-12T15:19:39 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:42 DEBUG Checking health with retries 3/20
2026-01-12T15:19:42 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:45 DEBUG Checking health with retries 4/20
2026-01-12T15:19:45 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:48 DEBUG Checking health with retries 5/20
2026-01-12T15:19:48 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:51 DEBUG Checking health with retries 6/20
2026-01-12T15:19:51 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:54 DEBUG Checking health with retries 7/20
2026-01-12T15:19:54 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:19:57 DEBUG Checking health with retries 8/20
2026-01-12T15:19:57 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:00 DEBUG Checking health with retries 9/20
2026-01-12T15:20:00 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:03 DEBUG Checking health with retries 10/20
2026-01-12T15:20:03 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:06 DEBUG Checking health with retries 11/20
2026-01-12T15:20:06 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:09 DEBUG Checking health with retries 12/20
2026-01-12T15:20:09 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:12 DEBUG Checking health with retries 13/20
2026-01-12T15:20:12 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:15 DEBUG Checking health with retries 14/20
2026-01-12T15:20:15 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:18 DEBUG Checking health with retries 15/20
2026-01-12T15:20:18 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:21 DEBUG Checking health with retries 16/20
2026-01-12T15:20:21 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:24 DEBUG Checking health with retries 17/20
2026-01-12T15:20:24 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:27 DEBUG Checking health with retries 18/20
2026-01-12T15:20:27 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:30 DEBUG Checking health with retries 19/20
2026-01-12T15:20:30 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:33 DEBUG Checking health with retries 20/20
2026-01-12T15:20:33 DEBUG Health check result was unhealthy: Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas
2026-01-12T15:20:36 ERROR Operation failed: installation check failure: installation check failed after 60 seconds timeout (20 attempts): Deployment `install-ac-installation-failed-upgrade-agent-control-deployment`: has 1 unavailable replicas

(...)
failures:

failures:
    k8s::agent_control_cli::installation::k8s_cli_install_agent_control_installation_failed_upgrade

```

</details>