### PR TITLE
chore: remove PR template to encourage better context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,8 @@
-<!-- Add a detailed description here. -->
-
+<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
 ## Checklist
-
-<!-- Place an '[x]' (no spaces) in all applicable fields
-     and feel free to add/remove depending on what's applicable to this PR. -->
-
 - [ ] Provided a meaningful title following conventional commit style.
 - [ ] Included a detailed description for the Pull Request.
 - [ ] Documentation under `docs` is aligned with the change.
 - [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
 - [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
+ -->


### PR DESCRIPTION
By removing the boilerplate, we aim to make the actual description stand out