### PR TITLE
feat: support global config for agent types

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -33,7 +33,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: oci.registry
+        default: "${nr-default:oci.registry}"
         variants:
           ac_config_field: "oci_registry_urls"
           values: [ "docker.io" ]
@@ -51,17 +51,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.username
+            default: "${nr-default:oci.auth.basic.username}"
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.password
+            default: "${nr-default:oci.auth.basic.password}"
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: oci.auth.bearer
+          default: "${nr-default:oci.auth.bearer}"
     version:
       description: "Agent version"
       type: string
@@ -102,7 +102,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: oci.registry
+        default: "${nr-default:oci.registry}"
         variants:
           ac_config_field: "oci_registry_urls"
           values: [ "docker.io" ]
@@ -120,17 +120,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.username
+            default: "${nr-default:oci.auth.basic.username}"
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.password
+            default: "${nr-default:oci.auth.basic.password}"
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: oci.auth.bearer
+          default: "${nr-default:oci.auth.bearer}"
     version:
       description: "Agent version"
       type: string

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -33,7 +33,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: docker.io
+        default: oci.registry
         variants:
           ac_config_field: "oci_registry_urls"
           values: [ "docker.io" ]
@@ -51,17 +51,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.username
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.password
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: ""
+          default: oci.auth.bearer
     version:
       description: "Agent version"
       type: string
@@ -102,7 +102,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: docker.io
+        default: oci.registry
         variants:
           ac_config_field: "oci_registry_urls"
           values: [ "docker.io" ]
@@ -120,17 +120,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.username
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.password
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: ""
+          default: oci.auth.bearer
     version:
       description: "Agent version"
       type: string

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -45,6 +45,23 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -97,6 +114,23 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -186,6 +220,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
       args:
@@ -256,6 +295,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
       args:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -49,6 +49,23 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -95,6 +112,23 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
+      auth:
+        basic:
+          username:
+            description: "Username for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+          password:
+            description: "Password for HTTP Basic authentication"
+            type: string
+            required: false
+            default: ""
+        bearer:
+          description: "Bearer token for authentication"
+          type: string
+          required: false
+          default: ""
     version:
       description: "Agent version"
       type: string
@@ -157,6 +191,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     version:
       path: ${nr-sub:packages.nrdot.dir}\\nrdot-collector.exe
       args:
@@ -190,6 +229,11 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
+            auth:
+              basic:
+                username: ${nr-var:oci.auth.basic.username}
+                password: ${nr-var:oci.auth.basic.password}
+              bearer: ${nr-var:oci.auth.bearer}
     health:
       interval: 30s
       initial_delay: 90s

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -37,7 +37,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: docker.io
+        default: oci.registry
         variants:
           ac_config_field: "oci_nrdot_registry_urls"
           values: [ "docker.io" ]
@@ -55,17 +55,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.username
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.password
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: ""
+          default: oci.auth.bearer
     version:
       description: "Agent version"
       type: string
@@ -100,7 +100,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: docker.io
+        default: oci.registry
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "docker.io" ]
@@ -118,17 +118,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.username
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: ""
+            default: oci.auth.basic.password
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: ""
+          default: oci.auth.bearer
     version:
       description: "Agent version"
       type: string

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -37,7 +37,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: oci.registry
+        default: "${nr-default:oci.registry}"
         variants:
           ac_config_field: "oci_nrdot_registry_urls"
           values: [ "docker.io" ]
@@ -55,17 +55,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.username
+            default: "${nr-default:oci.auth.basic.username}"
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.password
+            default: "${nr-default:oci.auth.basic.password}"
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: oci.auth.bearer
+          default: "${nr-default:oci.auth.bearer}"
     version:
       description: "Agent version"
       type: string
@@ -100,7 +100,7 @@ variables:
         description: "Package registry url"
         type: string
         required: false
-        default: oci.registry
+        default: "${nr-default:oci.registry}"
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "docker.io" ]
@@ -118,17 +118,17 @@ variables:
             description: "Username for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.username
+            default: "${nr-default:oci.auth.basic.username}"
           password:
             description: "Password for HTTP Basic authentication"
             type: string
             required: false
-            default: oci.auth.basic.password
+            default: "${nr-default:oci.auth.basic.password}"
         bearer:
           description: "Bearer token for authentication"
           type: string
           required: false
