### PR TITLE
feat: exit(1467) after windows self-update

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -13,6 +13,7 @@ pub mod uptime_report;
 pub mod version_updater;
 
 use crate::agent_control::defaults::AGENT_CONTROL_ID;
+use crate::agent_control::run::GracefulShutdownReason;
 use crate::checkers::health::health_checker::{HealthChecker, spawn_health_checker};
 use crate::checkers::health::with_start_time::HealthWithStartTime;
 use crate::event::AgentControlInternalEvent;
@@ -127,7 +128,7 @@ where
         }
     }
 
-    pub fn run(self) -> Result<(), AgentControlError> {
+    pub fn run(self) -> Result<GracefulShutdownReason, AgentControlError> {
         let ac_startup_span = info_span!("start_agent_control", id = AGENT_CONTROL_ID);
         let _ac_startup_span_guard = ac_startup_span.enter();
         info!("Starting the agents supervisor runtime");
@@ -189,7 +190,7 @@ where
         info!("Agents supervisor runtime successfully started");
         drop(_ac_startup_span_guard); // The span representing agent start finishes before entering in the `process_events` loop. Otherwise the span would be open while Agent Control runs.
 
-        self.process_events(running_sub_agents);
+        let shutdown_reason = self.process_events(running_sub_agents);
 
         if let Some(opamp_client) = self.opamp_client {
             info!("Stopping the OpAMP Client");
@@ -197,7 +198,7 @@ where
         }
 
         info!("AgentControl finished");
-        Ok(())
+        Ok(shutdown_reason)
     }
 
     // Recreates a Sub Agent by its agent_id meaning:
@@ -275,8 +276,8 @@ where
         mut sub_agents: StartedSubAgents<
             <<S as SubAgentBuilder>::NotStartedSubAgent as NotStartedSubAgent>::StartedSubAgent,
         >,
-    ) {
-        debug!("Listening for events");
+    ) -> GracefulShutdownReason {
+        debug!("Listening for events from agents");
         let never_receive = EventConsumer::from(never());
         let opamp_receiver = self
             .agent_control_opamp_consumer
@@ -345,10 +346,11 @@ where
                                         update_opamp_attributes(c, attributes)
                                     .inspect_err(|e| error!(error = %e, select_arm = "agent_control_internal_consumer", "processing version message")));
                                 },
-                                AgentControlInternalEvent::StopRequested() => {
-                                    debug!("Stopping Agent Control event processor after request");
+                                AgentControlInternalEvent::SelfUpdateRestartRequested() => {
+                                    debug!("Stopping Agent Control to apply self-update");
                                     self.agent_control_publisher.broadcast(AgentControlEvent::AgentControlStopped);
-                                    break sub_agents.stop();
+                                    sub_agents.stop();
+                                    break GracefulShutdownReason::SelfUpdate;
                                 }}
                         },
                     }
@@ -359,7 +361,8 @@ where
                     let _= agent_control_event.inspect_err(|err| error!(error = %err, select_arm = "application_event_consumer", "Receiving application event"));
                     debug!("Stopping Agent Control event processor");
                     self.agent_control_publisher.broadcast(AgentControlEvent::AgentControlStopped);
-                    break sub_agents.stop();
+                    sub_agents.stop();
+                    break GracefulShutdownReason::ExternalRequested;
                 },
                 recv(uptime_reporter.receiver()) -> _tick => { let _ = uptime_reporter.report(); },
             }

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -23,6 +23,15 @@ use tracing::debug;
 #[error("{0}")]
 pub struct RunError(String);
 
