### PR TITLE
fix: add missing crates to AC log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tower-test",
  "tracing",
  "tracing-appender",
@@ -4870,10 +4871,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.1",
 ]
 
@@ -4906,6 +4909,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2580,6 +2580,13 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
+## toml_writer <https://crates.io/crates/toml_writer>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
 ## tonic <https://crates.io/crates/tonic>
 
 Distributed under the following license(s):

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -125,6 +125,7 @@ memory-stats = "1.2.0"
 
 [build-dependencies]
 glob = "0.3.3"
+toml = "1.1.2"
 
 [[bin]]
 name = "newrelic-agent-control-k8s"

--- a/agent-control/build.rs
+++ b/agent-control/build.rs
@@ -10,8 +10,25 @@ use std::path::Path;
 const REGISTRY_PATH: &str = "agent-type-registry/";
 const GENERATED_REGISTRY_FILE: &str = "generated_agent_type_registry.rs";
 
+// List of crates whose logs are enabled at the configured level.
+const LOGGING_ENABLED_CRATES: &[&str] = &[
+    "newrelic_agent_control",
+    "self_replacer",
+    "resource_detection",
+    "fs",
+    // External crates (not workspace members) can also be added here freely.
+    "opamp_client",
+    "nr_auth",
+];
+
+// Workspace crates whose logs are explicitly disabled.
+// Every workspace member must appear in exactly one of the two lists — the build
+// fails otherwise, forcing an explicit decision when a new crate is added.
+const LOGGING_DISABLED_CRATES: &[&str] = &["wrapper_with_default", "e2e_runner"];
+
 fn main() {
     generate_agent_type_registry();
+    check_logging_crates();
     // setup the env variable for the generated registry path
     println!("cargo:rustc-env=GENERATED_REGISTRY_FILE={GENERATED_REGISTRY_FILE}");
     // re-run only if the registry has changed
@@ -48,6 +65,58 @@ fn set_git_commit() {
     };
 
     println!("cargo:rustc-env=GIT_COMMIT={value}");
+}
+
+/// Checks that all workspace members are listed in either LOGGING_ENABLED_CRATES or LOGGING_DISABLED_CRATES.
+/// This forces an explicit decision about logging for each crate, making it less likely that a new crate is added
+/// without considering its logging configuration.
+fn check_logging_crates() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let workspace_root = Path::new(&manifest_dir).join("..");
+
+    let workspace_toml_path = workspace_root.join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", workspace_toml_path.display());
+
+    let workspace_toml: toml::Table = fs::read_to_string(&workspace_toml_path)
+        .expect("Could not read workspace Cargo.toml")
+        .parse()
+        .expect("Could not parse workspace Cargo.toml");
+
+    let members = workspace_toml["workspace"]["members"]
+        .as_array()
+        .expect("workspace.members is not an array");
+
+    for member in members {
+        let member_path = member.as_str().expect("workspace member is not a string");
+        let member_toml_path = workspace_root.join(member_path).join("Cargo.toml");
+        println!("cargo:rerun-if-changed={}", member_toml_path.display());
+
+        let member_toml: toml::Table = fs::read_to_string(&member_toml_path)
+            .unwrap_or_else(|_| panic!("Could not read {member_path}/Cargo.toml"))
+            .parse()
+            .unwrap_or_else(|_| panic!("Could not parse {member_path}/Cargo.toml"));
+
+        let package_name = member_toml["package"]["name"]
+            .as_str()
+            .unwrap_or_else(|| panic!("package.name not found in {member_path}/Cargo.toml"));
+
+        // Cargo converts hyphens to underscores in crate names; tracing targets use the crate name form.
+        let crate_name = package_name.replace('-', "_");
+
+        let in_enabled = LOGGING_ENABLED_CRATES.contains(&crate_name.as_str());
+        let in_disabled = LOGGING_DISABLED_CRATES.contains(&crate_name.as_str());
+
+        if !in_enabled && !in_disabled {
+            panic!(
+                "\n\nWorkspace crate `{crate_name}` is not listed in LOGGING_ENABLED_CRATES or \
+                LOGGING_DISABLED_CRATES in build.rs.\n\
+                Add it to one of the lists to make an explicit logging decision.\n"
+            );
+        }
+    }
+
+    let crates_value = LOGGING_ENABLED_CRATES.join(",");
+    println!("cargo:rustc-env=LOGGING_ENABLED_CRATES={crates_value}");
 }
 
 fn generate_agent_type_registry() {

--- a/agent-control/src/instrumentation/config/logs/config.rs
+++ b/agent-control/src/instrumentation/config/logs/config.rs
@@ -11,7 +11,8 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::{EnvFilter, Registry};
 
-const LOGGING_ENABLED_CRATES: &[&str] = &["newrelic_agent_control", "opamp_client"];
+// The list of crates with enabled logging is generated at build time in `build.rs` and injected as an env variable.
+const LOGGING_ENABLED_CRATES: &str = env!("LOGGING_ENABLED_CRATES");
 
 const SPAN_ATTRIBUTES_MAX_LEVEL: &Level = &Level::INFO;
 
@@ -106,7 +107,7 @@ impl LoggingConfig {
             .with_default_directive(LevelFilter::OFF.into()) // Disables logs for any crate
             .parse_lossy("");
         // Enables and sets up the log level for known crates
-        for crate_name in LOGGING_ENABLED_CRATES {
+        for crate_name in LOGGING_ENABLED_CRATES.split(',') {
             let directive = format!("{}={}", crate_name, &level);
             env_filter =
                 env_filter.add_directive(Self::logging_directive(directive.as_str(), "level")?)
@@ -205,7 +206,15 @@ mod tests {
             TestCase {
                 name: "everything default",
                 config: Default::default(),
-                expected: "newrelic_agent_control=info,opamp_client=info,off",
+                expected: "newrelic_agent_control=info,resource_detection=info,self_replacer=info,opamp_client=info,nr_auth=info,fs=info,off",
+            },
+            TestCase {
+                name: "debug level applies to all known crates",
+                config: LoggingConfig {
+                    level: LogLevel(Level::DEBUG),
+                    ..Default::default()
+                },
+                expected: "newrelic_agent_control=debug,resource_detection=debug,self_replacer=debug,opamp_client=debug,nr_auth=debug,fs=debug,off",
             },
             TestCase {
                 name: "insecure fine grained overrides any logging",
@@ -222,7 +231,7 @@ mod tests {
                     insecure_fine_grained_level: Some("".into()),
                     ..Default::default()
                 },
-                expected: "newrelic_agent_control=info,opamp_client=info,off", // default
+                expected: "newrelic_agent_control=info,resource_detection=info,self_replacer=info,opamp_client=info,nr_auth=info,fs=info,off", // default
             },
             TestCase {
                 name: "several specific targets in insecure_fine_grained_level",

--- a/agent-control/tests/common/global_logger.rs
+++ b/agent-control/tests/common/global_logger.rs
@@ -15,7 +15,7 @@ pub fn init_logger() {
           target: true
           ansi_colors: true
           formatter: pretty
-        insecure_fine_grained_level: "newrelic_agent_control=trace,off"
+        level: debug
         show_spans: false
                 "#,
         )


### PR DESCRIPTION
Noticed that AC was not printed logs from self-replacer create because we forgot to add it to the list. Also auth crate was not added.
This PR adds them but also a mechanism to make this less likely to happen in the future whenever we add a new crate in the workspace. 