### PR TITLE
ci(fargate-runner): move required role to runtime policies

### DIFF
--- a/test/terraform/fargate/main.tf
+++ b/test/terraform/fargate/main.tf
@@ -114,11 +114,6 @@ module "agent_control_infra" {
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_system_identity_private_key}",
               "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_prod_system_identity_private_key}",
             ]
-          },
-          {
-            "Effect" : "Allow",
-            "Action" : "iam:PassRole",
-            "Resource" : "arn:aws:iam::${var.accountId}:role/Agent_Control_Canaries_*-EKS_Worker_Role"
           }
         ]
       }
@@ -131,6 +126,16 @@ module "agent_control_infra" {
   canaries_security_group             = var.canaries_security_group
   oidc_repository                     = var.oidc_repository
   oidc_role_name                      = var.oidc_role_name
-  task_runtime_custom_policies        = var.task_runtime_custom_policies
-  tags                                = var.tags
+  task_runtime_custom_policies = concat(var.task_runtime_custom_policies, [
+    jsonencode({
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Action" : "iam:PassRole",
+          "Resource" : "arn:aws:iam::${var.accountId}:role/Agent_Control_Canaries_*-EKS_Worker_Role"
+        }
+      ]
+    })
+  ])
+  tags = var.tags
 }


### PR DESCRIPTION
Move the required role to runtime policies, as per docs for `task_custom_policies`, this might have been added to the wrong property:

> Task _execution (launching)_ custom policies json. The rights provided here will be added to the role launching the Fargate task.
> [...]
> These rights are different from the ones the processes running inside of the Fargate task have. For instance, if the task needs to launch some EC2 instances, you'd need to give it ec2:* rights through the **task_runtime_custom_policies** variable.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
