### PR TITLE
fix(renovate): regex is no longer needed for git dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,30 +58,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "**/Cargo.toml"
-      ],
-      "matchStrings": [
-        "nr-auth = { git = \"https://github\\.com/newrelic/newrelic-auth-rs\\.git\", tag = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\" }"
-      ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "newrelic-auth-rs",
-      "packageNameTemplate": "newrelic/newrelic-auth-rs"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "**/Cargo.toml"
-      ],
-      "matchStrings": [
-        "opamp-client = { git = \"https://github\\.com/newrelic/newrelic-opamp-rs\\.git\", tag = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\" }"
-      ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "newrelic-opamp-rs",
-      "packageNameTemplate": "newrelic/newrelic-opamp-rs"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
         "/^\\.github/workflows/.*\\.yaml$/"
       ],
       "depNameTemplate": "newrelic/infrastructure-agent-artifacts",


### PR DESCRIPTION
git dependencies are now supported by the cargo manager.
Having the regex creates two duplicates PRs
<img width="438" height="852" alt="Screenshot 2026-04-17 at 16 22 47" src="https://github.com/user-attachments/assets/c6a60148-adee-4c6c-9362-06ff947085c7" />