+/// The reason Agent Control stopped gracefully.
+#[derive(Debug, PartialEq)]
+pub enum GracefulShutdownReason {
+    /// A stop was requested externally (SIGTERM, SCM stop).
+    ExternalRequested,
+    /// A successful self-update occurred, and the process needs to be restarted to apply the update.
+    SelfUpdate,
+}
+
 // k8s and on_host need to be public to allow integration tests to access the fn run_agent_control.
 
 pub mod k8s;

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -13,7 +13,8 @@ use crate::agent_control::health_checker::k8s::agent_control_health_checker_buil
 use crate::agent_control::http_server::runner::Runner;
 use crate::agent_control::resource_cleaner::k8s_garbage_collector::K8sGarbageCollector;
 use crate::agent_control::run::{
-    AgentControlRunner, Environment, RunError, setup_config_repository_and_store,
+    AgentControlRunner, Environment, GracefulShutdownReason, RunError,
+    setup_config_repository_and_store,
 };
 use crate::agent_control::version_updater::k8s::K8sACUpdater;
 use crate::agent_type::render::TemplateRenderer;
@@ -59,7 +60,7 @@ pub const NAMESPACE_AGENTS_VARIABLE_NAME: &str = "namespace_agents";
 pub const AGENT_CONTROL_MODE_K8S: Environment = Environment::K8s;
 
 impl AgentControlRunner {
-    pub fn run_k8s(self) -> Result<(), RunError> {
+    pub fn run_k8s(self) -> Result<GracefulShutdownReason, RunError> {
         let k8s_config = self.bootstrap_config.k8s.clone().ok_or(RunError(
             "k8s config missing while running on k8s".to_string(),
         ))?;

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -10,7 +10,8 @@ use crate::agent_control::defaults::{
 use crate::agent_control::http_server::runner::Runner;
 use crate::agent_control::resource_cleaner::no_op::NoOpResourceCleaner;
 use crate::agent_control::run::{
-    AgentControlRunner, Environment, RunError, RunningMode, setup_config_repository_and_store,
+    AgentControlRunner, Environment, GracefulShutdownReason, RunError, RunningMode,
+    setup_config_repository_and_store,
 };
 use crate::agent_control::version_updater::on_host::OnHostACUpdater;
 use crate::agent_control::version_updater::on_host::verify::ProcessVerifyExecutor;
@@ -82,7 +83,7 @@ type OnHostOpAMPClient = StartedHttpClient<
 type OnHostOpAMPConsumer = EventConsumer<OpAMPEvent>;
 
 impl AgentControlRunner {
-    pub fn run_onhost(self) -> Result<(), RunError> {
+    pub fn run_onhost(self) -> Result<GracefulShutdownReason, RunError> {
         let local_dir = self.base_paths.local_dir;
         let remote_dir = self.base_paths.remote_dir;
         let file_store = Arc::new(FileStore::new_local_fs(

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -101,7 +101,7 @@ where
 
         debug!("Agent Control binary replaced, stopping to allow the new version to start");
         self.agent_control_internal_publisher
-            .publish(AgentControlInternalEvent::StopRequested())
+            .publish(AgentControlInternalEvent::SelfUpdateRestartRequested())
             .map_err(|e| UpdaterError::UpdateFailed(format!("publishing stop request: {e}")))?;
 
         Ok(())

--- a/agent-control/src/bin/main_k8s.rs
+++ b/agent-control/src/bin/main_k8s.rs
@@ -41,4 +41,5 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
     AgentControlRunner::try_new(context.ac_runner_context)?
         .run_k8s()
         .map_err(|e| e.into())
+        .map(|_shutdown_reason| ())
 }

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -86,5 +86,7 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    run_result.map(|_| ())
+    // Shutdown reason is not used passed to this point.
+    run_result?;
+    Ok(())
 }

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -74,8 +74,7 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
     // Create the actual agent control runner with the rest of required configs
     // and the application_event_consumer and capture the result to report the error in windows
     let run_result = AgentControlRunner::try_new(context.ac_runner_context)
-        .and_then(|runner| runner.run_onhost().map_err(|e| e.into()))
-        .map(|_shutdown_reason| ());
+        .and_then(|runner| runner.run_onhost().map_err(|e| e.into()));
 
     #[cfg(target_family = "windows")]
     if let Some(handler) = context.stop_handler {
@@ -87,5 +86,5 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    run_result
+    run_result.map(|_| ())
 }

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -74,7 +74,8 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
     // Create the actual agent control runner with the rest of required configs
     // and the application_event_consumer and capture the result to report the error in windows
     let run_result = AgentControlRunner::try_new(context.ac_runner_context)
-        .and_then(|runner| runner.run_onhost().map_err(|e| e.into()));
+        .and_then(|runner| runner.run_onhost().map_err(|e| e.into()))
+        .map(|_shutdown_reason| ());
 
     #[cfg(target_family = "windows")]
     if let Some(handler) = context.stop_handler {

--- a/agent-control/src/command/windows.rs
+++ b/agent-control/src/command/windows.rs
@@ -1,6 +1,7 @@
 //! This module contains functions to handle the Windows version of the main, which involves a Windows Service
 //! running mode.
 
+use crate::agent_control::run::GracefulShutdownReason;
 use crate::event::channel::EventPublisher;
 use crate::{event::ApplicationEvent, utils::retry::retry};
 use std::error::Error;
@@ -43,7 +44,7 @@ impl WindowsServiceStopHandler {
     /// Consumes the handler so that [Drop] is not triggered for panic/error logic.
     pub fn teardown(
         mut self,
-        run_result: &Result<(), Box<dyn Error>>,
+        run_result: &Result<GracefulShutdownReason, Box<dyn Error>>,
     ) -> Result<(), Box<dyn Error>> {
         if let Some(handle) = self.handle.take() {
             debug!(
@@ -55,7 +56,9 @@ impl WindowsServiceStopHandler {
                     error!("Service stopping due to error: {err}");
                     ServiceExitCode::ServiceSpecific(1)
                 }
-                Ok(_) => ServiceExitCode::Win32(0),
+                // ERROR_RESTART_APPLICATION(1467) indicates that the a restart is needed due to a self-update
+                Ok(GracefulShutdownReason::SelfUpdate) => ServiceExitCode::Win32(1467),
+                Ok(GracefulShutdownReason::ExternalRequested) => ServiceExitCode::Win32(0),
             };
 
             set_service_as_stopped(handle, exit_code)?;

--- a/agent-control/src/event.rs
+++ b/agent-control/src/event.rs
@@ -61,7 +61,7 @@ impl SubAgentEvent {
 pub enum AgentControlInternalEvent {
     HealthUpdated(HealthWithStartTime),
     AgentControlAttributesUpdated(UpdateAttributesMessage),
-    StopRequested(),
+    SelfUpdateRestartRequested(),
 }
 
 /// Defines internal events for the SubAgent component.

--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -4,7 +4,7 @@ use newrelic_agent_control::agent_control::config_repository::repository::AgentC
 use newrelic_agent_control::agent_control::config_repository::store::AgentControlConfigStore;
 use newrelic_agent_control::agent_control::defaults::AUTH_PRIVATE_KEY_FILE_NAME;
 use newrelic_agent_control::agent_control::run::{
-    AgentControlRunner, BasePaths, Environment, RunError,
+    AgentControlRunner, BasePaths, Environment, GracefulShutdownReason, RunError,
 };
 use newrelic_agent_control::command::RunnerContext;
 use newrelic_agent_control::event::ApplicationEvent;
@@ -64,7 +64,7 @@ pub fn start_agent_control_with_custom_config(
 pub struct StartedAgentControl {
     application_event_publisher: EventPublisher<ApplicationEvent>,
 
-    handle: Option<std::thread::JoinHandle<Result<(), RunError>>>,
+    handle: Option<std::thread::JoinHandle<Result<GracefulShutdownReason, RunError>>>,
 }
 impl StartedAgentControl {
     pub fn has_gracefully_stopped(&mut self) -> bool {


### PR DESCRIPTION
This PR allows windows successful self-update to exit with Win32(1467) so the SCM triggers a service restart, while keeping and exit(0) for linux. 

To do that introduces `GracefulShutdownReason`, an enum that encodes why Agent Control stopped cleanly. 

Currently, `AgentControl::run()`, `run_onhost()`, and `run_k8s()` all returned `Result<(), ...>`, making it impossible for callers to distinguish between a normal external stop request (SIGTERM, SCM stop) and other future graceful exit paths. The enum is threaded through the call stack up to `_main`, where it is discarded for now with. 