### PR TITLE
feat: support oci auth in agent types

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -58,10 +58,11 @@ variables:
             required: false
             default: ""
         bearer:
-          description: "Bearer token for authentication"
-          type: string
-          required: false
-          default: ""
+          token:
+            description: "Bearer token for authentication"
+            type: string
+            required: false
+            default: ""
     version:
       description: "Agent version"
       type: string
@@ -127,10 +128,11 @@ variables:
             required: false
             default: ""
         bearer:
-          description: "Bearer token for authentication"
-          type: string
-          required: false
-          default: ""
+          token:
+            description: "Bearer token for authentication"
+            type: string
+            required: false
+            default: ""
     version:
       description: "Agent version"
       type: string
@@ -224,7 +226,8 @@ deployment:
               basic:
                 username: ${nr-var:oci.auth.basic.username}
                 password: ${nr-var:oci.auth.basic.password}
-              bearer: ${nr-var:oci.auth.bearer}
+              bearer:
+                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
       args:
@@ -299,7 +302,8 @@ deployment:
               basic:
                 username: ${nr-var:oci.auth.basic.username}
                 password: ${nr-var:oci.auth.basic.password}
-              bearer: ${nr-var:oci.auth.bearer}
+              bearer:
+                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
       args:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -45,6 +45,23 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -97,6 +114,23 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -186,6 +220,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
       args:
@@ -256,6 +295,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
       args:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -49,6 +49,23 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -95,6 +112,23 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -157,6 +191,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.nrdot.dir}\\nrdot-collector.exe
       args:
@@ -190,6 +229,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     health:
       interval: 30s
       initial_delay: 90s

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -62,10 +62,11 @@ variables:
             required: false
             default: ""
         bearer:
-          description: "Bearer token for authentication"
-          type: string
-          required: false
-          default: ""
+          token:
+            description: "Bearer token for authentication"
+            type: string
+            required: false
+            default: ""
     version:
       description: "Agent version"
       type: string
@@ -125,10 +126,11 @@ variables:
             required: false
             default: ""
         bearer:
-          description: "Bearer token for authentication"
-          type: string
-          required: false
-          default: ""
+          token:
+            description: "Bearer token for authentication"
+            type: string
+            required: false
+            default: ""
     version:
       description: "Agent version"
       type: string
@@ -195,7 +197,8 @@ deployment:
               basic:
                 username: ${nr-var:oci.auth.basic.username}
                 password: ${nr-var:oci.auth.basic.password}
-              bearer: ${nr-var:oci.auth.bearer}
+              bearer:
+                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.nrdot.dir}\\nrdot-collector.exe
       args:
@@ -233,7 +236,8 @@ deployment:
               basic:
                 username: ${nr-var:oci.auth.basic.username}
                 password: ${nr-var:oci.auth.basic.password}
-              bearer: ${nr-var:oci.auth.bearer}
+              bearer:
+                token: ${nr-var:oci.auth.bearer.token}
     health:
       interval: 30s
       initial_delay: 90s

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -27,4 +27,6 @@ pub enum AgentTypeError {
     ConflictingVariableDefinition(String),
     #[error("error parsing oci reference: {0}")]
     OCIReferenceParsingError(String),
+    #[error("error with OCI auth configuration: {0}")]
+    OCIAuthError(String),
 }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -741,11 +741,6 @@ executables:
             password: "",
             bearer: "token",
         };
-        const ALL: Self = Self {
-            username: "user",
-            password: "pass",
-            bearer: "token",
-        };
     }
 
     #[rstest]
@@ -754,7 +749,6 @@ executables:
     #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
     #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
     #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
-    #[case::all_credentials(PACKAGES, AuthCredentials::ALL, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
     fn test_auth_parsing(
         #[case] yaml: &str,
         #[case] creds: AuthCredentials,

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -778,7 +778,7 @@ executables:
             Variable::new_final_string_variable(creds.password.to_string()),
         );
         vars.insert(
-            "nr-var:oci.auth.bearer".to_string(),
+            "nr-var:oci.auth.bearer.token".to_string(),
             Variable::new_final_string_variable(creds.bearer.to_string()),
         );
 
