### PR TITLE
feat: reflect attributes update on http status server [NR-537428]

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -343,8 +343,9 @@ where
                                 },
                                 AgentControlInternalEvent::AgentControlAttributesUpdated(attributes) => {
                                     let _ = self.opamp_client.as_ref().map(|c|
-                                        update_opamp_attributes(c, attributes)
+                                        update_opamp_attributes(c, attributes.clone())
                                     .inspect_err(|e| error!(error = %e, select_arm = "agent_control_internal_consumer", "processing version message")));
+                                    self.agent_control_publisher.broadcast(AgentControlEvent::AgentDescriptionUpdated(attributes));
                                 },
                                 AgentControlInternalEvent::SelfUpdateRestartRequested() => {
                                     debug!("Stopping Agent Control to apply self-update");

--- a/agent-control/src/agent_control/http_server/status.rs
+++ b/agent-control/src/agent_control/http_server/status.rs
@@ -329,6 +329,10 @@ pub mod tests {
                 attributes: Default::default(),
             }
         }
+        pub fn with_attributes(mut self, attrs: HashMap<String, String>) -> Self {
+            self.attributes = attrs;
+            self
+        }
     }
 
     impl SubAgentStatus {
@@ -347,8 +351,9 @@ pub mod tests {
             }
         }
 
-        pub fn agent_id(&self) -> AgentID {
-            self.agent_id.clone()
+        pub fn with_attributes(mut self, attrs: HashMap<String, String>) -> Self {
+            self.attributes = attrs;
+            self
         }
     }
 
