### PR TITLE
fix(renovate): regexes should go in customManagers

### DIFF
--- a/.github/renovate-shared-base.json
+++ b/.github/renovate-shared-base.json
@@ -21,6 +21,21 @@
   "prConcurrentLimit": 0,
   "printConfig": true,
   "prHourlyLimit": 0,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Cargo.toml",
+        "**/Cargo.toml"
+      ],
+      "matchStrings": [
+        "rust-version\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "github actions",
@@ -65,19 +80,6 @@
         "major"
       ],
       "groupName": "go major updates"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "Cargo.toml",
-        "**/Cargo.toml"
-      ],
-      "matchStrings": [
-        "rust-version\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\""
-      ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust"
     }
   ]
 }


### PR DESCRIPTION
PackageRules were not the right places for regexes, we needed customManagers

I tested it in a fork https://github.com/paologallinaharbur/newrelic-agent-control/issues/9

