### PR TITLE
feat: create windows canary with infra-agent and alerts

### DIFF
--- a/.github/workflows/component_onhost_canaries.yml
+++ b/.github/workflows/component_onhost_canaries.yml
@@ -20,6 +20,9 @@ on:
       fleet_id:
         required: true
         type: string
+      windows_fleet_id:
+        required: true
+        type: string
       package_version:
         required: false
         type: string
@@ -57,7 +60,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "AC_CANARY_WINDOWS_PASSWORD=${{ secrets.AC_CANARY_WINDOWS_PASSWORD }} FLEET_ID=${{ inputs.fleet_id }} ENVIRONMENT=${{ inputs.environment }} PACKAGE_VERSION=${{ inputs.package_version }} test/onhost-canaries/terraform-${{ inputs.operation }}"
+          container_make_target: "AC_CANARY_WINDOWS_PASSWORD=${{ secrets.AC_CANARY_WINDOWS_PASSWORD }} FLEET_ID=${{ inputs.fleet_id }} WINDOWS_FLEET_ID=${{ inputs.windows_fleet_id }} ENVIRONMENT=${{ inputs.environment }} PACKAGE_VERSION=${{ inputs.package_version }} test/onhost-canaries/terraform-${{ inputs.operation }}"
           ecs_cluster_name: agent_control
           task_definition_name: agent_control
           cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -160,6 +160,7 @@ jobs:
       environment: staging
       # AC Staging Account `host-canaries-staging` fleet
       fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA"
+      windows_fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTljMjNjYy0yM2I2LTc1OTYtODBkNy0yMzAzYWIyYzcwMTA"
       operation: apply
       package_version: 0.100.${{ github.run_id }}
     secrets:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -189,6 +189,7 @@ jobs:
       environment: production
       # AC US Production Account `host-canaries-production` fleet
       fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWFlM2EyLTA3OTctNzczYS05Y2JjLWMzNzZkMjAwMWFkZg"
+      windows_fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWMyMjljLWVhYTQtN2JmNi04YWIyLTU2ZWI0YjE2ZWZjZQ"
       operation: apply
       package_version: ${{ github.event.inputs.tag || github.event.release.tag_name }}
     secrets:

--- a/.github/workflows/push_pr_onhost_canaries_apply.yml
+++ b/.github/workflows/push_pr_onhost_canaries_apply.yml
@@ -28,9 +28,11 @@ jobs:
           - environment: staging
             # AC Staging Account `host-canaries-staging` fleet
             fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA"
+            windows_fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTljMjNjYy0yM2I2LTc1OTYtODBkNy0yMzAzYWIyYzcwMTA"
           - environment: production
             # AC US Production Account `host-canaries-production` fleet
             fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWFlM2EyLTA3OTctNzczYS05Y2JjLWMzNzZkMjAwMWFkZg"
+            windows_fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWMyMjljLWVhYTQtN2JmNi04YWIyLTU2ZWI0YjE2ZWZjZQ"
     with:
       environment: ${{ matrix.environment }}
       fleet_id: ${{ matrix.fleet_id }}

--- a/.github/workflows/push_pr_onhost_canaries_plan.yml
+++ b/.github/workflows/push_pr_onhost_canaries_plan.yml
@@ -22,9 +22,11 @@ jobs:
           - environment: staging
             # AC Staging Account `host-canaries-staging` fleet
             fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA"
+            windows_fleet_id: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTljMjNjYy0yM2I2LTc1OTYtODBkNy0yMzAzYWIyYzcwMTA"
           - environment: production
             # AC US Production Account `host-canaries-production` fleet
             fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWFlM2EyLTA3OTctNzczYS05Y2JjLWMzNzZkMjAwMWFkZg"
+            windows_fleet_id: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWMyMjljLWVhYTQtN2JmNi04YWIyLTU2ZWI0YjE2ZWZjZQ"
     permissions:
       # required to oidc AWS
       id-token: write

--- a/test/onhost-canaries/Makefile
+++ b/test/onhost-canaries/Makefile
@@ -42,6 +42,7 @@ define check_env_vars
 	$(call check_env_var,ENVIRONMENT)
 	$(call check_env_var,SLACK_WEBHOOK_URL)
 	$(call check_env_var,FLEET_ID)
+	$(call check_env_var,WINDOWS_FLEET_ID)
 	$(call check_env_var,AC_CANARY_WINDOWS_PASSWORD)
 	if [ "$$ENVIRONMENT" = "staging" ]; then \
 		$(call check_env_var,NR_LICENSE_KEY); \
