### PR TITLE
feat: publish agent and sub-agent attributes to HTTP status server [NR-537428]

### DIFF
--- a/agent-control/src/agent_control/http_server/status.rs
+++ b/agent-control/src/agent_control/http_server/status.rs
@@ -12,22 +12,35 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 use url::Url;
 
+const IDENTIFYING_ATTRIBUTES_PREFIX: &str = "identifying";
+const NON_IDENTIFYING_ATTRIBUTES_PREFIX: &str = "non-identifying";
+
 /// Dynamic fields describing the agent; includes attributes like agent_version, instance_uid, ...
 pub(super) type AgentAttributes = HashMap<String, String>;
 
 /// Encodes the provided [AgentDescription] as key-val. If there is an overlap in non-identifying
 /// and identifying attributes, the identifying attributes take precedence.
 pub(super) fn build_agent_attributes(agent_description: AgentDescription) -> AgentAttributes {
-    let mut attributes = encode_attributes(agent_description.non_identifying_attributes);
-    attributes.extend(encode_attributes(agent_description.identifying_attributes));
+    let mut attributes = encode_attributes(
+        agent_description.non_identifying_attributes,
+        NON_IDENTIFYING_ATTRIBUTES_PREFIX,
+    );
+    attributes.extend(encode_attributes(
+        agent_description.identifying_attributes,
+        IDENTIFYING_ATTRIBUTES_PREFIX,
+    ));
     attributes
 }
 
 /// Helper to encode attributes from `agent_description` as key-val.
-fn encode_attributes(attributes: HashMap<String, DescriptionValueType>) -> HashMap<String, String> {
+/// The keys are prefixed by `{prefix}/`. Example `"agent.id"` with
+fn encode_attributes(
+    attributes: HashMap<String, DescriptionValueType>,
+    prefix: &str,
+) -> HashMap<String, String> {
     attributes
         .into_iter()
-        .map(|(k, v)| (k.to_string(), encode_description_value(v)))
+        .map(|(k, v)| (format!("{prefix}/{k}"), encode_description_value(v)))
         .collect()
 }
 
@@ -535,22 +548,22 @@ pub mod tests {
     #[case::non_identifying_only(
         HashMap::new(),
         HashMap::from([("k".to_string(), DescriptionValueType::String("v".to_string()))]),
-        vec![("k", "v")]
+        vec![("non-identifying/k", "v")]
     )]
     #[case::identifying_only(
         HashMap::from([("k".to_string(), DescriptionValueType::String("v".to_string()))]),
         HashMap::new(),
-        vec![("k", "v")]
+        vec![("identifying/k", "v")]
     )]
     #[case::merged_no_overlap(
         HashMap::from([("id".to_string(), DescriptionValueType::String("id_val".to_string()))]),
         HashMap::from([("non_id".to_string(), DescriptionValueType::String("non_id_val".to_string()))]),
-        vec![("id", "id_val"), ("non_id", "non_id_val")]
+        vec![("identifying/id", "id_val"), ("non-identifying/non_id", "non_id_val")]
     )]
-    #[case::identifying_takes_precedence_on_overlap(
+    #[case::both_present_when_key_in_both(
         HashMap::from([("shared".to_string(), DescriptionValueType::String("id_value".to_string()))]),
         HashMap::from([("shared".to_string(), DescriptionValueType::String("non_id_value".to_string()))]),
-        vec![("shared", "id_value")]
+        vec![("identifying/shared", "id_value"), ("non-identifying/shared", "non_id_value")]
     )]
     fn test_agent_description(
         #[case] identifying_attributes: HashMap<String, DescriptionValueType>,
@@ -585,7 +598,7 @@ pub mod tests {
 
         assert_eq!(
             build_agent_attributes(agent_description)
-                .get("k")
+                .get("identifying/k")
                 .map(String::as_str),
             Some(expected)
         );

--- a/agent-control/src/agent_control/http_server/status.rs
+++ b/agent-control/src/agent_control/http_server/status.rs
@@ -5,6 +5,7 @@ use crate::checkers::health::health_checker::Health;
 use crate::checkers::health::with_start_time::HealthWithStartTime;
 use crate::opamp::{LastErrorCode, LastErrorMessage};
 use crate::sub_agent::identity::AgentIdentity;
+use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
 use serde::Serialize;
 
 use std::collections::HashMap;
@@ -13,6 +14,35 @@ use url::Url;
 
 /// Dynamic fields describing the agent; includes attributes like agent_version, instance_uid, ...
 pub(super) type AgentAttributes = HashMap<String, String>;
+
+/// Encodes the provided [AgentDescription] as key-val. If there is an overlap in non-identifying
+/// and identifying attributes, the identifying attributes take precedence.
+pub(super) fn build_agent_attributes(agent_description: AgentDescription) -> AgentAttributes {
+    let mut attributes = encode_attributes(agent_description.non_identifying_attributes);
+    attributes.extend(encode_attributes(agent_description.identifying_attributes));
+    attributes
+}
+
+/// Helper to encode attributes from `agent_description` as key-val.
+fn encode_attributes(attributes: HashMap<String, DescriptionValueType>) -> HashMap<String, String> {
+    attributes
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), encode_description_value(v)))
+        .collect()
+}
+
+/// Helper to encode a description value as string. Bytes are encoded as lowercase hex characters.
+fn encode_description_value(v: DescriptionValueType) -> String {
+    match v {
+        DescriptionValueType::String(v) => v,
+        DescriptionValueType::Int(v) => v.to_string(),
+        DescriptionValueType::Bool(v) => v.to_string(),
+        DescriptionValueType::Float(v) => v.to_string(),
+        DescriptionValueType::Bytes(v) => v
+            .iter()
+            .fold(String::new(), |acc, b| format!("{acc}{b:02x}")),
+    }
+}
 
 /// Agent Control status and health information.
 /// This information will be shown when the status endpoint is called.
@@ -244,6 +274,10 @@ fn time_to_unix_timestamp(time: SystemTime) -> u64 {
 
 #[cfg(test)]
 pub mod tests {
+    use std::collections::HashMap;
+
+    use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
+    use rstest::rstest;
     use serde_json::json;
     use url::Url;
 
@@ -251,7 +285,7 @@ pub mod tests {
 
     use crate::agent_control::http_server::status::{
         AgentAttributes, AgentControlStatus, HealthInfo, OpAMPStatus, Status, SubAgentStatus,
-        SubAgentsStatus,
+        SubAgentsStatus, build_agent_attributes,
     };
     use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::opamp::{LastErrorCode, LastErrorMessage};
@@ -471,7 +505,7 @@ pub mod tests {
     fn test_attributes_omitted_when_empty() {
         let status = AgentControlStatus::default();
         let value = serde_json::to_value(&status).unwrap();
-        assert!(!value.as_object().unwrap().contains_key("description"));
+        assert!(!value.as_object().unwrap().contains_key("attributes"));
     }
 
     #[test]
@@ -493,6 +527,67 @@ pub mod tests {
                 "version": "1.2.3",
                 "instance_uid": "550e8400-e29b-41d4-a716-446655440000"
             })
+        );
+    }
+
+    #[rstest]
+    #[case::empty(HashMap::new(), HashMap::new(), vec![])]
+    #[case::non_identifying_only(
+        HashMap::new(),
+        HashMap::from([("k".to_string(), DescriptionValueType::String("v".to_string()))]),
+        vec![("k", "v")]
+    )]
+    #[case::identifying_only(
+        HashMap::from([("k".to_string(), DescriptionValueType::String("v".to_string()))]),
+        HashMap::new(),
+        vec![("k", "v")]
+    )]
+    #[case::merged_no_overlap(
+        HashMap::from([("id".to_string(), DescriptionValueType::String("id_val".to_string()))]),
+        HashMap::from([("non_id".to_string(), DescriptionValueType::String("non_id_val".to_string()))]),
+        vec![("id", "id_val"), ("non_id", "non_id_val")]
+    )]
+    #[case::identifying_takes_precedence_on_overlap(
+        HashMap::from([("shared".to_string(), DescriptionValueType::String("id_value".to_string()))]),
+        HashMap::from([("shared".to_string(), DescriptionValueType::String("non_id_value".to_string()))]),
+        vec![("shared", "id_value")]
+    )]
+    fn test_agent_description(
+        #[case] identifying_attributes: HashMap<String, DescriptionValueType>,
+        #[case] non_identifying_attributes: HashMap<String, DescriptionValueType>,
+        #[case] expected: Vec<(&str, &str)>,
+    ) {
+        let agent_description = AgentDescription {
+            identifying_attributes,
+            non_identifying_attributes,
+        };
+        let result = build_agent_attributes(agent_description);
+        assert_eq!(result.len(), expected.len());
+        for (key, val) in expected {
+            assert_eq!(result.get(key).map(String::as_str), Some(val));
+        }
+    }
+
+    #[rstest]
+    #[case::string(DescriptionValueType::String("hello".to_string()), "hello")]
+    #[case::int(DescriptionValueType::Int(42), "42")]
+    #[case::bool(DescriptionValueType::Bool(true), "true")]
+    #[case::float(DescriptionValueType::Float(4.13), "4.13")]
+    #[case::bytes(DescriptionValueType::Bytes(vec![0xde, 0xad, 0xbe, 0xef]), "deadbeef")]
+    fn test_agent_description_encode_types(
+        #[case] value: DescriptionValueType,
+        #[case] expected: &str,
+    ) {
+        let agent_description = AgentDescription {
+            identifying_attributes: HashMap::from([("k".to_string(), value)]),
+            non_identifying_attributes: Default::default(),
+        };
+
+        assert_eq!(
+            build_agent_attributes(agent_description)
+                .get("k")
+                .map(String::as_str),
+            Some(expected)
         );
     }
 }

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -75,8 +75,8 @@ async fn update_agent_control_status(
             );
             status.fleet.unreachable(error_code, error_message);
         }
-        AgentControlEvent::AgentDescriptionUpdated(agent_description) => {
-            trace!("Updating Agent Control attributes for HTTP-Server");
+        AgentControlEvent::AgentDescriptionSet(agent_description) => {
+            trace!("Setting Agent Control attributes for HTTP-Server");
             status.agent_control.attributes = build_agent_attributes(agent_description)
         }
     }
@@ -107,6 +107,10 @@ async fn update_sub_agent_status(sub_agent_event: SubAgentEvent, status: Arc<RwL
                 .or_insert_with(|| {
                     SubAgentStatus::with_identity(agent_identity).with_start_time(start_time)
                 });
+        }
+        SubAgentEvent::AgentDescriptionSet(agent_description) => {
+            trace!("Setting SubAgent attributes for HTTP-Server");
+            status.agent_control.attributes = build_agent_attributes(agent_description);
         }
     }
 }

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -108,9 +108,14 @@ async fn update_sub_agent_status(sub_agent_event: SubAgentEvent, status: Arc<RwL
                     SubAgentStatus::with_identity(agent_identity).with_start_time(start_time)
                 });
         }
