### PR TITLE
ci: automatically bump k8s canaries version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,35 @@
   "extends": [
     "github>newrelic/newrelic-agent-control//.github/renovate-shared-base.json"
   ],
+  // `config:recommended` uses `ignoreModulesAndTests`, which ignores **/test/** paths.
+  // However, we want to be able to update the k8s version cluster in the `eks_cluster`
+  // terraform module that we can find inside `test/k8s-canaries/terraform/modules`.
+  // For that reason, we override `ignorePaths`. The following is a copy from the above
+  // mentioned preset without the `**/test/**` glob pattern.
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
+  // Taking the above comment into account, we are ignoring everything else in the test folder.
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "**/test/**"
+      ],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [
+        "**/test/**/eks_cluster/variables.tf"
+      ],
+      "enabled": true
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -60,6 +89,18 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "newrelic-opamp-rs",
       "packageNameTemplate": "newrelic/newrelic-opamp-rs"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/eks_cluster/variables.tf"
+      ],
+      "matchStrings": [
+        "variable \"k8s_version\" {\n(.*\n)*?(..default.*=.*\"(?<currentValue>.*)\")\n(.*\n)*?}"
+      ],
+      "datasourceTemplate": "endoflife-date",
+      "depNameTemplate": "amazon-eks",
+      "extractVersionTemplate": "^(?<version>.*)-eks.+$"
     }
   ]
 }


### PR DESCRIPTION
Automatically bump k8s canaries version. Tested https://github.com/danielorihuela/newrelic-agent-control/pulls.

Output of the last run

```
{
      "branchName": "renovate/amazon-eks-1.x",
      "prNo": 9,
      "prTitle": "chore(deps): update dependency amazon-eks to v1.34",
      "result": "already-existed",
      "upgrades": [
        {
          "datasource": "endoflife-date",
          "depName": "amazon-eks",
          "displayPending": "",
          "fixedVersion": "1.33",
          "currentVersion": "1.33",
          "currentValue": "1.33",
          "newValue": "1.34",
          "newVersion": "1.34",
          "packageFile": "test/k8s-canaries/terraform/modules/eks_cluster/variables.tf",
          "updateType": "minor",
          "packageName": "amazon-eks"
        }
      ]
    },
```

PR wasn't created because it already existed, but as you can see, we detect that a new version is available and a PR is created with the latest version that eks accepts. Not the latest k8s version available.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
