### PR TITLE
chore(cli-image): fetch k8s tools from alpine images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,10 +38,21 @@
       "managerFilePatterns": [
         "/^Dockerfiles/Dockerfile_agent_control_cli$/"
       ],
-      "depNameTemplate": "helm/helm",
-      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "alpine/helm",
+      "datasourceTemplate": "docker",
       "matchStrings": [
-        "ARG HELM_VERSION=(?<currentValue>.+)"
+        "FROM alpine/helm:(?<currentValue>\\S+) AS helm"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Dockerfiles/Dockerfile_agent_control_cli$/"
+      ],
+      "depNameTemplate": "alpine/kubectl",
+      "datasourceTemplate": "docker",
+      "matchStrings": [
+        "FROM alpine/kubectl:(?<currentValue>\\S+) AS kubectl"
       ]
     },
     {

--- a/Dockerfiles/Dockerfile_agent_control_cli
+++ b/Dockerfiles/Dockerfile_agent_control_cli
@@ -1,29 +1,24 @@
 # Docker file used for the installation of the the Agent Control on k8s.
 
+# Use official alpine images as base stages for kubectl and helm
+# Automatically updated by Renovate
+FROM alpine/helm:4.1.0 AS helm
+FROM alpine/kubectl:1.35.0 AS kubectl
+
 FROM debian:trixie-slim
 
 ARG TARGETARCH
-# Automatically bumpled by a Renovate regex rule.
-ARG HELM_VERSION=v4.0.1
 
 COPY --chmod=755 bin/newrelic-agent-control-k8s-cli-${TARGETARCH} /bin/newrelic-agent-control-cli
 
+# Copy kubectl and helm from official alpine images
+COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=helm /usr/bin/helm /usr/local/bin/helm
+
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y ca-certificates curl && \
+    apt-get install -y ca-certificates && \
     apt-get clean
-
-# Install latest stable kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl"&& \
-    chmod +x kubectl && \
-    mv kubectl /usr/local/bin/kubectl
-
-# Install Helm
-RUN curl -LO "https://get.helm.sh/helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
-    tar -xzf "helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" && \
-    chmod +x "linux-$TARGETARCH/helm" && \
-    mv "linux-$TARGETARCH/helm" /usr/local/bin/helm && \
-    rm -rf "helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" linux-$TARGETARCH
 
 # Create a home directory for nobody user and set ownership
 # This is so Helm can actually run as it tries to write to the home directory


### PR DESCRIPTION
## Summary of the changes

This PR changes the way we construct the image for the k8s cli. Now it takes the tools (`kubectl` and `helm`) from the alpine corresponding images.

The corresponding renovate rules have also been updated.

This probably helps mitigating an issue that causes flakiness in the pipelines:

<details>
<summary>kubectl installation issue</summary>

```
agent-contro… │      [3/6] RUN apt-get update &&     apt-get upgrade -y &&     apt-get install -y ca-certificates curl &&     apt-get clean [done: 6.314s]
  agent-contro… │      [4/6] RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"&&     chmod +x kubectl &&     mv kubectl /usr/local/bin/kubectl
  agent-contro… │        → curl: Failed to extract a filename from the URL to use for storage
  agent-contro… │        → curl: (3) URL using bad/illegal format or missing URL
  agent-contro… │      
  agent-contro… │      ERROR IN: [4/6] RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"&&     chmod +x kubectl &&     mv kubectl /usr/local/bin/kubectl
  agent-contro… │ 
  agent-contro… │ ERROR: Build Failed: ImageBuild: process "/bin/sh -c curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl\"&&     chmod +x kubectl &&     mv kubectl /usr/local/bin/kubectl" did not complete successfully: exit code: 3
```

</details>

## Other options considered

(which can also be explored)

- Building our own base image and upload it to the repositories (requires its own maintenance although it could be automated)
- Caching layers (involves some complexity)
  - [Docker action cache](https://docs.docker.com/build/ci/github-actions/cache/) wouldn't apply when building the image in the Tiltfile