@@ -858,6 +858,7 @@ packages:
           basic:
             username: ${nr-var:oci.auth.basic.username}
             password: ${nr-var:oci.auth.basic.password}
-          bearer: ${nr-var:oci.auth.bearer}
+          bearer:
+            token: ${nr-var:oci.auth.bearer.token}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -106,6 +106,8 @@ mod tests {
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
     use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
+    use oci_client::secrets::RegistryAuth;
+    use rstest::rstest;
     use serde_yaml::Number;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -168,6 +170,7 @@ mod tests {
                     public_key_url: Some(TemplateableValue::from_template(
                         "${nr-var:public-key-url}".to_string(),
                     )),
+                    auth: package::Auth::default(),
                 },
             },
         };
@@ -176,7 +179,7 @@ mod tests {
             ("otel-first".to_string(), pkg.clone()),
             ("otel-second".to_string(), pkg),
         ]);
-        assert_eq!(on_host.packages, expected_packages)
+        assert_eq!(on_host.packages, expected_packages);
     }
 
     #[test]
@@ -716,6 +719,81 @@ executables:
         );
     }
 
+    struct AuthCredentials {
+        username: &'static str,
+        password: &'static str,
+        bearer: &'static str,
+    }
+
+    impl AuthCredentials {
+        const NONE: Self = Self {
+            username: "",
+            password: "",
+            bearer: "",
+        };
+        const BASIC: Self = Self {
+            username: "user",
+            password: "pass",
+            bearer: "",
+        };
+        const BEARER: Self = Self {
+            username: "",
+            password: "",
+            bearer: "token",
+        };
+        const ALL: Self = Self {
+            username: "user",
+            password: "pass",
+            bearer: "token",
+        };
+    }
+
+    #[rstest]
+    // This case checks backwards compatibility with old agent types not defining auth.
+    #[case::no_auth(PACKAGES_NO_AUTH, AuthCredentials::NONE, RegistryAuth::Anonymous)]
+    #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
+    #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
+    #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
+    #[case::all_credentials(PACKAGES, AuthCredentials::ALL, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
+    fn test_auth_parsing(
+        #[case] yaml: &str,
+        #[case] creds: AuthCredentials,
+        #[case] expected_auth: RegistryAuth,
+    ) {
+        let on_host: OnHost = serde_yaml::from_str(yaml).unwrap();
+
+        let mut vars = Variables::new();
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable("/filesystem".to_string()),
+        );
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+            Variable::new_final_string_variable("remote".to_string()),
+        );
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_SUB_AGENT_ID),
+            Variable::new_final_string_variable("agent-id".to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.basic.username".to_string(),
+            Variable::new_final_string_variable(creds.username.to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.basic.password".to_string(),
+            Variable::new_final_string_variable(creds.password.to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.bearer".to_string(),
+            Variable::new_final_string_variable(creds.bearer.to_string()),
+        );
+
+        let rendered = on_host.template_with(&vars).unwrap();
+        let pkg = rendered.packages.get("infra-agent").unwrap();
+
+        assert_eq!(pkg.download.oci.auth, expected_auth);
+    }
+
     pub const AGENT_GIVEN_YAML: &str = r#"
 health:
   interval: 3s
@@ -762,5 +840,30 @@ packages:
         repository: ${nr-var:repository}
         version: ${nr-var:version}
         public_key_url: ${nr-var:public-key-url}
+"#;
+
+    const PACKAGES_NO_AUTH: &str = r#"
+packages:
+  infra-agent:
+    download:
+      oci:
+        registry: docker.io
+        repository: repo/image
+        version: 0.0.1
+"#;
+
+    const PACKAGES: &str = r#"
+packages:
+  infra-agent:
+    download:
+      oci:
+        registry: docker.io
+        repository: repo/image
+        version: 0.0.1
+        auth:
+          basic:
+            username: ${nr-var:oci.auth.basic.username}
+            password: ${nr-var:oci.auth.basic.password}
+          bearer: ${nr-var:oci.auth.bearer}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -44,13 +44,18 @@ pub struct Oci {
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct Auth {
     pub basic: BasicAuth,
-    pub bearer: TemplateableValue<String>,
+    pub bearer: BearerAuth,
 }
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct BasicAuth {
     pub username: TemplateableValue<String>,
     pub password: TemplateableValue<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct BearerAuth {
+    pub token: TemplateableValue<String>,
 }
 
 impl Templateable for Package {
@@ -129,6 +134,7 @@ impl Templateable for Auth {
             })?;
         let token = self
             .bearer
+            .token
             .template_with(variables)
             .map_err(|_| AgentTypeError::OCIAuthError("error templating token".to_string()))?;
 
@@ -257,7 +263,7 @@ mod tests {
                     username: TemplateableValue::from_template("${nr-var:username}".to_string()),
                     password: TemplateableValue::from_template("${nr-var:password}".to_string()),
                 },
-                bearer: TemplateableValue::default(),
+                bearer: BearerAuth::default(),
             },
         };
 
@@ -283,7 +289,9 @@ mod tests {
             public_key_url: None,
             auth: Auth {
                 basic: BasicAuth::default(),
-                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+                bearer: BearerAuth {
+                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
+                },
             },
         };
 
@@ -320,7 +328,9 @@ mod tests {
                     username: TemplateableValue::from_template("${nr-var:username}".to_string()),
                     password: TemplateableValue::from_template("${nr-var:password}".to_string()),
                 },
-                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+                bearer: BearerAuth {
+                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
+                },
             },
         };
 

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -118,26 +118,30 @@ impl Templateable for Auth {
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         let username = self.basic.username.template_with(variables)?;
         let password = self.basic.password.template_with(variables)?;
-
-        if !username.is_empty() && !password.is_empty() {
-            debug!("Basic auth credentials provided, using basic auth");
-            return Ok(RegistryAuth::Basic(username, password));
-        }
-
-        debug!(
-            "Basic auth credentials not fully provided (username was empty: {}, password was empty: {})",
-            username.is_empty(),
-            password.is_empty()
-        );
-
         let token = self.bearer.template_with(variables)?;
-        if !token.is_empty() {
-            debug!("Bearer token provided, using bearer auth");
-            return Ok(RegistryAuth::Bearer(token));
-        }
 
-        debug!("No basic credentials or bearer token provided, falling back to anonymous auth");
-        Ok(RegistryAuth::Anonymous)
+        match (
+            !&username.is_empty(),
+            !&password.is_empty(),
+            !&token.is_empty(),
+        ) {
+            (false, false, false) => Ok(RegistryAuth::Anonymous),
+            (true, true, false) => {
+                debug!("Basic auth credentials provided, using basic auth");
+                Ok(RegistryAuth::Basic(username, password))
+            }
+            (false, false, true) => {
+                debug!("Bearer token provided, using bearer auth");
+                Ok(RegistryAuth::Bearer(token))
+            }
+            (true, true, true) => Err(AgentTypeError::OCIAuthError(
+                "multiple authentication methods provided, only one should be used".to_string(),
+            )),
+            (true, false, _) | (false, true, _) => Err(AgentTypeError::OCIAuthError(
+                "incomplete basic auth credentials provided, username or password is empty"
+                    .to_string(),
+            )),
+        }
     }
 }
 
