### PR TITLE
feat: add proxy to k8s staging on demand e2e test

### DIFF
--- a/.github/workflows/on_demand_staging_e2e.yml
+++ b/.github/workflows/on_demand_staging_e2e.yml
@@ -97,7 +97,7 @@ jobs:
           - fleet-control
           - dynamic
           - custom-repo
-          # proxy has issues pointing to staging
+          - proxy
     steps:
       - name: Record job start time
         run: echo "JOB_START_TIME=$(date +%s)" >> "$GITHUB_ENV"


### PR DESCRIPTION
Add proxy to k8s staging on demand e2e test.

The L2 key now is a parent and the e2e works.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
