### PR TITLE
feat(test): add signatures to oci integration tests [NR-520796]

### DIFF
--- a/agent-control/tests/common/oci_signer.rs
+++ b/agent-control/tests/common/oci_signer.rs
@@ -70,12 +70,12 @@ impl OCISigner {
     }
 
     /// Generates and push a cosign signature artifact to the reference.
-    pub fn sign_artifact(&self, reference: Reference) {
+    pub fn sign_artifact(&self, reference: &Reference) {
         tokio_runtime().block_on(async { self.sign_artifact_async(reference).await });
     }
 
-    async fn sign_artifact_async(&self, reference: Reference) {
-        let (cosign_signature_ref, source_image_digest) = self.triangulate(&reference).await;
+    async fn sign_artifact_async(&self, reference: &Reference) {
+        let (cosign_signature_ref, source_image_digest) = self.triangulate(reference).await;
 
         let signature_payload =
             self.signature_payload(&source_image_digest, &reference.to_string());


### PR DESCRIPTION
## 🚧 WIP

Signatures aren't in place yet ❗ 

## Summary

This PR adds signatures to OCI integration tests.

- Updates the current integration test: now the artifacts are signed and the corresponding public_key is included in the agent-type. Therefore signature verification should take place.
- Adds an additional integration test to check that the verification fails as expected: the agent-type includes the public key but the package isn't signed, therefore the corresponding remote configuration should fail.