### PR TITLE
fix: running supervisors unable to change log to file setting

### DIFF
--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -155,9 +155,10 @@ where
             on_host.version,
             on_host.packages,
             self.package_manager.clone(),
-        )
-        .with_file_logging(on_host.enable_file_logging, self.logging_path.to_path_buf())
-        .with_filesystem(on_host.filesystem))
+            on_host.enable_file_logging,
+            self.logging_path.to_path_buf(),
+            on_host.filesystem,
+        ))
     }
 }
 


### PR DESCRIPTION
Supervisor reconstruction (e.g. from incoming remote config) would ignore the configuration for file logging. Only the first time a supervisor is created was abiding to it.

This PR fixes that by making sure the logging path is passed between the non-started and started supervisors, this way we can still construct the non-started supervisor with this config inside the `apply`, always pointing to the same path.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
