### PR TITLE
feat: add integration test without flux checking for configmap creation

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [ part1, part2, flux-self-update ]
+        group: [ part1, part2, flux-self-update, without-flux ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/agent-control/Makefile
+++ b/agent-control/Makefile
@@ -40,10 +40,19 @@ test/onhost/oci-registry/integration:
 test/k8s:
 	cargo $(CARGO_CMD) $(PACKAGE_SA) --all-targets -- --skip on_host
 
+# K8S integration tests without Flux - runs directly without Tilt
+.PHONY: test/k8s/integration-without-flux
+test/k8s/integration-without-flux:
+	@echo "==> Updating kubeconfig for minikube..."
+	KUBECONFIG='./tests/k8s/.kubeconfig-dev' minikube update-context
+	@echo "==> Building agent-control-k8s binary..."
+	$(MAKE) -C .. BUILD_MODE=debug ARCH=$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') build-agent-control-k8s
+	@echo "==> Running integration tests without Flux..."
+	cargo test k8s::scenarios::without_flux -- --nocapture --ignored --test-threads=10
+
+# K8S integration tests with Flux
 .PHONY: test/k8s/integration
 test/k8s/integration: test/k8s/integration-part1 test/k8s/integration-part2
-
-
 
 .PHONY: test/k8s/integration-part1
 test/k8s/integration-part1:

--- a/agent-control/Makefile
+++ b/agent-control/Makefile
@@ -45,8 +45,6 @@ test/k8s:
 test/k8s/integration-without-flux:
 	@echo "==> Updating kubeconfig for minikube..."
 	KUBECONFIG='./tests/k8s/.kubeconfig-dev' minikube update-context
-	@echo "==> Building agent-control-k8s binary..."
-	$(MAKE) -C .. BUILD_MODE=debug ARCH=$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') build-agent-control-k8s
 	@echo "==> Running integration tests without Flux..."
 	cargo test k8s::scenarios::without_flux -- --nocapture --ignored --test-threads=10
 

--- a/agent-control/tests/k8s/data/config_map_type.yml
+++ b/agent-control/tests/k8s/data/config_map_type.yml
@@ -1,0 +1,26 @@
+namespace: newrelic
+name: com.newrelic.test_config_map
+version: 0.1.0
+variables:
+  k8s:
+    chart_values:
+      cm_content:
+        description: "configmap content"
+        type: yaml
+        required: false
+        default: { }
+deployment:
+  k8s:
+    health:
+      interval: 30s
+      initial_delay: 30s
+    objects:
+      values:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: test-config-map
+          namespace: ${nr-ac:namespace}
+        data:
+          deployment-config.yaml: |
+            ${nr-var:chart_values.cm_content}

--- a/agent-control/tests/k8s/data/k8s_config_map_type_creates_configmap/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_config_map_type_creates_configmap/local-data-agent-control.template
@@ -1,0 +1,17 @@
+fleet_control:
+  endpoint: <opamp-endpoint>
+  poll_interval: 5s
+  signature_validation:
+    public_key_server_url: <jwks-endpoint>
+k8s:
+  namespace: <ns>
+  namespace_agents: <agents-ns>
+  cluster_name: <cluster-name>
+  auth_secret:
+    secret_name: agent-control-auth
+    secret_key_name: private_key
+  # Add ConfigMap to the list of supported k8s object types
+  cr_type_meta:
+    - apiVersion: v1
+      kind: ConfigMap
+agents: {}

--- a/agent-control/tests/k8s/scenarios.rs
+++ b/agent-control/tests/k8s/scenarios.rs
@@ -7,3 +7,4 @@ mod garbage_collector;
 mod no_opamp;
 mod opamp;
 mod secrets_providers;
+mod without_flux;

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -1,0 +1,130 @@
+//! Integration tests for k8s without Flux
+//! These tests use a simplified environment with just agent-control binary and image.
+
+use crate::common::opamp::FakeServer;
+use crate::common::retry::retry;
+use crate::common::runtime::block_on;
+use crate::k8s::tools::agent_control::start_agent_control_with_testdata_config;
+use crate::k8s::tools::k8s_api::check_config_map_exist;
+use crate::k8s::tools::k8s_env::K8sEnv;
+use crate::k8s::tools::{agent_control, instance_id};
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::Api;
+use newrelic_agent_control::agent_control::agent_id::AgentID;
+use std::time::Duration;
+use tempfile::tempdir;
+
+const CONFIG_AGENT_TYPE_PATH: &str = "tests/k8s/data/config_map_type.yml";
+
+/// This test verifies that the config_map_type agent type creates
+/// a ConfigMap when configured through OpAMP.
+#[test]
+#[ignore = "needs k8s cluster"]
+fn k8s_config_map_type_creates_configmap() {
+    let test_name = "k8s_config_map_type_creates_configmap";
+
+    let mut server = FakeServer::start_new();
+
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    let _ac = start_agent_control_with_testdata_config(
+        test_name,
+        CONFIG_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        &namespace,
+        Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+
+    agent_control::wait_until_agent_control_with_opamp_is_started(
+        k8s.client.clone(),
+        namespace.as_str(),
+    );
+
+    let instance_id =
+        instance_id::get_instance_id(k8s.client.clone(), &namespace, &AgentID::AgentControl);
+
+    server.set_config_response(
+        instance_id.clone(),
+        r#"
+agents:
+  test-config-map:
+    agent_type: "newrelic/com.newrelic.test_config_map:0.1.0"
+    "#,
+    );
+
+    println!("Waiting for fleet-data ConfigMap to be created...");
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_exist(
+            k8s.client.clone(),
+            "fleet-data-test-config-map",
+            &namespace,
+        ))
+    });
+    println!("fleet-data ConfigMap exists!");
+
+    let subagent_instance_id = instance_id::get_instance_id(
+        k8s.client.clone(),
+        &namespace,
+        &AgentID::try_from("test-config-map").unwrap(),
+    );
+    server.set_config_response(
+        subagent_instance_id,
+        r#"
+chart_values:
+  cm_content:
+    some_key: "some_value"
+    "#,
+    );
+
+    println!("Waiting for test-config-map ConfigMap...");
+
+    let expected_configmap_name = "test-config-map";
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_exist(
+            k8s.client.clone(),
+            expected_configmap_name,
+            &namespace,
+        ))
+    });
+    println!("ConfigMap {} exists!", expected_configmap_name);
+
+    let api: Api<ConfigMap> = Api::namespaced(k8s.client.clone(), &namespace);
+    // Verify the ConfigMap content
+    let cm = block_on(api.get(expected_configmap_name)).expect("ConfigMap should exist");
+
+    // Check that the ConfigMap has the expected data keys
+    let data = cm.data.expect("ConfigMap should have data");
+    let deployment_config = data
+        .get("deployment-config.yaml")
+        .expect("deployment-config.yaml should exist");
+    assert!(
+        deployment_config.contains("some_key"),
+        "deployment-config.yaml should contain the generated configuration"
+    );
+    assert!(
+        deployment_config.contains("some_value"),
+        "deployment-config.yaml should contain the configured values"
+    );
+
+    // Test removal: remove the agent and verify the ConfigMap is deleted
+    server.set_config_response(
+        instance_id.clone(),
+        r#"
+agents: {}
+    "#,
+    );
+
+    // Verify that the ConfigMap is removed (garbage collected)
+    retry(120, Duration::from_secs(1), || {
+        if block_on(api.get(expected_configmap_name)).is_ok() {
+            return Err("ConfigMap still exists".into());
+        }
+        Ok(())
+    });
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,16 +2,19 @@
 
 ## Compiling and running Agent Control
 
