### PR TITLE
feat(apm): fix application name from a remote source

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -109,7 +109,7 @@ local_resource(
 )
 
 ac_flags = [
-  '--timeout=150s',
+  '--timeout=100s',
   '--create-namespace',
   '--set=agentControlDeployment.chartRepositoryUrl=http://chartmuseum.default.svc.cluster.local:8080',
   '--set=agentControlDeployment.chartVersion=0.0.1',
@@ -190,4 +190,4 @@ helm_resource(
 )
 
 # We had flaky e2e test failing due to timeout applying the chart on 30s
-update_settings(k8s_upsert_timeout_secs=200)
+update_settings(k8s_upsert_timeout_secs=100)

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_dotnet-0.1.0.yaml
@@ -3,6 +3,10 @@ name: com.newrelic.apm_dotnet
 version: 0.1.0
 variables:
   k8s:
+    applicationName:
+      description: "application name to leverage"
+      type: string
+      required: true
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
@@ -86,6 +90,8 @@ deployment:
           # Hence, the namespace is set to "nr-ac:namespace_agents".
           # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
           namespace: ${nr-ac:namespace_agents}
+          annotations:
+            newrelic.com/app-name: ${nr-var:applicationName}
         spec:
           agent:
             language: dotnet

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_java-0.1.0.yaml
@@ -3,6 +3,10 @@ name: com.newrelic.apm_java
 version: 0.1.0
 variables:
   k8s:
+    applicationName:
+      description: "application name to leverage"
+      type: string
+      required: true
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
@@ -91,6 +95,8 @@ deployment:
           # Hence, the namespace is set to "nr-ac:namespace_agents".
           # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
           namespace: ${nr-ac:namespace_agents}
+          annotations:
+            newrelic.com/app-name: ${nr-var:applicationName}
         spec:
           agent:
             language: java

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
@@ -3,6 +3,10 @@ name: com.newrelic.apm_node
 version: 0.1.0
 variables:
   k8s:
+    applicationName:
+      description: "application name to leverage"
+      type: string
+      required: true
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
@@ -86,6 +90,8 @@ deployment:
           # Hence, the namespace is set to "nr-ac:namespace_agents".
           # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
           namespace: ${nr-ac:namespace_agents}
+          annotations:
+            newrelic.com/app-name: ${nr-var:applicationName}
         spec:
           agent:
             language: nodejs

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_python-0.1.0.yaml
@@ -3,6 +3,10 @@ name: com.newrelic.apm_python
 version: 0.1.0
 variables:
   k8s:
+    applicationName:
+      description: "application name to leverage"
+      type: string
+      required: true
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
@@ -86,6 +90,8 @@ deployment:
           # Hence, the namespace is set to "nr-ac:namespace_agents".
           # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
           namespace: ${nr-ac:namespace_agents}
+          annotations:
+            newrelic.com/app-name: ${nr-var:applicationName}
         spec:
           agent:
             language: python

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
@@ -3,6 +3,10 @@ name: com.newrelic.apm_ruby
 version: 0.1.0
 variables:
   k8s:
+    applicationName:
+      description: "application name to leverage"
+      type: string
+      required: true
     podLabelSelector:
       description: "Pod label selector"
       type: yaml
@@ -86,6 +90,8 @@ deployment:
           # Hence, the namespace is set to "nr-ac:namespace_agents".
           # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
           namespace: ${nr-ac:namespace_agents}
+          annotations:
+            newrelic.com/app-name: ${nr-var:applicationName}
         spec:
           agent:
             language: ruby

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -45,11 +45,18 @@ static AGENT_TYPE_APM_DOTNET: LazyLock<AgentTypeValuesTestCase> =
         agent_type: "newrelic/com.newrelic.apm_dotnet:0.1.0",
         values_k8s: AgentTypeValues {
             cases: HashMap::from([
-                ("mandatory fields only", r#"version: "some-version""#),
+                (
+                    "mandatory fields only",
+                    r#"
+                version: "some-version"
+                applicationName: "whatever"
+                "#,
+                ),
                 (
                     "check all value types are correct",
                     r#"
                 version: "some-string"
+                applicationName: "whatever"
                 podLabelSelector:
                     yaml: object
                 namespaceLabelSelector:
@@ -70,11 +77,18 @@ static AGENT_TYPE_APM_JAVA: LazyLock<AgentTypeValuesTestCase> =
         agent_type: "newrelic/com.newrelic.apm_java:0.1.0",
         values_k8s: AgentTypeValues {
             cases: HashMap::from([
-                ("mandatory fields only", r#"version: "some-version""#),
+                (
+                    "mandatory fields only",
+                    r#"
+                version: "some-version"
+                applicationName: "whatever"
+                "#,
+                ),
                 (
                     "check all value types are correct",
                     r#"
                 version: "some-string"
+                applicationName: "whatever"
                 podLabelSelector:
                     yaml: object
                 namespaceLabelSelector:
@@ -95,11 +109,18 @@ static AGENT_TYPE_APM_NODE: LazyLock<AgentTypeValuesTestCase> =
         agent_type: "newrelic/com.newrelic.apm_node:0.1.0",
         values_k8s: AgentTypeValues {
             cases: HashMap::from([
-                ("mandatory fields only", r#"version: "some-version""#),
+                (
+                    "mandatory fields only",
+                    r#"
+                version: "some-version"
+                applicationName: "whatever"
+                "#,
+                ),
                 (
                     "check all value types are correct",
                     r#"
                 version: "some-string"
+                applicationName: "whatever"
                 podLabelSelector:
                     yaml: object
                 namespaceLabelSelector:
@@ -120,11 +141,18 @@ static AGENT_TYPE_APM_PYTHON: LazyLock<AgentTypeValuesTestCase> =
         agent_type: "newrelic/com.newrelic.apm_python:0.1.0",
         values_k8s: AgentTypeValues {
             cases: HashMap::from([
-                ("mandatory fields only", r#"version: "some-version""#),
+                (
+                    "mandatory fields only",
+                    r#"
+                version: "some-version"
+                applicationName: "whatever"
+                "#,
+                ),
                 (
                     "check all value types are correct",
                     r#"
                 version: "some-string"
+                applicationName: "whatever"
                 podLabelSelector:
                     yaml: object
                 namespaceLabelSelector:
@@ -145,11 +173,18 @@ static AGENT_TYPE_APM_RUBY: LazyLock<AgentTypeValuesTestCase> =
         agent_type: "newrelic/com.newrelic.apm_ruby:0.1.0",
         values_k8s: AgentTypeValues {
             cases: HashMap::from([
-                ("mandatory fields only", r#"version: "some-version""#),
+                (
+                    "mandatory fields only",
+                    r#"
+                version: "some-version"
+                applicationName: "whatever"
+                "#,
+                ),
                 (
                     "check all value types are correct",
                     r#"
                 version: "some-string"
+                applicationName: "whatever"
                 podLabelSelector:
                     yaml: object
                 namespaceLabelSelector:

--- a/agent-control/src/k8s/annotations.rs
+++ b/agent-control/src/k8s/annotations.rs
@@ -17,6 +17,13 @@ impl Annotations {
         annotations
     }
 
+    /// Adds extra annotations to the collection WITHOUT replacing existing ones.
+    pub fn append_extra_annotations(&mut self, annotations: &BTreeMap<String, String>) {
+        for (label, value) in annotations.iter() {
+            self.0.entry(label.clone()).or_insert(value.clone());
+        }
+    }
+
     pub fn get(&self) -> BTreeMap<String, String> {
         self.0.clone()
     }

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -131,8 +131,9 @@ impl NotStartedSupervisorK8s {
         // Merge default labels with the ones coming from the config with default labels taking precedence.
         labels.append_extra_labels(&k8s_obj.metadata.labels);
 
-        let annotations =
+        let mut annotations =
             Annotations::new_agent_type_id_annotation(&self.agent_identity.agent_type_id);
+        annotations.append_extra_annotations(&k8s_obj.metadata.annotations);
 
         let metadata = ObjectMeta {
             name: Some(k8s_obj.metadata.name.clone()),
@@ -575,6 +576,7 @@ pub mod tests {
                 ]),
                 name: TEST_NAME.to_string(),
                 namespace: TEST_NAMESPACE.to_string(),
+                ..Default::default()
             },
             ..Default::default()
         }

--- a/test/k8s-e2e/apm/ac-values-apm.yml
+++ b/test/k8s-e2e/apm/ac-values-apm.yml
@@ -20,6 +20,8 @@ agentControlDeployment:
       log:
         insecure_fine_grained_level: newrelic_agent_control=debug,opamp_client=trace,off
       agents:
+        infra:
+          agent_type: newrelic/com.newrelic.infrastructure:0.1.0
         operator:
           agent_type: newrelic/com.newrelic.k8s_agent_operator:0.1.0
         # One agent per language
@@ -34,10 +36,24 @@ agentControlDeployment:
         dotnet-agent:
           agent_type: newrelic/com.newrelic.apm_dotnet:0.1.0
     agentsConfig:
+      infra:
+        chart_version: "*" # Use latest
+        chart_values:
+          global: # add 'cluster_name' (nri-kubernetes events have 'clusterName' attribute)
+            customAttributes:
+              cluster_name: ${nr-env:NR_CLUSTER_NAME}
       operator:
         chart_version: "*"
+        chart_values:
+          k8s-agents-operator:
+            controllerManager:
+              manager:
+                image:
+                  repository: "pgallina/poc"
+                  version: "apm4"
       # One agent per language
       java-agent:
+        applicationName: "my-java-app"
         podLabelSelector:
           matchExpressions:
             - key: "app"
@@ -49,24 +65,28 @@ agentControlDeployment:
               - key: NRI
                 operator: Exists
       python-agent:
+        applicationName: "my-python-app"
         podLabelSelector:
           matchExpressions:
             - key: "app"
               operator: "In"
               values: [ "pythonapp" ]
       node-agent:
+        applicationName: "my-node-app"
         podLabelSelector:
           matchExpressions:
             - key: "app"
               operator: "In"
               values: [ "nodeapp" ]
       ruby-agent:
+        applicationName: "my-ruby-app"
         podLabelSelector:
           matchExpressions:
             - key: "app"
               operator: "In"
               values: [ "rubyapp" ]
       dotnet-agent:
+        applicationName: "my-dotnet-app"
         podLabelSelector:
           matchExpressions:
             - key: "app"

--- a/test/k8s-e2e/apm/e2e-apm.yml
+++ b/test/k8s-e2e/apm/e2e-apm.yml
@@ -1,13 +1,13 @@
 description: E2E Test
 
-custom_test_key: appName
+custom_test_key: clusterName
 
 scenarios:
-    # This test spawns AC along with the APM operator and five sample apps (Java, Python, Node.js, Ruby and .NET).
-    # Each app is instrumented with its corresponding APM agent via an Instrumentation CR created by AC.
-    # The test validates that each agent is healthy via the AC /status endpoint and that data is being reported to New Relic.
-    # Sample apps are basic web servers that respond to HTTP requests. Each Pod includes a lightweight sidecar that waits for 
-    # readiness and continuously generates local traffic to help validate agent instrumentation.
+  # This test spawns AC along with the APM operator and five sample apps (Java, Python, Node.js, Ruby and .NET).
+  # Each app is instrumented with its corresponding APM agent via an Instrumentation CR created by AC.
+  # The test validates that each agent is healthy via the AC /status endpoint and that data is being reported to New Relic.
+  # Sample apps are basic web servers that respond to HTTP requests. Each Pod includes a lightweight sidecar that waits for
+  # readiness and continuously generates local traffic to help validate agent instrumentation.
   - description: Deploy SA with APM operator and Java, Python and Node.js agents
     before:
       - echo The cluster name of the test is ${SCENARIO_TAG}
@@ -21,8 +21,9 @@ scenarios:
       - kubectl create -f ./javaapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-java/ | kubectl create -f -
       - kubectl create -f ./nodeapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-node/ | kubectl create -f -
       - kubectl create -f ./rubyapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-ruby/ | kubectl create -f -
-        # the dotnet container for linux/arm64 is broken, it doesn't have the binary. Do not expect this to work in Mac MX minikube.
+      # the dotnet container for linux/arm64 is broken, it doesn't have the binary. Do not expect this to work in Mac MX minikube.
       - kubectl create -f ./dotnetapp.yaml --dry-run=client -o yaml | sed s/placeholder/${SCENARIO_TAG}-dotnet/ | kubectl create -f -
+      - kubectl get pods --all-namespaces   -o yaml
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true
       - kubectl logs --tail=-1 -l app.kubernetes.io/instance=operator --all-containers --prefix=true -n newrelic-agents
@@ -30,13 +31,12 @@ scenarios:
       - cd ../../../ && tilt down
     tests:
       nrqls:
-        # Checks that the metric exist for the test scenario, an extra where testKey=$SCENARIO_TAG is always added.
-        # Due to that, the queries end with a comment. We want to override the automatic `testKey` with our own that includes the language.
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-java' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-python' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-node' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-ruby' -- comment disabling the appended testKey: "
-        - query: "SELECT * from Metric WHERE metricName = 'newrelic.goldenmetrics.apm.application.throughput' AND appName = '${SCENARIO_TAG}-dotnet' -- comment disabling the appended testKey: "
+        # Checks that the metric exist for the test scenario, an extra where clusterName=$SCENARIO_TAG is always added.
+        - query: "FROM Transaction  SELECT average(duration) where appName = 'my-java-app' "
+        - query: "FROM Transaction  SELECT average(duration) where appName = 'my-python-app' "
+        - query: "FROM Transaction  SELECT average(duration) where appName = 'my-node-app' "
+        - query: "FROM Transaction  SELECT average(duration) where appName = 'my-ruby-app' "
+        - query: "FROM Transaction  SELECT average(duration) where appName = 'my-dotnet-app' "
       scripts:
         # Check agent is healthy
         - |
@@ -49,17 +49,30 @@ scenarios:
           kubectl port-forward pods/${POD_NAME} 51200 > /dev/null 2>&1 &
           PORT_FORWARD_PID=$!
           sleep 5
-          response=$(curl -s "http://localhost:51200/status")
-          echo "response ${response}"
-          for agent in dotnet-agent java-agent node-agent python-agent ruby-agent; do
-              agent_status=$(echo "$response" | jq -r ".agents[\"${agent}\"].health_info.healthy")
-              if [ "$agent_status" != "true" ]; then
-                echo "${agent} is not healthy. Failing..."
-                exit 1
-              fi
-              echo "${agent} is healthy. Success." 
+          success=false
+          for retry in $(seq 1 5); do
+            response=$(curl -s "http://localhost:51200/status")
+            all_healthy=true
+            for agent in dotnet-agent java-agent node-agent python-agent ruby-agent; do
+                agent_status=$(echo "$response" | jq -r ".agents[\"${agent}\"].health_info.healthy")
+                if [ "$agent_status" != "true" ]; then
+                  echo "${agent} is not healthy. Retry $retry..."
+                  all_healthy=false
+                else
+                  echo "${agent} is healthy. Success."
+                fi
+            done
+            if [ "$all_healthy" = true ]; then
+              success=true
+              break
+            fi
+            sleep 30
           done
           kill $PORT_FORWARD_PID
+          if [ "$success" != true ]; then
+            echo "Some agents are not healthy after retries. Failing..."
+            exit 1
+          fi
 
         # Check entity guid is being sent
         - |


### PR DESCRIPTION
This PR leverages https://github.com/newrelic/newrelic-agent-control/pull/2167/changes to setup a desired app_name as decided by FC

It updates a e2e test to leverage the new feature