### PR TITLE
refactor: simplify render

### DIFF
--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -687,20 +687,20 @@ fn iterate_test_cases(environment: &Environment) {
         // Create default global defaults for OCI configuration
         let global_defaults = HashMap::from([
             (
-                "oci.registry".to_string(),
-                serde_yaml::Value::String("docker.io".to_string()),
+                Namespace::Default.namespaced_name("oci.registry"),
+                Variable::new_final_string_variable("docker.io".to_string()),
             ),
             (
-                "oci.auth.basic.username".to_string(),
-                serde_yaml::Value::String("".to_string()),
+                Namespace::Default.namespaced_name("oci.auth.basic.username"),
+                Variable::new_final_string_variable("".to_string()),
             ),
             (
-                "oci.auth.basic.password".to_string(),
-                serde_yaml::Value::String("".to_string()),
+                Namespace::Default.namespaced_name("oci.auth.basic.password"),
+                Variable::new_final_string_variable("".to_string()),
             ),
             (
-                "oci.auth.bearer".to_string(),
-                serde_yaml::Value::String("".to_string()),
+                Namespace::Default.namespaced_name("oci.auth.bearer"),
+                Variable::new_final_string_variable("".to_string()),
             ),
         ]);
 
@@ -738,7 +738,6 @@ fn iterate_test_cases(environment: &Environment) {
                 variables,
                 attributes,
                 values.additional_env.clone(),
-                HashMap::new(), // Secrets are not used in this test
                 global_defaults.clone(),
             );
 

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -1,6 +1,6 @@
 use crate::agent_type::{
     agent_attributes::AgentAttributes,
-    definition::AgentType,
+    definition::{AgentType, Variables},
     error::AgentTypeError,
     runtime_config::rendered::Runtime,
     templates::Templateable,
@@ -24,44 +24,27 @@ impl TemplateRenderer {
         agent_type: AgentType,
         values: YAMLConfig,
         attributes: AgentAttributes,
-        env_vars: HashMap<String, Variable>,
-        secrets: HashMap<String, Variable>,
-        global_defaults: HashMap<String, serde_yaml::Value>,
+        secrets: Variables,
+        global_defaults: Variables,
     ) -> Result<Runtime, AgentTypeError> {
         // Get empty variables and runtime_config from the agent-type
         let (variables, runtime_config) = (agent_type.variables, agent_type.runtime_config);
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables and secrets are taken into consideration (no other vars for example)
-        let values_expanded = values.template_with(&secrets)?;
-
-        // Expand templates in global defaults (so they can reference secrets/env vars)
-        let global_defaults_expanded = global_defaults.template_with(&secrets)?;
-
-        // Convert global defaults to Variables with nr-default namespace
-        let global_defaults_vars = global_defaults_expanded
-            .into_iter()
-            .map(|(key, value)| {
-                (
-                    Namespace::Default.namespaced_name(&key),
-                    Variable::from(value),
-                )
-            })
-            .collect::<HashMap<String, Variable>>();
-        let mut default_vars = global_defaults_vars;
-        default_vars.extend(env_vars.clone());
+        let mut default_vars = global_defaults;
+        default_vars.extend(secrets.clone());
 
         // Template defaults in variables, then fill with user values, then flatten
         let filled_variables = variables
             .template_defaults(&default_vars)?
-            .fill_with_values(values_expanded)?
+            .fill_with_values(values)?
             .flatten();
 
         Self::check_all_vars_are_populated(&filled_variables)?;
 
-        // Setup namespaced variables
-        let ns_variables = self.build_namespaced_variables(filled_variables, env_vars, &attributes);
-        // Render runtime config
+        // Setup namespaced variables (includes all env vars which enable template expansion)
+        let ns_variables = self.build_namespaced_variables(filled_variables, secrets, &attributes);
+
+        // Render runtime config - iterative templating resolves all nested templates automatically
         let rendered_runtime_config = runtime_config.template_with(&ns_variables)?;
 
         Ok(rendered_runtime_config)
@@ -111,7 +94,7 @@ impl TemplateRenderer {
         // Get the namespaced variables from sub-agent attributes
         let sub_agent_vars_iter = attributes.sub_agent_variables().into_iter();
 
-        // Join all variables together
+        // Join all variables together (including env vars/secrets for template expansion)
         vars_iter
             .chain(sub_agent_vars_iter)
             .chain(env_vars)
@@ -165,7 +148,6 @@ pub(crate) mod tests {
                 attributes,
                 HashMap::new(),
                 HashMap::new(),
-                HashMap::new(),
             )
             .unwrap();
 
@@ -202,7 +184,6 @@ pub(crate) mod tests {
             attributes,
             HashMap::new(),
             HashMap::new(),
-            HashMap::new(),
         );
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
@@ -222,7 +203,6 @@ pub(crate) mod tests {
             agent_type,
             values,
             attributes,
-            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
         );
@@ -245,7 +225,6 @@ pub(crate) mod tests {
                 agent_type,
                 values,
                 attributes,
-                HashMap::new(),
                 HashMap::new(),
                 HashMap::new(),
             )
@@ -296,7 +275,6 @@ pub(crate) mod tests {
                 agent_type,
                 values,
                 attributes,
-                HashMap::new(),
                 HashMap::new(),
                 HashMap::new(),
             )
@@ -382,7 +360,6 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
                 attributes,
                 HashMap::new(),
                 HashMap::new(),
-                HashMap::new(),
             )
             .unwrap();
 
@@ -406,7 +383,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
         let values = testing_values(K8S_CONFIG_YAML_VALUES);
         let attributes = testing_agent_attributes(&agent_id);
 
-        let env_vars = HashMap::from([
+        let secrets = HashMap::from([
             (
                 Namespace::EnvironmentVariable.namespaced_name("MY_VARIABLE"),
                 Variable::new_final_string_variable("my-value".to_string()),
@@ -436,14 +413,8 @@ substituted_2: my-value-2
             serde_yaml::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            env_vars,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let runtime_config =
+            renderer.render(agent_type, values, attributes, secrets, HashMap::new());
 
         let k8s = runtime_config.unwrap().deployment.k8s.unwrap();
         let cr1 = k8s.objects.get("cr1").unwrap();
@@ -497,14 +468,8 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             serde_yaml::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            secrets,
-            HashMap::new(),
-        );
+        let runtime_config =
+            renderer.render(agent_type, values, attributes, secrets, HashMap::new());
 
         let k8s = runtime_config.unwrap().deployment.k8s.unwrap();
         let values = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
@@ -526,7 +491,6 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             agent_type,
             values,
             attributes,
-            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
         );
@@ -572,20 +536,14 @@ deployment:
         let values = testing_values(K8S_CONFIG_YAML_VALUES);
         let attributes = testing_agent_attributes(&agent_id);
 
-        let env_vars = HashMap::from([(
+        let secrets = HashMap::from([(
             Namespace::EnvironmentVariable.namespaced_name("my_variable"),
             Variable::new_final_string_variable("my-value".to_string()),
         )]);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            env_vars,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let runtime_config =
+            renderer.render(agent_type, values, attributes, secrets, HashMap::new());
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -634,7 +592,6 @@ deployment:
                 agent_type,
                 values,
                 attributes,
-                HashMap::new(),
                 HashMap::new(),
                 HashMap::new(),
             )
@@ -709,20 +666,20 @@ path: /opt/first
 
         let global_defaults = HashMap::from([
             (
-                "path".to_string(),
-                serde_yaml::to_value("/opt/second").unwrap(),
+                Namespace::Default.namespaced_name("path"),
+                Variable::new_final_string_variable("/opt/second".to_string()),
             ),
             (
-                "registry_url".to_string(),
-                serde_yaml::to_value("test-registry-url").unwrap(),
+                Namespace::Default.namespaced_name("registry_url"),
+                Variable::new_final_string_variable("test-registry-url".to_string()),
             ),
             (
-                "enable_file_logging".to_string(),
-                serde_yaml::to_value(true).unwrap(),
+                Namespace::Default.namespaced_name("enable_file_logging"),
+                Variable::new_final_string_variable(true.to_string()),
             ),
         ]);
 
-        let env_vars = HashMap::from([(
+        let secrets = HashMap::from([(
             Namespace::EnvironmentVariable.namespaced_name("id"),
             Variable::new_final_string_variable("first".to_string()),
         )]);
@@ -730,14 +687,7 @@ path: /opt/first
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                env_vars,
-                HashMap::new(),
-                global_defaults,
-            )
+            .render(agent_type, values, attributes, secrets, global_defaults)
             .unwrap();
 
         let executable = extract_runtime_by_environment(runtime_config.clone())
@@ -798,12 +748,12 @@ deployment:
 
         let global_defaults = HashMap::from([
             (
-                "registry_url".to_string(),
-                serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap(),
+                Namespace::Default.namespaced_name("registry_url"),
+                Variable::from(serde_yaml::to_value("${nr-env:REGISTRY_URL}").unwrap()),
             ),
             (
-                "enable_file_logging".to_string(),
-                serde_yaml::to_value("${nr-env:ENABLE_FILE_LOGGING}").unwrap(),
+                Namespace::Default.namespaced_name("enable_file_logging"),
+                Variable::from(serde_yaml::to_value("${nr-env:ENABLE_FILE_LOGGING}").unwrap()),
             ),
         ]);
 
@@ -821,14 +771,7 @@ deployment:
         let renderer =
             TemplateRenderer::default().with_agent_control_variables(HashMap::new().into_iter());
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                secrets,
-                global_defaults,
-            )
+            .render(agent_type, values, attributes, secrets, global_defaults)
             .unwrap();
         assert_eq!(
             rendered::Args(vec!("test-registry-url/test-repository".to_string())),

--- a/agent-control/src/agent_type/templates.rs
+++ b/agent-control/src/agent_type/templates.rs
@@ -16,6 +16,7 @@ use super::templates_function::{Function, SupportedFunction};
 use super::variable::Variable;
 use super::variable::variable_type::VariableType;
 use regex::Regex;
+use std::collections::HashSet;
 use std::sync::OnceLock;
 
 /// Regular expression patterns for parsing template variables and functions.
@@ -81,35 +82,58 @@ impl Templateable for String {
 
 fn template_string(s: String, variables: &Variables) -> Result<String, AgentTypeError> {
     let re_template = template_re();
-
-    // Iterates over each found place holder replacing the value in the original string.
     let mut render_result = s.clone();
-    for captures in re_template.captures_iter(&s) {
-        // "Example with a template: ${nr-var:name|indent 2|to_upper}"
-        // templatable_placeholder="${nr-var:name|indent 2|to_upper}"
-        // captured_var="nr-var:name"
-        // captured_functions="|indent 2|to_upper"
-        let (templatable_placeholder, [captured_var, captured_functions]) = captures.extract();
+    let mut seen = HashSet::new();
+    seen.insert(s.clone());
 
-        // Get variable value
-        let normalized_var = normalized_var(captured_var, variables)?;
-        let value = normalized_var
-            .get_final_value()
-            .ok_or(AgentTypeError::MissingTemplateKey(
-                templatable_placeholder.to_string(),
-            ))?
-            .to_string();
+    // Keep templating until no more substitutions happen (iterative resolution)
+    loop {
+        let mut changed = false;
+        let current = render_result.clone();
 
-        // Apply functions
-        let functions: Vec<SupportedFunction> =
-            SupportedFunction::parse_function_list(captured_functions)
-                .map_err(|e| AgentTypeError::RenderingTemplate(e.to_string()))?;
-        let final_value = functions.iter().try_fold(value, |acc, m| {
-            m.apply(acc)
-                .map_err(|e| AgentTypeError::RenderingTemplate(e.to_string()))
-        })?;
+        // Collect all captures first to avoid borrowing issues
+        let captures_vec: Vec<_> = re_template.captures_iter(&current).collect();
 
-        render_result = render_result.replace(templatable_placeholder, &final_value);
+        for captures in captures_vec {
+            // "Example with a template: ${nr-var:name|indent 2|to_upper}"
+            // templatable_placeholder="${nr-var:name|indent 2|to_upper}"
+            // captured_var="nr-var:name"
+            // captured_functions="|indent 2|to_upper"
+            let (templatable_placeholder, [captured_var, captured_functions]) = captures.extract();
+
+            // Get variable value
+            let normalized_var = normalized_var(captured_var, variables)?;
+            let value = normalized_var
+                .get_final_value()
+                .ok_or(AgentTypeError::MissingTemplateKey(
+                    templatable_placeholder.to_string(),
+                ))?
+                .to_string();
+
+            // Apply functions
+            let functions: Vec<SupportedFunction> =
+                SupportedFunction::parse_function_list(captured_functions)
+                    .map_err(|e| AgentTypeError::RenderingTemplate(e.to_string()))?;
+            let final_value = functions.iter().try_fold(value, |acc, m| {
+                m.apply(acc)
+                    .map_err(|e| AgentTypeError::RenderingTemplate(e.to_string()))
+            })?;
+
+            render_result = render_result.replace(templatable_placeholder, &final_value);
+            changed = true;
+        }
+
+        // Exit loop if no changes were made (fully resolved)
+        if !changed {
+            break;
+        }
+
+        // Detect circular references: if this intermediate value was already seen, we're in a cycle
+        if !seen.insert(render_result.clone()) {
+            return Err(AgentTypeError::RenderingTemplate(format!(
+                "circular reference detected in template: {s}"
+            )));
+        }
     }
 
     Ok(render_result)
@@ -182,12 +206,16 @@ fn template_yaml_value_string(
 
     match var_spec.kind() {
         VariableType::Yaml(_) => {
-            var_value
-                .to_yaml_value()
-                .ok_or(AgentTypeError::UnexpectedValueForKey(
-                    var_name.to_string(),
-                    var_value.to_string(),
-                ))
+            let yaml_value =
+                var_value
+                    .to_yaml_value()
+                    .ok_or(AgentTypeError::UnexpectedValueForKey(
+                        var_name.to_string(),
+                        var_value.to_string(),
+                    ))?;
+            // Recursively template the YAML value to resolve any nested templates
+            // This enables iterative resolution: ${nr-var:x} -> YAML with ${nr-env:y} -> final value
+            yaml_value.template_with(variables)
         }
         VariableType::Bool(_) | VariableType::Number(_) => {
             serde_yaml::from_str(var_value.to_string().as_str()).map_err(AgentTypeError::SerdeYaml)
@@ -479,7 +507,7 @@ mod tests {
         a_yaml:
           key: value
         another_yaml:
-          "this.will.not.be.expanded": "${nr-var:change.me.string}" # A variable inside another other variable value is not expanded
+          "this.will.not.be.expanded": "CHANGED-STRING ${UNTOUCHED}" # With recursive templating, variables inside YAML values ARE now expanded
         string_key: "here, the value key: value\n is encoded as string because it is not alone"
         string_multiline_containing_yaml: |
           a_string: CHANGED-STRING ${UNTOUCHED}

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -7,7 +7,9 @@ use crate::agent_type::render::TemplateRenderer;
 use crate::agent_type::runtime_config::k8s::K8s;
 use crate::agent_type::runtime_config::on_host::rendered::OnHost;
 use crate::agent_type::runtime_config::{Deployment, Runtime, rendered};
+use crate::agent_type::variable::Variable;
 use crate::agent_type::variable::constraints::VariableConstraints;
+use crate::agent_type::variable::namespace::Namespace;
 use crate::agent_type::variable::secret_variables::{
     SecretVariables, SecretVariablesError, load_env_vars,
 };
@@ -183,21 +185,31 @@ where
                 EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string())
             })?;
 
-        let env_vars = load_env_vars();
-
         let mut secret_variables = SecretVariables::try_from(values.clone())?;
         let global_defaults_secrets =
             SecretVariables::try_from(YAMLConfig::from(self.global_defaults.clone()))?;
         secret_variables.merge(global_defaults_secrets);
-        let secrets = secret_variables.load_secrets(&self.secrets_providers)?;
+        let mut secrets = secret_variables.load_secrets(&self.secrets_providers)?;
+        secrets.extend(load_env_vars());
+
+        let global_defaults_vars = self
+            .global_defaults
+            .clone()
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    Namespace::Default.namespaced_name(&key),
+                    Variable::from(value),
+                )
+            })
+            .collect();
 
         let runtime_config = self.renderer.render(
             agent_type,
             values,
             attributes,
-            env_vars,
             secrets,
-            self.global_defaults.clone(),
+            global_defaults_vars,
         )?;
 
         Ok(EffectiveAgent::new(agent_identity.clone(), runtime_config))

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -1,7 +1,4 @@
 use crate::agent_control::config::AgentControlDynamicConfig;
-use crate::agent_type::definition::Variables;
-use crate::agent_type::error::AgentTypeError;
-use crate::agent_type::templates::Templateable;
 use opamp_client::opamp::proto::AgentCapabilities;
 use opamp_client::operation::capabilities::Capabilities;
 use serde::{Deserialize, Serialize};
@@ -65,24 +62,6 @@ impl YAMLConfig {
 #[derive(Error, Debug)]
 #[error("{0}")]
 pub struct YAMLConfigError(pub String);
-
-impl Templateable for YAMLConfig {
-    type Output = Self;
-
-    fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
-        Ok(Self(self.0.template_with(variables)?))
-    }
-}
-
-impl Templateable for HashMap<String, serde_yaml::Value> {
-    type Output = Self;
-
-    fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
-        self.into_iter()
-            .map(|(key, v)| Ok((key, v.template_with(variables)?)))
-            .collect()
-    }
-}
 
 impl From<YAMLConfig> for HashMap<String, serde_yaml::Value> {
     fn from(values: YAMLConfig) -> Self {


### PR DESCRIPTION
Potential refactor for https://github.com/newrelic/newrelic-agent-control/pull/2436.
This is totally optional and should only be reviewed if the previous PR is already merged.

Now `templating` is "iterative". If a template string results into another template string, then we will keep templating until we reach the final value. This removes the need to template variables first, and then template the `deployment` section.
We still need to template the defaults in it's own step because of type safety.