@@ -276,5 +280,39 @@ mod tests {
             rendered_oci.auth,
             RegistryAuth::Bearer("bearer-token".to_string())
         );
+    }
+
+    #[test]
+    fn test_auth_error_when_multiple_credentials_provided() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:username".to_string(),
+            Variable::new_final_string_variable("myuser".to_string()),
+        );
+        variables.insert(
+            "nr-var:password".to_string(),
+            Variable::new_final_string_variable("mypass".to_string()),
+        );
+        variables.insert(
+            "nr-var:token".to_string(),
+            Variable::new_final_string_variable("bearer-token".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("gcr.io".to_string()),
+            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
+            version: TemplateableValue::from_template("latest".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth {
+                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
+                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
+                },
+                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables);
+        matches!(rendered_oci, Err(AgentTypeError::OCIAuthError(_)));
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -3,9 +3,10 @@ use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
 use crate::agent_type::templates::Templateable;
 use crate::oci::reference_parser::ReferenceParser;
-use oci_client::Reference;
+use oci_client::{Reference, secrets::RegistryAuth};
 use serde::Deserialize;
 use std::str::FromStr;
+use tracing::debug;
 use url::Url;
 
 pub mod rendered;
@@ -35,6 +36,21 @@ pub struct Oci {
     pub version: TemplateableValue<String>,
     /// Public key url is expected to be a jwks.
     pub public_key_url: Option<TemplateableValue<String>>,
+    /// Authentication method for the OCI registry.
+    #[serde(default)]
+    pub auth: Auth,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct Auth {
+    pub basic: BasicAuth,
+    pub bearer: TemplateableValue<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct BasicAuth {
+    pub username: TemplateableValue<String>,
+    pub password: TemplateableValue<String>,
 }
 
 impl Templateable for Package {
@@ -87,10 +103,41 @@ impl Templateable for Oci {
             })?,
         );
 
+        let auth = self.auth.template_with(variables)?;
+
         Ok(Self::Output {
             reference,
             public_key_url,
+            auth,
         })
+    }
+}
+
+impl Templateable for Auth {
+    type Output = RegistryAuth;
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        let username = self.basic.username.template_with(variables)?;
+        let password = self.basic.password.template_with(variables)?;
+
+        if !username.is_empty() && !password.is_empty() {
+            debug!("Basic auth credentials provided, using basic auth");
+            return Ok(RegistryAuth::Basic(username, password));
+        }
+
+        debug!(
+            "Basic auth credentials not fully provided (username was empty: {}, password was empty: {})",
+            username.is_empty(),
+            password.is_empty()
+        );
+
+        let token = self.bearer.template_with(variables)?;
+        if !token.is_empty() {
+            debug!("Bearer token provided, using bearer auth");
+            return Ok(RegistryAuth::Bearer(token));
+        }
+
+        debug!("No basic credentials or bearer token provided, falling back to anonymous auth");
+        Ok(RegistryAuth::Anonymous)
     }
 }
 
