### PR TITLE
feat!: change default log dir

### DIFF
--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -57,7 +57,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "windows")] {
         pub const AGENT_CONTROL_LOCAL_DATA_DIR: &str = "C:\\Program Files\\New Relic\\newrelic-agent-control";
         pub const AGENT_CONTROL_DATA_DIR: &str = "C:\\ProgramData\\New Relic\\newrelic-agent-control";
-        pub const AGENT_CONTROL_LOG_DIR: &str = "C:\\ProgramData\\New Relic\\newrelic-agent-control\\logs";
+        pub const AGENT_CONTROL_LOG_DIR: &str = "C:\\ProgramData\\New Relic\\newrelic-agent-control\\log";
 
     } else {
         pub const AGENT_CONTROL_LOCAL_DATA_DIR: &str = "/etc/newrelic-agent-control";

--- a/agent-control/src/instrumentation/config/logs/file_logging.rs
+++ b/agent-control/src/instrumentation/config/logs/file_logging.rs
@@ -1,5 +1,5 @@
 use super::config::LoggingConfigError;
-use crate::agent_control::defaults::AGENT_CONTROL_LOG_FILENAME;
+use crate::agent_control::defaults::{AGENT_CONTROL_ID, AGENT_CONTROL_LOG_FILENAME};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
@@ -22,7 +22,7 @@ impl FileLoggingConfig {
 
         // if path is not specified into the config we fall back to a default path
         let path = self.path.unwrap_or(LogFilePath::new(
-            default_dir.clone(),
+            default_dir.join(AGENT_CONTROL_ID),
             PathBuf::from(AGENT_CONTROL_LOG_FILENAME),
         ));
         let file_appender = tracing_appender::rolling::hourly(path.parent, path.file_name);

--- a/agent-control/tests/on_host/logging/file_logging.rs
+++ b/agent-control/tests/on_host/logging/file_logging.rs
@@ -3,7 +3,8 @@ use super::level::TIME_FORMAT;
 use crate::on_host::cli::cmd_with_config_file;
 use newrelic_agent_control::{
     agent_control::defaults::{
-        AGENT_CONTROL_ID, FOLDER_NAME_LOCAL_DATA, STORE_KEY_LOCAL_DATA_CONFIG,
+        AGENT_CONTROL_ID, AGENT_CONTROL_LOG_FILENAME, FOLDER_NAME_LOCAL_DATA,
+        STORE_KEY_LOCAL_DATA_CONFIG,
     },
     on_host::file_store::build_config_name,
 };
@@ -34,8 +35,8 @@ fn default_log_level_no_root() {
         .join(FOLDER_NAME_LOCAL_DATA)
         .join(AGENT_CONTROL_ID);
     std::fs::create_dir_all(&config_path).unwrap();
-    let log_dir = dir.path().join("log");
-    let log_path = log_dir.join("agent_control.log");
+    let log_dir = dir.path().join("log").join(AGENT_CONTROL_ID);
+    let log_path = log_dir.join(AGENT_CONTROL_LOG_FILENAME);
 
     // Write the config file
     build_logging_config(
@@ -81,8 +82,8 @@ fn default_log_level_as_root() {
         .join(FOLDER_NAME_LOCAL_DATA)
         .join(AGENT_CONTROL_ID);
     std::fs::create_dir_all(&config_path).unwrap();
-    let log_dir = dir.path().join("log");
-    let log_path = log_dir.join("agent_control.log");
+    let log_dir = dir.path().join("log").join(AGENT_CONTROL_ID);
+    let log_path = log_dir.join(AGENT_CONTROL_LOG_FILENAME);
 
     // Write the config file
     build_logging_config(

--- a/docs/AC_repositories_and_files.md
+++ b/docs/AC_repositories_and_files.md
@@ -81,11 +81,12 @@ The following shows the directory structure used by Agent Control, assuming an e
     │                └── config
     │                      └── newrelic-infra.yml
     └── log
-        ├── newrelic-agent-control
-        │   └── newrelic-agent-control.log.2025-01-15-23
-        └── nr-infra
-            ├── stdout.log.2025-01-15-23
-            └── stderr.log.2025-01-15-23
+        └── newrelic-agent-control
+            |── agent-control
+            |   └── newrelic-agent-control.log.2025-01-15-23
+            └── nr-infra
+                ├── stdout.log.2025-01-15-23
+                └── stderr.log.2025-01-15-23
 ```
 
 ### Windows
@@ -117,7 +118,9 @@ C:\ProgramData\New Relic\newrelic-agent-control
 │   └───nr-infra
 │           instance_id.yaml
 │           remote_config.yaml
-├───logs
+├───log
+│   |───agent-control
+│   |       newrelic-agent-control.log.2025-01-15-23
 │   └───nr-infra
 │           stderr.log.2026-01-19-22
 └───packages


### PR DESCRIPTION
- unify base log dir name to `log` for all platforms
- move AC logs to a sub dir with the AC agent-id as other sub-agent logs and configs as discussed with @paologallinaharbur 

WIP:
- [x] Some manual tests to verify installation paths 