@@ -371,22 +376,6 @@ pub mod tests {
     }
 
     impl OpAMPStatus {
-        pub fn new(
-            enabled: bool,
-            endpoint: Option<Url>,
-            reachable: bool,
-            error_code: Option<LastErrorCode>,
-            error_message: Option<LastErrorMessage>,
-        ) -> Self {
-            OpAMPStatus {
-                enabled,
-                endpoint,
-                reachable,
-                error_code,
-                error_message,
-            }
-        }
-
         pub fn enabled_and_reachable(endpoint: Option<Url>) -> Self {
             OpAMPStatus {
                 enabled: true,

--- a/agent-control/src/agent_control/http_server/status.rs
+++ b/agent-control/src/agent_control/http_server/status.rs
@@ -329,9 +329,8 @@ pub mod tests {
                 attributes: Default::default(),
             }
         }
-        pub fn with_attributes(mut self, attrs: HashMap<String, String>) -> Self {
-            self.attributes = attrs;
-            self
+        pub fn with_attributes(self, attributes: HashMap<String, String>) -> Self {
+            Self { attributes, ..self }
         }
     }
 
@@ -351,9 +350,8 @@ pub mod tests {
             }
         }
 
-        pub fn with_attributes(mut self, attrs: HashMap<String, String>) -> Self {
-            self.attributes = attrs;
-            self
+        pub fn with_attributes(self, attributes: HashMap<String, String>) -> Self {
+            Self { attributes, ..self }
         }
     }
 

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -128,15 +128,12 @@ mod tests {
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
-    use fake::faker::boolean::en;
-    use fake::faker::filesystem::en::Semver;
-    use fake::faker::lorem::en::{Word, Words};
-    use fake::{Fake, Faker};
+    use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
+    use rstest::rstest;
     use tokio::runtime::Handle;
     use tokio::sync::RwLock;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::sleep;
-
     use url::Url;
 
     use crate::agent_control::agent_id::AgentID;
@@ -157,396 +154,503 @@ mod tests {
     use crate::event::SubAgentEvent::HealthUpdated;
     use crate::sub_agent::identity::AgentIdentity;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_events() {
-        struct Test {
-            _name: &'static str,
-            agent_control_event: Option<AgentControlEvent>,
-            sub_agent_event: Option<SubAgentEvent>,
-            current_status: Arc<RwLock<Status>>,
-            expected_status: Status,
-        }
-        impl Test {
-            async fn run(&self) {
-                if let Some(agent_control_event) = self.agent_control_event.clone() {
-                    update_agent_control_status(agent_control_event, self.current_status.clone())
-                        .await;
-                }
-                if let Some(sub_agent_event) = self.sub_agent_event.clone() {
-                    update_sub_agent_status(sub_agent_event, self.current_status.clone()).await;
-                }
-                let st = self.current_status.read().await;
-                assert_eq!(self.expected_status, *st, "{}", self._name);
-            }
-        }
+    fn fixed_fleet() -> OpAMPStatus {
+        OpAMPStatus::enabled_and_reachable(Some(Url::try_from("http://127.0.0.1").unwrap()))
+    }
 
-        // Generate stubs. We'll use this to assert on what doesn't need to change
-        // in the events
-        let opamp_status_random = opamp_status_random();
-        let agent_control_status_random = agent_control_status_random();
-        let sub_agents_status_random = sub_agents_status_random();
+    fn fixed_agent_control() -> AgentControlStatus {
+        AgentControlStatus::new_healthy("running".to_string())
+    }
 
-        let tests = vec![
-            Test {
-                _name: "Unhealthy Agent Control becomes healthy",
-                agent_control_event: Some(AgentControlEvent::HealthUpdated(
-                    HealthWithStartTime::new(
-                        Healthy::new().with_status("some status".to_string()).into(),
-                        SystemTime::UNIX_EPOCH,
-                    ),
-                )),
-                sub_agent_event: None,
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: AgentControlStatus::new_unhealthy(
-                        String::from("some status"),
-                        String::from("some error"),
-                    ),
-                    fleet: opamp_status_random.clone(),
-                    agents: sub_agents_status_random.clone(),
-                })),
-                expected_status: Status {
-                    agent_control: AgentControlStatus::new_healthy(String::from("some status")),
-                    fleet: opamp_status_random.clone(),
-                    agents: sub_agents_status_random.clone(),
-                },
-            },
-            Test {
-                _name: "Healthy Agent Control becomes unhealthy",
-                agent_control_event: Some(AgentControlEvent::HealthUpdated(
-                    HealthWithStartTime::new(
-                        Unhealthy::new(
-                            "some error message for agent control unhealthy".to_string(),
-                        )
-                        .with_status("some status".to_string())
-                        .into(),
-                        SystemTime::UNIX_EPOCH,
-                    ),
-                )),
-                sub_agent_event: None,
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: AgentControlStatus::new_healthy(String::from("some status")),
-                    fleet: opamp_status_random.clone(),
-                    agents: sub_agents_status_random.clone(),
-                })),
-                expected_status: Status {
-                    agent_control: AgentControlStatus::new_unhealthy(
-                        String::from("some status"),
-                        String::from("some error message for agent control unhealthy"),
-                    ),
-                    fleet: opamp_status_random.clone(),
-                    agents: sub_agents_status_random.clone(),
-                },
-            },
-            Test {
-                _name: "Sub Agent first healthy event should add it to the list",
-                agent_control_event: None,
-                sub_agent_event: Some(HealthUpdated(
-                    AgentIdentity::from((
-                        AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                    )),
-                    HealthWithStartTime::new(Healthy::default().into(), SystemTime::UNIX_EPOCH),
-                )),
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::default(),
-                })),
-                expected_status: Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::from([(
-                        AgentID::try_from("some-agent-id").unwrap(),
-                        SubAgentStatus::new(
-                            AgentID::try_from("some-agent-id").unwrap(),
-                            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                            0,
-                            HealthInfo::new(String::default(), true, None, 0, 0),
-                        ),
-                    )]),
-                },
-            },
-            Test {
-                _name: "Sub Agent first unhealthy event should add it to the list",
-                agent_control_event: None,
-                sub_agent_event: Some(HealthUpdated(
-                    AgentIdentity::from((
-                        AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                    )),
-                    HealthWithStartTime::new(
-                        Unhealthy::default()
-                            .with_last_error("this is an error message".to_string())
-                            .into(),
-                        SystemTime::UNIX_EPOCH,
-                    ),
-                )),
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::default(),
-                })),
-                expected_status: Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::from([(
-                        AgentID::try_from("some-agent-id").unwrap(),
-                        SubAgentStatus::new(
-                            AgentID::try_from("some-agent-id").unwrap(),
-                            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                            0,
-                            HealthInfo::new(
-                                String::default(),
-                                false,
-                                Some(String::from("this is an error message")),
-                                0,
-                                0,
-                            ),
-                        ),
-                    )]),
-                },
-            },
-            Test {
-                _name: "Sub Agent second unhealthy event should change existing one",
-                agent_control_event: None,
-                sub_agent_event: Some(HealthUpdated(
-                    AgentIdentity::from((
-                        AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                    )),
-                    HealthWithStartTime::new(
-                        Unhealthy::default()
-                            .with_last_error("this is an error message".to_string())
-                            .into(),
-                        SystemTime::UNIX_EPOCH,
-                    ),
-                )),
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::from([
-                        (
-                            AgentID::try_from("some-agent-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-agent-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    true,
-                                    Some(String::default()),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                        (
-                            AgentID::try_from("some-other-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-other-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    true,
-                                    Some(String::default()),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                    ]),
-                })),
-                expected_status: Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::from([
-                        (
-                            AgentID::try_from("some-agent-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-agent-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    false,
-                                    Some(String::from("this is an error message")),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                        (
-                            AgentID::try_from("some-other-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-other-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    true,
-                                    Some(String::default()),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                    ]),
-                },
-            },
-            Test {
-                _name: "Sub Agent gets removed",
-                agent_control_event: Some(SubAgentRemoved(
+    fn fixed_agents() -> SubAgentsStatus {
+        SubAgentsStatus::from([(
+            AgentID::try_from("fixed-agent-id").unwrap(),
+            SubAgentStatus::new(
+                AgentID::try_from("fixed-agent-id").unwrap(),
+                AgentTypeID::try_from("ns/type:1.0.0").unwrap(),
+                0,
+                HealthInfo::new(String::default(), true, None, 0, 0),
+            ),
+        )])
+    }
+
+    fn agent_identity(id: &str) -> AgentIdentity {
+        AgentIdentity::from((
+            AgentID::try_from(id).unwrap(),
+            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+        ))
+    }
+
+    fn agent_description(
+        identifying: &[(&str, &str)],
+        non_identifying: &[(&str, &str)],
+    ) -> AgentDescription {
+        AgentDescription {
+            identifying_attributes: identifying
+                .iter()
+                .map(|(k, v)| (k.to_string(), DescriptionValueType::String(v.to_string())))
+                .collect(),
+            non_identifying_attributes: non_identifying
+                .iter()
+                .map(|(k, v)| (k.to_string(), DescriptionValueType::String(v.to_string())))
+                .collect(),
+        }
+    }
+
+    #[rstest]
+    #[case::health_updated_becomes_healthy(
+        AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
+            Healthy::new().with_status("some status".to_string()).into(),
+            SystemTime::UNIX_EPOCH,
+        )),
+        Status {
+            agent_control: AgentControlStatus::new_unhealthy(
+                "some status".to_string(),
+                "some error".to_string(),
+            ),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: AgentControlStatus::new_healthy("some status".to_string()),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+    )]
+    #[case::health_updated_becomes_unhealthy(
+        AgentControlEvent::HealthUpdated(HealthWithStartTime::new(
+            Unhealthy::new("some error message for agent control unhealthy".to_string())
+                .with_status("some status".to_string())
+                .into(),
+            SystemTime::UNIX_EPOCH,
+        )),
+        Status {
+            agent_control: AgentControlStatus::new_healthy("some status".to_string()),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: AgentControlStatus::new_unhealthy(
+                "some status".to_string(),
+                "some error message for agent control unhealthy".to_string(),
+            ),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+    )]
+    #[case::sub_agent_removed(
+        SubAgentRemoved(AgentID::try_from("some-agent-id").unwrap()),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([
+                (
                     AgentID::try_from("some-agent-id").unwrap(),
-                )),
-                sub_agent_event: None,
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random.clone(),
-                    agents: SubAgentsStatus::from([
-                        (
-                            AgentID::try_from("some-agent-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-agent-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    true,
-                                    Some(String::default()),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                        (
-                            AgentID::try_from("some-other-id").unwrap(),
-                            SubAgentStatus::new(
-                                AgentID::try_from("some-other-id").unwrap(),
-                                AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                                0,
-                                HealthInfo::new(
-                                    String::default(),
-                                    true,
-                                    Some(String::default()),
-                                    0,
-                                    0,
-                                ),
-                            ),
-                        ),
-                    ]),
-                })),
-                expected_status: Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: opamp_status_random,
-                    agents: SubAgentsStatus::from([(
-                        AgentID::try_from("some-other-id").unwrap(),
-                        SubAgentStatus::new(
-                            AgentID::try_from("some-other-id").unwrap(),
-                            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
-                            0,
-                            HealthInfo::new(String::default(), true, Some(String::default()), 0, 0),
-                        ),
-                    )]),
-                },
-            },
-            Test {
-                _name: "OpAMP Agent gets unhealthy",
-                agent_control_event: Some(OpAMPConnectFailed(
-                    Some(404),
-                    String::from("some error msg"),
-                )),
-                sub_agent_event: None,
-                current_status: Arc::new(RwLock::new(Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: OpAMPStatus::enabled_and_reachable(Some(
-                        Url::try_from("http://127.0.0.1").unwrap(),
-                    )),
-                    agents: sub_agents_status_random.clone(),
-                })),
-                expected_status: Status {
-                    agent_control: agent_control_status_random.clone(),
-                    fleet: OpAMPStatus::enabled_and_unreachable(
-                        Some(Url::try_from("http://127.0.0.1").unwrap()),
-                        404,
-                        String::from("some error msg"),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-agent-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
-                    agents: sub_agents_status_random.clone(),
-                },
-            },
-        ];
-
-        for test in tests {
-            test.run().await;
-        }
+                ),
+                (
+                    AgentID::try_from("some-other-id").unwrap(),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-other-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(String::default(), true, None, 0, 0),
+                    ),
+                ),
+            ]),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-other-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-other-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                ),
+            )]),
+        },
+    )]
+    #[case::opamp_connected(
+        AgentControlEvent::OpAMPConnected,
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: OpAMPStatus::enabled_and_unreachable(
+                Some(Url::try_from("http://127.0.0.1").unwrap()),
+                503,
+                "service unavailable".to_string(),
+            ),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+    )]
+    #[case::opamp_connect_failed(
+        OpAMPConnectFailed(Some(404), "some error msg".to_string()),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: OpAMPStatus::enabled_and_unreachable(
+                Some(Url::try_from("http://127.0.0.1").unwrap()),
+                404,
+                "some error msg".to_string(),
+            ),
+            agents: fixed_agents(),
+        },
+    )]
+    #[case::agent_description_updated_sets_new_attributes(
+        AgentControlEvent::AgentDescriptionUpdated(agent_description(
+            &[("agent_version", "1.0.0")],
+            &[("host_name", "my-host")],
+        )),
+        Status {
+            agent_control: AgentControlStatus::new_healthy("running".to_string()),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
+                HashMap::from([
+                    ("agent_version".to_string(), "1.0.0".to_string()),
+                    ("host_name".to_string(), "my-host".to_string()),
+                ]),
+            ),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+    )]
+    #[case::agent_description_updated_extends_and_preserves_existing_attributes(
+        AgentControlEvent::AgentDescriptionUpdated(agent_description(
+            &[("agent_version", "2.0.0")],
+            &[("new_key", "new_val")],
+        )),
+        Status {
+            agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
+                HashMap::from([
+                    ("agent_version".to_string(), "1.0.0".to_string()),
+                    ("host_name".to_string(), "my-host".to_string()),
+                ]),
+            ),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+        Status {
+            agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
+                HashMap::from([
+                    ("agent_version".to_string(), "2.0.0".to_string()), // overwritten
+                    ("host_name".to_string(), "my-host".to_string()),   // preserved
+                    ("new_key".to_string(), "new_val".to_string()),     // added
+                ]),
+            ),
+            fleet: fixed_fleet(),
+            agents: fixed_agents(),
+        },
+    )]
+    #[tokio::test]
+    async fn test_update_agent_control_status(
+        #[case] event: AgentControlEvent,
+        #[case] current_status: Status,
+        #[case] expected_status: Status,
+    ) {
+        let status = Arc::new(RwLock::new(current_status));
+        update_agent_control_status(event, status.clone()).await;
+        assert_eq!(expected_status, *status.read().await);
     }
 