-          default: oci.auth.bearer
+          default: "${nr-default:oci.auth.bearer}"
     version:
       description: "Agent version"
       type: string

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -76,6 +76,10 @@ pub struct AgentControlConfig {
     /// Contains configuration for on-host self-update mechanism
     #[serde(default)]
     pub self_update: SelfUpdateConfig,
+
+    /// Global OCI registry configuration
+    #[serde(default)]
+    pub global_oci: OciConfig,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
@@ -94,6 +98,60 @@ pub struct PackagesConfig {
     pub signature_verification_enabled: SignatureVerificationEnabled,
 }
 
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct OciConfig {
+    registry: String,
+    auth: OciAuth,
+}
+
+impl Default for OciConfig {
+    fn default() -> Self {
+        Self {
+            registry: "docker.io".to_string(),
+            auth: OciAuth::default(),
+        }
+    }
+}
+
+impl OciConfig {
+    fn to_hashmap(&self) -> HashMap<String, serde_yaml::Value> {
+        let mut vars = HashMap::new();
+
+        vars.insert(
+            "oci.registry".to_string(),
+            serde_yaml::Value::String(self.registry.clone()),
+        );
+
+        vars.insert(
+            "oci.auth.basic.username".to_string(),
+            serde_yaml::Value::String(self.auth.basic.username.clone()),
+        );
+        vars.insert(
+            "oci.auth.basic.password".to_string(),
+            serde_yaml::Value::String(self.auth.basic.password.clone()),
+        );
+
+        vars.insert(
+            "oci.auth.bearer".to_string(),
+            serde_yaml::Value::String(self.auth.bearer.clone()),
+        );
+
+        vars
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+struct OciAuth {
+    basic: BasicAuth,
+    bearer: String,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+struct BasicAuth {
+    username: String,
+    password: String,
+}
+
 const DEFAULT_SIGNATURE_VERIFICATION_ENABLED: bool = true;
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_SIGNATURE_VERIFICATION_ENABLED)]
@@ -104,6 +162,12 @@ impl TryFrom<YAMLConfig> for AgentControlConfig {
 
     fn try_from(value: YAMLConfig) -> Result<Self, Self::Error> {
         serde_yaml::from_value(serde_yaml::to_value(value)?)
+    }
+}
+
+impl AgentControlConfig {
+    pub fn defaults(&self) -> HashMap<String, serde_yaml::Value> {
+        self.global_oci.to_hashmap()
     }
 }
 
@@ -1084,5 +1148,57 @@ k8s:
         agents.extend(infra());
         agents.extend(nrdot());
         agents
+    }
+
+    #[test]
+    fn test_oci_config_default_namespace() {
+        let default = OciConfig::default();
+        let vars = default.to_hashmap();
+        assert_eq!(vars.len(), 4);
+        assert_eq!(
+            vars.get("oci.registry"),
+            Some(&serde_yaml::Value::String("docker.io".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.basic.username"),
+            Some(&serde_yaml::Value::String("".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.basic.password"),
+            Some(&serde_yaml::Value::String("".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.bearer"),
+            Some(&serde_yaml::Value::String("".to_string()))
+        );
+
+        let oci_config_all = OciConfig {
+            registry: "custom.docker.io".to_string(),
+            auth: OciAuth {
+                basic: BasicAuth {
+                    username: "user".to_string(),
+                    password: "pass".to_string(),
+                },
+                bearer: "token".to_string(),
+            },
+        };
+        let vars = oci_config_all.to_hashmap();
+        assert_eq!(vars.len(), 4);
+        assert_eq!(
+            vars.get("oci.registry"),
+            Some(&serde_yaml::Value::String("custom.docker.io".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.basic.username"),
+            Some(&serde_yaml::Value::String("user".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.basic.password"),
+            Some(&serde_yaml::Value::String("pass".to_string()))
+        );
+        assert_eq!(
+            vars.get("oci.auth.bearer"),
+            Some(&serde_yaml::Value::String("token".to_string()))
+        );
     }
 }

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -94,7 +94,7 @@ pub struct AgentControlConfig {
 
 impl AgentControlConfig {
     pub fn defaults(&self) -> HashMap<String, serde_yaml::Value> {
-        self.global_defaults.oci.to_hashmap()
+        self.global_defaults.to_hashmap()
     }
 }
 
@@ -114,13 +114,80 @@ pub struct PackagesConfig {
     pub signature_verification_enabled: SignatureVerificationEnabled,
 }
 
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct GlobalDefaults {
     #[serde(default)]
     oci: OciConfig,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+impl GlobalDefaults {
+    /// Flattens the nested structure of GlobalDefaults into a single level HashMap with dot-separated keys.
+    ///
+    /// # Example
+    ///
+    /// Given the following GlobalDefaults structure:
+    /// ```ignore
+    /// GlobalDefaults {
+    ///   oci: OciConfig {
+    ///     registry: "docker.io",
+    ///     auth: OciAuth {
+    ///       basic: BasicAuth {
+    ///         username: "user",
+    ///         password: "pass",
+    ///       },
+    ///       bearer: "",
+    ///     },
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// we get the following HashMap:
+    /// ```ignore
+    /// {
+    ///   "oci.registry": "docker.io",
+    ///   "oci.auth.basic.username": "user",
+    ///   "oci.auth.basic.password": "pass",
+    ///   "oci.auth.bearer": "",
+    /// }
+    /// ```
+    fn to_hashmap(&self) -> HashMap<String, serde_yaml::Value> {
+        let value = serde_yaml::to_value(self).expect("GlobalDefaults should serialize to YAML");
+
+        let mut result = HashMap::new();
+
+        if let serde_yaml::Value::Mapping(map) = value {
+            for (key, val) in map {
+                if let Some(key_str) = key.as_str() {
+                    flatten_value(key_str, &val, &mut result);
+                }
+            }
+        }
+
+        result
+    }
+}
+
+fn flatten_value(
+    prefix: &str,
+    value: &serde_yaml::Value,
+    result: &mut HashMap<String, serde_yaml::Value>,
+) {
+    match value {
+        serde_yaml::Value::Mapping(map) => {
+            for (key, val) in map {
+                if let Some(key_str) = key.as_str() {
+                    let new_prefix = format!("{}.{}", prefix, key_str);
+                    flatten_value(&new_prefix, val, result);
+                }
+            }
+        }
+        _ => {
+            result.insert(prefix.to_string(), value.clone());
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct OciConfig {
     #[serde(default = "OciConfig::default_registry")]
     registry: String,
@@ -143,34 +210,7 @@ impl OciConfig {
     }
 }
 
-impl OciConfig {
-    fn to_hashmap(&self) -> HashMap<String, serde_yaml::Value> {
-        let mut vars = HashMap::new();
-
-        vars.insert(
-            "oci.registry".to_string(),
-            serde_yaml::Value::String(self.registry.clone()),
-        );
-
-        vars.insert(
-            "oci.auth.basic.username".to_string(),
-            serde_yaml::Value::String(self.auth.basic.username.clone()),
-        );
-        vars.insert(
-            "oci.auth.basic.password".to_string(),
-            serde_yaml::Value::String(self.auth.basic.password.clone()),
-        );
-
-        vars.insert(
-            "oci.auth.bearer".to_string(),
-            serde_yaml::Value::String(self.auth.bearer.clone()),
-        );
-
-        vars
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 struct OciAuth {
     #[serde(default)]
     basic: BasicAuth,
@@ -178,7 +218,7 @@ struct OciAuth {
     bearer: String,
 }
 
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 struct BasicAuth {
     username: String,
     password: String,
@@ -1177,8 +1217,8 @@ k8s:
     }
 
     #[test]
-    fn test_oci_config_default_values() {
-        let vars = OciConfig::default().to_hashmap();
+    fn test_global_defaults_base_values() {
+        let vars = GlobalDefaults::default().to_hashmap();
         assert_eq!(vars.len(), 4);
         assert!(vars.get("oci.registry").is_some_and(|v| v == "docker.io"));
         assert!(vars.get("oci.auth.basic.username").is_some_and(|v| v == ""));
@@ -1187,19 +1227,21 @@ k8s:
     }
 
     #[test]
-    fn test_oci_config_provided_values() {
-        let oci_config = OciConfig {
-            registry: "custom.docker.io".to_string(),
-            auth: OciAuth {
-                basic: BasicAuth {
-                    username: "user".to_string(),
-                    password: "pass".to_string(),
+    fn test_global_defaults_provided_values() {
+        let global_defaults = GlobalDefaults {
+            oci: OciConfig {
+                registry: "custom.docker.io".to_string(),
+                auth: OciAuth {
+                    basic: BasicAuth {
+                        username: "user".to_string(),
+                        password: "pass".to_string(),
+                    },
+                    bearer: "token".to_string(),
                 },
-                bearer: "token".to_string(),
             },
         };
 
-        let vars = oci_config.to_hashmap();
+        let vars = global_defaults.to_hashmap();
         assert_eq!(vars.len(), 4);
         assert!(
             vars.get("oci.registry")

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -76,6 +76,26 @@ pub struct AgentControlConfig {
     /// Contains configuration for on-host self-update mechanism
     #[serde(default)]
     pub self_update: SelfUpdateConfig,
+
+    /// Default values to override agent types variables
+    ///
+    /// These default values are intended to be used for variables that are common across multiple agent types
+    /// such as OCI registry credentials. By defining them in a single place, we can avoid duplication over different
+    /// agent types configurations and ensure consistency across them.
+    ///
+    /// This only works if the agent type definition declares a variable whose `default` field references
+    /// one of the default configured values, (e.g. `default: ${nr-default:oci.registry}`).
+    ///
+    /// For backwards compatibility reasons, these default values are optional. If not defined, they will be set to a set
+    /// of sensible defaults (e.g. `oci.registry` will default to `docker.io`).
+    #[serde(default)]
+    pub global_defaults: GlobalDefaults,
+}
+
+impl AgentControlConfig {
+    pub fn defaults(&self) -> HashMap<String, serde_yaml::Value> {
+        self.global_defaults.oci.to_hashmap()
+    }
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
@@ -92,6 +112,76 @@ pub struct SelfUpdateConfig {
 pub struct PackagesConfig {
     /// Indicates whether package signature verification is enabled or not
     pub signature_verification_enabled: SignatureVerificationEnabled,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct GlobalDefaults {
+    #[serde(default)]
+    oci: OciConfig,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct OciConfig {
+    #[serde(default = "OciConfig::default_registry")]
+    registry: String,
+    #[serde(default)]
+    auth: OciAuth,
+}
+
+impl Default for OciConfig {
+    fn default() -> Self {
+        Self {
+            registry: OciConfig::default_registry(),
+            auth: OciAuth::default(),
+        }
+    }
+}
+
+impl OciConfig {
+    fn default_registry() -> String {
+        "docker.io".to_string()
+    }
+}
+
+impl OciConfig {
+    fn to_hashmap(&self) -> HashMap<String, serde_yaml::Value> {
+        let mut vars = HashMap::new();
+
+        vars.insert(
+            "oci.registry".to_string(),
+            serde_yaml::Value::String(self.registry.clone()),
+        );
+
+        vars.insert(
+            "oci.auth.basic.username".to_string(),
+            serde_yaml::Value::String(self.auth.basic.username.clone()),
+        );
+        vars.insert(
+            "oci.auth.basic.password".to_string(),
+            serde_yaml::Value::String(self.auth.basic.password.clone()),
+        );
+
+        vars.insert(
+            "oci.auth.bearer".to_string(),
+            serde_yaml::Value::String(self.auth.bearer.clone()),
+        );
+
+        vars
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+struct OciAuth {
+    #[serde(default)]
+    basic: BasicAuth,
+    #[serde(default)]
+    bearer: String,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+struct BasicAuth {
+    username: String,
+    password: String,
 }
 
 const DEFAULT_SIGNATURE_VERIFICATION_ENABLED: bool = true;
@@ -1084,5 +1174,106 @@ k8s:
         agents.extend(infra());
         agents.extend(nrdot());
         agents
+    }
+
+    #[test]
+    fn test_oci_config_default_values() {
+        let vars = OciConfig::default().to_hashmap();
+        assert_eq!(vars.len(), 4);
+        assert!(vars.get("oci.registry").is_some_and(|v| v == "docker.io"));
+        assert!(vars.get("oci.auth.basic.username").is_some_and(|v| v == ""));
+        assert!(vars.get("oci.auth.basic.password").is_some_and(|v| v == ""));
+        assert!(vars.get("oci.auth.bearer").is_some_and(|v| v == ""));
+    }
+
+    #[test]
+    fn test_oci_config_provided_values() {
+        let oci_config = OciConfig {
+            registry: "custom.docker.io".to_string(),
+            auth: OciAuth {
+                basic: BasicAuth {
+                    username: "user".to_string(),
+                    password: "pass".to_string(),
+                },
+                bearer: "token".to_string(),
+            },
+        };
+
+        let vars = oci_config.to_hashmap();
+        assert_eq!(vars.len(), 4);
+        assert!(
+            vars.get("oci.registry")
+                .is_some_and(|v| v == "custom.docker.io")
+        );
+        assert!(
+            vars.get("oci.auth.basic.username")
+                .is_some_and(|v| v == "user")
+        );
+        assert!(
+            vars.get("oci.auth.basic.password")
+                .is_some_and(|v| v == "pass")
+        );
+        assert!(vars.get("oci.auth.bearer").is_some_and(|v| v == "token"));
+    }
+
+    #[test]
+    fn test_agent_control_config_oci_auth() {
+        let config = serde_yaml::from_str::<AgentControlConfig>(
+            r#"
+agents: {}
+"#,
+        );
+
+        let oci_config = config.unwrap().global_defaults.oci;
+        assert_eq!(oci_config.registry, "docker.io");
+        assert_eq!(oci_config.auth.basic.username, "");
+        assert_eq!(oci_config.auth.basic.password, "");
+        assert_eq!(oci_config.auth.bearer, "");
+
+        let config = serde_yaml::from_str::<AgentControlConfig>(
+            r#"
+agents: {}
+global_defaults:
+  oci:
+    registry: custom.docker.io
+"#,
+        );
+        let oci_config = config.unwrap().global_defaults.oci;
+        assert_eq!(oci_config.registry, "custom.docker.io");
+        assert_eq!(oci_config.auth.basic.username, "");
+        assert_eq!(oci_config.auth.basic.password, "");
+        assert_eq!(oci_config.auth.bearer, "");
+
+        let config = serde_yaml::from_str::<AgentControlConfig>(
+            r#"
+agents: {}
+global_defaults:
+  oci:
+    auth:
+      basic:
+        username: user
+        password: pass
+"#,
+        );
+        let oci_config = config.unwrap().global_defaults.oci;
+        assert_eq!(oci_config.registry, "docker.io");
+        assert_eq!(oci_config.auth.basic.username, "user");
+        assert_eq!(oci_config.auth.basic.password, "pass");
+        assert_eq!(oci_config.auth.bearer, "");
+
+        let config = serde_yaml::from_str::<AgentControlConfig>(
+            r#"
+agents: {}
+global_defaults:
+  oci:
+    auth:
+      bearer: token
+"#,
+        );
+        let oci_config = config.unwrap().global_defaults.oci;
+        assert_eq!(oci_config.registry, "docker.io");
+        assert_eq!(oci_config.auth.basic.username, "");
+        assert_eq!(oci_config.auth.basic.password, "");
+        assert_eq!(oci_config.auth.bearer, "token");
     }
 }

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -143,6 +143,8 @@ impl AgentControlRunner {
             ),
         ]);
 
+        let global_defaults = agent_control_config.defaults();
+
         let template_renderer = TemplateRenderer::default()
             .with_agent_control_variables(agent_control_variables.clone().into_iter());
 
@@ -161,6 +163,7 @@ impl AgentControlRunner {
             self.bootstrap_config.agent_type_var_constraints,
             secrets_providers,
             &self.base_paths.remote_dir,
+            global_defaults,
         ));
 
         let supervisor_builder = SupervisorBuilderK8s::new(k8s_client.clone(), k8s_config.clone());

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -104,6 +104,8 @@ impl AgentControlRunner {
             Variable::new_final_string_variable(identifiers.host_id.clone()),
         )]);
 
+        let global_defaults = agent_control_config.defaults();
+
         let instance_id_storer = Storer::from(file_store);
         let instance_id_getter =
             InstanceIDWithIdentifiersGetter::new(instance_id_storer, identifiers.clone());
@@ -152,6 +154,7 @@ impl AgentControlRunner {
             self.bootstrap_config.agent_type_var_constraints,
             secrets_providers,
             &remote_dir,
+            global_defaults,
         ));
 
         // We are setting client http in debug_assertions mode for tests

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -101,12 +101,9 @@ impl Tree<VariableDefinition> {
 }
 
 impl VariableTree {
-    pub fn template_defaults(
-        self,
-        global_defaults_vars: &Variables,
-    ) -> Result<Self, AgentTypeError> {
+    pub fn template_defaults(self, variables: &Variables) -> Result<Self, AgentTypeError> {
         let mut vars = self.0;
-        template_defaults_recursive(&mut vars, global_defaults_vars)?;
+        template_defaults_recursive(&mut vars, variables)?;
         Ok(Self(vars))
     }
 
@@ -120,15 +117,15 @@ impl VariableTree {
 
 fn template_defaults_recursive(
     agent_vars: &mut HashMap<String, Tree<Variable>>,
-    global_defaults_vars: &Variables,
+    variables: &Variables,
 ) -> Result<(), AgentTypeError> {
     for (_key, var_tree) in agent_vars.iter_mut() {
         match var_tree {
             Tree::End(variable) => {
-                variable.template_default(global_defaults_vars)?;
+                variable.template_default(variables)?;
             }
             Tree::Mapping(nested) => {
-                template_defaults_recursive(nested, global_defaults_vars)?;
+                template_defaults_recursive(nested, variables)?;
             }
         }
     }

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -101,21 +101,38 @@ impl Tree<VariableDefinition> {
 }
 
 impl VariableTree {
-    /// Returns a new [VariableTree] with the provided values assigned.
-    /// After user values are applied, global defaults are used to override agent-type defaults
-    /// for any variables that the user didn't provide.
-    pub fn fill_with_values(
+    pub fn template_defaults(
         self,
-        values: YAMLConfig,
-        global_defaults: HashMap<String, serde_yaml::Value>,
+        global_defaults_vars: &Variables,
     ) -> Result<Self, AgentTypeError> {
         let mut vars = self.0;
-        // First apply user-provided values
-        update_specs(values.into(), &mut vars)?;
-        // Then apply global defaults to variables not provided by user
-        apply_global_defaults(&mut vars, &global_defaults)?;
+        template_defaults_recursive(&mut vars, global_defaults_vars)?;
         Ok(Self(vars))
     }
+
+    /// Returns a new [VariableTree] with the provided values assigned.
+    pub fn fill_with_values(self, values: YAMLConfig) -> Result<Self, AgentTypeError> {
+        let mut vars = self.0;
+        update_specs(values.into(), &mut vars)?;
+        Ok(Self(vars))
+    }
+}
+
+fn template_defaults_recursive(
+    agent_vars: &mut HashMap<String, Tree<Variable>>,
+    global_defaults_vars: &Variables,
+) -> Result<(), AgentTypeError> {
+    for (_key, var_tree) in agent_vars.iter_mut() {
+        match var_tree {
+            Tree::End(variable) => {
+                variable.template_default(global_defaults_vars)?;
+            }
+            Tree::Mapping(nested) => {
+                template_defaults_recursive(nested, global_defaults_vars)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn update_specs(
@@ -133,35 +150,6 @@ fn update_specs(
             Tree::Mapping(m) => {
                 let v: HashMap<String, serde_yaml::Value> = serde_yaml::from_value(value)?;
                 update_specs(v, m)?
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Applies global defaults to variables that don't have user-provided values.
-/// For each variable in the tree, if the variable's default value exists as a key
-/// in global_defaults and the variable doesn't have a final_value (user didn't provide it),
-/// the global default value replaces the agent-type's default.
-///
-/// Example: If a variable has default "registry_url" and global_defaults contains
-/// {"registry_url": "docker.io"}, the variable's default will be replaced with "docker.io".
-fn apply_global_defaults(
-    agent_vars: &mut HashMap<String, Tree<Variable>>,
-    global_defaults: &HashMap<String, serde_yaml::Value>,
-) -> Result<(), AgentTypeError> {
-    for (_key, var_tree) in agent_vars.iter_mut() {
-        match var_tree {
-            Tree::End(variable) => {
-                // Look up by the variable's default value, not by the variable name
-                if let Some(default_key) = variable.get_default_as_key()
-                    && let Some(global_value) = global_defaults.get(&default_key)
-                {
-                    variable.set_default_from_global(global_value.clone())?;
-                }
-            }
-            Tree::Mapping(nested) => {
-                apply_global_defaults(nested, global_defaults)?;
             }
         }
     }
@@ -322,7 +310,7 @@ pub mod tests {
             let values = serde_yaml::from_str::<YAMLConfig>(yaml_values).unwrap();
             self.variables
                 .clone()
-                .fill_with_values(values, HashMap::new())
+                .fill_with_values(values)
                 .unwrap()
                 .flatten()
         }
@@ -588,7 +576,7 @@ restart_policy:
         let filled_variables_result = agent_type
             .variables
             .clone()
-            .fill_with_values(invalid_values, HashMap::new());
+            .fill_with_values(invalid_values);
         assert!(filled_variables_result.is_err());
         assert_eq!(
             filled_variables_result.unwrap_err().to_string(),

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -102,9 +102,18 @@ impl Tree<VariableDefinition> {
 
 impl VariableTree {
     /// Returns a new [VariableTree] with the provided values assigned.
-    pub fn fill_with_values(self, values: YAMLConfig) -> Result<Self, AgentTypeError> {
+    /// After user values are applied, global defaults are used to override agent-type defaults
+    /// for any variables that the user didn't provide.
+    pub fn fill_with_values(
+        self,
+        values: YAMLConfig,
+        global_defaults: HashMap<String, serde_yaml::Value>,
+    ) -> Result<Self, AgentTypeError> {
         let mut vars = self.0;
+        // First apply user-provided values
         update_specs(values.into(), &mut vars)?;
+        // Then apply global defaults to variables not provided by user
+        apply_global_defaults(&mut vars, &global_defaults)?;
         Ok(Self(vars))
     }
 }
@@ -124,6 +133,35 @@ fn update_specs(
             Tree::Mapping(m) => {
                 let v: HashMap<String, serde_yaml::Value> = serde_yaml::from_value(value)?;
                 update_specs(v, m)?
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Applies global defaults to variables that don't have user-provided values.
+/// For each variable in the tree, if the variable's default value exists as a key
+/// in global_defaults and the variable doesn't have a final_value (user didn't provide it),
+/// the global default value replaces the agent-type's default.
+///
+/// Example: If a variable has default "registry_url" and global_defaults contains
+/// {"registry_url": "docker.io"}, the variable's default will be replaced with "docker.io".
+fn apply_global_defaults(
+    agent_vars: &mut HashMap<String, Tree<Variable>>,
+    global_defaults: &HashMap<String, serde_yaml::Value>,
+) -> Result<(), AgentTypeError> {
+    for (_key, var_tree) in agent_vars.iter_mut() {
+        match var_tree {
+            Tree::End(variable) => {
+                // Look up by the variable's default value, not by the variable name
+                if let Some(default_key) = variable.get_default_as_key()
+                    && let Some(global_value) = global_defaults.get(&default_key)
+                {
+                    variable.set_default_from_global(global_value.clone())?;
+                }
+            }
+            Tree::Mapping(nested) => {
+                apply_global_defaults(nested, global_defaults)?;
             }
         }
     }
@@ -284,7 +322,7 @@ pub mod tests {
             let values = serde_yaml::from_str::<YAMLConfig>(yaml_values).unwrap();
             self.variables
                 .clone()
-                .fill_with_values(values)
+                .fill_with_values(values, HashMap::new())
                 .unwrap()
                 .flatten()
         }
@@ -550,7 +588,7 @@ restart_policy:
         let filled_variables_result = agent_type
             .variables
             .clone()
-            .fill_with_values(invalid_values);
+            .fill_with_values(invalid_values, HashMap::new());
         assert!(filled_variables_result.is_err());
         assert_eq!(
             filled_variables_result.unwrap_err().to_string(),

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -684,6 +684,26 @@ fn iterate_test_cases(environment: &Environment) {
 
         let agent_id = AgentID::try_from("random-agent-id").unwrap();
 
+        // Create default global defaults for OCI configuration
+        let global_defaults = HashMap::from([
+            (
+                "oci.registry".to_string(),
+                serde_yaml::Value::String("docker.io".to_string()),
+            ),
+            (
+                "oci.auth.basic.username".to_string(),
+                serde_yaml::Value::String("".to_string()),
+            ),
+            (
+                "oci.auth.basic.password".to_string(),
+                serde_yaml::Value::String("".to_string()),
+            ),
+            (
+                "oci.auth.bearer".to_string(),
+                serde_yaml::Value::String("".to_string()),
+            ),
+        ]);
+
         // Create the renderer with specifics for the environment
         let renderer = match environment {
             Environment::K8s => TemplateRenderer::default().with_agent_control_variables(
@@ -719,6 +739,7 @@ fn iterate_test_cases(environment: &Environment) {
                 attributes,
                 values.additional_env.clone(),
                 HashMap::new(), // Secrets are not used in this test
+                global_defaults.clone(),
             );
 
             assert!(

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -27,4 +27,6 @@ pub enum AgentTypeError {
     ConflictingVariableDefinition(String),
     #[error("error parsing oci reference: {0}")]
     OCIReferenceParsingError(String),
+    #[error("error with OCI auth configuration: {0}")]
+    OCIAuthError(String),
 }

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -47,11 +47,13 @@ impl TemplateRenderer {
                     Variable::from(value),
                 )
             })
-            .collect();
+            .collect::<HashMap<String, Variable>>();
+        let mut default_vars = global_defaults_vars;
+        default_vars.extend(env_vars.clone());
 
         // Template defaults in variables, then fill with user values, then flatten
         let filled_variables = variables
-            .template_defaults(&global_defaults_vars)?
+            .template_defaults(&default_vars)?
             .fill_with_values(values_expanded)?
             .flatten();
 
@@ -659,6 +661,11 @@ name: first
 version: 0.1.0
 variables:
   common:
+    id:
+      description: "id"
+      type: string
+      required: false
+      default: ${nr-env:id}
     path:
       description: "path"
       type: string
@@ -678,14 +685,14 @@ deployment:
   linux:
     enable_file_logging: ${nr-var:enable_file_logging}
     executables:
-      - id: first
+      - id: ${nr-var:id}
         path: ${nr-var:path}
         args:
           - "${nr-var:registry}"
   windows:
     enable_file_logging: ${nr-var:enable_file_logging}
     executables:
-      - id: first
+      - id: ${nr-var:id}
         path: ${nr-var:path}
         args:
           - "${nr-var:registry}"
@@ -715,6 +722,11 @@ path: /opt/first
             ),
         ]);
 
+        let env_vars = HashMap::from([(
+            Namespace::EnvironmentVariable.namespaced_name("id"),
+            Variable::new_final_string_variable("first".to_string()),
+        )]);
+
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
         let runtime_config = renderer
@@ -722,7 +734,7 @@ path: /opt/first
                 agent_type,
                 values,
                 attributes,
-                HashMap::new(),
+                env_vars,
                 HashMap::new(),
                 global_defaults,
             )
@@ -733,6 +745,7 @@ path: /opt/first
             .first()
             .unwrap()
             .clone();
+        assert_eq!("first".to_string(), executable.id.clone());
         assert_eq!("/opt/first".to_string(), executable.path.clone());
         assert_eq!(
             rendered::Args(vec!("test-registry-url/test-repository".to_string())),

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -669,14 +669,21 @@ variables:
       type: string
       required: false
       default: "${nr-default:registry_url}/test-repository"
+    enable_file_logging:
+      description: "enable file logging"
+      type: bool
+      required: false
+      default: ${nr-default:enable_file_logging}
 deployment:
   linux:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: ${nr-var:path}
         args:
           - "${nr-var:registry}"
   windows:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: ${nr-var:path}
@@ -702,6 +709,10 @@ path: /opt/first
                 "registry_url".to_string(),
                 serde_yaml::to_value("test-registry-url").unwrap(),
             ),
+            (
+                "enable_file_logging".to_string(),
+                serde_yaml::to_value(true).unwrap(),
+            ),
         ]);
 
         let renderer =
@@ -717,7 +728,7 @@ path: /opt/first
             )
             .unwrap();
 
-        let executable = extract_runtime_by_environment(runtime_config)
+        let executable = extract_runtime_by_environment(runtime_config.clone())
             .executables
             .first()
             .unwrap()
@@ -727,6 +738,7 @@ path: /opt/first
             rendered::Args(vec!("test-registry-url/test-repository".to_string())),
             executable.args.clone()
         );
+        assert!(extract_runtime_by_environment(runtime_config.clone()).enable_file_logging);
     }
 
     #[test]
@@ -744,15 +756,22 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: "${nr-default:registry_url}"
+      default: "${nr-default:registry_url}/test-repository"
+    enable_file_logging:
+      description: "enable file logging"
+      type: bool
+      required: false
+      default: ${nr-default:enable_file_logging}
 deployment:
   linux:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
         args:
           - "${nr-var:registry}"
   windows:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
@@ -764,15 +783,27 @@ deployment:
         let values = testing_values("");
         let attributes = testing_agent_attributes(&agent_id);
 
-        let global_defaults = HashMap::from([(
-            "registry_url".to_string(),
-            serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
-        )]);
+        let global_defaults = HashMap::from([
+            (
+                "registry_url".to_string(),
+                serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
+            ),
+            (
+                "enable_file_logging".to_string(),
+                serde_yaml::to_value("${nr-env:ENABLE_FILE_LOGGING}").unwrap(),
+            ),
+        ]);
 
-        let secrets = HashMap::from([(
-            Namespace::EnvironmentVariable.namespaced_name("REGISTRY_URL"),
-            Variable::new_final_string_variable("random-registry-url".to_string()),
-        )]);
+        let secrets = HashMap::from([
+            (
+                Namespace::EnvironmentVariable.namespaced_name("REGISTRY_URL"),
+                Variable::new_final_string_variable("test-registry-url".to_string()),
+            ),
+            (
+                Namespace::EnvironmentVariable.namespaced_name("ENABLE_FILE_LOGGING"),
+                Variable::from(serde_yaml::Value::Bool(true)),
+            ),
+        ]);
 
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
@@ -787,14 +818,15 @@ deployment:
             )
             .unwrap();
         assert_eq!(
-            rendered::Args(vec!("random-registry-url".to_string())),
-            extract_runtime_by_environment(runtime_config)
+            rendered::Args(vec!("test-registry-url/test-repository".to_string())),
+            extract_runtime_by_environment(runtime_config.clone())
                 .executables
                 .first()
                 .unwrap()
                 .args
                 .clone()
         );
+        assert!(extract_runtime_by_environment(runtime_config.clone()).enable_file_logging);
     }
 
     // Agent Type and Values definitions

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -114,15 +114,20 @@ fn global_defaults_to_variables(global_defaults: HashMap<String, serde_yaml::Val
     global_defaults
         .into_iter()
         .map(|(key, value)| {
-            // Convert the YAML value to a string representation
-            let string_value = match value {
-                serde_yaml::Value::String(s) => s,
-                other => serde_yaml::to_string(&other)
-                    .unwrap_or_else(|_| String::new())
-                    .trim()
-                    .to_string(),
+            // Create the appropriate Variable type based on the YAML value type
+            let var = match value {
+                serde_yaml::Value::String(s) => Variable::new_final_string_variable(s),
+                serde_yaml::Value::Bool(b) => Variable::new_final_bool_variable(b),
+                serde_yaml::Value::Number(n) => Variable::new_final_number_variable(n),
+                serde_yaml::Value::Mapping(m) => {
+                    let map: HashMap<String, serde_yaml::Value> = m
+                        .into_iter()
+                        .filter_map(|(k, v)| k.as_str().map(|s| (s.to_string(), v)))
+                        .collect();
+                    Variable::new_final_mapping_variable(map)
+                }
+                other => Variable::new_final_yaml_variable(other),
             };
-            let var = Variable::new_final_string_variable(string_value);
             (Namespace::Default.namespaced_name(&key), var)
         })
         .collect()
@@ -673,15 +678,22 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: "${nr-default:registry_url}"
+      default: "${nr-default:registry_url}/test-repository"
+    enable_file_logging:
+      description: "enable file logging"
+      type: bool
+      required: false
+      default: ${nr-default:enable_file_logging}
 deployment:
   linux:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
         args:
           - "${nr-var:registry}"
   windows:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
@@ -693,10 +705,16 @@ deployment:
         let values = testing_values("");
         let attributes = testing_agent_attributes(&agent_id);
 
-        let global_defaults = HashMap::from([(
-            "registry_url".to_string(),
-            serde_yaml::to_value("random-registry-url").unwrap(),
-        )]);
+        let global_defaults = HashMap::from([
+            (
+                "registry_url".to_string(),
+                serde_yaml::to_value("test-registry-url").unwrap(),
+            ),
+            (
+                "enable_file_logging".to_string(),
+                serde_yaml::to_value(true).unwrap(),
+            ),
+        ]);
 
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
@@ -711,13 +729,17 @@ deployment:
             )
             .unwrap();
         assert_eq!(
-            rendered::Args(vec!("random-registry-url".to_string())),
-            extract_runtime_by_environment(runtime_config)
+            rendered::Args(vec!("test-registry-url/test-repository".to_string())),
+            extract_runtime_by_environment(runtime_config.clone())
                 .executables
                 .first()
                 .unwrap()
                 .args
                 .clone()
+        );
+        assert_eq!(
+            true,
+            extract_runtime_by_environment(runtime_config.clone()).enable_file_logging
         );
     }
 
@@ -736,15 +758,22 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: "${nr-default:registry_url}"
+      default: "${nr-default:registry_url}/test-repository"
+    enable_file_logging:
+      description: "enable file logging"
+      type: bool
+      required: false
+      default: ${nr-default:enable_file_logging}
 deployment:
   linux:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
         args:
           - "${nr-var:registry}"
   windows:
+    enable_file_logging: ${nr-var:enable_file_logging}
     executables:
       - id: first
         path: /opt/first
@@ -756,15 +785,27 @@ deployment:
         let values = testing_values("");
         let attributes = testing_agent_attributes(&agent_id);
 
-        let global_defaults = HashMap::from([(
-            "registry_url".to_string(),
-            serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
-        )]);
+        let global_defaults = HashMap::from([
+            (
+                "registry_url".to_string(),
+                serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
+            ),
+            (
+                "enable_file_logging".to_string(),
+                serde_yaml::to_value("${nr-env:ENABLE_FILE_LOGGING}").unwrap(),
+            ),
+        ]);
 
-        let secrets = HashMap::from([(
-            Namespace::EnvironmentVariable.namespaced_name("REGISTRY_URL"),
-            Variable::new_final_string_variable("random-registry-url".to_string()),
-        )]);
+        let secrets = HashMap::from([
+            (
+                Namespace::EnvironmentVariable.namespaced_name("REGISTRY_URL"),
+                Variable::new_final_string_variable("test-registry-url".to_string()),
+            ),
+            (
+                Namespace::EnvironmentVariable.namespaced_name("ENABLE_FILE_LOGGING"),
+                Variable::new_final_bool_variable(true),
+            ),
+        ]);
 
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
@@ -779,13 +820,17 @@ deployment:
             )
             .unwrap();
         assert_eq!(
-            rendered::Args(vec!("random-registry-url".to_string())),
-            extract_runtime_by_environment(runtime_config)
+            rendered::Args(vec!("test-registry-url/test-repository".to_string())),
+            extract_runtime_by_environment(runtime_config.clone())
                 .executables
                 .first()
                 .unwrap()
                 .args
                 .clone()
+        );
+        assert_eq!(
+            true,
+            extract_runtime_by_environment(runtime_config.clone()).enable_file_logging
         );
     }
 

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -38,9 +38,21 @@ impl TemplateRenderer {
         // Expand templates in global defaults (so they can reference secrets/env vars)
         let global_defaults_expanded = global_defaults.template_with(&secrets)?;
 
-        // Fill agent variables with user values and global defaults, then flatten
+        // Convert global defaults to Variables with nr-default namespace
+        let global_defaults_vars = global_defaults_expanded
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    Namespace::Default.namespaced_name(&key),
+                    Variable::from(value),
+                )
+            })
+            .collect();
+
+        // Template defaults in variables, then fill with user values, then flatten
         let filled_variables = variables
-            .fill_with_values(values_expanded, global_defaults_expanded)?
+            .template_defaults(&global_defaults_vars)?
+            .fill_with_values(values_expanded)?
             .flatten();
 
         Self::check_all_vars_are_populated(&filled_variables)?;
@@ -330,7 +342,7 @@ pub(crate) mod tests {
                 agent_type
                     .variables
                     .clone()
-                    .fill_with_values(values, HashMap::new())
+                    .fill_with_values(values)
                     .is_err()
             )
         }
@@ -647,34 +659,50 @@ name: first
 version: 0.1.0
 variables:
   common:
+    path:
+      description: "path"
+      type: string
+      required: false
+      default: ${nr-default:path}
     registry:
       description: "registry url"
       type: string
       required: false
-      default: registry_url
+      default: "${nr-default:registry_url}/test-repository"
 deployment:
   linux:
     executables:
       - id: first
-        path: /opt/first
-        args: 
+        path: ${nr-var:path}
+        args:
           - "${nr-var:registry}"
   windows:
     executables:
       - id: first
-        path: /opt/first
-        args: 
+        path: ${nr-var:path}
+        args:
           - "${nr-var:registry}"
 "#,
             &AGENT_CONTROL_MODE_ON_HOST,
         );
-        let values = testing_values("");
+
+        let values = testing_values(
+            r#"
+path: /opt/first
+"#,
+        );
         let attributes = testing_agent_attributes(&agent_id);
 
-        let global_defaults = HashMap::from([(
-            "registry_url".to_string(),
-            serde_yaml::to_value("random-registry-url").unwrap(),
-        )]);
+        let global_defaults = HashMap::from([
+            (
+                "path".to_string(),
+                serde_yaml::to_value("/opt/second").unwrap(),
+            ),
+            (
+                "registry_url".to_string(),
+                serde_yaml::to_value("test-registry-url").unwrap(),
+            ),
+        ]);
 
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
@@ -688,14 +716,16 @@ deployment:
                 global_defaults,
             )
             .unwrap();
+
+        let executable = extract_runtime_by_environment(runtime_config)
+            .executables
+            .first()
+            .unwrap()
+            .clone();
+        assert_eq!("/opt/first".to_string(), executable.path.clone());
         assert_eq!(
-            rendered::Args(vec!("random-registry-url".to_string())),
-            extract_runtime_by_environment(runtime_config)
-                .executables
-                .first()
-                .unwrap()
-                .args
-                .clone()
+            rendered::Args(vec!("test-registry-url/test-repository".to_string())),
+            executable.args.clone()
         );
     }
 
@@ -714,19 +744,19 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: registry_url
+      default: "${nr-default:registry_url}"
 deployment:
   linux:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
   windows:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
 "#,
             &AGENT_CONTROL_MODE_ON_HOST,

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -26,6 +26,7 @@ impl TemplateRenderer {
         attributes: AgentAttributes,
         env_vars: HashMap<String, Variable>,
         secrets: HashMap<String, Variable>,
+        global_defaults: HashMap<String, serde_yaml::Value>,
     ) -> Result<Runtime, AgentTypeError> {
         // Get empty variables and runtime_config from the agent-type
         let (variables, runtime_config) = (agent_type.variables, agent_type.runtime_config);
@@ -34,8 +35,13 @@ impl TemplateRenderer {
         // Notice that only environment variables and secrets are taken into consideration (no other vars for example)
         let values_expanded = values.template_with(&secrets)?;
 
-        // Fill agent variables
-        let filled_variables = variables.fill_with_values(values_expanded)?.flatten();
+        // Expand templates in global defaults (so they can reference secrets/env vars)
+        let global_defaults_expanded = global_defaults.template_with(&secrets)?;
+
+        // Fill agent variables with user values and global defaults, then flatten
+        let filled_variables = variables
+            .fill_with_values(values_expanded, global_defaults_expanded)?
+            .flatten();
 
         Self::check_all_vars_are_populated(&filled_variables)?;
 
@@ -145,6 +151,7 @@ pub(crate) mod tests {
                 attributes,
                 HashMap::new(),
                 HashMap::new(),
+                HashMap::new(),
             )
             .unwrap();
 
@@ -181,6 +188,7 @@ pub(crate) mod tests {
             attributes,
             HashMap::new(),
             HashMap::new(),
+            HashMap::new(),
         );
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
@@ -200,6 +208,7 @@ pub(crate) mod tests {
             agent_type,
             values,
             attributes,
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
         );
@@ -222,6 +231,7 @@ pub(crate) mod tests {
                 agent_type,
                 values,
                 attributes,
+                HashMap::new(),
                 HashMap::new(),
                 HashMap::new(),
             )
@@ -274,6 +284,7 @@ pub(crate) mod tests {
                 attributes,
                 HashMap::new(),
                 HashMap::new(),
+                HashMap::new(),
             )
             .unwrap();
 
@@ -319,7 +330,7 @@ pub(crate) mod tests {
                 agent_type
                     .variables
                     .clone()
-                    .fill_with_values(values)
+                    .fill_with_values(values, HashMap::new())
                     .is_err()
             )
         }
@@ -355,6 +366,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
                 agent_type,
                 values,
                 attributes,
+                HashMap::new(),
                 HashMap::new(),
                 HashMap::new(),
             )
@@ -410,8 +422,14 @@ substituted_2: my-value-2
             serde_yaml::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(
+            agent_type,
+            values,
+            attributes,
+            env_vars,
+            HashMap::new(),
+            HashMap::new(),
+        );
 
         let k8s = runtime_config.unwrap().deployment.k8s.unwrap();
         let cr1 = k8s.objects.get("cr1").unwrap();
@@ -465,8 +483,14 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             serde_yaml::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, HashMap::new(), secrets);
+        let runtime_config = renderer.render(
+            agent_type,
+            values,
+            attributes,
+            HashMap::new(),
+            secrets,
+            HashMap::new(),
+        );
 
         let k8s = runtime_config.unwrap().deployment.k8s.unwrap();
         let values = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
@@ -488,6 +512,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             agent_type,
             values,
             attributes,
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
         );
@@ -539,8 +564,14 @@ deployment:
         )]);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(
+            agent_type,
+            values,
+            attributes,
+            env_vars,
+            HashMap::new(),
+            HashMap::new(),
+        );
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -591,10 +622,142 @@ deployment:
                 attributes,
                 HashMap::new(),
                 HashMap::new(),
+                HashMap::new(),
             )
             .unwrap();
         assert_eq!(
             rendered::Args(vec!("fake_value".to_string())),
+            extract_runtime_by_environment(runtime_config)
+                .executables
+                .first()
+                .unwrap()
+                .args
+                .clone()
+        );
+    }
+
+    #[test]
+    fn test_render_global_defaults() {
+        let agent_id = AgentID::try_from("some-agent-id").unwrap();
+
+        let agent_type = AgentType::build_for_testing(
+            r#"
+namespace: newrelic
+name: first
+version: 0.1.0
+variables:
+  common:
+    registry:
+      description: "registry url"
+      type: string
+      required: false
+      default: registry_url
+deployment:
+  linux:
+    executables:
+      - id: first
+        path: /opt/first
+        args: 
+          - "${nr-var:registry}"
+  windows:
+    executables:
+      - id: first
+        path: /opt/first
+        args: 
+          - "${nr-var:registry}"
+"#,
+            &AGENT_CONTROL_MODE_ON_HOST,
+        );
+        let values = testing_values("");
+        let attributes = testing_agent_attributes(&agent_id);
+
+        let global_defaults = HashMap::from([(
+            "registry_url".to_string(),
+            serde_yaml::to_value("random-registry-url").unwrap(),
+        )]);
+
+        let renderer =
+            TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
+        let runtime_config = renderer
+            .render(
+                agent_type,
+                values,
+                attributes,
+                HashMap::new(),
+                HashMap::new(),
+                global_defaults,
+            )
+            .unwrap();
+        assert_eq!(
+            rendered::Args(vec!("random-registry-url".to_string())),
+            extract_runtime_by_environment(runtime_config)
+                .executables
+                .first()
+                .unwrap()
+                .args
+                .clone()
+        );
+    }
+
+    #[test]
+    fn test_render_global_defaults_secret_expansion() {
+        let agent_id = AgentID::try_from("some-agent-id").unwrap();
+
+        let agent_type = AgentType::build_for_testing(
+            r#"
+namespace: newrelic
+name: first
+version: 0.1.0
+variables:
+  common:
+    registry:
+      description: "registry url"
+      type: string
+      required: false
+      default: registry_url
+deployment:
+  linux:
+    executables:
+      - id: first
+        path: /opt/first
+        args: 
+          - "${nr-var:registry}"
+  windows:
+    executables:
+      - id: first
+        path: /opt/first
+        args: 
+          - "${nr-var:registry}"
+"#,
+            &AGENT_CONTROL_MODE_ON_HOST,
+        );
+        let values = testing_values("");
+        let attributes = testing_agent_attributes(&agent_id);
+
+        let global_defaults = HashMap::from([(
+            "registry_url".to_string(),
+            serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
+        )]);
+
+        let secrets = HashMap::from([(
+            Namespace::EnvironmentVariable.namespaced_name("REGISTRY_URL"),
+            Variable::new_final_string_variable("random-registry-url".to_string()),
+        )]);
+
+        let renderer =
+            TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
+        let runtime_config = renderer
+            .render(
+                agent_type,
+                values,
+                attributes,
+                HashMap::new(),
+                secrets,
+                global_defaults,
+            )
+            .unwrap();
+        assert_eq!(
+            rendered::Args(vec!("random-registry-url".to_string())),
             extract_runtime_by_environment(runtime_config)
                 .executables
                 .first()

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -1,6 +1,6 @@
 use crate::agent_type::{
     agent_attributes::AgentAttributes,
-    definition::AgentType,
+    definition::{AgentType, Variables},
     error::AgentTypeError,
     runtime_config::rendered::Runtime,
     templates::Templateable,
@@ -38,9 +38,13 @@ impl TemplateRenderer {
         // Expand templates in global defaults (so they can reference secrets/env vars)
         let global_defaults_expanded = global_defaults.template_with(&secrets)?;
 
-        // Fill agent variables with user values and global defaults, then flatten
+        // Convert global defaults to Variables with nr-default namespace
+        let global_defaults_vars = global_defaults_to_variables(global_defaults_expanded);
+
+        // Template defaults in variables, then fill with user values, then flatten
         let filled_variables = variables
-            .fill_with_values(values_expanded, global_defaults_expanded)?
+            .template_defaults(&global_defaults_vars)?
+            .fill_with_values(values_expanded)?
             .flatten();
 
         Self::check_all_vars_are_populated(&filled_variables)?;
@@ -104,6 +108,24 @@ impl TemplateRenderer {
             .chain(self.ac_variables.clone())
             .collect::<HashMap<NamespacedVariableName, Variable>>()
     }
+}
+
+fn global_defaults_to_variables(global_defaults: HashMap<String, serde_yaml::Value>) -> Variables {
+    global_defaults
+        .into_iter()
+        .map(|(key, value)| {
+            // Convert the YAML value to a string representation
+            let string_value = match value {
+                serde_yaml::Value::String(s) => s,
+                other => serde_yaml::to_string(&other)
+                    .unwrap_or_else(|_| String::new())
+                    .trim()
+                    .to_string(),
+            };
+            let var = Variable::new_final_string_variable(string_value);
+            (Namespace::Default.namespaced_name(&key), var)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -330,7 +352,7 @@ pub(crate) mod tests {
                 agent_type
                     .variables
                     .clone()
-                    .fill_with_values(values, HashMap::new())
+                    .fill_with_values(values)
                     .is_err()
             )
         }
@@ -651,19 +673,19 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: registry_url
+      default: "${nr-default:registry_url}"
 deployment:
   linux:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
   windows:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
 "#,
             &AGENT_CONTROL_MODE_ON_HOST,
@@ -714,19 +736,19 @@ variables:
       description: "registry url"
       type: string
       required: false
-      default: registry_url
+      default: "${nr-default:registry_url}"
 deployment:
   linux:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
   windows:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - "${nr-var:registry}"
 "#,
             &AGENT_CONTROL_MODE_ON_HOST,

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -741,11 +741,6 @@ executables:
             password: "",
             bearer: "token",
         };
-        const ALL: Self = Self {
-            username: "user",
-            password: "pass",
-            bearer: "token",
-        };
     }
 
     #[rstest]
@@ -754,7 +749,6 @@ executables:
     #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
     #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
     #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
-    #[case::all_credentials(PACKAGES, AuthCredentials::ALL, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
     fn test_auth_parsing(
         #[case] yaml: &str,
         #[case] creds: AuthCredentials,

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -106,6 +106,8 @@ mod tests {
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
     use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
+    use oci_client::secrets::RegistryAuth;
+    use rstest::rstest;
     use serde_yaml::Number;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -168,6 +170,7 @@ mod tests {
                     public_key_url: Some(TemplateableValue::from_template(
                         "${nr-var:public-key-url}".to_string(),
                     )),
+                    auth: package::Auth::default(),
                 },
             },
         };
@@ -176,7 +179,7 @@ mod tests {
             ("otel-first".to_string(), pkg.clone()),
             ("otel-second".to_string(), pkg),
         ]);
-        assert_eq!(on_host.packages, expected_packages)
+        assert_eq!(on_host.packages, expected_packages);
     }
 
     #[test]
@@ -716,6 +719,81 @@ executables:
         );
     }
 
+    struct AuthCredentials {
+        username: &'static str,
+        password: &'static str,
+        bearer: &'static str,
+    }
+
+    impl AuthCredentials {
+        const NONE: Self = Self {
+            username: "",
+            password: "",
+            bearer: "",
+        };
+        const BASIC: Self = Self {
+            username: "user",
+            password: "pass",
+            bearer: "",
+        };
+        const BEARER: Self = Self {
+            username: "",
+            password: "",
+            bearer: "token",
+        };
+        const ALL: Self = Self {
+            username: "user",
+            password: "pass",
+            bearer: "token",
+        };
+    }
+
+    #[rstest]
+    // This case checks backwards compatibility with old agent types not defining auth.
+    #[case::no_auth(PACKAGES_NO_AUTH, AuthCredentials::NONE, RegistryAuth::Anonymous)]
+    #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
+    #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
+    #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
+    #[case::all_credentials(PACKAGES, AuthCredentials::ALL, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
+    fn test_auth_parsing(
+        #[case] yaml: &str,
+        #[case] creds: AuthCredentials,
+        #[case] expected_auth: RegistryAuth,
+    ) {
+        let on_host: OnHost = serde_yaml::from_str(yaml).unwrap();
+
+        let mut vars = Variables::new();
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable("/filesystem".to_string()),
+        );
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+            Variable::new_final_string_variable("remote".to_string()),
+        );
+        vars.insert(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_SUB_AGENT_ID),
+            Variable::new_final_string_variable("agent-id".to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.basic.username".to_string(),
+            Variable::new_final_string_variable(creds.username.to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.basic.password".to_string(),
+            Variable::new_final_string_variable(creds.password.to_string()),
+        );
+        vars.insert(
+            "nr-var:oci.auth.bearer".to_string(),
+            Variable::new_final_string_variable(creds.bearer.to_string()),
+        );
+
+        let rendered = on_host.template_with(&vars).unwrap();
+        let pkg = rendered.packages.get("infra-agent").unwrap();
+
+        assert_eq!(pkg.download.oci.auth, expected_auth);
+    }
+
     pub const AGENT_GIVEN_YAML: &str = r#"
 health:
   interval: 3s
@@ -762,5 +840,30 @@ packages:
         repository: ${nr-var:repository}
         version: ${nr-var:version}
         public_key_url: ${nr-var:public-key-url}
+"#;
+
+    const PACKAGES_NO_AUTH: &str = r#"
+packages:
+  infra-agent:
+    download:
+      oci:
+        registry: docker.io
+        repository: repo/image
+        version: 0.0.1
+"#;
+
+    const PACKAGES: &str = r#"
+packages:
+  infra-agent:
+    download:
+      oci:
+        registry: docker.io
+        repository: repo/image
+        version: 0.0.1
+        auth:
+          basic:
+            username: ${nr-var:oci.auth.basic.username}
+            password: ${nr-var:oci.auth.basic.password}
+          bearer: ${nr-var:oci.auth.bearer}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -118,26 +118,30 @@ impl Templateable for Auth {
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         let username = self.basic.username.template_with(variables)?;
         let password = self.basic.password.template_with(variables)?;
-
-        if !username.is_empty() && !password.is_empty() {
-            debug!("Basic auth credentials provided, using basic auth");
-            return Ok(RegistryAuth::Basic(username, password));
-        }
-
-        debug!(
-            "Basic auth credentials not fully provided (username was empty: {}, password was empty: {})",
-            username.is_empty(),
-            password.is_empty()
-        );
-
         let token = self.bearer.template_with(variables)?;
-        if !token.is_empty() {
-            debug!("Bearer token provided, using bearer auth");
-            return Ok(RegistryAuth::Bearer(token));
-        }
 
-        debug!("No basic credentials or bearer token provided, falling back to anonymous auth");
-        Ok(RegistryAuth::Anonymous)
+        match (
+            !&username.is_empty(),
+            !&password.is_empty(),
+            !&token.is_empty(),
+        ) {
+            (false, false, false) => Ok(RegistryAuth::Anonymous),
+            (true, true, false) => {
+                debug!("Basic auth credentials provided, using basic auth");
+                Ok(RegistryAuth::Basic(username, password))
+            }
+            (false, false, true) => {
+                debug!("Bearer token provided, using bearer auth");
+                Ok(RegistryAuth::Bearer(token))
+            }
+            (true, true, true) => Err(AgentTypeError::OCIAuthError(
+                "multiple authentication methods provided, only one should be used".to_string(),
+            )),
+            (true, false, _) | (false, true, _) => Err(AgentTypeError::OCIAuthError(
+                "incomplete basic auth credentials provided, username or password is empty"
+                    .to_string(),
+            )),
+        }
     }
 }
 
@@ -276,5 +280,39 @@ mod tests {
             rendered_oci.auth,
             RegistryAuth::Bearer("bearer-token".to_string())
         );
+    }
+
+    #[test]
+    fn test_auth_error_when_multiple_credentials_provided() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:username".to_string(),
+            Variable::new_final_string_variable("myuser".to_string()),
+        );
+        variables.insert(
+            "nr-var:password".to_string(),
+            Variable::new_final_string_variable("mypass".to_string()),
+        );
+        variables.insert(
+            "nr-var:token".to_string(),
+            Variable::new_final_string_variable("bearer-token".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("gcr.io".to_string()),
+            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
+            version: TemplateableValue::from_template("latest".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth {
+                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
+                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
+                },
+                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables);
+        matches!(rendered_oci, Err(AgentTypeError::OCIAuthError(_)));
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -3,9 +3,10 @@ use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
 use crate::agent_type::templates::Templateable;
 use crate::oci::reference_parser::ReferenceParser;
-use oci_client::Reference;
+use oci_client::{Reference, secrets::RegistryAuth};
 use serde::Deserialize;
 use std::str::FromStr;
+use tracing::debug;
 use url::Url;
 
 pub mod rendered;
@@ -35,6 +36,21 @@ pub struct Oci {
     pub version: TemplateableValue<String>,
     /// Public key url is expected to be a jwks.
     pub public_key_url: Option<TemplateableValue<String>>,
+    /// Authentication method for the OCI registry.
+    #[serde(default)]
+    pub auth: Auth,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct Auth {
+    pub basic: BasicAuth,
+    pub bearer: TemplateableValue<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+pub struct BasicAuth {
+    pub username: TemplateableValue<String>,
+    pub password: TemplateableValue<String>,
 }
 
 impl Templateable for Package {
@@ -87,10 +103,41 @@ impl Templateable for Oci {
             })?,
         );
 
+        let auth = self.auth.template_with(variables)?;
+
         Ok(Self::Output {
             reference,
             public_key_url,
+            auth,
         })
+    }
+}
+
+impl Templateable for Auth {
+    type Output = RegistryAuth;
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        let username = self.basic.username.template_with(variables)?;
+        let password = self.basic.password.template_with(variables)?;
+
+        if !username.is_empty() && !password.is_empty() {
+            debug!("Basic auth credentials provided, using basic auth");
+            return Ok(RegistryAuth::Basic(username, password));
+        }
+
+        debug!(
+            "Basic auth credentials not fully provided (username was empty: {}, password was empty: {})",
+            username.is_empty(),
+            password.is_empty()
+        );
+
+        let token = self.bearer.template_with(variables)?;
+        if !token.is_empty() {
+            debug!("Bearer token provided, using bearer auth");
+            return Ok(RegistryAuth::Bearer(token));
+        }
+
+        debug!("No basic credentials or bearer token provided, falling back to anonymous auth");
+        Ok(RegistryAuth::Anonymous)
     }
 }
 
@@ -158,6 +205,7 @@ mod tests {
             public_key_url: public_key_url
                 .clone()
                 .map(|_| TemplateableValue::from_template("${nr-var:public-key}".to_string())),
+            auth: Auth::default(),
         };
 
         let rendered_oci = oci.template_with(&variables);
@@ -168,5 +216,65 @@ mod tests {
         assert_eq!(rendered_oci.reference.tag(), expected_tag);
         assert_eq!(rendered_oci.reference.digest(), expected_digest);
         assert_eq!(rendered_oci.public_key_url, public_key_url);
+        assert_eq!(rendered_oci.auth, RegistryAuth::Anonymous);
+    }
+
+    #[test]
+    fn test_auth_basic_with_templated_values() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:username".to_string(),
+            Variable::new_final_string_variable("myuser".to_string()),
+        );
+        variables.insert(
+            "nr-var:password".to_string(),
+            Variable::new_final_string_variable("mypass".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("docker.io".to_string()),
+            repository: TemplateableValue::from_template("myrepo/myimage".to_string()),
+            version: TemplateableValue::from_template("1.0.0".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth {
+                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
+                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
+                },
+                bearer: TemplateableValue::default(),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables).unwrap();
+        assert_eq!(
+            rendered_oci.auth,
+            RegistryAuth::Basic("myuser".to_string(), "mypass".to_string())
+        );
+    }
+
+    #[test]
+    fn test_auth_bearer_with_templated_value() {
+        let mut variables = Variables::new();
+        variables.insert(
+            "nr-var:token".to_string(),
+            Variable::new_final_string_variable("bearer-token".to_string()),
+        );
+
+        let oci = Oci {
+            registry: TemplateableValue::from_template("gcr.io".to_string()),
+            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
+            version: TemplateableValue::from_template("latest".to_string()),
+            public_key_url: None,
+            auth: Auth {
+                basic: BasicAuth::default(),
+                bearer: TemplateableValue::from_template("${nr-var:token}".to_string()),
+            },
+        };
+
+        let rendered_oci = oci.template_with(&variables).unwrap();
+        assert_eq!(
+            rendered_oci.auth,
+            RegistryAuth::Bearer("bearer-token".to_string())
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -1,4 +1,4 @@
-use oci_client::Reference;
+use oci_client::{Reference, secrets::RegistryAuth};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,4 +17,5 @@ pub struct Download {
 pub struct Oci {
     pub reference: Reference,
     pub public_key_url: Option<Url>,
+    pub auth: RegistryAuth,
 }

--- a/agent-control/src/agent_type/variable.rs
+++ b/agent-control/src/agent_type/variable.rs
@@ -14,6 +14,8 @@ pub mod tree;
 pub mod variable_type;
 pub mod variants;
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
@@ -53,6 +55,53 @@ impl VariableDefinition {
     }
 }
 
+impl From<serde_yaml::Value> for Variable {
+    fn from(value: serde_yaml::Value) -> Self {
+        let variable_type = match value {
+            serde_yaml::Value::String(s) => VariableType::String(StringFields {
+                inner: Fields {
+                    required: false,
+                    default: None,
+                    final_value: Some(s),
+                },
+                variants: Default::default(),
+            }),
+            serde_yaml::Value::Bool(b) => VariableType::Bool(Fields {
+                required: false,
+                default: None,
+                final_value: Some(b),
+            }),
+            serde_yaml::Value::Number(n) => VariableType::Number(Fields {
+                required: false,
+                default: None,
+                final_value: Some(n),
+            }),
+            serde_yaml::Value::Mapping(m) => {
+                let map: HashMap<String, serde_yaml::Value> = m
+                    .into_iter()
+                    .filter_map(|(k, v)| k.as_str().map(|s| (s.to_string(), v)))
+                    .collect();
+
+                VariableType::MapStringYaml(Fields {
+                    required: false,
+                    default: None,
+                    final_value: Some(map),
+                })
+            }
+            _ => VariableType::Yaml(Fields {
+                required: false,
+                default: None,
+                final_value: Some(value),
+            }),
+        };
+
+        Self {
+            description: String::new(),
+            variable_type,
+        }
+    }
+}
+
 impl Variable {
     pub fn new_final_string_variable(final_value: impl ToString) -> Self {
         Self {
@@ -80,25 +129,11 @@ impl Variable {
         self.variable_type.merge_with_yaml_value(yaml)
     }
 
-    /// Sets the default value from a global default configuration.
-    /// Only applies if the user hasn't already provided a final value.
-    pub(crate) fn set_default_from_global(
+    pub fn template_default(
         &mut self,
-        value: serde_yaml::Value,
+        global_defaults_vars: &HashMap<String, Variable>,
     ) -> Result<(), AgentTypeError> {
-        // Only set default if we don't already have a final_value (user didn't provide it)
-        // Check final_value directly, not get_final_value() which includes defaults
-        if self.variable_type.has_final_value() {
-            return Ok(());
-        }
-
-        self.variable_type.set_default(value)
-    }
-
-    /// Gets the default value as a string key for looking up in global defaults.
-    /// Returns None if there's no default or if the default is not a string.
-    pub(crate) fn get_default_as_key(&self) -> Option<String> {
-        self.variable_type.get_default_as_key()
+        self.variable_type.template_default(global_defaults_vars)
     }
 
     pub fn kind(&self) -> &VariableType {

--- a/agent-control/src/agent_type/variable.rs
+++ b/agent-control/src/agent_type/variable.rs
@@ -64,8 +64,57 @@ impl Variable {
                     required: false,
                     default: None,
                     final_value: Some(final_value.to_string()),
+                    default_template: None,
                 },
                 variants: Default::default(),
+            }),
+        }
+    }
+
+    pub fn new_final_bool_variable(final_value: bool) -> Self {
+        Self {
+            description: String::new(),
+            variable_type: VariableType::Bool(Fields {
+                required: false,
+                default: None,
+                final_value: Some(final_value),
+                default_template: None,
+            }),
+        }
+    }
+
+    pub fn new_final_number_variable(final_value: serde_yaml::Number) -> Self {
+        Self {
+            description: String::new(),
+            variable_type: VariableType::Number(Fields {
+                required: false,
+                default: None,
+                final_value: Some(final_value),
+                default_template: None,
+            }),
+        }
+    }
+
+    pub fn new_final_mapping_variable(final_value: HashMap<String, serde_yaml::Value>) -> Self {
+        Self {
+            description: String::new(),
+            variable_type: VariableType::MapStringYaml(Fields {
+                required: false,
+                default: None,
+                final_value: Some(final_value),
+                default_template: None,
+            }),
+        }
+    }
+
+    pub fn new_final_yaml_variable(final_value: serde_yaml::Value) -> Self {
+        Self {
+            description: String::new(),
+            variable_type: VariableType::Yaml(Fields {
+                required: false,
+                default: None,
+                final_value: Some(final_value),
+                default_template: None,
             }),
         }
     }
@@ -164,6 +213,7 @@ mod tests {
 
     #[test]
     fn variable_definition_tree_deserialize() {
+        use super::fields::DefaultValue;
         let value = r#"
 foo:
   bar:
@@ -188,7 +238,7 @@ foo:
                         variable_type: VariableTypeDefinition::String(StringFieldsDefinition {
                             inner: FieldsDefinition {
                                 required: false,
-                                default: Some("a".to_string()),
+                                default: Some(DefaultValue::Value("a".to_string())),
                             },
                             variants: VariantsConfig {
                                 ac_config_field: Some("foo.bar.var_name".to_string()),

--- a/agent-control/src/agent_type/variable.rs
+++ b/agent-control/src/agent_type/variable.rs
@@ -80,6 +80,27 @@ impl Variable {
         self.variable_type.merge_with_yaml_value(yaml)
     }
 
+    /// Sets the default value from a global default configuration.
+    /// Only applies if the user hasn't already provided a final value.
+    pub(crate) fn set_default_from_global(
+        &mut self,
+        value: serde_yaml::Value,
+    ) -> Result<(), AgentTypeError> {
+        // Only set default if we don't already have a final_value (user didn't provide it)
+        // Check final_value directly, not get_final_value() which includes defaults
+        if self.variable_type.has_final_value() {
+            return Ok(());
+        }
+
+        self.variable_type.set_default(value)
+    }
+
+    /// Gets the default value as a string key for looking up in global defaults.
+    /// Returns None if there's no default or if the default is not a string.
+    pub(crate) fn get_default_as_key(&self) -> Option<String> {
+        self.variable_type.get_default_as_key()
+    }
+
     pub fn kind(&self) -> &VariableType {
         &self.variable_type
     }

--- a/agent-control/src/agent_type/variable.rs
+++ b/agent-control/src/agent_type/variable.rs
@@ -14,6 +14,8 @@ pub mod tree;
 pub mod variable_type;
 pub mod variants;
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
@@ -80,25 +82,11 @@ impl Variable {
         self.variable_type.merge_with_yaml_value(yaml)
     }
 
-    /// Sets the default value from a global default configuration.
-    /// Only applies if the user hasn't already provided a final value.
-    pub(crate) fn set_default_from_global(
+    pub fn template_default(
         &mut self,
-        value: serde_yaml::Value,
+        global_defaults_vars: &HashMap<String, Variable>,
     ) -> Result<(), AgentTypeError> {
-        // Only set default if we don't already have a final_value (user didn't provide it)
-        // Check final_value directly, not get_final_value() which includes defaults
-        if self.variable_type.has_final_value() {
-            return Ok(());
-        }
-
-        self.variable_type.set_default(value)
-    }
-
-    /// Gets the default value as a string key for looking up in global defaults.
-    /// Returns None if there's no default or if the default is not a string.
-    pub(crate) fn get_default_as_key(&self) -> Option<String> {
-        self.variable_type.get_default_as_key()
+        self.variable_type.template_default(global_defaults_vars)
     }
 
     pub fn kind(&self) -> &VariableType {

--- a/agent-control/src/agent_type/variable.rs
+++ b/agent-control/src/agent_type/variable.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
+    definition::Variables,
     error::AgentTypeError,
     trivial_value::TrivialValue,
     variable::{
@@ -129,11 +130,8 @@ impl Variable {
         self.variable_type.merge_with_yaml_value(yaml)
     }
 
-    pub fn template_default(
-        &mut self,
-        global_defaults_vars: &HashMap<String, Variable>,
-    ) -> Result<(), AgentTypeError> {
-        self.variable_type.template_default(global_defaults_vars)
+    pub fn template_default(&mut self, variables: &Variables) -> Result<(), AgentTypeError> {
+        self.variable_type.template_default(variables)
     }
 
     pub fn kind(&self) -> &VariableType {
@@ -211,6 +209,7 @@ mod tests {
 
     #[test]
     fn variable_definition_tree_deserialize() {
+        use super::fields::DefaultValue;
         let value = r#"
 foo:
   bar:
@@ -235,7 +234,7 @@ foo:
                         variable_type: VariableTypeDefinition::String(StringFieldsDefinition {
                             inner: FieldsDefinition {
                                 required: false,
-                                default: Some("a".to_string()),
+                                default: Some(DefaultValue::Value("a".to_string())),
                             },
                             variants: VariantsConfig {
                                 ac_config_field: Some("foo.bar.var_name".to_string()),

--- a/agent-control/src/agent_type/variable/fields.rs
+++ b/agent-control/src/agent_type/variable/fields.rs
@@ -119,11 +119,6 @@ where
         self.final_value = Some(value);
         Ok(())
     }
-
-    pub(crate) fn set_default(&mut self, value: T) -> Result<(), AgentTypeError> {
-        self.default = Some(value);
-        Ok(())
-    }
 }
 
 impl StringFields {
@@ -132,14 +127,6 @@ impl StringFields {
             return Err(AgentTypeError::InvalidVariant(self.variants.to_string()));
         }
         self.inner.set_final_value(value)?;
-        Ok(())
-    }
-
-    pub(crate) fn set_default(&mut self, value: String) -> Result<(), AgentTypeError> {
-        if !self.variants.is_valid(&value) {
-            return Err(AgentTypeError::InvalidVariant(self.variants.to_string()));
-        }
-        self.inner.set_default(value)?;
         Ok(())
     }
 }

--- a/agent-control/src/agent_type/variable/fields.rs
+++ b/agent-control/src/agent_type/variable/fields.rs
@@ -8,9 +8,52 @@ use crate::agent_type::{
     error::AgentTypeError,
     variable::{
         constraints::{VariableConstraints, VariantsConstraints},
+        namespace::Namespace,
         variants::{Variants, VariantsConfig},
     },
 };
+
+/// Represents a default value that can be either a direct value of type T or a template string
+#[derive(Debug, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
+pub enum DefaultValue<T>
+where
+    T: PartialEq,
+{
+    Value(T),
+    Template(String),
+}
+
+impl<'de, T> Deserialize<'de> for DefaultValue<T>
+where
+    T: serde::de::DeserializeOwned + PartialEq,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize as a YAML value first
+        let yaml_val = serde_yaml::Value::deserialize(deserializer)?;
+
+        // Try to parse it as type T
+        match serde_yaml::from_value::<T>(yaml_val.clone()) {
+            Ok(value) => Ok(DefaultValue::Value(value)),
+            Err(_) => {
+                // If parsing fails, check if it's a string (template)
+                if let serde_yaml::Value::String(s) = yaml_val
+                    && s.starts_with(format!("${{{}", Namespace::Default.to_string()).as_str())
+                    && s.ends_with("}")
+                {
+                    Ok(DefaultValue::Template(s))
+                } else {
+                    Err(serde::de::Error::custom(
+                        "default value must be of the correct type or a template string",
+                    ))
+                }
+            }
+        }
+    }
+}
 
 /// Defines the fields supported by a Variable in an Agent Type
 #[derive(Debug, PartialEq, Clone, Serialize)]
@@ -19,7 +62,7 @@ where
     T: PartialEq,
 {
     pub(crate) required: bool,
-    pub(crate) default: Option<T>,
+    pub(crate) default: Option<DefaultValue<T>>,
 }
 
 /// Type to support special default deserialization for 'null' Yaml value in 'default'.
@@ -49,6 +92,8 @@ where
     pub(crate) required: bool,
     pub(crate) default: Option<T>,
     pub(crate) final_value: Option<T>, // TODO: move this outside the struct and avoid mutating the variables
+    #[serde(skip)]
+    pub(crate) default_template: Option<String>, // Stores template string when default is a template
 }
 
 /// A [StringFieldsDefinition] including information known at runtime.
@@ -65,10 +110,18 @@ where
 {
     /// Returns the corresponding inner [Fields].
     pub fn with_config(self, _: &VariableConstraints) -> Fields<T> {
+        // Extract the value and template from DefaultValue
+        let (default, default_template) = match self.default {
+            Some(DefaultValue::Value(v)) => (Some(v), None),
+            Some(DefaultValue::Template(s)) => (None, Some(s)),
+            None => (None, None),
+        };
+
         Fields {
             required: self.required,
-            default: self.default,
+            default,
             final_value: None,
+            default_template,
         }
     }
 }
@@ -76,10 +129,18 @@ where
 impl YamlFieldsDefinition {
     /// Returns the corresponding inner [Fields].
     pub fn with_config(self, _: &VariableConstraints) -> Fields<serde_yaml::Value> {
+        // Extract the value and template from DefaultValue
+        let (default, default_template) = match self.inner.default {
+            Some(DefaultValue::Value(v)) => (Some(v), None),
+            Some(DefaultValue::Template(s)) => (None, Some(s)),
+            None => (None, None),
+        };
+
         Fields {
             required: self.inner.required,
-            default: self.inner.default,
+            default,
             final_value: None,
+            default_template,
         }
     }
 }
@@ -88,8 +149,21 @@ impl StringFieldsDefinition {
     /// Returns the corresponding [StringFields] according to the provided configuration.
     pub fn with_config(self, constraints: &VariableConstraints) -> StringFields {
         let variants = self.build_variants(&constraints.variants);
+
+        // Extract the value and template from DefaultValue
+        let (default, default_template) = match self.inner.default {
+            Some(DefaultValue::Value(v)) => (Some(v), None),
+            Some(DefaultValue::Template(s)) => (Some(s.clone()), Some(s)),
+            None => (None, None),
+        };
+
         StringFields {
-            inner: self.inner.with_config(constraints),
+            inner: Fields {
+                required: self.inner.required,
+                default,
+                final_value: None,
+                default_template,
+            },
             variants,
         }
     }
@@ -133,7 +207,7 @@ impl StringFields {
 
 impl<'de, T> Deserialize<'de> for FieldsDefinition<T>
 where
-    T: Deserialize<'de> + PartialEq,
+    T: serde::de::DeserializeOwned + PartialEq,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -141,9 +215,10 @@ where
     {
         use serde::de::Error;
         // intermediate serialization type to validate `default` and `required` fields
+        // We use serde_yaml::Value first to handle both direct values and template strings
         #[derive(Debug, Deserialize)]
-        struct IntermediateValueKind<T: PartialEq> {
-            default: Option<T>,
+        struct IntermediateValueKind {
+            default: Option<serde_yaml::Value>,
             required: bool,
         }
 
@@ -162,7 +237,10 @@ where
         }
 
         Ok(FieldsDefinition {
-            default: intermediate_spec.default,
+            default: intermediate_spec.default.and_then(|yaml_val| {
+                // The DefaultValue deserializer will handle converting this
+                serde_yaml::from_value::<DefaultValue<T>>(yaml_val).ok()
+            }),
             required: intermediate_spec.required,
         })
     }
@@ -198,7 +276,7 @@ impl<'de> Deserialize<'de> for YamlFieldsDefinition {
         Ok(YamlFieldsDefinition {
             inner: FieldsDefinition {
                 required: intermediate_spec.required,
-                default: intermediate_spec.default,
+                default: intermediate_spec.default.map(DefaultValue::Value),
             },
         })
     }
@@ -232,6 +310,7 @@ mod tests {
                 required,
                 default,
                 final_value,
+                default_template: None,
             }
         }
     }
@@ -248,6 +327,7 @@ mod tests {
                     required,
                     default,
                     final_value,
+                    default_template: None,
                 },
                 variants,
             }
@@ -256,8 +336,12 @@ mod tests {
 
     impl YamlFieldsDefinition {
         pub(crate) fn new(required: bool, default: Option<serde_yaml::Value>) -> Self {
+            use super::DefaultValue;
             Self {
-                inner: FieldsDefinition { required, default },
+                inner: FieldsDefinition {
+                    required,
+                    default: default.map(DefaultValue::Value),
+                },
             }
         }
     }

--- a/agent-control/src/agent_type/variable/fields.rs
+++ b/agent-control/src/agent_type/variable/fields.rs
@@ -8,6 +8,7 @@ use crate::agent_type::{
     error::AgentTypeError,
     variable::{
         constraints::{VariableConstraints, VariantsConstraints},
+        namespace::Namespace,
         variants::{Variants, VariantsConfig},
     },
 };
@@ -19,7 +20,17 @@ where
     T: PartialEq,
 {
     pub(crate) required: bool,
-    pub(crate) default: Option<T>,
+    pub(crate) default: Option<DefaultValue<T>>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
+pub enum DefaultValue<T>
+where
+    T: PartialEq,
+{
+    Value(T),
+    Template(String),
 }
 
 /// Type to support special default deserialization for 'null' Yaml value in 'default'.
@@ -47,7 +58,8 @@ where
     T: PartialEq,
 {
     pub(crate) required: bool,
-    pub(crate) default: Option<T>,
+    #[serde(flatten)]
+    pub(crate) default: Option<DefaultValue<T>>,
     pub(crate) final_value: Option<T>, // TODO: move this outside the struct and avoid mutating the variables
 }
 
@@ -133,7 +145,7 @@ impl StringFields {
 
 impl<'de, T> Deserialize<'de> for FieldsDefinition<T>
 where
-    T: Deserialize<'de> + PartialEq,
+    T: serde::de::DeserializeOwned + PartialEq,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -142,8 +154,8 @@ where
         use serde::de::Error;
         // intermediate serialization type to validate `default` and `required` fields
         #[derive(Debug, Deserialize)]
-        struct IntermediateValueKind<T: PartialEq> {
-            default: Option<T>,
+        struct IntermediateValueKind {
+            default: Option<serde_yaml::Value>,
             required: bool,
         }
 
@@ -162,9 +174,57 @@ where
         }
 
         Ok(FieldsDefinition {
-            default: intermediate_spec.default,
             required: intermediate_spec.required,
+            default: intermediate_spec
+                .default
+                .map(serde_yaml::from_value::<DefaultValue<T>>)
+                .transpose()
+                .map_err(|_| {
+                    D::Error::custom(AgentTypeError::Parse(
+                        "default value is not of the correct type".to_string(),
+                    ))
+                })?,
         })
+    }
+}
+
+impl<T> DefaultValue<T>
+where
+    T: PartialEq,
+{
+    pub fn as_value(&self) -> Option<&T> {
+        match self {
+            DefaultValue::Value(v) => Some(v),
+            DefaultValue::Template(_) => None,
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for DefaultValue<T>
+where
+    T: serde::de::DeserializeOwned + PartialEq,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let yaml_val = serde_yaml::Value::deserialize(deserializer)?;
+
+        match serde_yaml::from_value::<T>(yaml_val.clone()) {
+            Ok(value) => Ok(DefaultValue::Value(value)),
+            Err(_) => {
+                if let serde_yaml::Value::String(s) = yaml_val
+                    && s.starts_with(format!("${{{}", Namespace::Default).as_str())
+                    && s.ends_with("}")
+                {
+                    Ok(DefaultValue::Template(s))
+                } else {
+                    Err(serde::de::Error::custom(
+                        "default value must be of the correct type or an `nr-default` template string",
+                    ))
+                }
+            }
+        }
     }
 }
 
@@ -198,7 +258,7 @@ impl<'de> Deserialize<'de> for YamlFieldsDefinition {
         Ok(YamlFieldsDefinition {
             inner: FieldsDefinition {
                 required: intermediate_spec.required,
-                default: intermediate_spec.default,
+                default: intermediate_spec.default.map(DefaultValue::Value),
             },
         })
     }
@@ -221,7 +281,7 @@ mod tests {
         },
     };
 
-    use super::Fields;
+    use super::{DefaultValue, Fields};
 
     impl<T> Fields<T>
     where
@@ -230,7 +290,7 @@ mod tests {
         pub(crate) fn new(required: bool, default: Option<T>, final_value: Option<T>) -> Self {
             Self {
                 required,
-                default,
+                default: default.map(DefaultValue::Value),
                 final_value,
             }
         }
@@ -246,7 +306,7 @@ mod tests {
             Self {
                 inner: Fields::<String> {
                     required,
-                    default,
+                    default: default.map(DefaultValue::Value),
                     final_value,
                 },
                 variants,
@@ -257,7 +317,10 @@ mod tests {
     impl YamlFieldsDefinition {
         pub(crate) fn new(required: bool, default: Option<serde_yaml::Value>) -> Self {
             Self {
-                inner: FieldsDefinition { required, default },
+                inner: FieldsDefinition {
+                    required,
+                    default: default.map(DefaultValue::Value),
+                },
             }
         }
     }

--- a/agent-control/src/agent_type/variable/fields.rs
+++ b/agent-control/src/agent_type/variable/fields.rs
@@ -119,6 +119,11 @@ where
         self.final_value = Some(value);
         Ok(())
     }
+
+    pub(crate) fn set_default(&mut self, value: T) -> Result<(), AgentTypeError> {
+        self.default = Some(value);
+        Ok(())
+    }
 }
 
 impl StringFields {
@@ -127,6 +132,14 @@ impl StringFields {
             return Err(AgentTypeError::InvalidVariant(self.variants.to_string()));
         }
         self.inner.set_final_value(value)?;
+        Ok(())
+    }
+
+    pub(crate) fn set_default(&mut self, value: String) -> Result<(), AgentTypeError> {
+        if !self.variants.is_valid(&value) {
+            return Err(AgentTypeError::InvalidVariant(self.variants.to_string()));
+        }
+        self.inner.set_default(value)?;
         Ok(())
     }
 }

--- a/agent-control/src/agent_type/variable/namespace.rs
+++ b/agent-control/src/agent_type/variable/namespace.rs
@@ -17,6 +17,9 @@ pub enum Namespace {
     Vault,
     File,
     K8sSecret,
+
+    // References global default values configured in the agent control configuration.
+    Default,
 }
 
 impl Namespace {
@@ -37,6 +40,9 @@ impl Namespace {
     /// Encapsulates the secrets retrieved from K8s Secrets
     const K8S_SECRET: &'static str = "kubesec";
     const FILE_SECRET: &'static str = "file";
+
+    /// Encapsulates global default values from agent control configuration
+    const DEFAULT: &'static str = "default";
 
     pub fn namespaced_name(&self, name: impl AsRef<str>) -> NamespacedVariableName {
         format!("{}{}{}", self, Self::PREFIX_NS_SEPARATOR, name.as_ref())
@@ -64,6 +70,7 @@ impl Display for Namespace {
             Self::Vault => Self::VAULT_SECRET,
             Self::File => Self::FILE_SECRET,
             Self::K8sSecret => Self::K8S_SECRET,
+            Self::Default => Self::DEFAULT,
         };
         write!(f, "{}{ns}", Self::PREFIX)
     }
@@ -101,6 +108,10 @@ mod tests {
         assert_eq!(
             "nr-file:test".to_string(),
             Namespace::File.namespaced_name("test")
+        );
+        assert_eq!(
+            "nr-default:test".to_string(),
+            Namespace::Default.namespaced_name("test")
         );
     }
 }

--- a/agent-control/src/agent_type/variable/namespace.rs
+++ b/agent-control/src/agent_type/variable/namespace.rs
@@ -11,6 +11,9 @@ pub enum Namespace {
     SubAgent,
     AgentControl,
 
+    // References global default values configured in the agent control configuration.
+    Default,
+
     // Below variables are "secret" variables.
     // These are loaded every time a remote config is received.
     EnvironmentVariable,
@@ -29,6 +32,9 @@ impl Namespace {
     const SUB_AGENT: &'static str = "sub";
     /// Encapsulates attributes related to the agent-control
     const AC: &'static str = "ac";
+
+    /// Encapsulates global default values from agent control configuration
+    const DEFAULT: &'static str = "default";
 
     /// Encapsulates the environment variables
     const ENVIRONMENT_VARIABLE: &'static str = "env";
@@ -60,6 +66,7 @@ impl Display for Namespace {
             Self::Variable => Self::VARIABLE,
             Self::SubAgent => Self::SUB_AGENT,
             Self::AgentControl => Self::AC,
+            Self::Default => Self::DEFAULT,
             Self::EnvironmentVariable => Self::ENVIRONMENT_VARIABLE,
             Self::Vault => Self::VAULT_SECRET,
             Self::File => Self::FILE_SECRET,
@@ -89,6 +96,10 @@ mod tests {
         assert_eq!(
             "nr-ac:test".to_string(),
             Namespace::AgentControl.namespaced_name("test")
+        );
+        assert_eq!(
+            "nr-default:test".to_string(),
+            Namespace::Default.namespaced_name("test")
         );
         assert_eq!(
             "nr-vault:test".to_string(),

--- a/agent-control/src/agent_type/variable/secret_variables.rs
+++ b/agent-control/src/agent_type/variable/secret_variables.rs
@@ -121,6 +121,16 @@ impl SecretVariables {
             .expect("Namespace format should be valid");
         self.variables.entry(prefix).or_default().insert(var_name);
     }
+
+    /// Merges another SecretVariables into self, combining all secret references.
+    pub fn merge(&mut self, other: SecretVariables) {
+        for (namespace, variables) in other.variables {
+            self.variables
+                .entry(namespace)
+                .or_default()
+                .extend(variables);
+        }
+    }
 }
 
 /// Loads all environment variables present in the system.
@@ -220,5 +230,33 @@ eof"#;
         };
         let result = secrets.load_secrets(&SecretsProviders::default()).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_merge_secrets() {
+        let mut secrets1 = SecretVariables {
+            variables: HashMap::from([(
+                "nr-vault".to_string(),
+                HashSet::from(["PATH_A".to_string(), "PATH_B".to_string()]),
+            )]),
+        };
+
+        let secrets2 = SecretVariables {
+            variables: HashMap::from([(
+                "nr-vault".to_string(),
+                HashSet::from(["PATH_C".to_string()]),
+            )]),
+        };
+
+        secrets1.merge(secrets2);
+        let expected = HashMap::from([(
+            "nr-vault".to_string(),
+            HashSet::from([
+                "PATH_A".to_string(),
+                "PATH_B".to_string(),
+                "PATH_C".to_string(),
+            ]),
+        )]);
+        assert_eq!(secrets1.variables, expected);
     }
 }

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -84,6 +84,19 @@ impl VariableType {
         Ok(())
     }
 
+    /// Sets the default value for this variable type from a global default.
+    /// This replaces the agent-type's default value.
+    pub(crate) fn set_default(&mut self, value: serde_yaml::Value) -> Result<(), AgentTypeError> {
+        match self {
+            VariableType::String(f) => f.set_default(serde_yaml::from_value(value)?),
+            VariableType::Bool(f) => f.set_default(serde_yaml::from_value(value)?),
+            VariableType::Number(f) => f.set_default(serde_yaml::from_value(value)?),
+            VariableType::MapStringYaml(f) => f.set_default(serde_yaml::from_value(value)?),
+            VariableType::Yaml(f) => f.set_default(value),
+        }?;
+        Ok(())
+    }
+
     pub(crate) fn get_final_value(&self) -> Option<TrivialValue> {
         match self {
             VariableType::String(f) => f
@@ -112,6 +125,27 @@ impl VariableType {
                 .or(f.default.as_ref())
                 .cloned()
                 .map(TrivialValue::Yaml),
+        }
+    }
+
+    /// Gets the default value as a string key for looking up in global defaults.
+    /// Returns None if there's no default or if the default is not a string type.
+    /// Only String variables can have their defaults looked up in global defaults.
+    pub(crate) fn get_default_as_key(&self) -> Option<String> {
+        match self {
+            VariableType::String(f) => f.inner.default.clone(),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the variable has a user-provided final value (not just a default).
+    pub(crate) fn has_final_value(&self) -> bool {
+        match self {
+            VariableType::String(f) => f.inner.final_value.is_some(),
+            VariableType::Bool(f) => f.final_value.is_some(),
+            VariableType::Number(f) => f.final_value.is_some(),
+            VariableType::MapStringYaml(f) => f.final_value.is_some(),
+            VariableType::Yaml(f) => f.final_value.is_some(),
         }
     }
 }

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
     error::AgentTypeError,
+    templates::Templateable,
     trivial_value::TrivialValue,
     variable::{
         constraints::VariableConstraints,
@@ -84,19 +85,6 @@ impl VariableType {
         Ok(())
     }
 
-    /// Sets the default value for this variable type from a global default.
-    /// This replaces the agent-type's default value.
-    pub(crate) fn set_default(&mut self, value: serde_yaml::Value) -> Result<(), AgentTypeError> {
-        match self {
-            VariableType::String(f) => f.set_default(serde_yaml::from_value(value)?),
-            VariableType::Bool(f) => f.set_default(serde_yaml::from_value(value)?),
-            VariableType::Number(f) => f.set_default(serde_yaml::from_value(value)?),
-            VariableType::MapStringYaml(f) => f.set_default(serde_yaml::from_value(value)?),
-            VariableType::Yaml(f) => f.set_default(value),
-        }?;
-        Ok(())
-    }
-
     pub(crate) fn get_final_value(&self) -> Option<TrivialValue> {
         match self {
             VariableType::String(f) => f
@@ -128,25 +116,21 @@ impl VariableType {
         }
     }
 
-    /// Gets the default value as a string key for looking up in global defaults.
-    /// Returns None if there's no default or if the default is not a string type.
-    /// Only String variables can have their defaults looked up in global defaults.
-    pub(crate) fn get_default_as_key(&self) -> Option<String> {
+    pub(crate) fn template_default(
+        &mut self,
+        global_defaults_vars: &HashMap<String, super::Variable>,
+    ) -> Result<(), AgentTypeError> {
         match self {
-            VariableType::String(f) => f.inner.default.clone(),
-            _ => None,
+            VariableType::String(f) => {
+                if let Some(default) = &f.inner.default {
+                    // Template the default value
+                    let templated = default.clone().template_with(global_defaults_vars)?;
+                    f.inner.default = Some(templated);
+                }
+            }
+            _ => {}
         }
-    }
-
-    /// Returns true if the variable has a user-provided final value (not just a default).
-    pub(crate) fn has_final_value(&self) -> bool {
-        match self {
-            VariableType::String(f) => f.inner.final_value.is_some(),
-            VariableType::Bool(f) => f.final_value.is_some(),
-            VariableType::Number(f) => f.final_value.is_some(),
-            VariableType::MapStringYaml(f) => f.final_value.is_some(),
-            VariableType::Yaml(f) => f.final_value.is_some(),
-        }
+        Ok(())
     }
 }
 

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
     error::AgentTypeError,
-    templates::Templateable,
     trivial_value::TrivialValue,
     variable::{
         constraints::VariableConstraints,
@@ -120,6 +119,8 @@ impl VariableType {
         &mut self,
         global_defaults_vars: &HashMap<String, super::Variable>,
     ) -> Result<(), AgentTypeError> {
+        use crate::agent_type::templates::Templateable;
+
         match self {
             VariableType::String(f) => {
                 if let Some(default) = &f.inner.default {
@@ -128,7 +129,58 @@ impl VariableType {
                     f.inner.default = Some(templated);
                 }
             }
-            _ => {}
+            VariableType::Bool(f) => {
+                // For bool types with template defaults, extract and inject the value directly
+                if let Some(template) = &f.default_template {
+                    let resolved = template.clone().template_with(global_defaults_vars)?;
+                    // Parse the resolved string as bool
+                    f.default = Some(resolved.parse().map_err(|_| {
+                        AgentTypeError::Parse(format!(
+                            "Cannot parse '{}' as bool from template '{}'",
+                            resolved, template
+                        ))
+                    })?);
+                }
+            }
+            VariableType::Number(f) => {
+                // For number types with template defaults, extract and inject the value directly
+                if let Some(template) = &f.default_template {
+                    let resolved = template.clone().template_with(global_defaults_vars)?;
+                    // Parse the resolved string as number
+                    f.default = Some(serde_yaml::from_str(&resolved).map_err(|e| {
+                        AgentTypeError::Parse(format!(
+                            "Cannot parse '{}' as number from template '{}': {}",
+                            resolved, template, e
+                        ))
+                    })?);
+                }
+            }
+            VariableType::MapStringYaml(f) => {
+                // For map types with template defaults, extract and inject the value directly
+                if let Some(template) = &f.default_template {
+                    let resolved = template.clone().template_with(global_defaults_vars)?;
+                    // Parse the resolved string as map
+                    f.default = Some(serde_yaml::from_str(&resolved).map_err(|e| {
+                        AgentTypeError::Parse(format!(
+                            "Cannot parse '{}' as map from template '{}': {}",
+                            resolved, template, e
+                        ))
+                    })?);
+                }
+            }
+            VariableType::Yaml(f) => {
+                // For yaml types with template defaults, extract and inject the value directly
+                if let Some(template) = &f.default_template {
+                    let resolved = template.clone().template_with(global_defaults_vars)?;
+                    // Parse the resolved string as yaml
+                    f.default = Some(serde_yaml::from_str(&resolved).map_err(|e| {
+                        AgentTypeError::Parse(format!(
+                            "Cannot parse '{}' as yaml from template '{}': {}",
+                            resolved, template, e
+                        ))
+                    })?);
+                }
+            }
         }
         Ok(())
     }

--- a/agent-control/src/agent_type/variable/variable_type.rs
+++ b/agent-control/src/agent_type/variable/variable_type.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::agent_type::{
     error::AgentTypeError,
@@ -10,7 +10,7 @@ use crate::agent_type::{
     trivial_value::TrivialValue,
     variable::{
         constraints::VariableConstraints,
-        fields::{StringFields, StringFieldsDefinition, YamlFieldsDefinition},
+        fields::{DefaultValue, StringFields, StringFieldsDefinition, YamlFieldsDefinition},
     },
 };
 
@@ -91,26 +91,29 @@ impl VariableType {
                 .inner
                 .final_value
                 .as_ref()
-                .or(f.inner.default.as_ref())
+                .or(f.inner.default.as_ref().and_then(|d| d.as_value()))
                 .cloned()
                 .map(TrivialValue::String),
-            VariableType::Bool(f) => f.final_value.or(f.default).map(TrivialValue::Bool),
+            VariableType::Bool(f) => f
+                .final_value
+                .or(f.default.as_ref().and_then(|d| d.as_value()).copied())
+                .map(TrivialValue::Bool),
             VariableType::Number(f) => f
                 .final_value
                 .as_ref()
-                .or(f.default.as_ref())
+                .or(f.default.as_ref().and_then(|d| d.as_value()))
                 .cloned()
                 .map(TrivialValue::Number),
             VariableType::MapStringYaml(f) => f
                 .final_value
                 .as_ref()
-                .or(f.default.as_ref())
+                .or(f.default.as_ref().and_then(|d| d.as_value()))
                 .cloned()
                 .map(TrivialValue::MapStringYaml),
             VariableType::Yaml(f) => f
                 .final_value
                 .as_ref()
-                .or(f.default.as_ref())
+                .or(f.default.as_ref().and_then(|d| d.as_value()))
                 .cloned()
                 .map(TrivialValue::Yaml),
         }
@@ -118,20 +121,58 @@ impl VariableType {
 
     pub(crate) fn template_default(
         &mut self,
-        global_defaults_vars: &HashMap<String, super::Variable>,
+        variables: &HashMap<String, super::Variable>,
     ) -> Result<(), AgentTypeError> {
         match self {
             VariableType::String(f) => {
-                if let Some(default) = &f.inner.default {
-                    // Template the default value
-                    let templated = default.clone().template_with(global_defaults_vars)?;
-                    f.inner.default = Some(templated);
+                let value = match &f.inner.default {
+                    Some(DefaultValue::Value(value)) => value.clone(),
+                    Some(DefaultValue::Template(template)) => template.clone(),
+                    None => return Ok(()),
+                };
+                let templated = value.template_with(variables)?;
+                f.inner.default = Some(DefaultValue::Value(templated));
+            }
+            VariableType::Bool(f) => {
+                if let Some(DefaultValue::Template(template)) = &f.default {
+                    let value = template.clone().template_with(variables)?;
+                    f.default = Some(parse_default(value, template.clone())?);
                 }
             }
-            _ => {}
+            VariableType::Number(f) => {
+                if let Some(DefaultValue::Template(template)) = &f.default {
+                    let value = template.clone().template_with(variables)?;
+                    f.default = Some(parse_default(value, template.clone())?);
+                }
+            }
+            VariableType::MapStringYaml(f) => {
+                if let Some(DefaultValue::Template(template)) = &f.default {
+                    let value = template.clone().template_with(variables)?;
+                    f.default = Some(parse_default(value, template.clone())?);
+                }
+            }
+            VariableType::Yaml(f) => {
+                if let Some(DefaultValue::Template(template)) = &f.default {
+                    let value = template.clone().template_with(variables)?;
+                    f.default = Some(parse_default(value, template.clone())?);
+                }
+            }
         }
         Ok(())
     }
+}
+
+fn parse_default<T: PartialEq + DeserializeOwned>(
+    value: String,
+    template: String,
+) -> Result<DefaultValue<T>, AgentTypeError> {
+    let result = serde_yaml::from_str::<T>(&value).map_err(|e| {
+        AgentTypeError::Parse(format!(
+            "template '{template}' was resolved to '{value}' which is not a map: {e}",
+        ))
+    })?;
+
+    Ok(DefaultValue::Value(result))
 }
 
 #[cfg(test)]

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -790,6 +790,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     use super::super::sub_agent::effective_agents_assembler::LocalEffectiveAgentsAssembler;
     use super::super::sub_agent::remote_config_parser::AgentRemoteConfigParser;
@@ -816,7 +817,6 @@ pub mod tests {
     use opamp_client::opamp::proto::{RemoteConfigStatus, RemoteConfigStatuses};
     use opamp_client::operation::capabilities::Capabilities;
     use rstest::*;
-    use std::collections::HashMap;
     use std::ops::Deref;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -1098,6 +1098,7 @@ deployment:
             VariableConstraints::default(),
             SecretsProviders::default(),
             PathBuf::default().as_path(),
+            HashMap::new(),
         ));
 
         SubAgent::new(
@@ -1226,6 +1227,7 @@ deployment:
             VariableConstraints::default(),
             SecretsProviders::default(),
             PathBuf::default().as_path(),
+            HashMap::new(),
         ));
 
         let sub_agent = SubAgent::new(
@@ -1872,6 +1874,7 @@ deployment:
             VariableConstraints::default(),
             SecretsProviders::default(),
             PathBuf::default().as_path(),
+            HashMap::new(),
         ));
 
         let supervisor = sub_agent.init_supervisor();

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -15,6 +15,7 @@ use crate::secrets_provider::SecretsProviders;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::values::yaml_config::YAMLConfig;
 
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -130,6 +131,7 @@ where
     variable_constraints: VariableConstraints,
     secrets_providers: SecretsProviders,
     remote_dir: PathBuf,
+    global_defaults: HashMap<String, serde_yaml::Value>,
 }
 
 impl<R> LocalEffectiveAgentsAssembler<R>
@@ -142,6 +144,7 @@ where
         variable_constraints: VariableConstraints,
         secrets_providers: SecretsProviders,
         remote_dir: &Path,
+        global_defaults: HashMap<String, serde_yaml::Value>,
     ) -> Self {
         LocalEffectiveAgentsAssembler {
             registry,
@@ -149,6 +152,7 @@ where
             variable_constraints,
             secrets_providers,
             remote_dir: remote_dir.to_path_buf(),
+            global_defaults,
         }
     }
 }
@@ -163,33 +167,38 @@ where
         values: YAMLConfig,
         environment: &Environment,
     ) -> Result<EffectiveAgent, EffectiveAgentsAssemblerError> {
-        // Load the agent type definition
         let agent_type_definition = self
             .registry
             .get(&agent_identity.agent_type_id.to_string())?;
-        // Build the corresponding agent type
+
         let agent_type = build_agent_type(
             agent_type_definition,
             environment,
             &self.variable_constraints,
         )?;
 
-        // Build the agent attributes
         let attributes =
             AgentAttributes::try_new(agent_identity.id.to_owned(), self.remote_dir.to_path_buf())
                 .map_err(|e| {
                 EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string())
             })?;
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables are taken into consideration (no other vars for example)
-        let secret_variables = SecretVariables::try_from(values.clone())?;
         let env_vars = load_env_vars();
+
+        let mut secret_variables = SecretVariables::try_from(values.clone())?;
+        let global_defaults_secrets =
+            SecretVariables::try_from(YAMLConfig::from(self.global_defaults.clone()))?;
+        secret_variables.merge(global_defaults_secrets);
         let secrets = secret_variables.load_secrets(&self.secrets_providers)?;
 
-        let runtime_config = self
-            .renderer
-            .render(agent_type, values, attributes, env_vars, secrets)?;
+        let runtime_config = self.renderer.render(
+            agent_type,
+            values,
+            attributes,
+            env_vars,
+            secrets,
+            self.global_defaults.clone(),
+        )?;
 
         Ok(EffectiveAgent::new(agent_identity.clone(), runtime_config))
     }
@@ -291,6 +300,7 @@ pub(crate) mod tests {
                 variable_constraints: VariableConstraints::default(),
                 secrets_providers: SecretsProviders::default(),
                 remote_dir: PathBuf::default(),
+                global_defaults: HashMap::new(),
             }
         }
     }

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -90,6 +90,12 @@ impl From<YAMLConfig> for HashMap<String, serde_yaml::Value> {
     }
 }
 
+impl From<HashMap<String, serde_yaml::Value>> for YAMLConfig {
+    fn from(values: HashMap<String, serde_yaml::Value>) -> Self {
+        YAMLConfig(values)
+    }
+}
+
 impl TryFrom<&AgentControlDynamicConfig> for YAMLConfig {
     type Error = YAMLConfigError;
 
@@ -301,7 +307,7 @@ deployment:
 
         let filled_variables = agent_type
             .variables
-            .fill_with_values(input_structure)
+            .fill_with_values(input_structure, HashMap::new())
             .unwrap();
 
         assert_eq!(expected, filled_variables.0);
@@ -324,7 +330,9 @@ deployment:
         let agent_type =
             AgentType::build_for_testing(EXAMPLE_AGENT_YAML_REPLACE, &AGENT_CONTROL_MODE_ON_HOST);
 
-        let result = agent_type.variables.fill_with_values(input_structure);
+        let result = agent_type
+            .variables
+            .fill_with_values(input_structure, HashMap::new());
 
         assert!(result.is_err());
         assert_eq!(

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -307,7 +307,7 @@ deployment:
 
         let filled_variables = agent_type
             .variables
-            .fill_with_values(input_structure, HashMap::new())
+            .fill_with_values(input_structure)
             .unwrap();
 
         assert_eq!(expected, filled_variables.0);
@@ -330,9 +330,7 @@ deployment:
         let agent_type =
             AgentType::build_for_testing(EXAMPLE_AGENT_YAML_REPLACE, &AGENT_CONTROL_MODE_ON_HOST);
 
-        let result = agent_type
-            .variables
-            .fill_with_values(input_structure, HashMap::new());
+        let result = agent_type.variables.fill_with_values(input_structure);
 
         assert!(result.is_err());
         assert_eq!(

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -100,7 +100,26 @@ Specifies if providing a value for this variable is required or not. If `require
 
 ##### `default` (optional)
 
-A default value for this variable, for the cases where no configuration value has been passed for this variable when creating an instance for the agent type. Its value must be of the same type as the one declared for the variable.
+A default value for this variable, for the cases where no configuration value has been passed for this variable when creating an instance for the agent type. Its value must be of the same type as the one declared for the variable or a templatable string using `nr-default`.
+
+Example:
+
+```yaml
+default: "${nr-default:oci.registry}"
+```
+
+This values come from the `global_defaults` field in the `AgentControlConfig`. They can be accessed by concatenating the nested keys from `global_defaults` to the key of the final value to access. In other words, to access the username in
+
+```yaml
+global_defaults:
+  oci:
+    auth:
+      basic:
+        username: user
+        password: pass
+```
+
+we have to use `${nr-default:oci.auth.basic.username}`.
 
 In the case of the `yaml` variable type, is recommended to explicitly set a 'null' default value as `default: null`.
 


### PR DESCRIPTION
This PR adds support for global defaults in Agent Control, which allows setting "base" values for all agent types that will be instantiated in the host machine.

Notice that this feature works for k8s too, even though it's not needed at the moment.

Also, this PR is on top of https://github.com/newrelic/newrelic-agent-control/pull/2414.

### Context

In the refinement, it was decided that the user should be able to configure some default values "globally" (for all agent types) and that these should be overridable in an agent-per-agent basis.

Something along these lines (this is not the final shape of the config).

```yaml
# Agent Control Config
agent_control:
   oci:
   	registry: ...
   	auth: ...

# Then agent types can be configured like
nr_infra_agent:
  oci:
    repository: ...
    version: ...
# Non configured and mandatory fields will use the global defaults

# We can also override global defaults
nr_infra_agent_specific_host_machine:
  oci:
    repository: ...
    version: ...
    registry: specific-url
```

Essentially, we have two requirements:

1. We must have a way of defining global defaults that all agent types can use
    We can promote using these as much as possible, but it's the responsibility of the agent type author to use them.
2. Global defaults have less weight than specific agent type configurations.
    Basically, if a user sets the value of a variable, this takes precedence over the global default.

From a technical point of view, we have two additional requirement.

1. Ensure that authentication methods can point to a secret, environment variable, or similar.
2. Backwards compatibility

### Review

I think the easier way to review this PR is to check all changes at once. If you want to go commit by commit, here you have the hight level summary. Read it to understand what each commit adds.

* commit 1 adds global config and simple string replacement in defaults
* commit 2 adds templatable strings in defaults
* commit 3 extends support of templatable defaults for other types (booleans, numbers, etc)
* commit 4 modifies the docs
* commit 5 automates the generation of the hashmap with default values
* commit 6 add support for nr-env in the `default` field of the `variables` section

### Technical decisions

**Added `nr-default` namespace**

I added a new namespace called `nr-default` to handle the rendering of default values in the `variables` section. This was not strictly needed, and someone could argue that's even a bad decision. However, I think it helps with consistency. Let me explain this contradiction.

We have several supported namespaces for agent types template rendering. We have `nr-env`, `nr-ac`, `nr-sub` and `nr-var`. All of them are rendered in the `deployment` section of the agent type definition. This is the "runtime" part. Adding an `nr-default` seems a good idea, until you realize that we are going to use this one in the `variables` section, which is supposed to be static. I don't think that's a big deal. Now `default` values will be dynamic.
My main concern is that we now have two groups of namespaces. One of them work inside `variables` and one of them works inside `deployments`.

I decided to go down that path to reuse abstractions and keep some degree of consistency with our terminology. I acknowledge that it could be confusing for agent type authors. They might assume they can use `nr-default` in the `deployment` section. That's not the case, and I assume that we should solve that through documentation. We could  use a different abstraction and have something different from `nr-default`. Maybe `global-default:whatever`. However, I'm not sure this will be clearer and it requires extra effort to duplicate and generalize all the code or part of the code that we have for templating.

We could also pass `nr-default` values along with the other namespaces to template the `deployment` section, but I didn't think it was useful. The idea is to have a global default that can be overridden. With the current implementation that separation is a feature, not a bug. It won't work because it's not supposed to work. 

Regarding other namespaces. I don't they they make sense to support in the `variables` section. I only added support for `nr-env`. In case an agent type author wants to retrieve the value from an env var by default, and give the user the possibility to change it. I'm not sure this is that useful. We can remove it.

Open to feedback!!!

**Add `DefaultValue`**

Now that we can template default values in the `variable` section, we need a way to postpone type checking. Hence, I introduced this new struct `DefaultValue` that allows storing in the default field either a value or a template string.

The type checking is postponed from agent type loading to default values templating. Without this, we can't have global default values with types other than string (e.g. bool). This is strictly not necessary for the current feature, but we might need it in the future. It's best to introduce that now.

**Two-step rendering**

The renderer is getting more complex. Originally, we had a "two-step rendering" process.

1. Discover secrets
2. Load secrets
3. Template user configured values with secrets (first render step)
4. Fill agent type variables
5. Template `deployment` section (second render step)

The master piece in charge of templating is `template_string`, which assumes that the received variables contain the final value. Thus, this second step rendering was needed. If the `template_string` was able to detect that a template resulted into another template, we could try replacing them in a loop until we get a final value. This is a potential improvement refactor suggested by @DavSanchez.

Now, we need to templatise the default values in the `variables` section. This requires a tweak.

1. Discover secrets (from user configured values AND global defaults)
2. Load secrets
3. Template user configured values with secrets (first render step)
4. Template global defaults with secrets (second render step)
5. Fill agent type variables
6. Template `deployment` section (third render step)

Why is the extra step (4) needed? 
Variables have a specific type (bool, yaml, etc), and the only way we can make sure that the template in the default field can be templatised into the expected type, is by doing it at the beginning. That way, when we fill the agent type variables, we can check that the type is as expected. Otherwise, we would always receive a template string, which is not always the expected type.

**Backwards compatibility**

The new global defaults are optional. We are not using rust `Optional` type, but we if the fields are missing when deserializing the data, we will use default values. With that, old agent control configs without default values will still work.