### PR TITLE
feat: add public key to agent type

### DIFF
--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -446,6 +446,7 @@ deployment:
           oci:
             registry: ${nr-var:registry}
             repository: ${nr-var:repository}
+            public_key: ${nr-var:public_key}
             version: ${nr-var:version}
 "#;
 

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -165,6 +165,9 @@ mod tests {
                         "${nr-var:repository}".to_string(),
                     ),
                     version: TemplateableValue::from_template("${nr-var:version}".to_string()),
+                    public_key_url: Some(TemplateableValue::from_template(
+                        "${nr-var:public-key-url}".to_string(),
+                    )),
                 },
             },
         };
@@ -177,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_packages_reserved_variable_dir() {
+    fn test_packages_reserved_variable_dir_and_no_public_key_url() {
         // Define an OnHost with one package and an executable using the reserved var
         let yaml = r#"
 executables:
@@ -754,6 +757,7 @@ packages:
         registry: ${nr-var:registry}
         repository: ${nr-var:repository}
         version: ${nr-var:version}
+        public_key_url: ${nr-var:public-key-url}
   otel-second:
     type: tar.gz
     download:
@@ -761,5 +765,6 @@ packages:
         registry: ${nr-var:registry}
         repository: ${nr-var:repository}
         version: ${nr-var:version}
+        public_key_url: ${nr-var:public-key-url}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -15,4 +15,5 @@ pub struct Download {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Oci {
     pub reference: Reference,
+    pub public_key_url: Option<String>,
 }

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -228,6 +228,7 @@ fn create_agent_type(local_dir: &TempDir, agent_id: &str, platform: &Platform) -
       registry: {OCI_TEST_REGISTRY_URL}
       repository: test
       version: ${{nr-var:fake_variable}}
+      public_key: https://public.key
 "#
     );
 


### PR DESCRIPTION
Add the public_key to Oci templating. 

It is an Option<TemplateableValue<String>> so for the moment is empty in the 2 agent_type defining oci packages.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