-    fn uri_to_url(uri: http::Uri) -> Option<Url> {
-        let uri_str = uri.to_string();
-        Url::try_from(uri_str.as_str()).ok()
-    }
-
-    // create random OpAMP status
-    fn opamp_status_random() -> OpAMPStatus {
-        // There is no fake instance for the `Url` type, so we will assemble it step by step from an `Uri`,
-        // given that all URLs are URIs but not all URIs are URLs.
-        let endpoint = uri_to_url(Faker.fake::<http::Uri>());
-        let reachable = en::Boolean(50).fake::<bool>();
-        let enabled = en::Boolean(50).fake::<bool>();
-        let error_code = Some((400..599).fake::<u16>());
-        let error_message = Some(Words(3..5).fake::<Vec<String>>().join(" "));
-
-        OpAMPStatus::new(enabled, endpoint, reachable, error_code, error_message)
-    }
-
-    // create random Agent Control status
-    fn agent_control_status_random() -> AgentControlStatus {
-        let healthy = en::Boolean(50).fake::<bool>();
-
-        //random status
-        let status = Word().fake::<String>();
-
-        if healthy {
-            AgentControlStatus::new_healthy(status.clone())
-        } else {
-            AgentControlStatus::new_unhealthy(status, Words(3..5).fake::<Vec<String>>().join(" "))
-        }
-    }
-
-    // create random Sub Agent status
-    fn sub_agent_status_random() -> SubAgentStatus {
-        let healthy = en::Boolean(50).fake::<bool>();
-        let last_error = healthy
-            .then_some(Words(3..5).fake::<Vec<String>>().join(" "))
-            .or(Some(String::default()));
-        let agent_id = AgentID::try_from(Word().fake::<&str>()).unwrap();
-        let agent_type_fqn = format!(
-            "{}/{}:{}",
-            Word().fake::<&str>(),
-            Word().fake::<&str>(),
-            Semver().fake::<String>(),
-        );
-        let agent_type = AgentTypeID::try_from(agent_type_fqn.as_str()).unwrap();
-        //random status
-        let status = Word().fake::<String>();
-
-        SubAgentStatus::new(
-            agent_id,
-            agent_type,
-            0,
-            HealthInfo::new(status, healthy, last_error, 0, 0),
-        )
-    }
-
-    // create N (0..5) random Sub Agent status
-    fn sub_agents_status_random() -> SubAgentsStatus {
-        let sub_agents_amount = (0..5).fake::<u32>();
-        let mut sub_agents: HashMap<AgentID, SubAgentStatus> = HashMap::new();
-        for _ in 0..sub_agents_amount {
-            let sub_agent = sub_agent_status_random();
-            sub_agents.insert(sub_agent.agent_id(), sub_agent);
-        }
-        SubAgentsStatus::from(sub_agents)
+    #[rstest]
+    #[case::health_updated_first_healthy(
+        HealthUpdated(
+            agent_identity("some-agent-id"),
+            HealthWithStartTime::new(Healthy::default().into(), SystemTime::UNIX_EPOCH),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::default(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                ),
+            )]),
+        },
+    )]
+    #[case::health_updated_first_unhealthy(
+        HealthUpdated(
+            agent_identity("some-agent-id"),
+            HealthWithStartTime::new(
+                Unhealthy::default()
+                    .with_last_error("this is an error message".to_string())
+                    .into(),
+                SystemTime::UNIX_EPOCH,
+            ),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::default(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(
+                        String::default(),
+                        false,
+                        Some("this is an error message".to_string()),
+                        0,
+                        0,
+                    ),
+                ),
+            )]),
+        },
+    )]
+    #[case::health_updated_changes_existing_agent(
+        HealthUpdated(
+            agent_identity("some-agent-id"),
+            HealthWithStartTime::new(
+                Unhealthy::default()
+                    .with_last_error("this is an error message".to_string())
+                    .into(),
+                SystemTime::UNIX_EPOCH,
+            ),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([
+                (
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-agent-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(String::default(), true, None, 0, 0),
+                    ),
+                ),
+                (
+                    AgentID::try_from("some-other-id").unwrap(),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-other-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(String::default(), true, None, 0, 0),
+                    ),
+                ),
+            ]),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([
+                (
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-agent-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(
+                            String::default(),
+                            false,
+                            Some("this is an error message".to_string()),
+                            0,
+                            0,
+                        ),
+                    ),
+                ),
+                (
+                    AgentID::try_from("some-other-id").unwrap(),
+                    SubAgentStatus::new(
+                        AgentID::try_from("some-other-id").unwrap(),
+                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        0,
+                        HealthInfo::new(String::default(), true, None, 0, 0),
+                    ),
+                ),
+            ]),
+        },
+    )]
+    #[case::sub_agent_started_adds_new_agent(
+        SubAgentEvent::SubAgentStarted(agent_identity("some-agent-id"), SystemTime::UNIX_EPOCH),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::default(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::with_identity(agent_identity("some-agent-id"))
+                    .with_start_time(SystemTime::UNIX_EPOCH),
+            )]),
+        },
+    )]
+    #[case::sub_agent_started_does_not_override_existing(
+        SubAgentEvent::SubAgentStarted(agent_identity("some-agent-id"), SystemTime::UNIX_EPOCH),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                ),
+            )]),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                ),
+            )]),
+        },
+    )]
+    #[case::agent_description_updated_sets_attributes_on_known_agent(
+        SubAgentEvent::AgentDescriptionUpdated(
+            agent_identity("some-agent-id"),
+            agent_description(&[("agent_version", "1.0.0")], &[("host_name", "my-host")]),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                ),
+            )]),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                )
+                .with_attributes(HashMap::from([
+                    ("agent_version".to_string(), "1.0.0".to_string()),
+                    ("host_name".to_string(), "my-host".to_string()),
+                ])),
+            )]),
+        },
+    )]
+    #[case::agent_description_updated_extends_and_preserves_existing_attributes(
+        SubAgentEvent::AgentDescriptionUpdated(
+            agent_identity("some-agent-id"),
+            agent_description(&[("agent_version", "2.0.0")], &[("new_key", "new_val")]),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                )
+                .with_attributes(HashMap::from([
+                    ("agent_version".to_string(), "1.0.0".to_string()),
+                    ("host_name".to_string(), "my-host".to_string()),
+                ])),
+            )]),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::new(
+                    AgentID::try_from("some-agent-id").unwrap(),
+                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    0,
+                    HealthInfo::new(String::default(), true, None, 0, 0),
+                )
+                .with_attributes(HashMap::from([
+                    ("agent_version".to_string(), "2.0.0".to_string()), // overwritten
+                    ("host_name".to_string(), "my-host".to_string()),   // preserved
+                    ("new_key".to_string(), "new_val".to_string()),     // added
+                ])),
+            )]),
+        },
+    )]
+    #[case::agent_description_updated_creates_agent_when_absent(
+        SubAgentEvent::AgentDescriptionUpdated(
+            agent_identity("some-agent-id"),
+            agent_description(&[("agent_version", "1.0.0")], &[]),
+        ),
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::default(),
+        },
+        Status {
+            agent_control: fixed_agent_control(),
+            fleet: fixed_fleet(),
+            agents: SubAgentsStatus::from([(
+                AgentID::try_from("some-agent-id").unwrap(),
+                SubAgentStatus::with_identity(agent_identity("some-agent-id"))
+                    .with_attributes(HashMap::from([(
+                        "agent_version".to_string(),
+                        "1.0.0".to_string(),
+                    )])),
+            )]),
+        },
+    )]
+    #[tokio::test]
+    async fn test_update_sub_agent_status(
+        #[case] event: SubAgentEvent,
+        #[case] current_status: Status,
+        #[case] expected_status: Status,
+    ) {
+        let status = Arc::new(RwLock::new(current_status));
+        update_sub_agent_status(event, status.clone()).await;
+        assert_eq!(expected_status, *status.read().await);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -75,9 +75,10 @@ async fn update_agent_control_status(
             );
             status.fleet.unreachable(error_code, error_message);
         }
