### PR TITLE
feat: update supervisor trait [NR-497494]

### DIFF
--- a/agent-control/src/sub_agent/supervisor.rs
+++ b/agent-control/src/sub_agent/supervisor.rs
@@ -9,7 +9,7 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```rust,ignore
 //! // Build
 //! let supervisor_starter = builder.build_supervisor(effective_agent)?;
 //!
@@ -33,6 +33,30 @@ use std::{error::Error, marker::Sized};
 pub mod builder;
 pub mod starter;
 pub mod stopper;
+
+/// Defines the error to be returned when there is a problem applying configuration
+/// to a supervisor.
+///
+/// # Usage Example
+///
+/// ```rust,ìgnore
+/// let supervisor = match supervisor.apply(effective_agent) {
+///     Ok(new_supervisor) => new_supervisor,
+///     Err(apply_err) => {
+///         warn!("Error applying effective agent: {}", apply_err.reason)
+///         apply_err.supervisor
+///     }
+/// }
+/// ```
+#[derive(thiserror::Error)]
+#[error("failure applying configuration to supervisor: {reason}")]
+pub struct ApplyError<S: Supervisor> {
+    /// Reason explaining the issue
+    pub reason: String,
+    /// Supervisor should keep be kept as a result of the failed applied. It can be
+    /// the previous supervisor.
+    pub supervisor: S,
+}
 
 /// Constructs a supervisor for managing sub-agent lifecycle.
 ///
@@ -111,7 +135,6 @@ pub trait SupervisorStarter {
 /// * `ApplyError` - The error type returned when applying configuration changes fails
 /// * `StopError` - The error type returned when stopping fails
 pub trait Supervisor: Sized {
-    type ApplyError: Error;
     type StopError: Error;
 
     /// Applies a new effective agent configuration to the running supervisor.
@@ -130,8 +153,11 @@ pub trait Supervisor: Sized {
     /// # Returns
     ///
     /// * `Ok(Self)` - A supervisor instance with the new configuration applied
-    /// * `Err(Self::ApplyError)` - If there is an error applying the configuration
-    fn apply(self, effective_agent: EffectiveAgent) -> Result<Self, Self::ApplyError>;
+    /// * `Err(ApplyError)` - If there is an error applying the configuration. [ApplyError] contains the
+    ///   [Supervisor] that is expected to keep running along with the reason why the configuration failed,
+    ///   the could be `self` or a different supervisor, allowing a recovery mechanism in case of failure.
+    ///
+    fn apply(self, effective_agent: EffectiveAgent) -> Result<Self, ApplyError<Self>>;
 
     /// Stops the supervisor and cleans up all associated resources.
     ///


### PR DESCRIPTION
Refactors the Supervisor trait's error handling by introducing a standardized ApplyError type that encapsulates both the failure reason and the supervisor instance that should continue running.

## Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields
     and feel free to add/remove depending on what's applicable to this PR. -->

- [x] Provided a meaningful title following conventional commit style.
- [x] Included a detailed description for the Pull Request.
- [x] Documentation under `docs` is aligned with the change.
- [x] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [x] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
