### PR TITLE
docs: add code style guidelines

### DIFF
--- a/docs/style/naming.md
+++ b/docs/style/naming.md
@@ -1,0 +1,108 @@
+# Naming
+
+## General
+
+- Names **must** be meaningful, well thought, and discussed/agreed when there are doubts.
+- Define a **ubiquitous language** and stick to it.
+- Follow the [Rust API naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html).
+
+## Singular by default
+
+Use singular names for modules and structs:
+
+```rust
+// 👍 Good:
+mod agent_type;
+
+// 👎 Bad:
+mod agent_types;
+```
+
+## Struct and trait names
+
+Struct and trait names should contain the main object they represent. Names should be meaningful even when used outside their defining module:
+
+```rust
+// 👍 Good:
+struct SupervisorStopped;
+trait SupervisorID;
+
+// 👎 Bad:
+struct Stopped;   // unclear outside context
+trait ID;         // unclear outside context
+```
+
+## Service names
+
+Services are named as noun forms of verbs and include the object they interact with:
+
+```rust
+// 👍 Good:
+struct UserCreator;
+struct AgentStarter;
+
+// 👎 Bad:
+struct CreateUser;  // verb-first
+struct StartAgent;  // verb-first
+struct Updater;     // no object
+```
+
+Service variable names should also include the object:
+
+```rust
+// 👍 Good:
+self.supervisor_group_resolver.retrieve_group(...)
+
+// 👎 Bad:
+self.resolver.retrieve_group(...)
+```
+
+## Service method names
+
+Service methods should use imperative verbs that self-describe their action:
+
+```rust
+user_creator.create(user);
+agent_starter.start(agent);
+```
+
+## Variable names
+
+Variables should be named after their type or the concept they represent:
+
+```rust
+// 👍 Good:
+let agent_type = AgentType::default();
+let started_agent_type = AgentType::default();
+let super_agent_cfg = load_config();
+
+// 👎 Bad:
+let a = AgentType::new();          // too short
+let agnt = AgentType::new();       // abbreviation
+let agent = AgentType::new();      // ambiguous: Agent or AgentType?
+let cfg = load_config();           // what config? who owns it?
+```
+
+## Loop variable names
+
+Loop variables should be as meaningful as any other variable — a small loop can grow:
+
+```rust
+// 👍 Good:
+for (agent_id, agent_cfg) in agents.iter() { ... }
+for (variable_fqn, end_spec) in agent_type.variables.iter() { ... }
+
+// 👎 Bad:
+for (k, agent_cfg) in agents.iter() { ... }
+for (k, v) in agent_type.variables.iter() { ... }
+```
+
+## Generic type parameter names
+
+Generic parameters should be consistent. Prefer a word matching the trait or combination of traits over single letters:
+
+```rust
+// 👍 Good:
+where Sender: Sender
+where SyncedSender: Sender + Sync
+```