@@ -70,6 +71,7 @@ test/onhost-canaries/terraform-plan:
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_fleet_id=${FLEET_ID} \
+	TF_VAR_windows_fleet_id=${WINDOWS_FLEET_ID} \
 	TF_VAR_package_version=${PACKAGE_VERSION} \
 	TF_VAR_slack_webhook_url=${SLACK_WEBHOOK_URL} \
 	TF_VAR_windows_password="${AC_CANARY_WINDOWS_PASSWORD}" \
@@ -85,6 +87,7 @@ test/onhost-canaries/terraform-apply:
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_fleet_id=${FLEET_ID} \
+	TF_VAR_windows_fleet_id=${WINDOWS_FLEET_ID} \
 	TF_VAR_package_version=${PACKAGE_VERSION} \
 	TF_VAR_slack_webhook_url=${SLACK_WEBHOOK_URL} \
 	TF_VAR_windows_password="${AC_CANARY_WINDOWS_PASSWORD}" \
@@ -99,6 +102,7 @@ test/onhost-canaries/terraform-destroy:
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_fleet_id=${FLEET_ID} \
+	TF_VAR_windows_fleet_id=${WINDOWS_FLEET_ID} \
 	TF_VAR_package_version=${PACKAGE_VERSION} \
 	TF_VAR_slack_webhook_url=${SLACK_WEBHOOK_URL} \
 	TF_VAR_windows_password="${AC_CANARY_WINDOWS_PASSWORD}" \

--- a/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
+++ b/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
@@ -201,7 +201,7 @@
               Region              = "{{ 'Staging' if infra_staging | bool else 'us' }}"
               ServiceOverwrite    = $true
               FleetEnabled        = $true
-              FleetId             = "{{ fleet_id }}"
+              FleetId             = "{{ windows_fleet_id }}"
               AuthClientId        = "{{ system_identity_client_id }}"
               AuthPrivateKeyPath  = "{{ agent_control_private_key }}"
           }

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -29,7 +29,13 @@ variable "package_version" {
 }
 
 variable "fleet_id" {
-  description = "New Relic Fleet ID"
+  description = "New Relic Linux Fleet ID"
+  type        = string
+}
+
+
+variable "windows_fleet_id" {
+  description = "New Relic Windows Fleet ID"
   type        = string
 }
 
@@ -100,7 +106,7 @@ locals {
   // We decided to recompute the hostnames here as the "env-provisioner" module does.
   // If env-provisioner changes the way it computes the hostnames, we need to change
   // it here too. However, terraform plan will properly list all the resources that
-  // will be created and we can spot any problems with the hostnames..
+  // will be created and we can spot any problems with the hostnames.
   hostnames = [for k, v in local.ec2_instances : "${var.ec2_prefix}-${replace(k, "/[:.]/", "-")}"]
   infra_staging = var.nr_region == "Staging" ? "true" : "false"
 }
@@ -116,7 +122,7 @@ module "agent_control-canary-env-provisioner" {
   ssh_pub_key        = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
   inventory_template = "../ansible/inventory-template.tmpl"
   inventory_output   = var.inventory_output
-  ansible_playbook   = "-e system_identity_client_id=${var.system_identity_client_id} -e nr_license_key=${var.license_key} -e repo_endpoint=${var.repository_endpoint} -e package_version=${var.package_version} -e fleet_id=${var.fleet_id} -e opamp_endpoint=${var.opamp_endpoint} -e token_endpoint=${var.token_endpoint} -e signature_validation_endpoint=${var.signature_validation_endpoint} -e otlp_endpoint=${var.otlp_endpoint} -e infra_staging=${local.infra_staging} ../ansible/install_ac_with_basic_config.yml"
+  ansible_playbook   = "-e system_identity_client_id=${var.system_identity_client_id} -e nr_license_key=${var.license_key} -e repo_endpoint=${var.repository_endpoint} -e package_version=${var.package_version} -e fleet_id=${var.fleet_id} -e windows_fleet_id=${var.windows_fleet_id} -e opamp_endpoint=${var.opamp_endpoint} -e token_endpoint=${var.token_endpoint} -e signature_validation_endpoint=${var.signature_validation_endpoint} -e otlp_endpoint=${var.otlp_endpoint} -e infra_staging=${local.infra_staging} ../ansible/install_ac_with_basic_config.yml"
   ec2_otels          = local.ec2_instances
 }
 


### PR DESCRIPTION
Create windows canary with infra-agent and alerts.

It uses the hardcoded testing-infra-agent v1.71.4 since there is no public repo sync with the latest infra-agent release.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