-        SubAgentEvent::AgentDescriptionSet(agent_description) => {
+        SubAgentEvent::AgentDescriptionSet(agent_identity, agent_description) => {
             trace!("Setting SubAgent attributes for HTTP-Server");
-            status.agent_control.attributes = build_agent_attributes(agent_description);
+            let attributes = build_agent_attributes(agent_description);
+            status
+                .agents
+                .entry(agent_identity.id.clone())
+                .or_insert_with(|| SubAgentStatus::with_identity(agent_identity))
+                .attributes = attributes;
         }
     }
 }

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -1,4 +1,4 @@
-use crate::agent_control::http_server::status::{Status, SubAgentStatus};
+use crate::agent_control::http_server::status::{Status, SubAgentStatus, build_agent_attributes};
 use crate::event::{AgentControlEvent, SubAgentEvent};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -75,8 +75,13 @@ async fn update_agent_control_status(
             );
             status.fleet.unreachable(error_code, error_message);
         }
+        AgentControlEvent::AgentDescriptionUpdated(agent_description) => {
+            trace!("Updating Agent Control attributes for HTTPServer");
+            status.agent_control.attributes = build_agent_attributes(agent_description)
+        }
     }
 }
+
 async fn update_sub_agent_status(sub_agent_event: SubAgentEvent, status: Arc<RwLock<Status>>) {
     let mut status = status.write().await;
     match sub_agent_event {

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -76,7 +76,7 @@ async fn update_agent_control_status(
             status.fleet.unreachable(error_code, error_message);
         }
         AgentControlEvent::AgentDescriptionUpdated(agent_description) => {
-            trace!("Updating Agent Control attributes for HTTPServer");
+            trace!("Updating Agent Control attributes for HTTP-Server");
             status.agent_control.attributes = build_agent_attributes(agent_description)
         }
     }

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -23,8 +23,8 @@ use crate::agent_type::version_config::{
 };
 use crate::checkers::version::k8s::checkers::spawn_version_checker;
 use crate::checkers::version::k8s::helmrelease::HelmReleaseVersionChecker;
-use crate::event::AgentControlInternalEvent;
 use crate::event::channel::{EventPublisher, pub_sub};
+use crate::event::{AgentControlEvent, AgentControlInternalEvent};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::opamp::client_builder::BuildOpAMPClient;
@@ -111,20 +111,26 @@ impl AgentControlRunner {
             )
         });
 
+        let agent_identity = AgentIdentity::new_agent_control_identity();
+        let opamp_start_settings = build_ac_opamp_start_settings(
+            &instance_id_getter,
+            &agent_identity,
+            &k8s_config,
+            &identifiers,
+        )?;
+
+        self.agent_control_publisher
+            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
+                opamp_start_settings.agent_description.clone(),
+            ));
+
         // Build and start AC OpAMP client
         let (maybe_client, maybe_opamp_consumer) = opamp_client_builder
             .as_ref()
             .map(|builder| -> Result<_, RunError> {
                 info!("Starting Agent Control OpAMP client");
-                let agent_identity = AgentIdentity::new_agent_control_identity();
-                let settings = build_ac_opamp_start_settings(
-                    &instance_id_getter,
-                    &agent_identity,
-                    &k8s_config,
-                    &identifiers,
-                )?;
                 builder
-                    .build_and_start(agent_identity, settings)
+                    .build_and_start(agent_identity, opamp_start_settings)
                     .map_err(|err| RunError(format!("error initializing OpAMP client: {err}")))
             })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -34,7 +34,7 @@ use crate::opamp::http::builder::OpAMPHttpClientBuilder;
 use crate::opamp::instance_id::getter::{InstanceIDGetter, InstanceIDWithIdentifiersGetter};
 use crate::opamp::instance_id::k8s::identifiers::{Identifiers, get_identifiers};
 use crate::opamp::instance_id::storer::Storer;
-use crate::opamp::operations::start_settings;
+use crate::opamp::operations::{agent_description, start_settings};
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::secret_retriever::k8s::retrieve::K8sSecretRetriever;
@@ -46,7 +46,7 @@ use crate::sub_agent::k8s::builder::SupervisorBuilderK8s;
 use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
 use crate::utils::thread_context::StartedThreadContext;
 use crate::{k8s::configmap_store::ConfigMapStore, sub_agent::k8s::builder::K8sSubAgentBuilder};
-use opamp_client::operation::settings::{DescriptionValueType, StartSettings};
+use opamp_client::operation::settings::{AgentDescription, DescriptionValueType, StartSettings};
 use resource_detection::system::hostname::get_hostname;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -112,16 +112,15 @@ impl AgentControlRunner {
         });
 
         let agent_identity = AgentIdentity::new_agent_control_identity();
-        let opamp_start_settings = build_ac_opamp_start_settings(
-            &instance_id_getter,
+        let agent_description = agent_description(
             &agent_identity,
-            &k8s_config,
-            &identifiers,
-        )?;
+            agent_control_additional_opamp_identifying_attributes(&k8s_config),
+            agent_control_opamp_non_identifying_attributes(&identifiers, &k8s_config),
+        );
 
         self.agent_control_publisher
             .broadcast(AgentControlEvent::AgentDescriptionSet(
-                opamp_start_settings.agent_description.clone(),
+                agent_description.clone(),
             ));
 
         // Build and start AC OpAMP client
@@ -129,6 +128,11 @@ impl AgentControlRunner {
             .as_ref()
             .map(|builder| -> Result<_, RunError> {
                 info!("Starting Agent Control OpAMP client");
+                let opamp_start_settings = build_ac_opamp_start_settings(
+                    &instance_id_getter,
+                    &agent_identity,
+                    agent_description,
+                )?;
                 builder
                     .build_and_start(agent_identity, opamp_start_settings)
                     .map_err(|err| RunError(format!("error initializing OpAMP client: {err}")))
@@ -305,24 +309,17 @@ fn start_cd_version_checker(
     )
 }
 
-/// Builds the OpAMP [StartSettings] for Agent Control on Kubernetes, including the agent
-/// identity and all identifying and non-identifying attributes.
+/// Builds the OpAMP [StartSettings] for Agent Control on Kubernetes.
 pub fn build_ac_opamp_start_settings(
     instance_id_getter: &impl InstanceIDGetter,
     agent_identity: &AgentIdentity,
-    k8s_config: &K8sConfig,
-    identifiers: &Identifiers,
+    agent_description: AgentDescription,
 ) -> Result<StartSettings, RunError> {
     let instance_id = instance_id_getter
         .get(&agent_identity.id)
         .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
 
-    Ok(start_settings(
-        instance_id,
-        agent_identity,
-        agent_control_additional_opamp_identifying_attributes(k8s_config),
-        agent_control_opamp_non_identifying_attributes(identifiers, k8s_config),
-    ))
+    Ok(start_settings(instance_id, agent_description))
 }
 
 pub fn agent_control_opamp_non_identifying_attributes(

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -120,7 +120,7 @@ impl AgentControlRunner {
         )?;
 
         self.agent_control_publisher
-            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
+            .broadcast(AgentControlEvent::AgentDescriptionSet(
                 opamp_start_settings.agent_description.clone(),
             ));
 

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -127,7 +127,7 @@ impl AgentControlRunner {
         )?;
 
         self.agent_control_publisher
-            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
+            .broadcast(AgentControlEvent::AgentDescriptionSet(
                 opamp_start_settings.agent_description.clone(),
             ));
 

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -31,7 +31,7 @@ use crate::opamp::http::client::HttpOpAMPClient;
 use crate::opamp::instance_id::getter::{InstanceIDGetter, InstanceIDWithIdentifiersGetter};
 use crate::opamp::instance_id::on_host::identifiers::{Identifiers, IdentifiersProvider};
 use crate::opamp::instance_id::storer::Storer;
-use crate::opamp::operations::start_settings;
+use crate::opamp::operations::{agent_description, start_settings};
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::package::oci::downloader::OCIArtifactDownloader;
@@ -52,7 +52,7 @@ use oci_client::client::ClientConfig;
 use oci_client::client::ClientProtocol;
 use opamp_client::http::StartedHttpClient;
 use opamp_client::http::client::OpAMPHttpClient;
-use opamp_client::operation::settings::{DescriptionValueType, StartSettings};
+use opamp_client::operation::settings::{AgentDescription, DescriptionValueType, StartSettings};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -119,22 +119,25 @@ impl AgentControlRunner {
         });
 
         let agent_identity = AgentIdentity::new_agent_control_identity();
-        let opamp_start_settings = build_ac_opamp_start_settings(
-            &instance_id_getter,
-            &agent_identity,
-            &identifiers,
-            RunningMode::Normal,
-        )?;
+        let agent_description =
+            build_ac_onhost_agent_description(&agent_identity, &identifiers, RunningMode::Normal);
 
         self.agent_control_publisher
             .broadcast(AgentControlEvent::AgentDescriptionSet(
-                opamp_start_settings.agent_description.clone(),
+                agent_description.clone(),
             ));
 
         // Build and start AC OpAMP client
         let (maybe_client, maybe_sa_opamp_consumer) = opamp_client_builder
             .as_ref()
-            .map(|builder| start_ac_opamp_client(builder, agent_identity, opamp_start_settings))
+            .map(|builder| {
+                let opamp_start_settings = build_ac_opamp_start_settings(
+                    &instance_id_getter,
+                    &agent_identity,
+                    agent_description,
+                )?;
+                start_ac_opamp_client(builder, agent_identity, opamp_start_settings)
+            })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
             .transpose()?
             .map(|(client, consumer)| (Some(client), Some(consumer)))
@@ -277,24 +280,30 @@ pub fn opamp_client_builder(
     OpAMPClientBuilder::new(poll_interval, http_builder, loader)
 }
 
-/// Builds the OpAMP [StartSettings] for Agent Control, including the agent identity and
-/// all identifying and non-identifying attributes.
+/// Builds the OpAMP [StartSettings] for Agent Control on-host.
 pub fn build_ac_opamp_start_settings(
     instance_id_getter: &impl InstanceIDGetter,
     agent_identity: &AgentIdentity,
-    identifiers: &Identifiers,
-    running_mode: RunningMode,
+    agent_description: AgentDescription,
 ) -> Result<StartSettings, RunError> {
     let instance_id = instance_id_getter
         .get(&agent_identity.id)
         .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
 
-    Ok(start_settings(
-        instance_id,
+    Ok(start_settings(instance_id, agent_description))
+}
+
+/// Builds the [AgentDescription] for Agent Control on-host.
+pub fn build_ac_onhost_agent_description(
+    agent_identity: &AgentIdentity,
+    identifiers: &Identifiers,
+    running_mode: RunningMode,
+) -> AgentDescription {
+    agent_description(
         agent_identity,
         ac_identifying_attributes(),
         ac_non_identifying_attributes(identifiers, running_mode),
-    ))
+    )
 }
 
 pub fn start_ac_opamp_client(

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -16,8 +16,8 @@ use crate::agent_control::version_updater::updater::NoOpUpdater;
 use crate::agent_type::render::TemplateRenderer;
 use crate::agent_type::variable::Variable;
 use crate::checkers::health::noop::NoOpHealthChecker;
-use crate::event::OpAMPEvent;
 use crate::event::channel::{EventConsumer, pub_sub};
+use crate::event::{AgentControlEvent, OpAMPEvent};
 use crate::http::config::ProxyConfig;
 use crate::oci;
 use crate::on_host::file_store::FileStore;
@@ -118,19 +118,23 @@ impl AgentControlRunner {
             )
         });
 
+        let agent_identity = AgentIdentity::new_agent_control_identity();
+        let opamp_start_settings = build_ac_opamp_start_settings(
+            &instance_id_getter,
+            &agent_identity,
+            &identifiers,
+            RunningMode::Normal,
+        )?;
+
+        self.agent_control_publisher
+            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
+                opamp_start_settings.agent_description.clone(),
+            ));
+
         // Build and start AC OpAMP client
         let (maybe_client, maybe_sa_opamp_consumer) = opamp_client_builder
             .as_ref()
