### PR TITLE
chore(test): simplify on-host logs-based test

### DIFF
--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -896,16 +896,18 @@ pub mod tests {
 
         thread::sleep(Duration::from_secs(1));
 
-        tracing_test::internal::logs_assert("newrelic_agent_control", |lines| {
-            let count = lines.iter().filter(|line| line.contains("hello!")).count();
+        logs_assert(|lines| {
+            let count = lines
+                .iter()
+                .filter(|l| l.contains("Restarting supervisor"))
+                .count();
             match count {
-                4 => Ok(()),
+                3 => Ok(()),
                 n => Err(format!(
-                    "Expected 4 lines with 'hello!' corresponding to 1 run + 3 retries, got {n}"
+                    "The supervisor should be restarted 3 times. Expected 3 lines, got {n}"
                 )),
             }
-        })
-        .unwrap();
+        });
     }
 
     #[test]


### PR DESCRIPTION
This PR simplifies the check performed in one of the tests of the on-host supervisor. It counts the log lines matching the supervisor restart instead of counting the lines produced by the command itself.

We stop using [tracing_test::internal::logs_assert](https://docs.rs/tracing-test/latest/tracing_test/internal/fn.logs_assert.html) that doesn't filter out logs from the current test (check details in [tracing-test docs](https://docs.rs/tracing-test/latest/tracing_test/internal/fn.logs_assert.html)). It usage causes issues if more than one test tries to implement assertions over the same set of tests. I've tested the new behavior by temporarily adding a copy of the current test (which is already removed).