### PR TITLE
ci(fargate-runner): add passrole as custom policy

### DIFF
--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -118,7 +118,7 @@ module "agent_control_infra" {
           {
             "Effect" : "Allow",
             "Action" : "iam:PassRole",
-            "Resource" : "arn:aws:iam:${var.region}:${var.accountId}:role/Agent_Control_Canaries_*-EKS_Worker_Role"
+            "Resource" : "arn:aws:iam::${var.accountId}:role/Agent_Control_Canaries_*-EKS_Worker_Role"
           }
         ]
       }


### PR DESCRIPTION
The `terraform apply` that was attempted after the changes in RBAC from https://github.com/newrelic/newrelic-agent-control/pull/2076 found an error in the Fargate runner due to IAM-related policy restrictions.

I am adding the required policy for our canaries to attempt the `apply` again.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
