### PR TITLE
chore: address deprecation notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,13 +98,13 @@ archives:
   - id: linux
     formats: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - newrelic-agent-control-linux
       - newrelic-agent-control-cli-linux
   - id: windows
     formats: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - newrelic-agent-control-windows
       - newrelic-agent-control-cli-windows
     files:


### PR DESCRIPTION
just locally compiled and saw a mention to deprecated fields https://goreleaser.com/resources/deprecations/#archivesbuilds