-            .map(|builder| {
-                let agent_identity = AgentIdentity::new_agent_control_identity();
-                let settings = build_ac_opamp_start_settings(
-                    &instance_id_getter,
-                    &agent_identity,
-                    &identifiers,
-                    RunningMode::Normal,
-                )?;
-                start_ac_opamp_client(builder, agent_identity, settings)
-            })
+            .map(|builder| start_ac_opamp_client(builder, agent_identity, opamp_start_settings))
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
             .transpose()?
             .map(|(client, consumer)| (Some(client), Some(consumer)))

--- a/agent-control/src/command/on_host_checks/opamp.rs
+++ b/agent-control/src/command/on_host_checks/opamp.rs
@@ -5,8 +5,8 @@ use crate::{
     agent_control::run::{
         RunningMode,
         on_host::{
-            ac_identifiers, build_ac_opamp_start_settings, opamp_client_builder,
-            start_ac_opamp_client,
+            ac_identifiers, build_ac_onhost_agent_description, build_ac_opamp_start_settings,
+            opamp_client_builder, start_ac_opamp_client,
         },
     },
     command::on_host_checks::config::VerifiedConfig,
@@ -49,14 +49,12 @@ pub fn check_connectivity(
     // - The check sends an `AgentToServer` message and processes a `ServerToAgent` via
     //   `process_message`, doing more work than strictly necessary for connectivity verification
     let agent_identity = AgentIdentity::new_agent_control_identity();
-    let settings = build_ac_opamp_start_settings(
-        &instance_id_getter,
-        &agent_identity,
-        &identifiers,
-        RunningMode::Verify,
-    )?;
+    let agent_description =
+        build_ac_onhost_agent_description(&agent_identity, &identifiers, RunningMode::Verify);
+    let start_settings =
+        build_ac_opamp_start_settings(&instance_id_getter, &agent_identity, agent_description)?;
     let (client, _consumer) =
-        start_ac_opamp_client(&opamp_client_builder, agent_identity, settings)?;
+        start_ac_opamp_client(&opamp_client_builder, agent_identity, start_settings)?;
     client.stop()?;
 
     info!("OpAMP connectivity check successful");

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -47,7 +47,7 @@ pub enum AgentControlEvent {
 pub enum SubAgentEvent {
     HealthUpdated(AgentIdentity, HealthWithStartTime),
     SubAgentStarted(AgentIdentity, SystemTime),
-    AgentDescriptionSet(AgentDescription),
+    AgentDescriptionSet(AgentIdentity, AgentDescription),
 }
 
 impl SubAgentEvent {

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -37,7 +37,7 @@ pub enum AgentControlEvent {
     HealthUpdated(HealthWithStartTime),
     SubAgentRemoved(AgentID),
     AgentControlStopped,
-    AgentDescriptionUpdated(AgentDescription),
+    AgentDescriptionSet(AgentDescription),
     OpAMPConnected,
     OpAMPConnectFailed(Option<LastErrorCode>, LastErrorMessage),
 }
@@ -47,6 +47,7 @@ pub enum AgentControlEvent {
 pub enum SubAgentEvent {
     HealthUpdated(AgentIdentity, HealthWithStartTime),
     SubAgentStarted(AgentIdentity, SystemTime),
+    AgentDescriptionSet(AgentDescription),
 }
 
 impl SubAgentEvent {

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -8,6 +8,8 @@ pub mod broadcaster;
 pub mod cancellation;
 pub mod channel;
 
+use opamp_client::operation::settings::AgentDescription;
+
 use crate::checkers::health::with_start_time::HealthWithStartTime;
 use crate::opamp::attributes::UpdateAttributesMessage;
 use crate::opamp::{LastErrorCode, LastErrorMessage};
@@ -35,6 +37,7 @@ pub enum AgentControlEvent {
     HealthUpdated(HealthWithStartTime),
     SubAgentRemoved(AgentID),
     AgentControlStopped,
+    AgentDescriptionUpdated(AgentDescription),
     OpAMPConnected,
     OpAMPConnectFailed(Option<LastErrorCode>, LastErrorMessage),
 }

--- a/agent-control/src/opamp/operations.rs
+++ b/agent-control/src/opamp/operations.rs
@@ -29,19 +29,20 @@ pub fn sub_agent_start_settings<IG: InstanceIDGetter>(
 
     Ok(start_settings(
         instance_id_getter.get(&agent_identity.id)?,
-        agent_identity,
-        additional_identifying_attributes,
-        non_identifying_attributes,
+        agent_description(
+            agent_identity,
+            additional_identifying_attributes,
+            non_identifying_attributes,
+        ),
     ))
 }
 
-/// Builds the OpAMP StartSettings corresponding to the provided arguments for any sub agent and agent control.
-pub fn start_settings(
-    instance_id: InstanceID,
+/// Builds [AgentDescription] from the provided [AgentIdentity] and additional attributes
+pub fn agent_description(
     agent_identity: &AgentIdentity,
     additional_identifying_attributes: HashMap<String, DescriptionValueType>,
     non_identifying_attributes: HashMap<String, DescriptionValueType>,
-) -> StartSettings {
+) -> AgentDescription {
     let mut identifying_attributes = HashMap::from([
         (
             OPAMP_SERVICE_NAME.to_string(),
@@ -59,14 +60,22 @@ pub fn start_settings(
 
     identifying_attributes.extend(additional_identifying_attributes);
 
+    AgentDescription {
+        identifying_attributes,
+        non_identifying_attributes,
+    }
+}
+
+/// Builds the OpAMP StartSettings corresponding to the provided arguments for any sub agent and agent control.
+pub fn start_settings(
+    instance_id: InstanceID,
+    agent_description: AgentDescription,
+) -> StartSettings {
     StartSettings {
         instance_uid: instance_id.into(),
         capabilities: default_capabilities(),
         custom_capabilities: Some(default_custom_capabilities()),
-        agent_description: AgentDescription {
-            identifying_attributes,
-            non_identifying_attributes,
-        },
+        agent_description,
     }
 }
 

--- a/agent-control/src/opamp/operations.rs
+++ b/agent-control/src/opamp/operations.rs
@@ -1,18 +1,11 @@
 use super::instance_id::InstanceID;
-use super::{
-    client_builder::{BuildOpAMPClient, OpAMPClientBuilderError},
-    instance_id::getter::InstanceIDGetter,
-};
+use super::{client_builder::OpAMPClientBuilderError, instance_id::getter::InstanceIDGetter};
 use crate::agent_control::defaults::{
     OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SUPERVISOR_KEY,
     PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, default_custom_capabilities,
 };
 use crate::sub_agent::identity::AgentIdentity;
-use crate::{
-    agent_control::agent_id::AgentID,
-    event::{OpAMPEvent, channel::EventConsumer},
-    sub_agent::error::SubAgentError,
-};
+use crate::{agent_control::agent_id::AgentID, sub_agent::error::SubAgentError};
 use opamp_client::{
     StartedClient,
     operation::settings::{AgentDescription, DescriptionValueType, StartSettings},
@@ -20,17 +13,12 @@ use opamp_client::{
 use std::collections::HashMap;
 use tracing::info;
 
-pub fn build_sub_agent_opamp<OB, IG>(
-    opamp_builder: &OB,
+pub fn sub_agent_start_settings<IG: InstanceIDGetter>(
     instance_id_getter: &IG,
     agent_identity: &AgentIdentity,
     additional_identifying_attributes: HashMap<String, DescriptionValueType>,
     mut non_identifying_attributes: HashMap<String, DescriptionValueType>,
-) -> Result<(OB::Client, EventConsumer<OpAMPEvent>), OpAMPClientBuilderError>
-where
-    OB: BuildOpAMPClient,
-    IG: InstanceIDGetter,
-{
+) -> Result<StartSettings, OpAMPClientBuilderError> {
     let agent_control_id = AgentID::AgentControl;
     let parent_instance_id = instance_id_getter.get(&agent_control_id)?;
 
@@ -39,14 +27,12 @@ where
         DescriptionValueType::Bytes(parent_instance_id.into()),
     );
 
-    let start_settings = start_settings(
+    Ok(start_settings(
         instance_id_getter.get(&agent_identity.id)?,
         agent_identity,
         additional_identifying_attributes,
         non_identifying_attributes,
-    );
-
-    opamp_builder.build_and_start(agent_identity.clone(), start_settings)
+    ))
 }
 
 /// Builds the OpAMP StartSettings corresponding to the provided arguments for any sub agent and agent control.

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -7,7 +7,7 @@ use crate::event::channel::pub_sub;
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::opamp::instance_id::getter::InstanceIDGetter;
-use crate::opamp::operations::build_sub_agent_opamp;
+use crate::opamp::operations::sub_agent_start_settings;
 use crate::sub_agent::SubAgent;
 use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssembler};
 use crate::sub_agent::identity::AgentIdentity;
@@ -63,24 +63,33 @@ where
     ) -> Result<Self::NotStartedSubAgent, SubAgentBuilderError> {
         debug!("building subAgent");
 
+        let opamp_start_settings = sub_agent_start_settings(
+            &self.instance_id_getter,
+            agent_identity,
+            HashMap::from([(
+                OPAMP_SERVICE_VERSION.to_string(),
+                agent_identity.agent_type_id.version().to_string().into(),
+            )]),
+            HashMap::from([(
+                CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
+                DescriptionValueType::String(self.k8s_config.cluster_name.to_string()),
+            )]),
+        )
+        .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))?;
+
+        self.sub_agent_publisher
+            .broadcast(SubAgentEvent::AgentDescriptionSet(
+                agent_identity.clone(),
+                opamp_start_settings.agent_description.clone(),
+            ));
+
         let (maybe_opamp_client, sub_agent_opamp_consumer) = self
             .opamp_builder
             .as_ref()
             .map(|builder| {
-                build_sub_agent_opamp(
-                    builder,
-                    &self.instance_id_getter,
-                    agent_identity,
-                    HashMap::from([(
-                        OPAMP_SERVICE_VERSION.to_string(),
-                        agent_identity.agent_type_id.version().to_string().into(),
-                    )]),
-                    HashMap::from([(
-                        CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
-                        DescriptionValueType::String(self.k8s_config.cluster_name.to_string()),
-                    )]),
-                )
-                .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))
+                builder
+                    .build_and_start(agent_identity.clone(), opamp_start_settings)
+                    .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))
             })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
             .transpose()?

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -371,6 +371,7 @@ pub mod tests {
                 ),
             ]),
         );
+
         if opamp_builder_fails {
             opamp_builder
                 .expect_build_and_start()

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -181,7 +181,7 @@ pub mod tests {
     use crate::opamp::http::builder::HttpClientBuilderError;
     use crate::opamp::instance_id::InstanceID;
     use crate::opamp::instance_id::getter::tests::MockInstanceIDGetter;
-    use crate::opamp::operations::start_settings;
+    use crate::opamp::operations::{agent_description, start_settings};
     use crate::sub_agent::effective_agents_assembler::tests::MockEffectiveAgentAssembler;
     use crate::sub_agent::remote_config_parser::tests::MockRemoteConfigParser;
     use crate::sub_agent::supervisor::tests::MockSupervisorStarter;
@@ -364,21 +364,23 @@ pub mod tests {
         let mut opamp_builder = MockOpAMPClientBuilder::new();
         let start_settings = start_settings(
             instance_id.clone(),
-            &agent_identity,
-            HashMap::from([(
-                OPAMP_SERVICE_VERSION.to_string(),
-                agent_identity.agent_type_id.version().to_string().into(),
-            )]),
-            HashMap::from([
-                (
-                    CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
-                    DescriptionValueType::String(TEST_CLUSTER_NAME.to_string()),
-                ),
-                (
-                    PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
-                    DescriptionValueType::Bytes(instance_id.clone().into()),
-                ),
-            ]),
+            agent_description(
+                &agent_identity,
+                HashMap::from([(
+                    OPAMP_SERVICE_VERSION.to_string(),
+                    agent_identity.agent_type_id.version().to_string().into(),
+                )]),
+                HashMap::from([
+                    (
+                        CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
+                        DescriptionValueType::String(TEST_CLUSTER_NAME.to_string()),
+                    ),
+                    (
+                        PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
+                        DescriptionValueType::Bytes(instance_id.clone().into()),
+                    ),
+                ]),
+            ),
         );
 
         if opamp_builder_fails {

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -7,7 +7,7 @@ use crate::event::broadcaster::unbounded::UnboundedBroadcast;
 use crate::event::channel::pub_sub;
 use crate::opamp::client_builder::BuildOpAMPClient;
 use crate::opamp::instance_id::getter::InstanceIDGetter;
-use crate::opamp::operations::build_sub_agent_opamp;
+use crate::opamp::operations::sub_agent_start_settings;
 use crate::package::manager::PackageManager;
 use crate::sub_agent::SubAgent;
 use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssembler};
@@ -66,27 +66,35 @@ where
             .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))?
             .into();
 
+        let opamp_start_settings = sub_agent_start_settings(
+            &self.instance_id_getter,
+            agent_identity,
+            HashMap::from([(
+                OPAMP_SERVICE_VERSION.to_string(),
+                agent_identity.agent_type_id.version().to_string().into(),
+            )]),
+            HashMap::from([
+                (HOST_NAME_ATTRIBUTE_KEY.to_string(), hostname),
+                (
+                    OS_ATTRIBUTE_KEY.to_string(),
+                    DescriptionValueType::String(OS_ATTRIBUTE_VALUE.to_string()),
+                ),
+            ]),
+        )
+        .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))?;
+        self.sub_agent_publisher
+            .broadcast(SubAgentEvent::AgentDescriptionSet(
+                agent_identity.clone(),
+                opamp_start_settings.agent_description.clone(),
+            ));
+
         let (maybe_opamp_client, sub_agent_opamp_consumer) = self
             .opamp_builder
             .as_ref()
             .map(|builder| {
-                build_sub_agent_opamp(
-                    builder,
-                    &self.instance_id_getter,
-                    agent_identity,
-                    HashMap::from([(
-                        OPAMP_SERVICE_VERSION.to_string(),
-                        agent_identity.agent_type_id.version().to_string().into(),
-                    )]),
-                    HashMap::from([
-                        (HOST_NAME_ATTRIBUTE_KEY.to_string(), hostname),
-                        (
-                            OS_ATTRIBUTE_KEY.to_string(),
-                            DescriptionValueType::String(OS_ATTRIBUTE_VALUE.to_string()),
-                        ),
-                    ]),
-                )
-                .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))
+                builder
+                    .build_and_start(agent_identity.clone(), opamp_start_settings)
+                    .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))
             })
             // Transpose changes Option<Result<T, E>> to Result<Option<T>, E>, enabling the use of `?` to handle errors in this function
             .transpose()?