-As of now, Agent Control is supported on Linux (x86_64 and aarch64). The program is written in Rust, and for multiplatform compilation we leverage [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) and musl libc.
+As of now, Agent Control is supported on Linux (x86_64 and aarch64). The program is written in Rust, and for
+multiplatform compilation we leverage [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) and musl libc.
 
 ### On-host
 
 To compile and run locally:
 
-1. Install the [Rust toolchain](https://www.rust-lang.org/tools/install) for your system, also add the targets you wish to compile for, e.g. (`rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl`).
+1. Install the [Rust toolchain](https://www.rust-lang.org/tools/install) for your system, also add the targets you wish
+   to compile for, e.g. (`rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl`).
 2. Install Zig with one of the [supported methods](https://github.com/ziglang/zig#installation).
 3. Install `cargo-zigbuild` with `cargo install --locked cargo-zigbuild`.
-4. Run `cargo zigbuild --bin newrelic-agent-control --target <ARCH>-unknown-linux-musl`, where `<ARCH>` is either `x86_64` or `aarch64`, depending on your system.
+4. Run `cargo zigbuild --bin newrelic-agent-control --target <ARCH>-unknown-linux-musl`, where `<ARCH>` is either
+   `x86_64` or `aarch64`, depending on your system.
     - On macOS, you might run into an error like the following:
 
       ```console
@@ -21,13 +24,16 @@ To compile and run locally:
         = note: error: unable to search for static library /<SOME_PATH_TO_RLIB_FILE>.rlib: ProcessFdQuotaExceeded
       ```
 
-      This is a [known](https://github.com/ziglang/zig/issues/23273) [issue](https://github.com/rust-cross/cargo-zigbuild/issues/329). To address it, increase the number of file descriptors for the current shell session with:
+      This is
+      a [known](https://github.com/ziglang/zig/issues/23273) [issue](https://github.com/rust-cross/cargo-zigbuild/issues/329).
+      To address it, increase the number of file descriptors for the current shell session with:
 
       ```sh
       ulimit -n 4096
       ```
 
-5. `newrelic-agent-control` binary will be generated at `./target/<ARCH>-unknown-linux-musl/debug/newrelic-agent-control`
+5. `newrelic-agent-control` binary will be generated at
+   `./target/<ARCH>-unknown-linux-musl/debug/newrelic-agent-control`
 6. Prepare a `local_config.yaml` file in `/etc/newrelic-agent-control/local-data/agent-control`, example:
 
     ```yaml
@@ -40,7 +46,8 @@ To compile and run locally:
         agent_type: "newrelic/com.newrelic.opentelemetry.collector:0.1.0"
     ```
 
-7. Place values files in the folder `/etc/newrelic-agent-control/local-data/{AGENT-ID}/` where `AGENT-ID` is a key in the
+7. Place values files in the folder `/etc/newrelic-agent-control/local-data/{AGENT-ID}/` where `AGENT-ID` is a key in
+   the
    `agents:` list. Example:
 
     ```yaml
@@ -55,7 +62,8 @@ To compile and run locally:
 
 #### Cross-compilation for Windows
 
-The steps below work for the `x86_64-pc-windows-msvc` target only. It is also possible to compile the project for the `x86_64-pc-windows-gnu` target using `cargo-zigbuild`.
+The steps below work for the `x86_64-pc-windows-msvc` target only. It is also possible to compile the project for the
+`x86_64-pc-windows-gnu` target using `cargo-zigbuild`.
 
 1. Install the [Rust toolchain](https://www.rust-lang.org/tools/install): `rustup target add x86_64-pc-windows-msvc`
 2. Install [cargo-xwin](https://github.com/rust-cross/cargo-xwin) and dependencies.
@@ -72,31 +80,40 @@ The steps below work for the `x86_64-pc-windows-msvc` target only. It is also po
    ❯ cargo xwin build --bin newrelic-agent-control --target x86_64-pc-windows-msvc --release
    ```
 
-   ⚠️ This method doesn't work for building debug binaries (`--release` is required). As `cargo-xwin` doesn't provide `msvcrtd.lib` (the debug version of the C runtime library).
+   ⚠️ This method doesn't work for building debug binaries (`--release` is required). As `cargo-xwin` doesn't provide
+   `msvcrtd.lib` (the debug version of the C runtime library).
 
 #### AC Service Windows vs Linux
 
 On Linux, Agent Control is expected to run as a system service, managed by `systemd`.
-Such service file is packaged in the `.deb` and `.rpm` installers by goreleaser and it is installed and enabled by the `postinstall.sh` script.
+Such service file is packaged in the `.deb` and `.rpm` installers by goreleaser and it is installed and enabled by the
+`postinstall.sh` script.
 
-On the other hand, on Windows, Agent Control is expected to run as a Windows Service that is installed using the `install.ps1` script that takes care of registering the service and install AC.
+On the other hand, on Windows, Agent Control is expected to run as a Windows Service that is installed using the
+`install.ps1` script that takes care of registering the service and install AC.
 
-On both Operating Systems, an `environment_variables.yaml` file is created to store environment variables that Agent Control will use when running as a service. This file is created at installation time and it is located at the Agent Control configuration directory.
+On both Operating Systems, an `environment_variables.yaml` file is created to store environment variables that Agent
+Control will use when running as a service. This file is created at installation time and it is located at the Agent
+Control configuration directory.
 
 ### Kubernetes
 
-We use [`minikube`](https://minikube.sigs.k8s.io/docs/) and [`tilt`](https://tilt.dev/) to launch a local cluster and deploy the Agent Control [charts](https://github.com/newrelic/helm-charts/tree/master/charts/agent-control).
+We use [`minikube`](https://minikube.sigs.k8s.io/docs/) and [`tilt`](https://tilt.dev/) to launch a local cluster and
+deploy the Agent Control [charts](https://github.com/newrelic/helm-charts/tree/master/charts/agent-control).
 
 #### Prerequisites
 
-- Install the [Rust toolchain](https://www.rust-lang.org/tools/install) for your system, also add the targets you wish to compile for, e.g. (`rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl`).
+- Install the [Rust toolchain](https://www.rust-lang.org/tools/install) for your system, also add the targets you wish
+  to compile for, e.g. (`rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl`).
 - Install Zig with one of the [supported methods](https://github.com/ziglang/zig#installation).
 - Install `cargo-zigbuild` with `cargo install --locked cargo-zigbuild`.
 - Install `minikube` for local Kubernetes cluster emulation.
 - Ensure you have `tilt` installed for managing local development environments.
 - Add an Agent Control values file in `local/agent-control-tilt.yml`.
 
-Note: Adding the `'chart_repo'` setting, pointing to the [New Relic charts](https://github.com/newrelic/helm-charts/tree/master/charts) on a local path, allows using local helm charts.
+Note: Adding the `'chart_repo'` setting, pointing to
+the [New Relic charts](https://github.com/newrelic/helm-charts/tree/master/charts) on a local path, allows using local
+helm charts.
 
 #### Steps
 
@@ -114,7 +131,9 @@ On macOS, you might run into an error like the following:
   = note: error: unable to search for static library /<SOME_PATH_TO_RLIB_FILE>.rlib: ProcessFdQuotaExceeded
 ```
 
-This is a [known](https://github.com/ziglang/zig/issues/23273) [issue](https://github.com/rust-cross/cargo-zigbuild/issues/329). To address it, increase the number of file descriptors for the current shell session with:
+This is
+a [known](https://github.com/ziglang/zig/issues/23273) [issue](https://github.com/rust-cross/cargo-zigbuild/issues/329).
+To address it, increase the number of file descriptors for the current shell session with:
 
 ```sh
 ulimit -n 4096
@@ -126,7 +145,8 @@ See [diagnose issues with agent control logging](https://docs.newrelic.com/docs/
 
 ### Disable Fleet Control
 
-Users can disable remote management just by commenting its configuration out from `/etc/newrelic-agent-control/local-data/agent-control/local_config.yaml` (on-host):
+Users can disable remote management just by commenting its configuration out from
+`/etc/newrelic-agent-control/local-data/agent-control/local_config.yaml` (on-host):
 
 ```yaml
 # fleet_control:
@@ -158,10 +178,12 @@ agent-control-deployment:
 
 ### Agent Control Health
 
-There is a service that ultimately exposes a `/status` endpoint for Agent Control itself. This service performs a series of checks to determine the output (both in HTTP status code and message):
+There is a service that ultimately exposes a `/status` endpoint for Agent Control itself. This service performs a series
+of checks to determine the output (both in HTTP status code and message):
 
 - Reachability of Fleet Control endpoint (if Fleet Control is enabled at all).
-- Active agents and health of each one, in the same form as used by the OpAMP protocol, mentioned when discussing [sub-agent health](./INTEGRATING_AGENTS.md#health-status).
+- Active agents and health of each one, in the same form as used by the OpAMP protocol, mentioned when
+  discussing [sub-agent health](./INTEGRATING_AGENTS.md#health-status).
 
 ```json
 {
@@ -193,13 +215,15 @@ Users need to enable the local server by adding the following setting in the Age
 
 ```yaml
 server:
-    enabled: true
-    # default values (change if needed)
-    #host: "127.0.0.1"
-    #port: 51200
+  enabled: true
+  # default values (change if needed)
+  #host: "127.0.0.1"
+  #port: 51200
 ```
 
-For Kubernetes, the status endpoint is enabled by default. You can access this easily by performing a Kubernetes [port-forward](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/), using the following commands **on separate shells**:
+For Kubernetes, the status endpoint is enabled by default. You can access this easily by performing a
+Kubernetes [port-forward](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/),
+using the following commands **on separate shells**:
 
 ```console
 $ kubectl port-forward ac-agent-control-6558446569-rtwh4 -n newrelic 51200:51200
@@ -248,7 +272,9 @@ make -C agent-control test/onhost/integration
 
 #### Tests that require root user
 
-Running tests that require root user can be not straight-forward, as the Rust toolchain installers like `rustup` tend to not install them globally on a system, so doing `sudo cargo` won't work. An easy way to run the root-required tests is spinning up a container where the user is root and running them there with:
+Running tests that require root user can be not straight-forward, as the Rust toolchain installers like `rustup` tend to
+not install them globally on a system, so doing `sudo cargo` won't work. An easy way to run the root-required tests is
+spinning up a container where the user is root and running them there with:
 
 ```sh
 make -C agent-control test/onhost/root/integration
@@ -264,19 +290,30 @@ make -C agent-control test/k8s
 
 #### Tests that require an existing Kubernetes cluster
 
+For full integration tests using Flux:
+
 ```sh
 make -C agent-control test/k8s/integration
 ```
 
+For full integration tests without Flux:
+
+```sh
+make -C agent-control test/k8s/integration-without-flux
+```
+
 ## Coverage
 
-Generate coverage information easily by running the following `make` recipe from the root directory (will install `cargo-llvm-cov` if it's not installed already):
+Generate coverage information easily by running the following `make` recipe from the root directory (will install
+`cargo-llvm-cov` if it's not installed already):
 
 ```console
 make coverage
 ```
 
-By default, this will generate a report in `lcov` format on `coverage/lcov.info` that IDEs such as VSCode can read via [certain extensions](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters). To modify the output format and the output location, use the variables `COVERAGE_OUT_FORMAT` and `COVERAGE_OUT_FILEPATH`:
+By default, this will generate a report in `lcov` format on `coverage/lcov.info` that IDEs such as VSCode can read
+via [certain extensions](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters). To
+modify the output format and the output location, use the variables `COVERAGE_OUT_FORMAT` and `COVERAGE_OUT_FILEPATH`:
 
 ```console
 COVERAGE_OUT_FORMAT=json COVERAGE_OUT_FILEPATH=jcov-info.json make coverage
@@ -286,9 +323,11 @@ COVERAGE_OUT_FORMAT=json COVERAGE_OUT_FILEPATH=jcov-info.json make coverage
 
 ### Heap Profiling
 
-Heap profiling is supported via the [`dhat` crate](https://docs.rs/dhat/latest/dhat/) and is gated behind the `dhat-heap` feature flag. It can be used to detect memory leaks and analyze heap allocations.
+Heap profiling is supported via the [`dhat` crate](https://docs.rs/dhat/latest/dhat/) and is gated behind the
+`dhat-heap` feature flag. It can be used to detect memory leaks and analyze heap allocations.
 
-To build with heap profiling enabled, use the `release-debug` profile (which inherits from `release` but keeps debug symbols) together with the feature flag:
+To build with heap profiling enabled, use the `release-debug` profile (which inherits from `release` but keeps debug
+symbols) together with the feature flag:
 
 ```sh
 cargo build -p newrelic_agent_control --profile release-debug --features dhat-heap
@@ -303,7 +342,10 @@ Open `dhat-heap.json` in the [DHAT Viewer](https://nnethercote.github.io/dh_view
 
 ### Ad-hoc Profiling
 
-Ad-hoc profiling is also supported via `dhat` and is gated behind the `dhat-ad-hoc` feature flag. Unlike heap profiling, it requires manually annotating the code you want to profile — no annotations are added by default at the time of writing this. See the [`dhat` ad-hoc profiling documentation](https://docs.rs/dhat/latest/dhat/#setup-ad-hoc-profiling) for details on how to instrument your code.
+Ad-hoc profiling is also supported via `dhat` and is gated behind the `dhat-ad-hoc` feature flag. Unlike heap profiling,
+it requires manually annotating the code you want to profile — no annotations are added by default at the time of
+writing this. See the [`dhat` ad-hoc profiling documentation](https://docs.rs/dhat/latest/dhat/#setup-ad-hoc-profiling)
+for details on how to instrument your code.
 
 ```sh
 cargo build -p newrelic_agent_control --profile release-debug --features dhat-ad-hoc
@@ -311,7 +353,8 @@ cargo build -p newrelic_agent_control --profile release-debug --features dhat-ad
 
 ## Codeql
 
-Codeql is executed automatically in GitHub pipelines, in order to check the results locally you need to install the tool and download rust queries:
+Codeql is executed automatically in GitHub pipelines, in order to check the results locally you need to install the tool
+and download rust queries:
 
 ```console
 ❯ brew install codeql
@@ -346,4 +389,6 @@ Check the results
 
 ## Additional information
 
-We maintain separate directories for other documented topics under this `docs` directory and in other Markdown files throughout the codebase. The latter will be centralized under the `docs` directory over time. Feel free to check these documents and ask doubts or propose changes!
+We maintain separate directories for other documented topics under this `docs` directory and in other Markdown files
+throughout the codebase. The latter will be centralized under the `docs` directory over time. Feel free to check these
+documents and ask doubts or propose changes!


### PR DESCRIPTION
- Create tilt and harness for integration tests using k8s AC without flux.
- Create a test that uses a custom agent type that creates a Configmap and ensure it's created with the right content.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