-        AgentControlEvent::AgentDescriptionSet(agent_description) => {
+        AgentControlEvent::AgentDescriptionUpdated(agent_description) => {
             trace!("Setting Agent Control attributes for HTTP-Server");
-            status.agent_control.attributes = build_agent_attributes(agent_description)
+            let attributes_update = build_agent_attributes(agent_description);
+            status.agent_control.attributes.extend(attributes_update);
         }
     }
 }
@@ -108,14 +109,15 @@ async fn update_sub_agent_status(sub_agent_event: SubAgentEvent, status: Arc<RwL
                     SubAgentStatus::with_identity(agent_identity).with_start_time(start_time)
                 });
         }
-        SubAgentEvent::AgentDescriptionSet(agent_identity, agent_description) => {
+        SubAgentEvent::AgentDescriptionUpdated(agent_identity, agent_description) => {
             trace!("Setting SubAgent attributes for HTTP-Server");
-            let attributes = build_agent_attributes(agent_description);
+            let attributes_update = build_agent_attributes(agent_description);
             status
                 .agents
                 .entry(agent_identity.id.clone())
                 .or_insert_with(|| SubAgentStatus::with_identity(agent_identity))
-                .attributes = attributes;
+                .attributes
+                .extend(attributes_update);
         }
     }
 }

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -115,6 +115,7 @@ async fn update_sub_agent_status(sub_agent_event: SubAgentEvent, status: Arc<RwL
             status
                 .agents
                 .entry(agent_identity.id.clone())
+                // New entry if sub-agent was unknown (Eg: SubAgentStarted was never received)
                 .or_insert_with(|| SubAgentStatus::with_identity(agent_identity))
                 .attributes
                 .extend(attributes_update);

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -326,8 +326,8 @@ mod tests {
         Status {
             agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
                 HashMap::from([
-                    ("agent_version".to_string(), "1.0.0".to_string()),
-                    ("host_name".to_string(), "my-host".to_string()),
+                    ("identifying/agent_version".to_string(), "1.0.0".to_string()),
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()),
                 ]),
             ),
             fleet: fixed_fleet(),
@@ -342,8 +342,8 @@ mod tests {
         Status {
             agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
                 HashMap::from([
-                    ("agent_version".to_string(), "1.0.0".to_string()),
-                    ("host_name".to_string(), "my-host".to_string()),
+                    ("identifying/agent_version".to_string(), "1.0.0".to_string()),
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()),
                 ]),
             ),
             fleet: fixed_fleet(),
@@ -352,9 +352,9 @@ mod tests {
         Status {
             agent_control: AgentControlStatus::new_healthy("running".to_string()).with_attributes(
                 HashMap::from([
-                    ("agent_version".to_string(), "2.0.0".to_string()), // overwritten
-                    ("host_name".to_string(), "my-host".to_string()),   // preserved
-                    ("new_key".to_string(), "new_val".to_string()),     // added
+                    ("identifying/agent_version".to_string(), "2.0.0".to_string()), // overwritten
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()), // preserved
+                    ("non-identifying/new_key".to_string(), "new_val".to_string()),  // added
                 ]),
             ),
             fleet: fixed_fleet(),
@@ -573,8 +573,8 @@ mod tests {
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )
                 .with_attributes(HashMap::from([
-                    ("agent_version".to_string(), "1.0.0".to_string()),
-                    ("host_name".to_string(), "my-host".to_string()),
+                    ("identifying/agent_version".to_string(), "1.0.0".to_string()),
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()),
                 ])),
             )]),
         },
