### PR TITLE
fix: remove leftover secrets

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -202,5 +202,3 @@ jobs:
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
-      AC_CANARY_WINDOWS_PASSWORD: ${{ secrets.AC_CANARY_WINDOWS_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}


### PR DESCRIPTION
pre-release pipepline failing due to this https://github.com/newrelic/newrelic-agent-control/actions/runs/24400571373