--- a/agent-control/tests/common/http_port.rs
+++ b/agent-control/tests/common/http_port.rs
@@ -8,3 +8,7 @@ pub fn available_port() -> u16 {
         .unwrap()
         .port()
 }
+
+pub fn status_server_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/status")
+}

--- a/agent-control/tests/common/http_port.rs
+++ b/agent-control/tests/common/http_port.rs
@@ -1,0 +1,10 @@
+use std::net::TcpListener;
+
+/// Returns an available local port by binding and immediately releasing an ephemeral socket.
+pub fn available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind ephemeral port")
+        .local_addr()
+        .unwrap()
+        .port()
+}

--- a/agent-control/tests/common/mod.rs
+++ b/agent-control/tests/common/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod attributes;
 pub(super) mod effective_config;
 pub(super) mod global_logger;
 pub(super) mod health;
+pub(super) mod http_port;
 pub(super) mod oci;
 pub(super) mod opamp;
 pub(super) mod process_finder;

--- a/agent-control/tests/k8s/scenarios.rs
+++ b/agent-control/tests/k8s/scenarios.rs
@@ -4,6 +4,7 @@ mod config_signature;
 mod cr_based_agents;
 mod fail_remote_config;
 mod garbage_collector;
+mod http_status_server;
 mod no_opamp;
 mod opamp;
 mod secrets_providers;

