### PR TITLE
chore(ci/cd): ignore cache error

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -178,6 +178,7 @@ jobs:
           identifier: 'release'
           restore-strategy: ${{ github.ref == 'refs/heads/main' && 'exact' || 'nearest' }}
           save-cache: true
+        continue-on-error: true
 
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2


### PR DESCRIPTION
Following same "fix" done by @gsanchezgavier. 
I'll create a task to investigate the root cause