### PR TITLE
feat(test): check that configuration can be loaded with CRLF [NR-522309]

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -603,7 +603,7 @@ agents: {}
         ]
         .into_iter()
         .for_each(|cfg_lf| {
-            let cfg_crlf = cfg_lf.replace("\n", "\n\r");
+            let cfg_crlf = cfg_lf.replace("\n", "\r\n");
             let from_lf: AgentControlConfig = serde_yaml::from_str(cfg_lf).unwrap();
             let from_crlf: AgentControlConfig = serde_yaml::from_str(&cfg_crlf).unwrap();
             assert_eq!(from_lf, from_crlf);


### PR DESCRIPTION
Add unit test to verify configuration parsing with Windows CRLF line endings. It verifies YAML parsing produces identical results regardless of line ending style.