--- a/docs/style/naming.md
+++ b/docs/style/naming.md
@@ -96,13 +96,3 @@ for (variable_fqn, end_spec) in agent_type.variables.iter() { ... }
 for (k, agent_cfg) in agents.iter() { ... }
 for (k, v) in agent_type.variables.iter() { ... }
 ```
-
-## Generic type parameter names
-
-Generic parameters should be consistent. Prefer a word matching the trait or combination of traits over single letters:
-
-```rust
-// 👍 Good:
-where Sender: Sender
-where SyncedSender: Sender + Sync
-```

--- a/docs/style/structure.md
+++ b/docs/style/structure.md
@@ -1,0 +1,101 @@
+# Structure
+
+## Abstractions
+
+Only the minimum required abstractions should be created.
+
+- Abstractions **MUST** be created when multiple implementations exist.
+- Abstractions **SHOULD** be created because they make sense, not because of convenience.
+- Abstractions **CAN** be created to allow mocks in testing.
+- Abstractions should not be coupled to underlying implementations. The error returned by a trait method should not know about specific implementations.
+
+## Constructors
+
+Constructors should not execute actions beyond validations.
+
+```rust
+// 👎 Bad:
+// Constructors should not trigger side effects
+impl Agent {
+    fn default() -> Self {
+        self.load_agent_cfgs(); // side effect in constructor
+        ...
+    }
+}
+```
+
+- Use `Default` trait for constructors **without** parameters.
+- Use `new` function name for constructors **with** parameters.
+
+### Nullary constructors vs `Default`
+
+`Default::default()` should be deterministic — two calls must create **exactly the same value**.
+
+A `pub fn new() -> T` can be added for types where this is not the case (e.g. types containing a `SystemTime`, a key pair, or similar non-deterministic values). To avoid Clippy warnings in these situations, use a name other than `new`, such as `create`, `generate`, etc.
+
+## `From`/`Into` Traits
+
+Use Rust's `From` and `Into` traits for conversion and transformation:
+
+```rust
+// 👍 Good: converting between error types or equivalent structs
+impl From<SerializationError> for MyError { ... }
+impl From<WireConfig> for InternalConfig { ... }
+
+// 👎 Bad: using From for creation or as a getter
+impl From<&ProcessRunner<Started>> for Metadata {
+    fn from(value: &ProcessRunner<Started>) -> Self {
+        value.metadata.clone() // this is a getter, not a conversion
+    }
+}
+```
+
+- Use for: error-to-error conversion, struct-to-equivalent-struct conversion.
+- Do not use for: object creation, getters.
+
+## Getter Signature
+
+When a fetched value might not exist, use this signature:
+
+```rust
+fn get() -> Result<Option<Value>, Error>
+```
+
+Return `None` to denote the absence of the value. Only deviate when the absence must trigger a side effect (e.g. creating a new instance ID if one does not exist).
+
+## Visibility
+
+- General rule: expose as little as necessary.
+- Struct fields should be private; expose only public methods.
+
+## Size
+
+Functions and methods should be small. If a method has many responsibilities, it should delegate to other methods:
+
+```rust
+// 👍 Good:
+fn run(&self) {
+    self.run_opamp_client();
+    self.loop_event();
+    self.shutdown();
+}
+
+// 👎 Bad:
+fn run(&self) {
+    // ... create OpAMP client inline ...
+    // ... loop event inline ...
+    // ... handle shutdown inline ...
+}
+```
+
+## Serialization / Intermediate Structs
+
+Intermediate structs used only for deserialization should be hidden inside the service/module that uses them (not exposed publicly).
+
+```rust
+// 👍 Good: helper is private inside the deserializer module
+struct EndSpecDeserializeHelper { ... }
+
+// 👎 Bad: helper is a top-level public type
+pub struct IntermediateEndSpec { ... }
+```

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -1,0 +1,86 @@
+# Testing
+
+## Test module
+
+Test-only code must live under `mod tests`, not in production code paths. Do not mix test and production code:
+
+```rust
+// 👎 Bad: test constructor mixed into production impl block
+impl Resolver {
+    #[cfg(test)]
+    fn new<T>(source: T) -> Self { ... }
+
+    fn build_config(self) -> Result<SuperAgentConfig, SuperAgentConfigError> { ... }
+}
+
+// 👍 Good: test constructor is inside the test module
+#[cfg(test)]
+mod tests {
+    impl Resolver {
+        fn new<T>(source: T) -> Self { ... }
+    }
+
+    #[test]
+    fn test_something() { ... }
+}
+```
+
+## Assertions
+
+Tests must assert on values, not only on the absence of errors:
+
+```rust
+// 👎 Bad: only asserts the operation didn't panic
+let config = parse_config(input);
+assert!(config.is_ok());
+
+// 👍 Good: asserts the parsed values are correct
+let config = parse_config(input).unwrap();
+assert_eq!(config.name, "expected-name");
+assert_eq!(config.timeout_secs, 30);
+```
+
+## `assert_eq!` argument order
+
+Rust's standard library convention is `assert_eq!(actual, expected)` — natural language order: "assert that `<actual>` equals `<expected>`":
+
+```rust
+// 👍 Good: actual first, expected second
+assert_eq!(config.name, "expected-name");
+
+// 👎 Bad: expected first (xUnit convention — not idiomatic Rust)
+assert_eq!("expected-name", config.name);
+```
+
+## Test helpers
+
+When multiple tests repeat the same setup (e.g. creating a temp dir and fixed file paths), extract it into a small struct rather than duplicating the lines in every test. Keep the helper minimal — just enough to eliminate the repetition without hiding what each test is actually doing.
+
+## Parameterized tests with `rstest`
+
+When multiple test cases exercise the same logic with different inputs or expected outputs, use [`rstest`](https://docs.rs/rstest) instead of duplicating test functions:
+
+```rust
+use rstest::rstest;
+
+#[rstest]
+#[case("applying", ConfigState::Applying)]
+#[case("failed",   ConfigState::Failed)]
+fn parses_config_state(#[case] input: &str, #[case] expected: ConfigState) {
+    let state: ConfigState = input.parse().unwrap();
+    assert_eq!(state, expected);
+}
+```
+
+Use named cases (`#[case::name(...)]`) when the inputs alone do not make the intent clear:
+
+```rust
+#[rstest]
+#[case::single_layer(vec!["application/vnd.newrelic.agent.layer.tar+gzip"])]
+#[case::extra_layers(vec!["application/vnd.newrelic.agent.layer.tar+gzip", "application/vnd.custom.extra.v1"])]
+fn accepts_valid_manifest(#[case] layer_media_types: Vec<&str>) {
+    // ...
+}
+```
+
+Do not use `rstest` for a single case or when the implemented logic has complex conditionals based on test parameters — write a plain `#[test]` instead.