--- a/agent-control/tests/k8s/scenarios/http_status_server.rs
+++ b/agent-control/tests/k8s/scenarios/http_status_server.rs
@@ -11,8 +11,9 @@ use crate::k8s::tools::agent_control::{
 use crate::k8s::tools::k8s_api::create_values_secret;
 use crate::k8s::tools::k8s_env::K8sEnv;
 use newrelic_agent_control::agent_control::defaults::{
-    AGENT_CONTROL_VERSION, CLUSTER_NAME_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
-    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_VERSION,
+    AGENT_CONTROL_ID, AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
+    CLUSTER_NAME_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, OPAMP_SUPERVISOR_KEY,
 };
 use newrelic_agent_control::agent_control::run::{BasePaths, Environment};
 use serde_json::json;
@@ -83,82 +84,68 @@ fn test_k8s_http_status_endpoint_response() {
         Environment::K8s,
     );
 
+    let expected_fleet = json!({
+        "enabled": true,
+        "endpoint": opamp_server.endpoint(),
+        "reachable": true,
+    });
+
     retry(30, Duration::from_secs(1), || {
         let body: serde_json::Value = reqwest::blocking::get(status_server_url(status_server_port))
             .map_err(|e| format!("request failed: {e}"))?
             .json()
             .map_err(|e| format!("json parse failed: {e}"))?;
 
-        // fleet fields are set from config at server init, not event-driven
-        if body["fleet"]["enabled"] != json!(true) {
-            return Err(format!("expected fleet.enabled=true, got: {}", body["fleet"]).into());
+        if body["fleet"] != expected_fleet {
+            return Err(format!("expected fleet={expected_fleet}, got: {}", body["fleet"]).into());
         }
 
-        // agent_control.attributes is populated by the AgentDescriptionUpdated event
-        let ac_attrs = body["agent_control"]["attributes"]
-            .as_object()
-            .ok_or("agent_control.attributes not present or not an object")?;
-
-        let got_version = ac_attrs
-            .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY} missing"))?;
-        if got_version != AGENT_CONTROL_VERSION {
-            return Err(format!(
-                "expected {OPAMP_AGENT_VERSION_ATTRIBUTE_KEY}={AGENT_CONTROL_VERSION}, got {got_version}"
-            )
-            .into());
+        let ac_attrs = &body["agent_control"]["attributes"];
+        if !ac_attrs.is_object() {
+            return Err("agent_control.attributes not present or not an object".into());
         }
-
-        let got_cluster = ac_attrs
-            .get(CLUSTER_NAME_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{CLUSTER_NAME_ATTRIBUTE_KEY} missing"))?;
-        if got_cluster != TEST_CLUSTER_NAME {
-            return Err(format!(
-                "expected {CLUSTER_NAME_ATTRIBUTE_KEY}={TEST_CLUSTER_NAME}, got {got_cluster}"
-            )
-            .into());
+        let expected_ac_attrs = [
+            (
+                OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+                json!(AGENT_CONTROL_VERSION),
+            ),
+            (CLUSTER_NAME_ATTRIBUTE_KEY, json!(TEST_CLUSTER_NAME)),
+            (OPAMP_SERVICE_NAME, json!(AGENT_CONTROL_TYPE)),
+            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
+            (OPAMP_SUPERVISOR_KEY, json!(AGENT_CONTROL_ID)),
+        ];
+        for (key, expected) in expected_ac_attrs {
+            if ac_attrs[key] != expected {
+                return Err(format!("expected {key}={expected}, got: {}", ac_attrs[key]).into());
+            }
         }
-
-        if ac_attrs
-            .get(HOST_NAME_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
+        if ac_attrs[HOST_NAME_ATTRIBUTE_KEY]
+            .as_str()
             .unwrap_or("")
             .is_empty()
         {
             return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
         }
 
-        // sub-agent attributes are populated from AgentDescriptionSet
-        let sub_attrs = body["agents"][AGENT_ID]["attributes"]
-            .as_object()
-            .ok_or(format!(
-                "agents.{AGENT_ID}.attributes not present or not an object"
-            ))?;
-
-        let got_service_version = sub_attrs
-            .get(OPAMP_SERVICE_VERSION)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{OPAMP_SERVICE_VERSION} missing from sub-agent"))?;
-        if got_service_version != "0.0.1" {
-            return Err(format!(
-                "expected sub-agent {OPAMP_SERVICE_VERSION}=0.0.1, got {got_service_version}"
-            )
-            .into());
+        let sub_attrs = &body["agents"][AGENT_ID]["attributes"];
+        if !sub_attrs.is_object() {
+            return Err(
+                format!("agents.{AGENT_ID}.attributes not present or not an object").into(),
+            );
         }
-
-        let got_sub_cluster = sub_attrs
-            .get(CLUSTER_NAME_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!(
-                "{CLUSTER_NAME_ATTRIBUTE_KEY} missing from sub-agent"
-            ))?;
-        if got_sub_cluster != TEST_CLUSTER_NAME {
-            return Err(format!(
-                "expected sub-agent {CLUSTER_NAME_ATTRIBUTE_KEY}={TEST_CLUSTER_NAME}, got {got_sub_cluster}"
-            )
-            .into());
+        let expected_sub_attrs = [
+            (OPAMP_SERVICE_VERSION, json!("0.0.1")),
+            (CLUSTER_NAME_ATTRIBUTE_KEY, json!(TEST_CLUSTER_NAME)),
+            (OPAMP_SERVICE_NAME, json!("com.newrelic.custom_agent")),
+            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
+            (OPAMP_SUPERVISOR_KEY, json!(AGENT_ID)),
+        ];
+        for (key, expected) in expected_sub_attrs {
+            if sub_attrs[key] != expected {
+                return Err(
+                    format!("expected sub {key}={expected}, got: {}", sub_attrs[key]).into(),
+                );
+            }
         }
 
         Ok(())

--- a/agent-control/tests/k8s/scenarios/http_status_server.rs
+++ b/agent-control/tests/k8s/scenarios/http_status_server.rs
@@ -2,42 +2,61 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::http_port::available_port;
 use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::on_host::tools::config::create_agent_control_config_with_status_server;
+use crate::common::runtime::block_on;
+use crate::k8s::tools::agent_control::{
+    DUMMY_PRIVATE_KEY, K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET, TEST_CLUSTER_NAME,
+    create_k8s_agent_control_config_with_status_server,
+};
+use crate::k8s::tools::k8s_api::create_values_secret;
+use crate::k8s::tools::k8s_env::K8sEnv;
 use newrelic_agent_control::agent_control::defaults::{
-    AGENT_CONTROL_VERSION, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    AGENT_CONTROL_VERSION, CLUSTER_NAME_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
 };
-use newrelic_agent_control::agent_control::run::BasePaths;
-use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
+use newrelic_agent_control::agent_control::run::{BasePaths, Environment};
 use serde_json::json;
 use std::time::Duration;
 use tempfile::tempdir;
 
-/// The /status endpoint should return the expected response shape:
+/// The /status endpoint should return the expected response shape in k8s mode:
 /// - fleet fields reflect the configured OpAMP connection
 /// - agents is empty when no sub-agents are configured
-/// - agent_control.attributes contains the agent description derived from OpAMP start settings
+/// - agent_control.attributes contains the agent description derived from OpAMP start settings,
+///   including k8s-specific attributes like cluster.name
 #[test]
-fn test_http_status_endpoint_response() {
+#[ignore = "needs a k8s cluster"]
+fn test_k8s_http_status_endpoint_response() {
     let opamp_server = FakeServer::start_new();
-    let local_dir = tempdir().expect("failed to create local temp dir");
-    let remote_dir = tempdir().expect("failed to create remote temp dir");
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
 
     let status_server_port = available_port();
-    create_agent_control_config_with_status_server(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
+    create_k8s_agent_control_config_with_status_server(
+        k8s.client.clone(),
+        &namespace,
+        &opamp_server.endpoint(),
+        &opamp_server.jwks_endpoint(),
         status_server_port,
+        tmp_dir.path(),
     );
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.path().to_path_buf(),
-        remote_dir: remote_dir.path().to_path_buf(),
-        log_dir: local_dir.path().to_path_buf(),
-    };
-    let _ac = start_agent_control_with_custom_config(base_paths, AGENT_CONTROL_MODE_ON_HOST);
+    create_values_secret(
+        k8s.client.clone(),
+        &namespace,
+        K8S_PRIVATE_KEY_SECRET,
+        K8S_KEY_SECRET,
+        DUMMY_PRIVATE_KEY.to_string(),
+    );
+
+    let _ac = start_agent_control_with_custom_config(
+        BasePaths {
+            local_dir: tmp_dir.path().to_path_buf(),
+            remote_dir: tmp_dir.path().join("remote"),
+            log_dir: tmp_dir.path().join("log"),
+        },
+        Environment::K8s,
+    );
 
     retry(30, Duration::from_secs(1), || {
         let body: serde_json::Value =
@@ -56,7 +75,7 @@ fn test_http_status_endpoint_response() {
             return Err(format!("expected empty agents, got: {}", body["agents"]).into());
         }
 
-        // agent_control.attributes is populated
+        // agent_control.attributes is populated by the AgentDescriptionUpdated event
         let attrs = body["agent_control"]["attributes"]
             .as_object()
             .ok_or("agent_control.attributes not present or not an object")?;
@@ -72,13 +91,13 @@ fn test_http_status_endpoint_response() {
             .into());
         }
 
-        let got_host_id = attrs
-            .get(HOST_ID_ATTRIBUTE_KEY)
+        let got_cluster = attrs
+            .get(CLUSTER_NAME_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
-            .ok_or(format!("{HOST_ID_ATTRIBUTE_KEY} missing"))?;
-        if got_host_id != "integration-test" {
+            .ok_or(format!("{CLUSTER_NAME_ATTRIBUTE_KEY} missing"))?;
+        if got_cluster != TEST_CLUSTER_NAME {
             return Err(format!(
-                "expected {HOST_ID_ATTRIBUTE_KEY}=integration-test, got {got_host_id}"
+                "expected {CLUSTER_NAME_ATTRIBUTE_KEY}={TEST_CLUSTER_NAME}, got {got_cluster}"
             )
             .into());
         }

--- a/agent-control/tests/k8s/scenarios/http_status_server.rs
+++ b/agent-control/tests/k8s/scenarios/http_status_server.rs
@@ -104,27 +104,42 @@ fn test_k8s_http_status_endpoint_response() {
         if !ac_attrs.is_object() {
             return Err("agent_control.attributes not present or not an object".into());
         }
-        let expected_ac_attrs = [
+        let expected_ac_attrs = vec![
             (
-                OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+                format!("identifying/{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY}"),
                 json!(AGENT_CONTROL_VERSION),
             ),
-            (CLUSTER_NAME_ATTRIBUTE_KEY, json!(TEST_CLUSTER_NAME)),
-            (OPAMP_SERVICE_NAME, json!(AGENT_CONTROL_TYPE)),
-            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
-            (OPAMP_SUPERVISOR_KEY, json!(AGENT_CONTROL_ID)),
+            (
+                format!("non-identifying/{CLUSTER_NAME_ATTRIBUTE_KEY}"),
+                json!(TEST_CLUSTER_NAME),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAME}"),
+                json!(AGENT_CONTROL_TYPE),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAMESPACE}"),
+                json!(AGENT_CONTROL_NAMESPACE),
+            ),
+            (
+                format!("identifying/{OPAMP_SUPERVISOR_KEY}"),
+                json!(AGENT_CONTROL_ID),
+            ),
         ];
-        for (key, expected) in expected_ac_attrs {
-            if ac_attrs[key] != expected {
-                return Err(format!("expected {key}={expected}, got: {}", ac_attrs[key]).into());
+        for (key, expected) in &expected_ac_attrs {
+            if ac_attrs[key.as_str()] != *expected {
+                return Err(
+                    format!("expected {key}={expected}, got: {}", ac_attrs[key.as_str()]).into(),
+                );
             }
         }
-        if ac_attrs[HOST_NAME_ATTRIBUTE_KEY]
+        let ac_host_name_key = format!("non-identifying/{HOST_NAME_ATTRIBUTE_KEY}");
+        if ac_attrs[ac_host_name_key.as_str()]
             .as_str()
             .unwrap_or("")
             .is_empty()
         {
-            return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+            return Err(format!("{ac_host_name_key} is missing or empty").into());
         }
 
         let sub_attrs = &body["agents"][AGENT_ID]["attributes"];
@@ -133,18 +148,35 @@ fn test_k8s_http_status_endpoint_response() {
                 format!("agents.{AGENT_ID}.attributes not present or not an object").into(),
             );
         }
-        let expected_sub_attrs = [
-            (OPAMP_SERVICE_VERSION, json!("0.0.1")),
-            (CLUSTER_NAME_ATTRIBUTE_KEY, json!(TEST_CLUSTER_NAME)),
-            (OPAMP_SERVICE_NAME, json!("com.newrelic.custom_agent")),
-            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
-            (OPAMP_SUPERVISOR_KEY, json!(AGENT_ID)),
+        let expected_sub_attrs = vec![
+            (
+                format!("identifying/{OPAMP_SERVICE_VERSION}"),
+                json!("0.0.1"),
+            ),
+            (
+                format!("non-identifying/{CLUSTER_NAME_ATTRIBUTE_KEY}"),
+                json!(TEST_CLUSTER_NAME),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAME}"),
+                json!("com.newrelic.custom_agent"),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAMESPACE}"),
+                json!(AGENT_CONTROL_NAMESPACE),
+            ),
+            (
+                format!("identifying/{OPAMP_SUPERVISOR_KEY}"),
+                json!(AGENT_ID),
+            ),
         ];
-        for (key, expected) in expected_sub_attrs {
-            if sub_attrs[key] != expected {
-                return Err(
-                    format!("expected sub {key}={expected}, got: {}", sub_attrs[key]).into(),
-                );
+        for (key, expected) in &expected_sub_attrs {
+            if sub_attrs[key.as_str()] != *expected {
+                return Err(format!(
+                    "expected sub {key}={expected}, got: {}",
+                    sub_attrs[key.as_str()]
+                )
+                .into());
             }
         }
 

--- a/agent-control/tests/k8s/scenarios/http_status_server.rs
+++ b/agent-control/tests/k8s/scenarios/http_status_server.rs
@@ -1,17 +1,18 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
-use crate::common::http_port::available_port;
+use crate::common::http_port::{available_port, status_server_url};
 use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
 use crate::common::runtime::block_on;
 use crate::k8s::tools::agent_control::{
-    DUMMY_PRIVATE_KEY, K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET, TEST_CLUSTER_NAME,
+    CUSTOM_AGENT_TYPE_PATH, DUMMY_PRIVATE_KEY, DYNAMIC_AGENT_TYPE_FILENAME, K8S_KEY_SECRET,
+    K8S_PRIVATE_KEY_SECRET, TEST_CLUSTER_NAME, create_config_map,
     create_k8s_agent_control_config_with_status_server,
 };
 use crate::k8s::tools::k8s_api::create_values_secret;
 use crate::k8s::tools::k8s_env::K8sEnv;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_VERSION, CLUSTER_NAME_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
-    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_VERSION,
 };
 use newrelic_agent_control::agent_control::run::{BasePaths, Environment};
 use serde_json::json;
@@ -20,16 +21,31 @@ use tempfile::tempdir;
 
 /// The /status endpoint should return the expected response shape in k8s mode:
 /// - fleet fields reflect the configured OpAMP connection
-/// - agents is empty when no sub-agents are configured
+/// - agents contains the configured sub-agent with its attributes
 /// - agent_control.attributes contains the agent description derived from OpAMP start settings,
 ///   including k8s-specific attributes like cluster.name
 #[test]
 #[ignore = "needs a k8s cluster"]
 fn test_k8s_http_status_endpoint_response() {
+    const AGENT_ID: &str = "hello-world";
+    const AGENT_TYPE: &str = "newrelic/com.newrelic.custom_agent:0.0.1";
+
     let opamp_server = FakeServer::start_new();
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
     let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    // Copy the k8s custom agent type into the dynamic agent types directory
+    let agent_type_file_path = tmp_dir.path().join(DYNAMIC_AGENT_TYPE_FILENAME);
+    std::fs::create_dir_all(agent_type_file_path.parent().unwrap()).unwrap();
+    std::fs::copy(CUSTOM_AGENT_TYPE_PATH, &agent_type_file_path).unwrap();
+
+    let agents = format!(
+        r#"
+  {AGENT_ID}:
+    agent_type: "{AGENT_TYPE}"
+"#
+    );
 
     let status_server_port = available_port();
     create_k8s_agent_control_config_with_status_server(
@@ -39,7 +55,16 @@ fn test_k8s_http_status_endpoint_response() {
         &opamp_server.jwks_endpoint(),
         status_server_port,
         tmp_dir.path(),
+        &agents,
     );
+
+    // Sub-agent values ConfigMap (empty chart_values)
+    block_on(create_config_map(
+        k8s.client.clone(),
+        &namespace,
+        AGENT_ID,
+        "chart_values:\n".to_string(),
+    ));
 
     create_values_secret(
         k8s.client.clone(),
@@ -59,28 +84,22 @@ fn test_k8s_http_status_endpoint_response() {
     );
 
     retry(30, Duration::from_secs(1), || {
-        let body: serde_json::Value =
-            reqwest::blocking::get(format!("http://127.0.0.1:{status_server_port}/status"))
-                .map_err(|e| format!("request failed: {e}"))?
-                .json()
-                .map_err(|e| format!("json parse failed: {e}"))?;
+        let body: serde_json::Value = reqwest::blocking::get(status_server_url(status_server_port))
+            .map_err(|e| format!("request failed: {e}"))?
+            .json()
+            .map_err(|e| format!("json parse failed: {e}"))?;
 
         // fleet fields are set from config at server init, not event-driven
         if body["fleet"]["enabled"] != json!(true) {
             return Err(format!("expected fleet.enabled=true, got: {}", body["fleet"]).into());
         }
 
-        // no sub-agents configured
-        if body["agents"] != json!({}) {
-            return Err(format!("expected empty agents, got: {}", body["agents"]).into());
-        }
-
         // agent_control.attributes is populated by the AgentDescriptionUpdated event
-        let attrs = body["agent_control"]["attributes"]
+        let ac_attrs = body["agent_control"]["attributes"]
             .as_object()
             .ok_or("agent_control.attributes not present or not an object")?;
 
-        let got_version = attrs
+        let got_version = ac_attrs
             .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .ok_or(format!("{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY} missing"))?;
@@ -91,7 +110,7 @@ fn test_k8s_http_status_endpoint_response() {
             .into());
         }
 
-        let got_cluster = attrs
+        let got_cluster = ac_attrs
             .get(CLUSTER_NAME_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .ok_or(format!("{CLUSTER_NAME_ATTRIBUTE_KEY} missing"))?;
@@ -102,13 +121,44 @@ fn test_k8s_http_status_endpoint_response() {
             .into());
         }
 
-        if attrs
+        if ac_attrs
             .get(HOST_NAME_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .is_empty()
         {
             return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+        }
+
+        // sub-agent attributes are populated from AgentDescriptionSet
+        let sub_attrs = body["agents"][AGENT_ID]["attributes"]
+            .as_object()
+            .ok_or(format!(
+                "agents.{AGENT_ID}.attributes not present or not an object"
+            ))?;
+
+        let got_service_version = sub_attrs
+            .get(OPAMP_SERVICE_VERSION)
+            .and_then(|v| v.as_str())
+            .ok_or(format!("{OPAMP_SERVICE_VERSION} missing from sub-agent"))?;
+        if got_service_version != "0.0.1" {
+            return Err(format!(
+                "expected sub-agent {OPAMP_SERVICE_VERSION}=0.0.1, got {got_service_version}"
+            )
+            .into());
+        }
+
+        let got_sub_cluster = sub_attrs
+            .get(CLUSTER_NAME_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .ok_or(format!(
+                "{CLUSTER_NAME_ATTRIBUTE_KEY} missing from sub-agent"
+            ))?;
+        if got_sub_cluster != TEST_CLUSTER_NAME {
+            return Err(format!(
+                "expected sub-agent {CLUSTER_NAME_ATTRIBUTE_KEY}={TEST_CLUSTER_NAME}, got {got_sub_cluster}"
+            )
+            .into());
         }
 
         Ok(())

--- a/agent-control/tests/k8s/tools/agent_control.rs
+++ b/agent-control/tests/k8s/tools/agent_control.rs
@@ -195,6 +195,7 @@ pub fn create_local_agent_control_config(
 
 /// Creates the AC config (ConfigMap + local file) with the HTTP status server enabled on the given port.
 /// Uses [TEST_CLUSTER_NAME] as the cluster name.
+/// `agents` is the YAML value for the `agents:` key (e.g. `"{}"` for empty, or an indented block for sub-agents).
 pub fn create_k8s_agent_control_config_with_status_server(
     client: Client,
     ac_ns: &str,
@@ -202,6 +203,7 @@ pub fn create_k8s_agent_control_config_with_status_server(
     jwks_endpoint: &str,
     status_server_port: u16,
     local_dir: &Path,
+    agents: &str,
 ) {
     let content = format!(
         r#"fleet_control:
@@ -217,7 +219,7 @@ k8s:
   auth_secret:
     secret_name: {K8S_PRIVATE_KEY_SECRET}
     secret_key_name: {K8S_KEY_SECRET}
-agents: {{}}
+agents: {agents}
 server:
   enabled: true
   port: {status_server_port}

--- a/agent-control/tests/k8s/tools/agent_control.rs
+++ b/agent-control/tests/k8s/tools/agent_control.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use std::{fs::File, io::Write};
 
 pub const TEST_CLUSTER_NAME: &str = "minikube";
+
 pub const CUSTOM_AGENT_TYPE_PATH: &str = "tests/k8s/data/custom_agent_type.yml";
 pub const CUSTOM_AGENT_TYPE_SPLIT_NS_PATH: &str = "tests/k8s/data/custom_agent_type_split_ns.yml";
 pub const CUSTOM_AGENT_TYPE_SECRETS_PATH: &str = "tests/k8s/data/custom_agent_type_secrets.yml";
@@ -186,6 +187,54 @@ pub fn create_local_agent_control_config(
     let local = tmp_dir.join(FOLDER_NAME_LOCAL_DATA).join(AGENT_CONTROL_ID);
     std::fs::create_dir_all(&local).unwrap();
 
+    File::create(local.join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)))
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+}
+
+/// Creates the AC config (ConfigMap + local file) with the HTTP status server enabled on the given port.
+/// Uses [TEST_CLUSTER_NAME] as the cluster name.
+pub fn create_k8s_agent_control_config_with_status_server(
+    client: Client,
+    ac_ns: &str,
+    opamp_endpoint: &str,
+    jwks_endpoint: &str,
+    status_server_port: u16,
+    local_dir: &Path,
+) {
+    let content = format!(
+        r#"fleet_control:
+  endpoint: {opamp_endpoint}
+  poll_interval: 5s
+  signature_validation:
+    public_key_server_url: {jwks_endpoint}
+k8s:
+  namespace: {ac_ns}
+  namespace_agents: {ac_ns}
+  cluster_name: {TEST_CLUSTER_NAME}
+  secret_private_key_name: {K8S_PRIVATE_KEY_SECRET}
+  auth_secret:
+    secret_name: {K8S_PRIVATE_KEY_SECRET}
+    secret_key_name: {K8S_KEY_SECRET}
+agents: {{}}
+server:
+  enabled: true
+  port: {status_server_port}
+"#
+    );
+
+    block_on(create_config_map(
+        client,
+        ac_ns,
+        ConfigMapStore::build_cm_name(&AgentID::AgentControl, FOLDER_NAME_LOCAL_DATA).as_str(),
+        content.clone(),
+    ));
+
+    let local = local_dir
+        .join(FOLDER_NAME_LOCAL_DATA)
+        .join(AGENT_CONTROL_ID);
+    std::fs::create_dir_all(&local).unwrap();
     File::create(local.join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)))
         .unwrap()
         .write_all(content.as_bytes())

--- a/agent-control/tests/on_host/scenarios.rs
+++ b/agent-control/tests/on_host/scenarios.rs
@@ -3,6 +3,7 @@ mod empty_config;
 mod file_logging;
 mod filesystem_ops;
 mod health_check;
+mod http_status_server;
 mod install_remote_package;
 mod invalid_remote_config;
 mod memory_benchmark;

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -87,27 +87,42 @@ fn test_http_status_endpoint_response() {
         if !ac_attrs.is_object() {
             return Err("agent_control.attributes not present or not an object".into());
         }
-        let expected_ac_attrs = [
+        let expected_ac_attrs = vec![
             (
-                OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+                format!("identifying/{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY}"),
                 json!(AGENT_CONTROL_VERSION),
             ),
-            (HOST_ID_ATTRIBUTE_KEY, json!(HOST_ID)),
-            (OPAMP_SERVICE_NAME, json!(AGENT_CONTROL_TYPE)),
-            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
-            (OPAMP_SUPERVISOR_KEY, json!(AGENT_CONTROL_ID)),
+            (
+                format!("non-identifying/{HOST_ID_ATTRIBUTE_KEY}"),
+                json!(HOST_ID),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAME}"),
+                json!(AGENT_CONTROL_TYPE),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAMESPACE}"),
+                json!(AGENT_CONTROL_NAMESPACE),
+            ),
+            (
+                format!("identifying/{OPAMP_SUPERVISOR_KEY}"),
+                json!(AGENT_CONTROL_ID),
+            ),
         ];
-        for (key, expected) in expected_ac_attrs {
-            if ac_attrs[key] != expected {
-                return Err(format!("expected {key}={expected}, got: {}", ac_attrs[key]).into());
+        for (key, expected) in &expected_ac_attrs {
+            if ac_attrs[key.as_str()] != *expected {
+                return Err(
+                    format!("expected {key}={expected}, got: {}", ac_attrs[key.as_str()]).into(),
+                );
             }
         }
-        if ac_attrs[HOST_NAME_ATTRIBUTE_KEY]
+        let ac_host_name_key = format!("non-identifying/{HOST_NAME_ATTRIBUTE_KEY}");
+        if ac_attrs[ac_host_name_key.as_str()]
             .as_str()
             .unwrap_or("")
             .is_empty()
         {
-            return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+            return Err(format!("{ac_host_name_key} is missing or empty").into());
         }
 
         // Check sub-agent attributes
@@ -117,26 +132,44 @@ fn test_http_status_endpoint_response() {
                 format!("agents.{AGENT_ID}.attributes not present or not an object").into(),
             );
         }
-        let expected_sub_attrs = [
-            (OPAMP_SERVICE_VERSION, json!("0.1.0")),
-            (OS_ATTRIBUTE_KEY, json!(OS_ATTRIBUTE_VALUE)),
-            (OPAMP_SERVICE_NAME, json!("com.newrelic.custom_agent")),
-            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
-            (OPAMP_SUPERVISOR_KEY, json!(AGENT_ID)),
+        let expected_sub_attrs = vec![
+            (
+                format!("identifying/{OPAMP_SERVICE_VERSION}"),
+                json!("0.1.0"),
+            ),
+            (
+                format!("non-identifying/{OS_ATTRIBUTE_KEY}"),
+                json!(OS_ATTRIBUTE_VALUE),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAME}"),
+                json!("com.newrelic.custom_agent"),
+            ),
+            (
+                format!("identifying/{OPAMP_SERVICE_NAMESPACE}"),
+                json!(AGENT_CONTROL_NAMESPACE),
+            ),
+            (
+                format!("identifying/{OPAMP_SUPERVISOR_KEY}"),
+                json!(AGENT_ID),
+            ),
         ];
-        for (key, expected) in expected_sub_attrs {
-            if sub_attrs[key] != expected {
-                return Err(
-                    format!("expected sub {key}={expected}, got: {}", sub_attrs[key]).into(),
-                );
+        for (key, expected) in &expected_sub_attrs {
+            if sub_attrs[key.as_str()] != *expected {
+                return Err(format!(
+                    "expected sub {key}={expected}, got: {}",
+                    sub_attrs[key.as_str()]
+                )
+                .into());
             }
         }
-        if sub_attrs[HOST_NAME_ATTRIBUTE_KEY]
+        let sub_host_name_key = format!("non-identifying/{HOST_NAME_ATTRIBUTE_KEY}");
+        if sub_attrs[sub_host_name_key.as_str()]
             .as_str()
             .unwrap_or("")
             .is_empty()
         {
-            return Err(format!("sub-agent {HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+            return Err(format!("sub-agent {sub_host_name_key} is missing or empty").into());
         }
 
         Ok(())

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -1,0 +1,105 @@
+use crate::common::agent_control::start_agent_control_with_custom_config;
+use crate::common::opamp::FakeServer;
+use crate::common::retry::retry;
+use crate::on_host::tools::config::create_agent_control_config_with_status_server;
+use newrelic_agent_control::agent_control::defaults::{
+    AGENT_CONTROL_VERSION, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+};
+use newrelic_agent_control::agent_control::run::BasePaths;
+use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
+use serde_json::json;
+use std::net::TcpListener;
+use std::time::Duration;
+use tempfile::tempdir;
+
+/// The /status endpoint should return the expected response shape:
+/// - fleet fields reflect the configured OpAMP connection
+/// - agents is empty when no sub-agents are configured
+/// - agent_control.attributes contains the agent description derived from OpAMP start settings
+#[test]
+fn test_http_status_endpoint_response() {
+    let opamp_server = FakeServer::start_new();
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    let status_server_port = available_port();
+    create_agent_control_config_with_status_server(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        "{}".to_string(),
+        local_dir.path().to_path_buf(),
+        status_server_port,
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+    let _ac = start_agent_control_with_custom_config(base_paths, AGENT_CONTROL_MODE_ON_HOST);
+
+    retry(30, Duration::from_secs(1), || {
+        let body: serde_json::Value =
+            reqwest::blocking::get(format!("http://127.0.0.1:{status_server_port}/status"))
+                .map_err(|e| format!("request failed: {e}"))?
+                .json()
+                .map_err(|e| format!("json parse failed: {e}"))?;
+
+        // fleet fields are set from config at server init, not event-driven
+        if body["fleet"]["enabled"] != json!(true) {
+            return Err(format!("expected fleet.enabled=true, got: {}", body["fleet"]).into());
+        }
+
+        // no sub-agents configured
+        if body["agents"] != json!({}) {
+            return Err(format!("expected empty agents, got: {}", body["agents"]).into());
+        }
+
+        // agent_control.attributes is populated
+        let attrs = body["agent_control"]["attributes"]
+            .as_object()
+            .ok_or("agent_control.attributes not present or not an object")?;
+
+        let got_version = attrs
+            .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .ok_or(format!("{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY} missing"))?;
+        if got_version != AGENT_CONTROL_VERSION {
+            return Err(format!(
+                "expected {OPAMP_AGENT_VERSION_ATTRIBUTE_KEY}={AGENT_CONTROL_VERSION}, got {got_version}"
+            )
+            .into());
+        }
+
+        let got_host_id = attrs
+            .get(HOST_ID_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .ok_or(format!("{HOST_ID_ATTRIBUTE_KEY} missing"))?;
+        if got_host_id != "integration-test" {
+            return Err(format!(
+                "expected {HOST_ID_ATTRIBUTE_KEY}=integration-test, got {got_host_id}"
+            )
+            .into());
+        }
+
+        if attrs
+            .get(HOST_NAME_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+        }
+
+        Ok(())
+    });
+}
+
+fn available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind ephemeral port")
+        .local_addr()
+        .unwrap()
+        .port()
+}

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -8,8 +8,10 @@ use crate::on_host::tools::config::{
 };
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use newrelic_agent_control::agent_control::defaults::{
-    AGENT_CONTROL_VERSION, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
-    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_VERSION, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
+    AGENT_CONTROL_ID, AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
+    HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, OPAMP_SUPERVISOR_KEY,
+    OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -62,88 +64,79 @@ fn test_http_status_endpoint_response() {
     };
     let _ac = start_agent_control_with_custom_config(base_paths, AGENT_CONTROL_MODE_ON_HOST);
 
+    let expected_fleet = json!({
+        "enabled": true,
+        "endpoint": opamp_server.endpoint(),
+        "reachable": true,
+    });
+
     retry(30, Duration::from_secs(1), || {
+        // Query the status server endpoint
         let body: serde_json::Value = reqwest::blocking::get(status_server_url(status_server_port))
             .map_err(|e| format!("request failed: {e}"))?
             .json()
             .map_err(|e| format!("json parse failed: {e}"))?;
 
-        // fleet fields are set from config at server init, not event-driven
-        if body["fleet"]["enabled"] != json!(true) {
-            return Err(format!("expected fleet.enabled=true, got: {}", body["fleet"]).into());
+        // Check fleet sections
+        if body["fleet"] != expected_fleet {
+            return Err(format!("expected fleet={expected_fleet}, got: {}", body["fleet"]).into());
         }
 
-        // agent_control.attributes is populated
-        let ac_attrs = body["agent_control"]["attributes"]
-            .as_object()
-            .ok_or("agent_control.attributes not present or not an object")?;
-
-        let got_version = ac_attrs
-            .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY} missing"))?;
-        if got_version != AGENT_CONTROL_VERSION {
-            return Err(format!(
-                "expected {OPAMP_AGENT_VERSION_ATTRIBUTE_KEY}={AGENT_CONTROL_VERSION}, got {got_version}"
-            )
-            .into());
+        // Check Agent Control attributes
+        let ac_attrs = &body["agent_control"]["attributes"];
+        if !ac_attrs.is_object() {
+            return Err("agent_control.attributes not present or not an object".into());
         }
-
-        let got_host_id = ac_attrs
-            .get(HOST_ID_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{HOST_ID_ATTRIBUTE_KEY} missing"))?;
-        if got_host_id != HOST_ID {
-            return Err(
-                format!("expected {HOST_ID_ATTRIBUTE_KEY}={HOST_ID}, got {got_host_id}").into(),
-            );
+        let expected_ac_attrs = [
+            (
+                OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+                json!(AGENT_CONTROL_VERSION),
+            ),
+            (HOST_ID_ATTRIBUTE_KEY, json!(HOST_ID)),
+            (OPAMP_SERVICE_NAME, json!(AGENT_CONTROL_TYPE)),
+            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
+            (OPAMP_SUPERVISOR_KEY, json!(AGENT_CONTROL_ID)),
+        ];
+        for (key, expected) in expected_ac_attrs {
+            if ac_attrs[key] != expected {
+                return Err(format!("expected {key}={expected}, got: {}", ac_attrs[key]).into());
+            }
         }
-
-        if ac_attrs
-            .get(HOST_NAME_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
+        if ac_attrs[HOST_NAME_ATTRIBUTE_KEY]
+            .as_str()
             .unwrap_or("")
             .is_empty()
         {
             return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
         }
 
-        // sub-agent attributes are populated from AgentDescriptionSet
-        let sub_attrs = body["agents"][AGENT_ID]["attributes"]
-            .as_object()
-            .ok_or(format!(
-                "agents.{AGENT_ID}.attributes not present or not an object"
-            ))?;
-
-        let got_service_version = sub_attrs
-            .get(OPAMP_SERVICE_VERSION)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{OPAMP_SERVICE_VERSION} missing from sub-agent"))?;
-        if got_service_version != "0.1.0" {
-            return Err(format!(
-                "expected sub-agent {OPAMP_SERVICE_VERSION}=0.1.0, got {got_service_version}"
-            )
-            .into());
+        // Check sub-agent attributes
+        let sub_attrs = &body["agents"][AGENT_ID]["attributes"];
+        if !sub_attrs.is_object() {
+            return Err(
+                format!("agents.{AGENT_ID}.attributes not present or not an object").into(),
+            );
         }
-
-        if sub_attrs
-            .get(HOST_NAME_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
+        let expected_sub_attrs = [
+            (OPAMP_SERVICE_VERSION, json!("0.1.0")),
+            (OS_ATTRIBUTE_KEY, json!(OS_ATTRIBUTE_VALUE)),
+            (OPAMP_SERVICE_NAME, json!("com.newrelic.custom_agent")),
+            (OPAMP_SERVICE_NAMESPACE, json!(AGENT_CONTROL_NAMESPACE)),
+            (OPAMP_SUPERVISOR_KEY, json!(AGENT_ID)),
+        ];
+        for (key, expected) in expected_sub_attrs {
+            if sub_attrs[key] != expected {
+                return Err(
+                    format!("expected sub {key}={expected}, got: {}", sub_attrs[key]).into(),
+                );
+            }
+        }
+        if sub_attrs[HOST_NAME_ATTRIBUTE_KEY]
+            .as_str()
             .unwrap_or("")
             .is_empty()
         {
             return Err(format!("sub-agent {HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
-        }
-
-        let got_os = sub_attrs
-            .get(OS_ATTRIBUTE_KEY)
-            .and_then(|v| v.as_str())
-            .ok_or(format!("{OS_ATTRIBUTE_KEY} missing from sub-agent"))?;
-        if got_os != OS_ATTRIBUTE_VALUE {
-            return Err(format!(
-                "expected sub-agent {OS_ATTRIBUTE_KEY}={OS_ATTRIBUTE_VALUE}, got {got_os}"
-            )
-            .into());
         }
 
         Ok(())

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -1,11 +1,15 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
-use crate::common::http_port::available_port;
+use crate::common::http_port::{available_port, status_server_url};
 use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::on_host::tools::config::create_agent_control_config_with_status_server;
+use crate::on_host::consts::NO_CONFIG;
+use crate::on_host::tools::config::{
+    create_agent_control_config_with_status_server, create_local_config,
+};
+use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_VERSION, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
-    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_VERSION, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -15,21 +19,40 @@ use tempfile::tempdir;
 
 /// The /status endpoint should return the expected response shape:
 /// - fleet fields reflect the configured OpAMP connection
-/// - agents is empty when no sub-agents are configured
+/// - agents contains the configured sub-agent with its attributes
 /// - agent_control.attributes contains the agent description derived from OpAMP start settings
 #[test]
 fn test_http_status_endpoint_response() {
+    const AGENT_ID: &str = "nr-sleep-agent";
+    const HOST_ID: &str = "integration-test";
+
     let opamp_server = FakeServer::start_new();
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
+    let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
+
+    let agents = format!(
+        r#"
+  {AGENT_ID}:
+    agent_type: "{sleep_agent_type}"
+"#
+    );
+
     let status_server_port = available_port();
     create_agent_control_config_with_status_server(
+        HOST_ID,
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
-        "{}".to_string(),
+        agents,
         local_dir.path().to_path_buf(),
         status_server_port,
+    );
+
+    create_local_config(
+        AGENT_ID.to_string(),
+        NO_CONFIG.to_string(),
+        local_dir.path().into(),
     );
 
     let base_paths = BasePaths {
@@ -40,28 +63,22 @@ fn test_http_status_endpoint_response() {
     let _ac = start_agent_control_with_custom_config(base_paths, AGENT_CONTROL_MODE_ON_HOST);
 
     retry(30, Duration::from_secs(1), || {
-        let body: serde_json::Value =
-            reqwest::blocking::get(format!("http://127.0.0.1:{status_server_port}/status"))
-                .map_err(|e| format!("request failed: {e}"))?
-                .json()
-                .map_err(|e| format!("json parse failed: {e}"))?;
+        let body: serde_json::Value = reqwest::blocking::get(status_server_url(status_server_port))
+            .map_err(|e| format!("request failed: {e}"))?
+            .json()
+            .map_err(|e| format!("json parse failed: {e}"))?;
 
         // fleet fields are set from config at server init, not event-driven
         if body["fleet"]["enabled"] != json!(true) {
             return Err(format!("expected fleet.enabled=true, got: {}", body["fleet"]).into());
         }
 
-        // no sub-agents configured
-        if body["agents"] != json!({}) {
-            return Err(format!("expected empty agents, got: {}", body["agents"]).into());
-        }
-
         // agent_control.attributes is populated
-        let attrs = body["agent_control"]["attributes"]
+        let ac_attrs = body["agent_control"]["attributes"]
             .as_object()
             .ok_or("agent_control.attributes not present or not an object")?;
 
-        let got_version = attrs
+        let got_version = ac_attrs
             .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .ok_or(format!("{OPAMP_AGENT_VERSION_ATTRIBUTE_KEY} missing"))?;
@@ -72,24 +89,61 @@ fn test_http_status_endpoint_response() {
             .into());
         }
 
-        let got_host_id = attrs
+        let got_host_id = ac_attrs
             .get(HOST_ID_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .ok_or(format!("{HOST_ID_ATTRIBUTE_KEY} missing"))?;
-        if got_host_id != "integration-test" {
-            return Err(format!(
-                "expected {HOST_ID_ATTRIBUTE_KEY}=integration-test, got {got_host_id}"
-            )
-            .into());
+        if got_host_id != HOST_ID {
+            return Err(
+                format!("expected {HOST_ID_ATTRIBUTE_KEY}={HOST_ID}, got {got_host_id}").into(),
+            );
         }
 
-        if attrs
+        if ac_attrs
             .get(HOST_NAME_ATTRIBUTE_KEY)
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .is_empty()
         {
             return Err(format!("{HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+        }
+
+        // sub-agent attributes are populated from AgentDescriptionSet
+        let sub_attrs = body["agents"][AGENT_ID]["attributes"]
+            .as_object()
+            .ok_or(format!(
+                "agents.{AGENT_ID}.attributes not present or not an object"
+            ))?;
+
+        let got_service_version = sub_attrs
+            .get(OPAMP_SERVICE_VERSION)
+            .and_then(|v| v.as_str())
+            .ok_or(format!("{OPAMP_SERVICE_VERSION} missing from sub-agent"))?;
+        if got_service_version != "0.1.0" {
+            return Err(format!(
+                "expected sub-agent {OPAMP_SERVICE_VERSION}=0.1.0, got {got_service_version}"
+            )
+            .into());
+        }
+
+        if sub_attrs
+            .get(HOST_NAME_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(format!("sub-agent {HOST_NAME_ATTRIBUTE_KEY} is missing or empty").into());
+        }
+
+        let got_os = sub_attrs
+            .get(OS_ATTRIBUTE_KEY)
+            .and_then(|v| v.as_str())
+            .ok_or(format!("{OS_ATTRIBUTE_KEY} missing from sub-agent"))?;
+        if got_os != OS_ATTRIBUTE_VALUE {
+            return Err(format!(
+                "expected sub-agent {OS_ATTRIBUTE_KEY}={OS_ATTRIBUTE_VALUE}, got {got_os}"
+            )
+            .into());
         }
 
         Ok(())

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -31,6 +31,38 @@ pub fn create_agent_control_config(
     );
 }
 
+/// Extends [create_agent_control_config] enabling the HTTP status server on the given port.
+pub fn create_agent_control_config_with_status_server(
+    opamp_server_endpoint: String,
+    jwks_endpoint: String,
+    agents: String,
+    local_dir: PathBuf,
+    status_server_port: u16,
+) {
+    let agent_control_config = format!(
+        r#"
+host_id: integration-test
+fleet_control:
+  endpoint: {}
+  poll_interval: 5s
+  signature_validation:
+    public_key_server_url: {}
+agents: {}
+server:
+  enabled: true
+  port: {}
+"#,
+        opamp_server_endpoint, jwks_endpoint, agents, status_server_port,
+    );
+    create_file(
+        agent_control_config,
+        local_dir
+            .join(FOLDER_NAME_LOCAL_DATA)
+            .join(AGENT_CONTROL_ID)
+            .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)),
+    );
+}
+
 /// Extends [create_agent_control_config] with a proxy configuration parameter.
 pub fn create_agent_control_config_with_proxy(
     opamp_server_endpoint: String,

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -33,6 +33,7 @@ pub fn create_agent_control_config(
 
 /// Extends [create_agent_control_config] enabling the HTTP status server on the given port.
 pub fn create_agent_control_config_with_status_server(
+    host_id: &str,
     opamp_server_endpoint: String,
     jwks_endpoint: String,
     agents: String,
@@ -41,18 +42,17 @@ pub fn create_agent_control_config_with_status_server(
 ) {
     let agent_control_config = format!(
         r#"
-host_id: integration-test
+host_id: {host_id}
 fleet_control:
-  endpoint: {}
+  endpoint: {opamp_server_endpoint}
   poll_interval: 5s
   signature_validation:
-    public_key_server_url: {}
-agents: {}
+    public_key_server_url: {jwks_endpoint}
+agents: {agents}
 server:
   enabled: true
-  port: {}
+  port: {status_server_port}
 "#,
-        opamp_server_endpoint, jwks_endpoint, agents, status_server_port,
     );
     create_file(
         agent_control_config,


### PR DESCRIPTION
## Summary

The `/status` HTTP endpoint previously had no visibility into agent attributes (version, host name, cluster name, instance UID, etc.) Those were assembled only for the OpAMP client and never surfaced elsewhere. This PR wires the AgentDescription built during OpAMP setup into the status server so attributes are always visible, even when OpAMP is disabled.

## Notes for reviewers

* New integration tests included to check that the status-server works as expected (k8s and on-host).
* See the 'out of scope' section

## Out of scope

Attributes updates are not published to the status server for now. We can publish an additional event to the corresponding publisher for AC and sub-agents, but it involves an important refactor over information used to communicate the attributes change because we are currently using the OpAMP's proto types directly (See [attributes.rs](https://github.com/newrelic/newrelic-agent-control/blob/ab78a659473dfc09602fa1aed1abbcdd151b5b4d/agent-control/src/opamp/attributes.rs#L41-L45) for details). This will be addressed in a follow-up PR.