@@ -596,8 +596,8 @@ mod tests {
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )
                 .with_attributes(HashMap::from([
-                    ("agent_version".to_string(), "1.0.0".to_string()),
-                    ("host_name".to_string(), "my-host".to_string()),
+                    ("identifying/agent_version".to_string(), "1.0.0".to_string()),
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()),
                 ])),
             )]),
         },
@@ -613,9 +613,9 @@ mod tests {
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )
                 .with_attributes(HashMap::from([
-                    ("agent_version".to_string(), "2.0.0".to_string()), // overwritten
-                    ("host_name".to_string(), "my-host".to_string()),   // preserved
-                    ("new_key".to_string(), "new_val".to_string()),     // added
+                    ("identifying/agent_version".to_string(), "2.0.0".to_string()), // overwritten
+                    ("non-identifying/host_name".to_string(), "my-host".to_string()), // preserved
+                    ("non-identifying/new_key".to_string(), "new_val".to_string()),  // added
                 ])),
             )]),
         },
@@ -637,7 +637,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::with_identity(agent_identity("some-agent-id"))
                     .with_attributes(HashMap::from([(
-                        "agent_version".to_string(),
+                        "identifying/agent_version".to_string(),
                         "1.0.0".to_string(),
                     )])),
             )]),

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -120,7 +120,7 @@ impl AgentControlRunner {
         );
 
         self.agent_control_publisher
