### PR TITLE
fix: move tmp folder inside AC filesystem (NR-523554)

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -191,6 +191,13 @@ deployment:
           # For the same reason we are also changing the location of the integration binaries.
           NRIA_APP_DATA_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra"
           NRIA_AGENT_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra"
+          # TODO
+          # This is a non public infra-agent config variable that allows us to change the location of the agent temporary files, which is used currently
+          # for storing fluent-bit generated configuration files. Currently infra-agent does not clean-up on start this directory if
+          # not on the default location, making this configs to potentially grow indefinitely with fluent-bit generated files.
+          # In the future this clean up process should be handled by the infra-agent itself or by AC file system clean up policies (same as the ones
+          # that are going to remove integration configs whenever variables are removed)
+          NRIA_AGENT_TEMP_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra\\tmp"
           # On windows, logs are written to 'NRIA_APP_DATA_DIR/newrelic-infra.log' and this cannot be disabled.
           # To avoid disks exhaustion issues, a default log rotation policy is applied to this log file.
           NRIA_LOG_ROTATE_MAX_SIZE_MB: "50"


### PR DESCRIPTION
There is still a `newrelic-infra/tmp` folder, created by the infrastructure agent, despite all the environment variables we set (not everything is under filesystem)

This PR make use of the non public infra-agent config to change this folder location. 

- [x] Still pending some confirmation from infra-agent team on the use of this.
- [x] Manually checked fluent bit works as expected.