@@ -158,6 +205,7 @@ mod tests {
             public_key_url: public_key_url
                 .clone()
                 .map(|_| TemplateableValue::from_template("${nr-var:public-key}".to_string())),
+            auth: Auth::default(),
         };
 
         let rendered_oci = oci.template_with(&variables);
@@ -168,5 +216,65 @@ mod tests {
         assert_eq!(rendered_oci.reference.tag(), expected_tag);
         assert_eq!(rendered_oci.reference.digest(), expected_digest);
         assert_eq!(rendered_oci.public_key_url, public_key_url);
+        assert_eq!(rendered_oci.auth, RegistryAuth::Anonymous);
+    }
+
+    #[test]
+    fn test_auth_basic_with_templated_values() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:username".to_string(),
+            Variable::new_final_string_variable("myuser".to_string()),
+        );
+        variables.insert(
+            "nr-var:password".to_string(),
+            Variable::new_final_string_variable("mypass".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("docker.io".to_string()),
+            repository: TemplateableValue::from_template("myrepo/myimage".to_string()),
+            version: TemplateableValue::from_template("1.0.0".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth {
+                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
+                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
+                },
+                bearer: TemplateableValue::default(),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables).unwrap();
+        assert_eq!(
+            rendered_oci.auth,
+            RegistryAuth::Basic("myuser".to_string(), "mypass".to_string())
+        );
+    }
+
+    #[test]
+    fn test_auth_bearer_with_templated_value() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:token".to_string(),
+            Variable::new_final_string_variable("bearer-token".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("gcr.io".to_string()),
+            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
+            version: TemplateableValue::from_template("latest".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth::default(),
+                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables).unwrap();
+        assert_eq!(
+            rendered_oci.auth,
+            RegistryAuth::Bearer("bearer-token".to_string())
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -116,25 +116,37 @@ impl Templateable for Oci {
 impl Templateable for Auth {
     type Output = RegistryAuth;
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        let username = self.basic.username.template_with(variables)?;
-        let password = self.basic.password.template_with(variables)?;
-        let token = self.bearer.template_with(variables)?;
+        let username = self
+            .basic
+            .username
+            .template_with(variables)
+            .map_err(|err| {
+                AgentTypeError::OCIAuthError(format!("error templating username: {err}"))
+            })?;
+        let password =
+            self.basic.password.template_with(variables).map_err(|_| {
+                AgentTypeError::OCIAuthError("error templating password".to_string())
+            })?;
+        let token = self
+            .bearer
+            .template_with(variables)
+            .map_err(|_| AgentTypeError::OCIAuthError("error templating token".to_string()))?;
 
         match (
-            !&username.is_empty(),
-            !&password.is_empty(),
-            !&token.is_empty(),
+            &username.is_empty(),
+            &password.is_empty(),
+            &token.is_empty(),
         ) {
-            (false, false, false) => Ok(RegistryAuth::Anonymous),
-            (true, true, false) => {
+            (true, true, true) => Ok(RegistryAuth::Anonymous),
+            (false, false, true) => {
                 debug!("Basic auth credentials provided, using basic auth");
                 Ok(RegistryAuth::Basic(username, password))
             }
-            (false, false, true) => {
+            (true, true, false) => {
                 debug!("Bearer token provided, using bearer auth");
                 Ok(RegistryAuth::Bearer(token))
             }
-            (true, true, true) => Err(AgentTypeError::OCIAuthError(
+            (false, false, false) => Err(AgentTypeError::OCIAuthError(
                 "multiple authentication methods provided, only one should be used".to_string(),
             )),
             (true, false, _) | (false, true, _) => Err(AgentTypeError::OCIAuthError(

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -302,20 +302,27 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_auth_error_when_multiple_credentials_provided() {
+    #[rstest]
+    #[case::multiple_credentials_provided("myuser", "mypass", "bearer-token")]
+    #[case::no_username_in_basic_auth("", "mypass", "")]
+    #[case::no_password_in_basic_auth("myuser", "", "")]
+    fn test_auth_credentials_error(
+        #[case] username: String,
+        #[case] password: String,
+        #[case] token: String,
+    ) {
         let mut variables = Variables::new();
         variables.insert(
             "nr-var:username".to_string(),
-            Variable::new_final_string_variable("myuser".to_string()),
+            Variable::new_final_string_variable(username),
         );
         variables.insert(
             "nr-var:password".to_string(),
-            Variable::new_final_string_variable("mypass".to_string()),
+            Variable::new_final_string_variable(password),
         );
         variables.insert(
             "nr-var:token".to_string(),
-            Variable::new_final_string_variable("bearer-token".to_string()),
+            Variable::new_final_string_variable(token),
         );
 
         let oci = Oci {

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -1,4 +1,4 @@
-use oci_client::Reference;
+use oci_client::{Reference, secrets::RegistryAuth};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,4 +17,5 @@ pub struct Download {
 pub struct Oci {
     pub reference: Reference,
     pub public_key_url: Option<Url>,
+    pub auth: RegistryAuth,
 }


### PR DESCRIPTION
Add OCI authentication support (anonymous, basic, bearer) to agent types.

### Context

Some clients can't use the docker public registry. This is the first step supporting authentication (including mirrors). Specifically, this PR modifies Agent Types and it's internal representation in Agent Control to support the different [authentication methods supported by the oci rust client](https://docs.rs/oci-client/latest/oci_client/secrets/enum.RegistryAuth.html).

### Technical decisions

**Implicit anonymous authentication**

The "anonymous" authentication method doesn't have any input parameters. There's nothing to configure on the `deployment` section of the agent type. We could have a boolean flag to enable or disable it, but I don't see what would be the advantage of doing that, other than making AC fail if no auth is provided and "anonymous" is disabled. However, I would expect the registry itself to return an error if we can't access it with an "anonymous" authentication account.

With that in mind, having it implicit seems the best approach. We don't add extra complexity to AC and let the registry handle authentication failures.

```yaml
auth:
  anonymous: {} --------> Doesn't make any sense
  basic:
    username: ${nr-var:oci.auth.basic.username}
    password: ${nr-var:oci.auth.basic.password}
  bearer: ${nr-var:oci.auth.bearer}
```

**Optional new auth field**

Old agent types don't have an `auth` field for the `oci` variable. Therefore, for backwards compatibility, we are forced to make this new field optional. This doesn't mean that the value is `Optional` in the rust codebase, but that we will use the default auth value if it's not there. The default value will end up transformed into `RegistryAuth::Anonymous`.

**Arbitrary authentication precedence**

The current implementation follows these rules:

1. If agent type doesn't have auth configured -> anonymous
2. If agent type configures auth and user configures basic credentials -> basic
3. If agent type configures auth and user configures bearer credentials -> bearer
4. If agent type configures auth and user configures basic + bearer credentials -> basic

We could easily throw an error if both basic + bearer credentials are configured. If we do that, then a working deployment might fail just because the user configured two methods of authentication instead of one. Not punishing it and forcing a new deployment seems a good idea. Specially when a user shouldn't configure on purpose more than one method.

That said, the precedence is arbitrary. We prefer basic credentials because they have lower risk of expiring.

Feedback on that front is welcome.

**AC understands empty username or password as wrong credentials**

We don't differentiate between empty basic credentials and none basic credentials. This makes the code representation and handling easier. No `Optional` and no changing behaviour.
This seems a sane behaviour given that an empty username and/or empty password decreases security. In that case, the user should be using anonymous, and that's what AC will chose if no bearer is configured.

I don't see a use case for empty username and/or password.

There's one disadvatange. If there's a use case for empty username and/or password, we don't support it. Again, I don't see why this would be the case so we discarded it.

**If auth is configured, all credentials are mandatory**

In other words, the `deployment` section is forced to have all the possible methods of authentication there.

GOOD
```yaml
auth:
  basic:
    username: ${nr-var:oci.auth.basic.username}
    password: ${nr-var:oci.auth.basic.password}
  bearer: ${nr-var:oci.auth.bearer}
```

Or what's the same. An agent type author cannot only configure one type of authentication.

BAD
```yaml
auth:
  bearer: ${nr-var:oci.auth.bearer}
```

Given that the burden of authentication is not on the agent type author, but on the registry configuration, we are just asking the author to copy paste a yaml template. Doesn't seem a big deal. On the bright side, this makes sure that clients with mirrors don't have issues because their preferred authentication method is unsupported by the agent (as long as it's supported on AC). By forcing agent type authors, we also "protect" them from having to publish a new version if an auth method is missing. A minor thing honestly. The big advantage here is on the user side.

From AC side, we avoid adding `Optional` for each method and then having to deal with that on the codebase and the parsing. Probably not a big change, but it's less code at the end of the day.

The disadvantage is that if we ever add any other authentication method, we will need to make it `Optional` and be inconsistent or make all of the methods `Optional` and change the behaviour of AC (that's not a breaking change, but could be confusing). I almost forgot, we could make it mandatory and add a breaking change to all agent types. Not good.

All in all, authentication methods shouldn't change. I believe the advatanges outweight the potential disadvantages.