--- a/docs/style/types.md
+++ b/docs/style/types.md
@@ -1,0 +1,80 @@
+# Types
+
+## Encoding state in types
+
+Prefer different types over different values of the same type for representing state:
+
+```rust
+// 👍 Good: separate types for each state
+struct Stopped;
+struct Running;
+
+// 👎 Bad: bool field to represent binary state
+struct Agent {
+    running: bool,
+}
+```
+
+Do not use a `bool` field inside a struct to represent binary state. If an enum is truly needed, it is almost always better than a `bool` because it can be extended and both the type and its variants can have explanatory names.
+
+## Type-state pattern
+
+When two or more types participate in a state transition and share many fields or behavior, use the [type-state pattern](https://zerotomastery.io/blog/rust-typestate-patterns/) with generics:
+
+```rust
+struct Stopped;
+struct Running;
+struct Finished {
+    result_message: String,
+}
+
+pub struct Transition<T> {
+    name: String,
+    modified_timestamp: u64,
+    state: T,
+}
+
+impl<T> Transition<T> {
+    fn with_modification_time(self) -> Self { /* ... */ }
+}
+
+impl Transition<Stopped> {
+    pub fn run(self) -> Transition<Running> { /* ... */ }
+}
+
+impl Transition<Running> {
+    pub fn wait(self) -> Transition<Finished> { /* ... */ }
+}
+
+impl Transition<Finished> {
+    pub fn get_result_msg(&self) -> &str {
+        &self.state.result_message
+    }
+}
+```
+
+This pattern gives compile-time guarantees: calling `run` twice, or calling `wait` before `run`, is a compiler error.
+
+**Use this pattern only when:**
+
+- Each parameterized type uses the same shared fields frequently.
+- The state type parameters (`T`s) are minimal — ideally empty marker types.
+- When state types carry no data, use `PhantomData` instead of a field.
+
+**Restrict valid type parameters** using trait bounds or sealed traits when exposing types with this pattern publicly.
+
+> This pattern has an impact on readability — do not use it lightly.
+
+## Enums
+
+Use `enum`s for types whose values can have very different data but ultimately represent the same concept, and where all variants may be checked and operated on differently:
+
+```rust
+// 👍 Good: events from different domains are separate types
+enum SubAgentEvent { ... }
+enum OpAMPEvent { ... }
+```
+
+- Errors and events that operate on different domains must be different types.
+- Avoid enums with too many variants.
+- Each variant should have a distinct `Display` implementation so its origin can be located in the code.

--- a/docs/style/types.md
+++ b/docs/style/types.md
@@ -15,7 +15,7 @@ struct Agent {
 }
 ```
 
-Do not use a `bool` field inside a struct to represent binary state. If an enum is truly needed, it is almost always better than a `bool` because it can be extended and both the type and its variants can have explanatory names.
+Do not use a `bool` field inside a struct to represent binary state. An enum is almost always better than a `bool` because it can be extended and both the type and its variants can have explanatory names.
 
 ## Type-state pattern
 


### PR DESCRIPTION
migrate our guidelines in confluence to the repo to facilitate AI coding agents skills contrains unification