### PR TITLE
refactor: move public key URL from fetcher to config verifier [NR-520796]

### DIFF
--- a/agent-control/src/opamp/remote_config/validators/signature/validator.rs
+++ b/agent-control/src/opamp/remote_config/validators/signature/validator.rs
@@ -79,10 +79,11 @@ impl SignatureValidator {
         let http_client = HttpClient::new(http_config)
             .map_err(|e| SignatureValidatorError::BuildingValidator(e.to_string()))?;
 
-        let public_key_fetcher = PublicKeyFetcher::new(http_client, public_key_server_url);
+        let public_key_fetcher = PublicKeyFetcher::new(http_client);
 
-        let pubkey_verifier_store = VerifierStore::try_new(public_key_fetcher)
-            .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
+        let pubkey_verifier_store =
+            VerifierStore::try_new(public_key_fetcher, public_key_server_url)
+                .map_err(|err| SignatureValidatorError::BuildingValidator(err.to_string()))?;
 
         Ok(Self {
             public_key_store: Some(pubkey_verifier_store),


### PR DESCRIPTION
This PR moves the public_key_server_url from being stored in PublicKeyFetcher to being stored in VerifierStore and passed as a parameter during fetch operations.

This allow us using the fetcher to fetch public-keys when verifying signatures for OCI artifacts.
