### PR TITLE
chore: rollback packaged agents

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,28 +58,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^.goreleaser.yml$/"
-      ],
-      "depNameTemplate": "newrelic/infrastructure-agent",
-      "datasourceTemplate": "github-releases",
-      "matchStrings": [
-        " *- NEWRELIC_INFRA_AGENT_VERSION=(?<currentValue>.+)"
-      ]
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^.goreleaser.yml$/"
-      ],
-      "depNameTemplate": "newrelic/nrdot-collector-releases",
-      "datasourceTemplate": "github-releases",
-      "matchStrings": [
-        " *- NR_OTEL_COLLECTOR_VERSION=(?<currentValue>.+)"
-      ]
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
         "**/Cargo.toml"
       ],
       "matchStrings": [

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,7 @@
 version: 2
 project_name: newrelic-agent-control
 env:
-  # Artifacts Versions
-  # Currently the only way to update the sub-agent versions is rebuild the binary of the agent-control
+  # This version should be kept fixed.
   - NEWRELIC_INFRA_AGENT_VERSION=1.71.1
   - NR_OTEL_COLLECTOR_VERSION=1.5.0
 builds:


### PR DESCRIPTION
Fixing versions of the bundled agents and removed the automation
```
- NEWRELIC_INFRA_AGENT_VERSION=1.71.1
- NR_OTEL_COLLECTOR_VERSION=1.5.0
```
