### PR TITLE
refactor: extract OpAMP settings build into separed functions [NR-537428]

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -46,7 +46,7 @@ use crate::sub_agent::k8s::builder::SupervisorBuilderK8s;
 use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
 use crate::utils::thread_context::StartedThreadContext;
 use crate::{k8s::configmap_store::ConfigMapStore, sub_agent::k8s::builder::K8sSubAgentBuilder};
-use opamp_client::operation::settings::DescriptionValueType;
+use opamp_client::operation::settings::{DescriptionValueType, StartSettings};
 use resource_detection::system::hostname::get_hostname;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -114,20 +114,21 @@ impl AgentControlRunner {
         // Build and start AC OpAMP client
         let (maybe_client, maybe_opamp_consumer) = opamp_client_builder
             .as_ref()
-            .map(|builder| -> Result<_, _> {
+            .map(|builder| -> Result<_, RunError> {
                 info!("Starting Agent Control OpAMP client");
                 let agent_identity = AgentIdentity::new_agent_control_identity();
-                let start_settings = start_settings(
-                    instance_id_getter.get(&agent_identity.id)?,
+                let settings = build_ac_opamp_start_settings(
+                    &instance_id_getter,
                     &agent_identity,
-                    agent_control_additional_opamp_identifying_attributes(&k8s_config),
-                    agent_control_opamp_non_identifying_attributes(&identifiers, &k8s_config),
-                );
-                builder.build_and_start(agent_identity, start_settings)
+                    &k8s_config,
+                    &identifiers,
+                )?;
+                builder
+                    .build_and_start(agent_identity, settings)
+                    .map_err(|err| RunError(format!("error initializing OpAMP client: {err}")))
             })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
-            .transpose()
-            .map_err(|err| RunError(format!("error initializing OpAMP client: {err}")))?
+            .transpose()?
             .map(|(client, consumer)| (Some(client), Some(consumer)))
             .unwrap_or_default();
 
@@ -296,6 +297,26 @@ fn start_cd_version_checker(
         VersionCheckerInterval::default(),
         AGENT_CONTROL_VERSION_CHECKER_INITIAL_DELAY,
     )
+}
+
+/// Builds the OpAMP [StartSettings] for Agent Control on Kubernetes, including the agent
+/// identity and all identifying and non-identifying attributes.
+pub fn build_ac_opamp_start_settings(
+    instance_id_getter: &impl InstanceIDGetter,
+    agent_identity: &AgentIdentity,
+    k8s_config: &K8sConfig,
+    identifiers: &Identifiers,
+) -> Result<StartSettings, RunError> {
+    let instance_id = instance_id_getter
+        .get(&agent_identity.id)
+        .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
+
+    Ok(start_settings(
+        instance_id,
+        agent_identity,
+        agent_control_additional_opamp_identifying_attributes(k8s_config),
+        agent_control_opamp_non_identifying_attributes(identifiers, k8s_config),
+    ))
 }
 
 pub fn agent_control_opamp_non_identifying_attributes(

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -52,7 +52,7 @@ use oci_client::client::ClientConfig;
 use oci_client::client::ClientProtocol;
 use opamp_client::http::StartedHttpClient;
 use opamp_client::http::client::OpAMPHttpClient;
-use opamp_client::operation::settings::DescriptionValueType;
+use opamp_client::operation::settings::{DescriptionValueType, StartSettings};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -79,8 +79,6 @@ type OnHostOpAMPClient = StartedHttpClient<
     >,
 >;
 type OnHostOpAMPConsumer = EventConsumer<OpAMPEvent>;
-type OnHostInstanceIdGetter =
-    InstanceIDWithIdentifiersGetter<Storer<FileStore<LocalFile, DirectoryManagerFs>, Identifiers>>;
 
 impl AgentControlRunner {
     pub fn run_onhost(self) -> Result<(), RunError> {
@@ -124,12 +122,14 @@ impl AgentControlRunner {
         let (maybe_client, maybe_sa_opamp_consumer) = opamp_client_builder
             .as_ref()
             .map(|builder| {
-                start_ac_opamp_client(
-                    builder,
+                let agent_identity = AgentIdentity::new_agent_control_identity();
+                let settings = build_ac_opamp_start_settings(
                     &instance_id_getter,
+                    &agent_identity,
                     &identifiers,
                     RunningMode::Normal,
-                )
+                )?;
+                start_ac_opamp_client(builder, agent_identity, settings)
             })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
             .transpose()?
@@ -273,29 +273,34 @@ pub fn opamp_client_builder(
     OpAMPClientBuilder::new(poll_interval, http_builder, loader)
 }
 
-pub fn start_ac_opamp_client(
-    builder: &OnHostOpAMPClientBuilder,
-    instance_id_getter: &OnHostInstanceIdGetter,
+/// Builds the OpAMP [StartSettings] for Agent Control, including the agent identity and
+/// all identifying and non-identifying attributes.
+pub fn build_ac_opamp_start_settings(
+    instance_id_getter: &impl InstanceIDGetter,
+    agent_identity: &AgentIdentity,
     identifiers: &Identifiers,
     running_mode: RunningMode,
-) -> Result<(OnHostOpAMPClient, OnHostOpAMPConsumer), RunError> {
-    info!("Starting Agent Control OpAMP client");
-
-    let agent_identity = AgentIdentity::new_agent_control_identity();
+) -> Result<StartSettings, RunError> {
     let instance_id = instance_id_getter
         .get(&agent_identity.id)
         .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
 
-    let agent_identity = AgentIdentity::new_agent_control_identity();
-    let start_settings = start_settings(
+    Ok(start_settings(
         instance_id,
-        &agent_identity,
+        agent_identity,
         ac_identifying_attributes(),
         ac_non_identifying_attributes(identifiers, running_mode),
-    );
+    ))
+}
 
+pub fn start_ac_opamp_client(
+    builder: &OnHostOpAMPClientBuilder,
+    agent_identity: AgentIdentity,
+    settings: StartSettings,
+) -> Result<(OnHostOpAMPClient, OnHostOpAMPConsumer), RunError> {
+    info!("Starting Agent Control OpAMP client");
     builder
-        .build_and_start(agent_identity, start_settings)
+        .build_and_start(agent_identity, settings)
         .map_err(|err| RunError(format!("error initializing OpAMP client: {err}")))
 }
 

--- a/agent-control/src/command/on_host_checks/opamp.rs
+++ b/agent-control/src/command/on_host_checks/opamp.rs
@@ -2,10 +2,16 @@ use opamp_client::StartedClient;
 use tracing::info;
 
 use crate::{
-    agent_control::run::RunningMode,
-    agent_control::run::on_host::{ac_identifiers, opamp_client_builder, start_ac_opamp_client},
+    agent_control::run::{
+        RunningMode,
+        on_host::{
+            ac_identifiers, build_ac_opamp_start_settings, opamp_client_builder,
+            start_ac_opamp_client,
+        },
+    },
     command::on_host_checks::config::VerifiedConfig,
     opamp::instance_id::{getter::InstanceIDWithIdentifiersGetter, storer::Storer},
+    sub_agent::identity::AgentIdentity,
 };
 
 pub fn check_connectivity(
@@ -42,12 +48,15 @@ pub fn check_connectivity(
     // - Even when calling `stop`, the thread might still get spawned
     // - The check sends an `AgentToServer` message and processes a `ServerToAgent` via
     //   `process_message`, doing more work than strictly necessary for connectivity verification
-    let (client, _consumer) = start_ac_opamp_client(
-        &opamp_client_builder,
+    let agent_identity = AgentIdentity::new_agent_control_identity();
+    let settings = build_ac_opamp_start_settings(
         &instance_id_getter,
+        &agent_identity,
         &identifiers,
         RunningMode::Verify,
     )?;
+    let (client, _consumer) =
+        start_ac_opamp_client(&opamp_client_builder, agent_identity, settings)?;
     client.stop()?;
 
     info!("OpAMP connectivity check successful");


### PR DESCRIPTION
The OpAMP StartSettings were previously built inline inside start_ac_opamp_client (on-host) and inline in the runner closure (k8s), tightly coupling settings assembly with client startup. This refactor separates the two concerns by introducing dedicated functions in both runners.

The motivation for this refactor was reusing the start-settings to be propagated to the status-http-server and enrich the information the status-http-server provides with these settings information.