-            .broadcast(AgentControlEvent::AgentDescriptionSet(
+            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
                 agent_description.clone(),
             ));
 

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -125,7 +125,7 @@ impl AgentControlRunner {
             build_ac_onhost_agent_description(&agent_identity, &identifiers, RunningMode::Normal);
 
         self.agent_control_publisher
-            .broadcast(AgentControlEvent::AgentDescriptionSet(
+            .broadcast(AgentControlEvent::AgentDescriptionUpdated(
                 agent_description.clone(),
             ));
 

--- a/agent-control/src/checkers/guid/k8s/checker.rs
+++ b/agent-control/src/checkers/guid/k8s/checker.rs
@@ -7,12 +7,12 @@ use crate::event::channel::{EventConsumer, EventPublisher};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::{get_name, get_namespace, get_type_meta};
-use crate::opamp::attributes::{
-    Attribute, AttributeType, UpdateAttributesMessage, publish_update_attributes_event,
-};
+use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use kube::api::DynamicObject;
+use opamp_client::operation::settings::AgentDescription;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::thread::sleep;
@@ -99,11 +99,13 @@ where
                     info!("Agent guid changed to: {}", current_guid.guid);
                     publish_update_attributes_event(
                         &guid_event_publisher,
-                        guid_event_generator(vec![Attribute::from((
-                            AttributeType::Identifying,
-                            current_guid.opamp_field.clone(),
-                            current_guid.guid.clone(),
-                        ))]),
+                        guid_event_generator(AgentDescription {
+                            identifying_attributes: HashMap::from([(
+                                current_guid.opamp_field.clone(),
+                                current_guid.guid.clone().into(),
+                            )]),
+                            ..Default::default()
+                        }),
                     );
                     last_guid = Some(current_guid);
                 }

--- a/agent-control/src/checkers/guid/k8s/checker.rs
+++ b/agent-control/src/checkers/guid/k8s/checker.rs
@@ -7,7 +7,7 @@ use crate::event::channel::{EventConsumer, EventPublisher};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::{get_name, get_namespace, get_type_meta};
-use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
+use crate::opamp::attributes::{UpdatedAttributesMessage, publish_update_attributes_event};
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use kube::api::DynamicObject;
@@ -73,7 +73,7 @@ pub(crate) fn spawn_guid_checker<S, T, F>(
 where
     S: GuidChecker + Send + Sync + 'static,
     T: Debug + Send + Sync + 'static,
-    F: Fn(UpdateAttributesMessage) -> T + Send + Sync + 'static,
+    F: Fn(UpdatedAttributesMessage) -> T + Send + Sync + 'static,
 {
     let thread_name = format!("{guid_checker_id}_{GUID_CHECKER_THREAD_NAME}");
     let mut last_guid: Option<EntityGuid> = None;

--- a/agent-control/src/checkers/version/k8s/checkers.rs
+++ b/agent-control/src/checkers/version/k8s/checkers.rs
@@ -9,7 +9,7 @@ use crate::event::channel::{EventConsumer, EventPublisher};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::{get_namespace, get_type_meta};
-use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
+use crate::opamp::attributes::{UpdatedAttributesMessage, publish_update_attributes_event};
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use kube::api::{DynamicObject, TypeMeta};
@@ -120,7 +120,7 @@ pub(crate) fn spawn_version_checker<V, T, F>(
 where
     V: VersionChecker + Send + Sync + 'static,
     T: Debug + Send + Sync + 'static,
-    F: Fn(UpdateAttributesMessage) -> T + Send + Sync + 'static,
+    F: Fn(UpdatedAttributesMessage) -> T + Send + Sync + 'static,
 {
     let thread_name = format!("{version_checker_id}_{VERSION_CHECKER_THREAD_NAME}");
     // Stores if the version was retrieved in last iteration for logging purposes.

--- a/agent-control/src/checkers/version/k8s/checkers.rs
+++ b/agent-control/src/checkers/version/k8s/checkers.rs
@@ -13,7 +13,7 @@ use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attribute
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use kube::api::{DynamicObject, TypeMeta};
-use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
+use opamp_client::operation::settings::AgentDescription;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread::sleep;
@@ -183,6 +183,7 @@ mod tests {
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
     use kube::api::{DynamicObject, TypeMeta};
     use mockall::{Sequence, mock};
+    use opamp_client::operation::settings::DescriptionValueType;
     use std::{sync::Arc, time::Duration};
 
     mock! {

--- a/agent-control/src/checkers/version/k8s/checkers.rs
+++ b/agent-control/src/checkers/version/k8s/checkers.rs
@@ -9,12 +9,12 @@ use crate::event::channel::{EventConsumer, EventPublisher};
 #[cfg_attr(test, mockall_double::double)]
 use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::{get_namespace, get_type_meta};
-use crate::opamp::attributes::{
-    Attribute, AttributeType, UpdateAttributesMessage, publish_update_attributes_event,
-};
+use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use kube::api::{DynamicObject, TypeMeta};
+use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread::sleep;
 use tracing::{debug, info, info_span, warn};
@@ -145,11 +145,13 @@ where
 
                 publish_update_attributes_event(
                     &version_event_publisher,
-                    version_event_generator(vec![Attribute::from((
-                        AttributeType::Identifying,
-                        agent_data.opamp_field,
-                        agent_data.version,
-                    ))]),
+                    version_event_generator(AgentDescription {
+                        identifying_attributes: HashMap::from([(
+                            agent_data.opamp_field,
+                            agent_data.version.into(),
+                        )]),
+                        ..Default::default()
+                    }),
                 );
             }
             Err(error) => {
@@ -356,11 +358,13 @@ mod tests {
 
         // Check that we received the expected version event
         assert_eq!(
-            SubAgentInternalEvent::AgentAttributesUpdated(vec![Attribute::from((
-                AttributeType::Identifying,
-                OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY,
-                "1.0.0".to_string(),
-            ))],),
+            SubAgentInternalEvent::AgentAttributesUpdated(AgentDescription {
+                identifying_attributes: HashMap::from([(
+                    OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                    DescriptionValueType::String("1.0.0".to_string()),
+                )]),
+                ..Default::default()
+            }),
             version_consumer.as_ref().recv().unwrap()
         );
 

--- a/agent-control/src/checkers/version/onhost.rs
+++ b/agent-control/src/checkers/version/onhost.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use crate::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
 use crate::agent_type::runtime_config::on_host::executable::rendered::Args;
-use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
+use crate::opamp::attributes::{UpdatedAttributesMessage, publish_update_attributes_event};
 use opamp_client::operation::settings::AgentDescription;
 use regex::Regex;
 use std::collections::HashMap;
@@ -51,7 +51,7 @@ pub(crate) fn check_version<V, T, F>(
 ) where
     V: VersionChecker + Send + Sync + 'static,
     T: Debug + Send + Sync + 'static,
-    F: Fn(UpdateAttributesMessage) -> T + Send + Sync + 'static,
+    F: Fn(UpdatedAttributesMessage) -> T + Send + Sync + 'static,
 {
     let span = info_span!(
         "version_check",

--- a/agent-control/src/checkers/version/onhost.rs
+++ b/agent-control/src/checkers/version/onhost.rs
@@ -2,10 +2,10 @@ use std::process::Command;
 
 use crate::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
 use crate::agent_type::runtime_config::on_host::executable::rendered::Args;
-use crate::opamp::attributes::{
-    Attribute, AttributeType, UpdateAttributesMessage, publish_update_attributes_event,
-};
+use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
+use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
 use regex::Regex;
+use std::collections::HashMap;
 
 use crate::checkers::version::{AgentVersion, VersionCheckError, VersionChecker};
 use crate::event::channel::EventPublisher;
@@ -67,11 +67,13 @@ pub(crate) fn check_version<V, T, F>(
 
             publish_update_attributes_event(
                 &version_event_publisher,
-                version_event_generator(vec![Attribute::from((
-                    AttributeType::Identifying,
-                    agent_data.opamp_field,
-                    agent_data.version,
-                ))]),
+                version_event_generator(AgentDescription {
+                    identifying_attributes: HashMap::from([(
+                        agent_data.opamp_field,
+                        agent_data.version.into(),
+                    )]),
+                    ..Default::default()
+                }),
             );
         }
         Err(error) => {
@@ -154,11 +156,13 @@ mod tests {
 
         // Check that we received the expected version event
         assert_eq!(
-            SubAgentInternalEvent::AgentAttributesUpdated(vec![Attribute::from((
-                AttributeType::Identifying,
-                OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY,
-                "1.0.0".to_string(),
-            ))],),
+            SubAgentInternalEvent::AgentAttributesUpdated(AgentDescription {
+                identifying_attributes: HashMap::from([(
+                    OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY.to_string(),
+                    DescriptionValueType::String("1.0.0".to_string()),
+                )]),
+                ..Default::default()
+            }),
             version_consumer.as_ref().recv().unwrap()
         );
 

--- a/agent-control/src/checkers/version/onhost.rs
+++ b/agent-control/src/checkers/version/onhost.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use crate::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
 use crate::agent_type::runtime_config::on_host::executable::rendered::Args;
 use crate::opamp::attributes::{UpdateAttributesMessage, publish_update_attributes_event};
-use opamp_client::operation::settings::{AgentDescription, DescriptionValueType};
+use opamp_client::operation::settings::AgentDescription;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -94,6 +94,7 @@ mod tests {
 
     use super::*;
 
+    use opamp_client::operation::settings::DescriptionValueType;
     use rstest::rstest;
 
     #[rstest]

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -37,7 +37,7 @@ pub enum AgentControlEvent {
     HealthUpdated(HealthWithStartTime),
     SubAgentRemoved(AgentID),
     AgentControlStopped,
-    AgentDescriptionSet(AgentDescription),
+    AgentDescriptionUpdated(AgentDescription),
     OpAMPConnected,
     OpAMPConnectFailed(Option<LastErrorCode>, LastErrorMessage),
 }
@@ -47,7 +47,7 @@ pub enum AgentControlEvent {
 pub enum SubAgentEvent {
     HealthUpdated(AgentIdentity, HealthWithStartTime),
     SubAgentStarted(AgentIdentity, SystemTime),
-    AgentDescriptionSet(AgentIdentity, AgentDescription),
+    AgentDescriptionUpdated(AgentIdentity, AgentDescription),
 }
 
 impl SubAgentEvent {

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -11,7 +11,7 @@ pub mod channel;
 use opamp_client::operation::settings::AgentDescription;
 
 use crate::checkers::health::with_start_time::HealthWithStartTime;
-use crate::opamp::attributes::UpdateAttributesMessage;
+use crate::opamp::attributes::UpdatedAttributesMessage;
 use crate::opamp::{LastErrorCode, LastErrorMessage};
 use crate::sub_agent::identity::AgentIdentity;
 use crate::{agent_control::agent_id::AgentID, opamp::remote_config::OpampRemoteConfig};
@@ -60,7 +60,7 @@ impl SubAgentEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub enum AgentControlInternalEvent {
     HealthUpdated(HealthWithStartTime),
-    AgentControlAttributesUpdated(UpdateAttributesMessage),
+    AgentControlAttributesUpdated(UpdatedAttributesMessage),
     SelfUpdateRestartRequested(),
 }
 
@@ -69,5 +69,5 @@ pub enum AgentControlInternalEvent {
 pub enum SubAgentInternalEvent {
     StopRequested,
     AgentHealthInfo(HealthWithStartTime),
-    AgentAttributesUpdated(UpdateAttributesMessage),
+    AgentAttributesUpdated(UpdatedAttributesMessage),
 }

--- a/agent-control/src/opamp/attributes.rs
+++ b/agent-control/src/opamp/attributes.rs
@@ -12,22 +12,24 @@ pub type UpdatedAttributesMessage = AgentDescription;
 
 /// Updates the attributes of the OpAMP agent
 ///
-/// If an attribute already exists, it will be updated. If it doesn't, it will be added.
+/// The provided `agent_description` is expected to contain the attributes to be updated only.
+/// If an attribute already exists, it will be updated. If it doesn't, it will be added. No
+/// attribute is removed in any case.
 pub fn update_opamp_attributes<C>(
     opamp_client: &C,
-    new_attributes: AgentDescription,
+    agent_description: AgentDescription,
 ) -> Result<(), ClientError>
 where
     C: StartedClient,
 {
-    let agent_description = opamp_client.get_agent_description()?;
+    let current_agent_description = opamp_client.get_agent_description()?;
     let updated_agent_description =
-        update_agent_description_attributes(agent_description, new_attributes);
+        merge_agent_description(current_agent_description, agent_description);
 
     opamp_client.set_agent_description(updated_agent_description)
 }
 
-fn update_agent_description_attributes(
+fn merge_agent_description(
     old_agent_description: ProtoAgentDescription,
     new_attributes: AgentDescription,
 ) -> ProtoAgentDescription {
@@ -104,7 +106,7 @@ mod tests {
             non_identifying_attributes: vec![new_key_value("non_identifying1", "value1")],
         };
 
-        let updated_description = update_agent_description_attributes(
+        let updated_description = merge_agent_description(
             agent_description.clone(),
             AgentDescription {
                 identifying_attributes: HashMap::from([

--- a/agent-control/src/opamp/attributes.rs
+++ b/agent-control/src/opamp/attributes.rs
@@ -8,7 +8,7 @@ use tracing::error;
 use crate::event::channel::EventPublisher;
 
 /// Event message type for updating OpAMP agent attributes
-pub type UpdateAttributesMessage = AgentDescription;
+pub type UpdatedAttributesMessage = AgentDescription;
 
 /// Updates the attributes of the OpAMP agent
 ///

--- a/agent-control/src/opamp/attributes.rs
+++ b/agent-control/src/opamp/attributes.rs
@@ -1,74 +1,21 @@
 use std::fmt::Debug;
 
-use opamp_client::opamp::proto::any_value::Value;
-use opamp_client::opamp::proto::{AgentDescription, AnyValue, KeyValue};
+use opamp_client::opamp::proto::{AgentDescription as ProtoAgentDescription, KeyValue};
+use opamp_client::operation::settings::AgentDescription;
 use opamp_client::{ClientError, StartedClient};
 use tracing::error;
 
 use crate::event::channel::EventPublisher;
 
 /// Event message type for updating OpAMP agent attributes
-pub type UpdateAttributesMessage = Vec<Attribute>;
-
-/// Represents the type of an [AgentDescription message in OpAMP](https://opentelemetry.io/docs/specs/opamp/#agentdescription-message)
-#[derive(Debug, Clone, PartialEq)]
-pub enum AttributeType {
-    Identifying,
-    NonIdentifying,
-}
-
-/// Represents an agent attribute
-///
-/// Simple wrapper for [`KeyValue`] and it's type, that simplifies the creation
-/// of agent attributes.
-///
-/// ## Example:
-/// ```
-/// # use newrelic_agent_control::opamp::attributes::{Attribute, AttributeType};
-/// let attr = Attribute::from((AttributeType::Identifying, "key", "value"));
-/// ```
-/// instead of (assume we don't care about the type for this example):
-/// ```
-/// # use opamp_client::opamp::proto::any_value::Value;
-/// # use opamp_client::opamp::proto::{AnyValue, KeyValue};
-/// let attr = KeyValue {
-///     key: "key".into(),
-///     value: Some(AnyValue {
-///         value: Some(Value::StringValue("value".into())),
-///     }),
-/// };
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-pub struct Attribute {
-    attribute_type: AttributeType,
-    key_value: KeyValue,
-}
-
-impl<K, V> From<(AttributeType, K, V)> for Attribute
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    fn from((attribute_type, key, value): (AttributeType, K, V)) -> Self {
-        Attribute {
-            attribute_type,
-            key_value: KeyValue {
-                key: String::from(key.as_ref()),
-                value: Some(AnyValue {
-                    value: Some(Value::StringValue(String::from(value.as_ref()))),
-                }),
-            },
-        }
-    }
-}
+pub type UpdateAttributesMessage = AgentDescription;
 
 /// Updates the attributes of the OpAMP agent
 ///
 /// If an attribute already exists, it will be updated. If it doesn't, it will be added.
-/// If the `new_attributes` contain duplicated keys, the last occurrence will be kept.
 pub fn update_opamp_attributes<C>(
     opamp_client: &C,
-    new_attributes: Vec<Attribute>,
+    new_attributes: AgentDescription,
 ) -> Result<(), ClientError>
 where
     C: StartedClient,
@@ -81,33 +28,25 @@ where
 }
 
 fn update_agent_description_attributes(
-    old_agent_description: AgentDescription,
-    new_attributes: Vec<Attribute>,
-) -> AgentDescription {
-    let (new_identifying_attributes, new_non_identifying_attributes): (Vec<_>, Vec<_>) =
-        new_attributes
-            .into_iter()
-            .partition(|attribute| attribute.attribute_type == AttributeType::Identifying);
-
+    old_agent_description: ProtoAgentDescription,
+    new_attributes: AgentDescription,
+) -> ProtoAgentDescription {
+    let new_proto: ProtoAgentDescription = new_attributes.into();
     let mut agent_description = old_agent_description;
-    let key_value_iter = |attrs: Vec<Attribute>| attrs.into_iter().map(|attr| attr.key_value);
     agent_description.identifying_attributes = merge_attributes(
         agent_description.identifying_attributes,
-        key_value_iter(new_identifying_attributes),
+        new_proto.identifying_attributes.into_iter(),
     );
-
     agent_description.non_identifying_attributes = merge_attributes(
         agent_description.non_identifying_attributes,
-        key_value_iter(new_non_identifying_attributes),
+        new_proto.non_identifying_attributes.into_iter(),
     );
-
     agent_description
 }
 
 /// Merges new attributes into old attributes
 ///
 /// If an attribute already exists, it will be updated. If it doesn't, it will be added.
-/// If the `new_attributes` contain duplicated keys, the last occurrence will be kept.
 fn merge_attributes(
     old_attributes: Vec<KeyValue>,
     new_attributes: impl Iterator<Item = KeyValue>,
@@ -140,6 +79,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opamp_client::opamp::proto::any_value::Value;
+    use opamp_client::opamp::proto::{AnyValue, KeyValue};
+    use opamp_client::operation::settings::DescriptionValueType;
+    use std::collections::HashMap;
 
     fn new_key_value(key: &str, value: &str) -> KeyValue {
         KeyValue {
@@ -152,8 +95,7 @@ mod tests {
 
     #[test]
     fn test_update_agent_attributes() {
-        // Create base agent description
-        let agent_description = AgentDescription {
+        let agent_description = ProtoAgentDescription {
             identifying_attributes: vec![
                 new_key_value("identifying1", "value1"),
                 new_key_value("identifying3", "value3"),
@@ -162,46 +104,50 @@ mod tests {
             non_identifying_attributes: vec![new_key_value("non_identifying1", "value1")],
         };
 
-        // Check identifying attributes are correctly updated
-        // Here we check behaviour like order and duplicates
         let updated_description = update_agent_description_attributes(
             agent_description.clone(),
-            vec![
-                Attribute::from((AttributeType::Identifying, "identifying2", "new_value2")),
-                Attribute::from((AttributeType::Identifying, "identifying3", "new_value3")),
-                Attribute::from((
-                    AttributeType::NonIdentifying,
-                    "non_identifying2",
-                    "new_value2",
-                )),
-                Attribute::from((AttributeType::Identifying, "identifying4", "new_value4")),
-                Attribute::from((
-                    AttributeType::Identifying,
-                    "identifying4",
-                    "duplicated_value4",
-                )),
-            ],
+            AgentDescription {
+                identifying_attributes: HashMap::from([
+                    (
+                        "identifying2".to_string(),
+                        DescriptionValueType::String("new_value2".to_string()),
+                    ),
+                    (
+                        "identifying3".to_string(),
+                        DescriptionValueType::String("new_value3".to_string()),
+                    ),
+                    (
+                        "identifying4".to_string(),
+                        DescriptionValueType::String("new_value4".to_string()),
+                    ),
+                ]),
+                non_identifying_attributes: HashMap::from([(
+                    "non_identifying2".to_string(),
+                    DescriptionValueType::String("new_value2".to_string()),
+                )]),
+            },
         );
 
-        let expected_identifying_attributes = vec![
+        // Sort both sides before comparing since HashMap iteration order is non-deterministic.
+        let mut actual_identifying = updated_description.identifying_attributes;
+        actual_identifying.sort_by_key(|kv| kv.key.clone());
+        let mut expected_identifying = vec![
             new_key_value("identifying1", "value1"),
-            new_key_value("identifying3", "new_value3"),
-            new_key_value("identifying5", "value5"),
             new_key_value("identifying2", "new_value2"),
-            new_key_value("identifying4", "duplicated_value4"),
+            new_key_value("identifying3", "new_value3"),
+            new_key_value("identifying4", "new_value4"),
+            new_key_value("identifying5", "value5"),
         ];
-        assert_eq!(
-            expected_identifying_attributes,
-            updated_description.identifying_attributes
-        );
+        expected_identifying.sort_by_key(|kv| kv.key.clone());
+        assert_eq!(expected_identifying, actual_identifying);
 
-        let expected_non_identifying_attributes = vec![
+        let mut actual_non_identifying = updated_description.non_identifying_attributes;
+        actual_non_identifying.sort_by_key(|kv| kv.key.clone());
+        let mut expected_non_identifying = vec![
             new_key_value("non_identifying1", "value1"),
             new_key_value("non_identifying2", "new_value2"),
         ];
-        assert_eq!(
-            expected_non_identifying_attributes,
-            updated_description.non_identifying_attributes
-        );
+        expected_non_identifying.sort_by_key(|kv| kv.key.clone());
+        assert_eq!(expected_non_identifying, actual_non_identifying);
     }
 }

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -370,8 +370,10 @@ where
                             Ok(SubAgentInternalEvent::AgentAttributesUpdated(attributes)) => {
                                 debug!("Updating SubAgent attributes with: {:?}", attributes);
                                 let _ = self.maybe_opamp_client.as_ref().map(|c|
-                                    update_opamp_attributes(c, attributes)
+                                    update_opamp_attributes(c, attributes.clone())
                                 .inspect_err(|e| error!(error = %e, select_arm = "sub_agent_internal_consumer", "processing update agent attributes message")));
+
+                                self.sub_agent_publisher.broadcast(SubAgentEvent::AgentDescriptionUpdated(self.identity.clone(), attributes));
                             }
                         }
                     }

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -78,7 +78,7 @@ where
         .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))?;
 
         self.sub_agent_publisher
-            .broadcast(SubAgentEvent::AgentDescriptionSet(
+            .broadcast(SubAgentEvent::AgentDescriptionUpdated(
                 agent_identity.clone(),
                 opamp_start_settings.agent_description.clone(),
             ));

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -83,7 +83,7 @@ where
         )
         .map_err(|e| SubAgentBuilderError::OpampClientBuilderError(e.to_string()))?;
         self.sub_agent_publisher
-            .broadcast(SubAgentEvent::AgentDescriptionSet(
+            .broadcast(SubAgentEvent::AgentDescriptionUpdated(
                 agent_identity.clone(),
                 opamp_start_settings.agent_description.clone(),
             ));

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -261,7 +261,7 @@ where
             // The below argument expects a function "UpdateAttributesMessage -> T"
             // where T is the "event" sendable by the above publisher.
             // Using an enum variant that wraps a type is the same as a function taking the type.
-            // Basically, it's the same as passing "|x| SubAgentInternalEvent::UpdateAttributesMessage(x)"
+            // Basically, it's the same as passing "|x| SubAgentInternalEvent::AgentAttributesUpdated(x)"
             SubAgentInternalEvent::AgentAttributesUpdated,
         )
     }


### PR DESCRIPTION
PR on top of #2439 

## Summary

This PR wires up the status-server with attributes updates in order to reflect attributes changes such as `version` agents.

## Notes for reviewers

* An internal abstraction to represent attributes updates which was using OpAMP's proto types was replaced by OpAMP's `AgentDescription` directly, making it possible to publish the events that can be consumed by the status-server.
* The unit tests of the HTTP Server's status-updater module were refactored to use `rstest` instead of the previous table-like approach. Such unit-tests are also extended to cover the attributes update new use-case.