### PR TITLE
feat: global registry support

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -29,14 +29,6 @@ variables:
       required: false
       default: 18003
     oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_registry_urls"
-          values: [ "docker.io" ]
       repository:
         description: "Package repository name"
         type: string
@@ -81,14 +73,6 @@ variables:
       required: false
       default: 18003
     oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_registry_urls"
-          values: [ "docker.io" ]
       repository:
         description: "Package repository name"
         type: string
@@ -182,7 +166,6 @@ deployment:
       infra-agent:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
@@ -252,7 +235,6 @@ deployment:
       infra-agent:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -45,24 +45,6 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -115,24 +97,6 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -222,12 +186,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
       args:
@@ -298,12 +256,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
       args:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -33,14 +33,6 @@ variables:
         required: false
         default: 13133
     oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_nrdot_registry_urls"
-          values: [ "docker.io" ]
       repository:
         description: "Package repository name"
         type: string
@@ -79,14 +71,6 @@ variables:
         required: false
         default: 13133
     oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_nrdot_registry_repositories"
-          values: [ "docker.io" ]
       repository:
         description: "Package repository name"
         type: string
@@ -153,7 +137,6 @@ deployment:
       nrdot:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
@@ -186,7 +169,6 @@ deployment:
       nrdot:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -49,24 +49,6 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -113,24 +95,6 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -193,12 +157,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.nrdot.dir}\\nrdot-collector.exe
       args:
@@ -232,12 +190,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     health:
       interval: 30s
       initial_delay: 90s

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -76,6 +76,10 @@ pub struct AgentControlConfig {
     /// Contains configuration for on-host self-update mechanism
     #[serde(default)]
     pub self_update: SelfUpdateConfig,
+
+    /// Oci configuration (used for AC and agents packages)
+    #[serde(default)]
+    pub oci: OciConfig,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
@@ -92,6 +96,48 @@ pub struct SelfUpdateConfig {
 pub struct PackagesConfig {
     /// Indicates whether package signature verification is enabled or not
     pub signature_verification_enabled: SignatureVerificationEnabled,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OciConfig {
+    #[serde(default = "OciConfig::default_registry")]
+    pub registry: String,
+    #[serde(default)]
+    pub auth: OciAuth,
+}
+
+impl Default for OciConfig {
+    fn default() -> Self {
+        OciConfig {
+            registry: Self::default_registry(),
+            auth: OciAuth::default(),
+        }
+    }
+}
+
+impl OciConfig {
+    fn default_registry() -> String {
+        "docker.io".to_string()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+pub struct OciAuth {
+    #[serde(default)]
+    pub basic: BasicAuth,
+    #[serde(default)]
+    pub bearer: BearerAuth,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+pub struct BearerAuth {
+    pub token: String,
 }
 
 const DEFAULT_SIGNATURE_VERIFICATION_ENABLED: bool = true;
@@ -1039,6 +1085,31 @@ k8s:
 
         let result = AgentControlDynamicConfig::try_from(&opamp_config);
         assert_matches!(result, Err(AgentControlConfigError(_)));
+    }
+
+    #[test]
+    fn test_deserialize_oci_config() {
+        let config_input = r#"agents: {}"#;
+        let config = serde_yaml::from_str::<AgentControlConfig>(config_input).unwrap();
+        assert_eq!("docker.io".to_string(), config.oci.registry);
+
+        let config_input = r#"
+agents: {}
+oci:
+  auth:
+    bearer:
+      token: "token"
+"#;
+        let config = serde_yaml::from_str::<AgentControlConfig>(config_input).unwrap();
+        assert_eq!("docker.io".to_string(), config.oci.registry);
+
+        let config_input = r#"
+agents: {}
+oci:
+  registry: "custom-registry.io"
+"#;
+        let config = serde_yaml::from_str::<AgentControlConfig>(config_input).unwrap();
+        assert_eq!("custom-registry.io".to_string(), config.oci.registry);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -175,6 +175,7 @@ impl AgentControlRunner {
         let agents_package_manager = OCIPackageManager::new(
             OCIArtifactDownloader::new(
                 oci_client.clone(),
+                self.bootstrap_config.oci.registry.clone(),
                 agent_control_config
                     .agent_packages
                     .signature_verification_enabled
@@ -225,6 +226,7 @@ impl AgentControlRunner {
         let agent_control_package_manager = OCIPackageManager::new(
             OCIArtifactDownloader::new(
                 oci_client.clone(),
+                self.bootstrap_config.oci.registry.clone(),
                 agent_control_config
                     .self_update
                     .signature_verification_enabled

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -27,6 +27,4 @@ pub enum AgentTypeError {
     ConflictingVariableDefinition(String),
     #[error("error parsing oci reference: {0}")]
     OCIReferenceParsingError(String),
-    #[error("error with OCI auth configuration: {0}")]
-    OCIAuthError(String),
 }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -106,8 +106,6 @@ mod tests {
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
     use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
-    use oci_client::secrets::RegistryAuth;
-    use rstest::rstest;
     use serde_yaml::Number;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -170,7 +168,6 @@ mod tests {
                     public_key_url: Some(TemplateableValue::from_template(
                         "${nr-var:public-key-url}".to_string(),
                     )),
-                    auth: package::Auth::default(),
                 },
             },
         };
@@ -179,7 +176,7 @@ mod tests {
             ("otel-first".to_string(), pkg.clone()),
             ("otel-second".to_string(), pkg),
         ]);
-        assert_eq!(on_host.packages, expected_packages);
+        assert_eq!(on_host.packages, expected_packages)
     }
 
     #[test]
@@ -719,75 +716,6 @@ executables:
         );
     }
 
-    struct AuthCredentials {
-        username: &'static str,
-        password: &'static str,
-        bearer: &'static str,
-    }
-
-    impl AuthCredentials {
-        const NONE: Self = Self {
-            username: "",
-            password: "",
-            bearer: "",
-        };
-        const BASIC: Self = Self {
-            username: "user",
-            password: "pass",
-            bearer: "",
-        };
-        const BEARER: Self = Self {
-            username: "",
-            password: "",
-            bearer: "token",
-        };
-    }
-
-    #[rstest]
-    // This case checks backwards compatibility with old agent types not defining auth.
-    #[case::no_auth(PACKAGES_NO_AUTH, AuthCredentials::NONE, RegistryAuth::Anonymous)]
-    #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
-    #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
-    #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
-    fn test_auth_parsing(
-        #[case] yaml: &str,
-        #[case] creds: AuthCredentials,
-        #[case] expected_auth: RegistryAuth,
-    ) {
-        let on_host: OnHost = serde_yaml::from_str(yaml).unwrap();
-
-        let mut vars = Variables::new();
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable("/filesystem".to_string()),
-        );
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
-            Variable::new_final_string_variable("remote".to_string()),
-        );
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_SUB_AGENT_ID),
-            Variable::new_final_string_variable("agent-id".to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.basic.username".to_string(),
-            Variable::new_final_string_variable(creds.username.to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.basic.password".to_string(),
-            Variable::new_final_string_variable(creds.password.to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.bearer.token".to_string(),
-            Variable::new_final_string_variable(creds.bearer.to_string()),
-        );
-
-        let rendered = on_host.template_with(&vars).unwrap();
-        let pkg = rendered.packages.get("infra-agent").unwrap();
-
-        assert_eq!(pkg.download.oci.auth, expected_auth);
-    }
-
     pub const AGENT_GIVEN_YAML: &str = r#"
 health:
   interval: 3s
@@ -834,31 +762,5 @@ packages:
         repository: ${nr-var:repository}
         version: ${nr-var:version}
         public_key_url: ${nr-var:public-key-url}
-"#;
-
-    const PACKAGES_NO_AUTH: &str = r#"
-packages:
-  infra-agent:
-    download:
-      oci:
-        registry: docker.io
-        repository: repo/image
-        version: 0.0.1
-"#;
-
-    const PACKAGES: &str = r#"
-packages:
-  infra-agent:
-    download:
-      oci:
-        registry: docker.io
-        repository: repo/image
-        version: 0.0.1
-        auth:
-          basic:
-            username: ${nr-var:oci.auth.basic.username}
-            password: ${nr-var:oci.auth.basic.password}
-          bearer:
-            token: ${nr-var:oci.auth.bearer.token}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -160,7 +160,6 @@ mod tests {
         let pkg = Package {
             download: Download {
                 oci: Oci {
-                    registry: TemplateableValue::from_template("${nr-var:registry}".to_string()),
                     repository: TemplateableValue::from_template(
                         "${nr-var:repository}".to_string(),
                     ),
@@ -191,7 +190,6 @@ packages:
   my-pkg:
     download:
       oci:
-        registry: my.registry
         repository: my/repo
         version: latest
 "#;
@@ -221,7 +219,7 @@ packages:
                 .join("agent-id")
                 .join("stored_packages")
                 .join("my-pkg")
-                .join("oci_my_registry__my__repo_latest")
+                .join("oci_base_io__my__repo_latest")
                 .to_string_lossy()
                 .to_string(),
         );

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -26,8 +26,6 @@ pub struct Download {
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct Oci {
-    /// OCI registry url.
-    pub registry: TemplateableValue<String>,
     /// Repository name.
     pub repository: TemplateableValue<String>,
     /// Package version including tag, digest or tag + digest.
@@ -58,7 +56,7 @@ impl Templateable for Download {
 impl Templateable for Oci {
     type Output = rendered::Oci;
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        let registry = self.registry.template_with(variables)?;
+        let registry = "base.io";
         let repository = self.repository.template_with(variables)?;
         let mut version = self.version.template_with(variables)?;
 
@@ -133,10 +131,6 @@ mod tests {
 
         let mut variables = Variables::new();
         variables.insert(
-            "nr-var:registry".to_string(),
-            Variable::new_final_string_variable("registry.com".to_string()),
-        );
-        variables.insert(
             "nr-var:repository".to_string(),
             Variable::new_final_string_variable("repo".to_string()),
         );
@@ -152,7 +146,6 @@ mod tests {
         }
 
         let oci = Oci {
-            registry: TemplateableValue::from_template("${nr-var:registry}".to_string()),
             repository: TemplateableValue::from_template("${nr-var:repository}".to_string()),
             version: TemplateableValue::from_template("${nr-var:version}".to_string()),
             public_key_url: public_key_url
@@ -163,7 +156,7 @@ mod tests {
         let rendered_oci = oci.template_with(&variables);
         let rendered_oci = rendered_oci.unwrap();
 
-        assert_eq!(rendered_oci.reference.registry(), "registry.com");
+        assert_eq!(rendered_oci.reference.registry(), "base.io");
         assert_eq!(rendered_oci.reference.repository(), "repo");
         assert_eq!(rendered_oci.reference.tag(), expected_tag);
         assert_eq!(rendered_oci.reference.digest(), expected_digest);

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -3,10 +3,9 @@ use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
 use crate::agent_type::templates::Templateable;
 use crate::oci::reference_parser::ReferenceParser;
-use oci_client::{Reference, secrets::RegistryAuth};
+use oci_client::Reference;
 use serde::Deserialize;
 use std::str::FromStr;
-use tracing::debug;
 use url::Url;
 
 pub mod rendered;
@@ -36,26 +35,6 @@ pub struct Oci {
     pub version: TemplateableValue<String>,
     /// Public key url is expected to be a jwks.
     pub public_key_url: Option<TemplateableValue<String>>,
-    /// Authentication method for the OCI registry.
-    #[serde(default)]
-    pub auth: Auth,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct Auth {
-    pub basic: BasicAuth,
-    pub bearer: BearerAuth,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct BasicAuth {
-    pub username: TemplateableValue<String>,
-    pub password: TemplateableValue<String>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct BearerAuth {
-    pub token: TemplateableValue<String>,
 }
 
 impl Templateable for Package {
@@ -108,58 +87,10 @@ impl Templateable for Oci {
             })?,
         );
 
-        let auth = self.auth.template_with(variables)?;
-
         Ok(Self::Output {
             reference,
             public_key_url,
-            auth,
         })
-    }
-}
-
-impl Templateable for Auth {
-    type Output = RegistryAuth;
-    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        let username = self
-            .basic
-            .username
-            .template_with(variables)
-            .map_err(|err| {
-                AgentTypeError::OCIAuthError(format!("error templating username: {err}"))
-            })?;
-        let password =
-            self.basic.password.template_with(variables).map_err(|_| {
-                AgentTypeError::OCIAuthError("error templating password".to_string())
-            })?;
-        let token = self
-            .bearer
-            .token
-            .template_with(variables)
-            .map_err(|_| AgentTypeError::OCIAuthError("error templating token".to_string()))?;
-
-        match (
-            &username.is_empty(),
-            &password.is_empty(),
-            &token.is_empty(),
-        ) {
-            (true, true, true) => Ok(RegistryAuth::Anonymous),
-            (false, false, true) => {
-                debug!("Basic auth credentials provided, using basic auth");
-                Ok(RegistryAuth::Basic(username, password))
-            }
-            (true, true, false) => {
-                debug!("Bearer token provided, using bearer auth");
-                Ok(RegistryAuth::Bearer(token))
-            }
-            (false, false, false) => Err(AgentTypeError::OCIAuthError(
-                "multiple authentication methods provided, only one should be used".to_string(),
-            )),
-            (true, false, _) | (false, true, _) => Err(AgentTypeError::OCIAuthError(
-                "incomplete basic auth credentials provided, username or password is empty"
-                    .to_string(),
-            )),
-        }
     }
 }
 
@@ -227,7 +158,6 @@ mod tests {
             public_key_url: public_key_url
                 .clone()
                 .map(|_| TemplateableValue::from_template("${nr-var:public-key}".to_string())),
-            auth: Auth::default(),
         };
 
         let rendered_oci = oci.template_with(&variables);
@@ -238,110 +168,5 @@ mod tests {
         assert_eq!(rendered_oci.reference.tag(), expected_tag);
         assert_eq!(rendered_oci.reference.digest(), expected_digest);
         assert_eq!(rendered_oci.public_key_url, public_key_url);
-        assert_eq!(rendered_oci.auth, RegistryAuth::Anonymous);
-    }
-
-    #[test]
-    fn test_auth_basic_with_templated_values() {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:username".to_string(),
-            Variable::new_final_string_variable("myuser".to_string()),
-        );
-        variables.insert(
-            "nr-var:password".to_string(),
-            Variable::new_final_string_variable("mypass".to_string()),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("docker.io".to_string()),
-            repository: TemplateableValue::from_template("myrepo/myimage".to_string()),
-            version: TemplateableValue::from_template("1.0.0".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth {
-                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
-                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
-                },
-                bearer: BearerAuth::default(),
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables).unwrap();
-        assert_eq!(
-            rendered_oci.auth,
-            RegistryAuth::Basic("myuser".to_string(), "mypass".to_string())
-        );
-    }
-
-    #[test]
-    fn test_auth_bearer_with_templated_value() {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:token".to_string(),
-            Variable::new_final_string_variable("bearer-token".to_string()),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("gcr.io".to_string()),
-            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
-            version: TemplateableValue::from_template("latest".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth::default(),
-                bearer: BearerAuth {
-                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
-                },
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables).unwrap();
-        assert_eq!(
-            rendered_oci.auth,
-            RegistryAuth::Bearer("bearer-token".to_string())
-        );
-    }
-
-    #[rstest]
-    #[case::multiple_credentials_provided("myuser", "mypass", "bearer-token")]
-    #[case::no_username_in_basic_auth("", "mypass", "")]
-    #[case::no_password_in_basic_auth("myuser", "", "")]
-    fn test_auth_credentials_error(
-        #[case] username: String,
-        #[case] password: String,
-        #[case] token: String,
-    ) {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:username".to_string(),
-            Variable::new_final_string_variable(username),
-        );
-        variables.insert(
-            "nr-var:password".to_string(),
-            Variable::new_final_string_variable(password),
-        );
-        variables.insert(
-            "nr-var:token".to_string(),
-            Variable::new_final_string_variable(token),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("gcr.io".to_string()),
-            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
-            version: TemplateableValue::from_template("latest".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth {
-                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
-                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
-                },
-                bearer: BearerAuth {
-                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
-                },
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables);
-        matches!(rendered_oci, Err(AgentTypeError::OCIAuthError(_)));
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -1,4 +1,4 @@
-use oci_client::{Reference, secrets::RegistryAuth};
+use oci_client::Reference;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,5 +17,4 @@ pub struct Download {
 pub struct Oci {
     pub reference: Reference,
     pub public_key_url: Option<Url>,
-    pub auth: RegistryAuth,
 }

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -359,6 +359,14 @@ pub mod tests {
             self
         }
 
+        pub fn registry(&self) -> String {
+            self.server
+                .as_ref()
+                .expect("Call build() first")
+                .address()
+                .to_string()
+        }
+
         pub fn reference(&self) -> Reference {
             self.reference_on_server(self.server.as_ref().expect("Call build() first"))
         }

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -1,4 +1,4 @@
-use crate::oci::Client;
+use crate::oci::{Client, reference_parser::ReferenceParser};
 use crate::package::oci::artifact_definitions::LocalAgentPackage;
 use crate::utils::retry::retry;
 use oci_client::Reference;
@@ -30,6 +30,7 @@ pub struct OCIArtifactDownloader {
     signature_verification_enabled: bool,
     max_retries: usize,
     retry_interval: Duration,
+    registry: String,
 }
 
 impl OCIAgentDownloader for OCIArtifactDownloader {
@@ -68,12 +69,13 @@ const DEFAULT_RETRIES: usize = 0;
 
 impl OCIArtifactDownloader {
     /// Returns an artifact downloader with default retries setup.
-    pub fn new(client: Client, signature_verification_enabled: bool) -> Self {
+    pub fn new(client: Client, registry: String, signature_verification_enabled: bool) -> Self {
         OCIArtifactDownloader {
             client,
             signature_verification_enabled,
             max_retries: DEFAULT_RETRIES,
             retry_interval: Duration::default(),
+            registry,
         }
     }
 
@@ -107,6 +109,7 @@ impl OCIArtifactDownloader {
         reference: &Reference,
         public_key_url: &Url,
     ) -> Result<Reference, OCIDownloaderError> {
+        let reference = &reference_with_registry(reference, &self.registry);
         self.client
             .verify_signature(reference, public_key_url)
             .map_err(|err| OCIDownloaderError(err.to_string()))
@@ -117,6 +120,7 @@ impl OCIArtifactDownloader {
         reference: &Reference,
         package_dir: &Path,
     ) -> Result<LocalAgentPackage, OCIDownloaderError> {
+        let reference = &reference_with_registry(reference, &self.registry);
         let (image_manifest, _) = self
             .client
             .pull_image_manifest(reference)
@@ -134,6 +138,17 @@ impl OCIArtifactDownloader {
 
         Ok(LocalAgentPackage::new(media_type, layer_path))
     }
+}
+
+fn reference_with_registry(reference: &Reference, registry: &str) -> Reference {
+    let reference = reference.to_string();
+
+    let mut parts = reference.split('/').collect::<Vec<&str>>();
+    parts[0] = registry;
+
+    ReferenceParser::try_from(parts.join("/"))
+        .expect("Failed to parse reference with registry")
+        .into()
 }
 
 #[cfg(test)]
@@ -185,7 +200,7 @@ pub mod tests {
             .with_signature(&key_pair)
             .build();
 
-        let downloader = create_downloader(true);
+        let downloader = create_downloader(server.registry(), true);
         let dest_dir = tempdir().unwrap();
         let local_agent_package = downloader
             .download(&server.reference(), &Some(jwks_server.url), dest_dir.path())
@@ -211,7 +226,7 @@ pub mod tests {
             )
             .build();
 
-        let downloader = create_downloader(false);
+        let downloader = create_downloader(server.registry(), false);
         let dest_dir = tempdir().unwrap();
         let local_agent_package = downloader
             .download(&server.reference(), &Some(jwks_server.url), dest_dir.path())
@@ -234,7 +249,7 @@ pub mod tests {
             )
             .build();
 
-        let downloader = create_downloader(true);
+        let downloader = create_downloader(server.registry(), true);
         let dest_dir = tempdir().unwrap();
         let local_agent_package = downloader
             .download(&server.reference(), &None, dest_dir.path())
@@ -260,7 +275,7 @@ pub mod tests {
             )
             .build();
 
-        let downloader = create_downloader(false);
+        let downloader = create_downloader(server.registry(), false);
         let dest_dir = tempdir().unwrap();
         let local_agent_package = downloader
             .download(&server.reference(), &None, dest_dir.path())
@@ -282,7 +297,7 @@ pub mod tests {
             .with_artifact_type("application/vnd.unknown.type.v1")
             .build();
 
-        let downloader = create_downloader(false);
+        let downloader = create_downloader(server.registry(), false);
         let dest_dir = tempdir().unwrap();
         let err = downloader
             .download(&server.reference(), &None, dest_dir.path())
@@ -303,7 +318,7 @@ pub mod tests {
         let reference = Reference::from(
             ReferenceParser::from_str(&format!("{}/test-repo:v1.0.0", server.address())).unwrap(),
         );
-        let downloader = create_downloader(false);
+        let downloader = create_downloader(server.address().to_string(), false);
         let dest_dir = tempdir().unwrap();
         let err = downloader
             .download(&reference, &None, dest_dir.path())
@@ -328,7 +343,7 @@ pub mod tests {
             )
             .build(); // No signature
 
-        let downloader = create_downloader(true);
+        let downloader = create_downloader(server.registry(), true);
         let dest_dir = tempdir().unwrap();
         let err = downloader
             .download(&server.reference(), &Some(jwks_server.url), dest_dir.path())
@@ -358,7 +373,7 @@ pub mod tests {
 
         // Verify signature
         let reference = oci_mock_a.reference_on_server(&server);
-        let downloader = create_downloader(true);
+        let downloader = create_downloader(server.address().to_string(), true);
         let verified_reference = downloader
             .verified_package_signature_reference(&reference, &jwks_server.url)
             .expect("Signature should be verified successfully");
@@ -414,7 +429,7 @@ pub mod tests {
             .reference_on_server(&server)
             .clone_with_digest(oci_mock.manifest_digest());
 
-        let downloader = create_downloader(false);
+        let downloader = create_downloader(server.address().to_string(), false);
         let dest_dir = tempdir().unwrap();
         let result = downloader.download(&reference, &None, dest_dir.path());
         assert_matches!(result, Err(OCIDownloaderError(msg)) => {
@@ -422,7 +437,22 @@ pub mod tests {
         });
     }
 
-    fn create_downloader(signature_verification_enabled: bool) -> OCIArtifactDownloader {
+    #[test]
+    fn test_reference_with_registry() {
+        let reference = Reference::with_tag(
+            "docker.io".to_string(),
+            "newrelic".to_string(),
+            "v1.0.0".to_string(),
+        );
+        let registry = "mirror.io";
+        let reference_with_registry = reference_with_registry(&reference, registry);
+        assert_eq!(reference_with_registry.registry(), registry);
+    }
+
+    fn create_downloader(
+        registry: String,
+        signature_verification_enabled: bool,
+    ) -> OCIArtifactDownloader {
         let client = Client::try_new(
             ClientConfig {
                 protocol: ClientProtocol::Http,
@@ -432,6 +462,6 @@ pub mod tests {
             tokio_runtime(),
         )
         .unwrap();
-        OCIArtifactDownloader::new(client, signature_verification_enabled)
+        OCIArtifactDownloader::new(client, registry, signature_verification_enabled)
     }
 }

--- a/agent-control/tests/on_host/oci_package_management.rs
+++ b/agent-control/tests/on_host/oci_package_management.rs
@@ -33,7 +33,8 @@ fn test_install_and_uninstall_with_oci_registry() {
     let temp_dir = tempdir().unwrap();
     let base_path = temp_dir.path().to_path_buf();
 
-    let package_manager = new_testing_oci_package_manager(base_path.clone());
+    let package_manager =
+        new_testing_oci_package_manager(base_path.clone(), OCI_TEST_REGISTRY_URL.to_string());
 
     let agent_id = AgentID::try_from("test-agent").unwrap();
     let pkg_id = "test-package".to_string();
@@ -96,7 +97,8 @@ fn test_install_skips_download_if_exists_with_oci_registry() {
 
     let temp_dir = tempdir().unwrap();
     let base_path = temp_dir.path().to_path_buf();
-    let package_manager = new_testing_oci_package_manager(base_path.clone());
+    let package_manager =
+        new_testing_oci_package_manager(base_path.clone(), OCI_TEST_REGISTRY_URL.to_string());
 
     let agent_id = AgentID::try_from("test-agent").unwrap();
     let pkg_id = "test-package-idempotency";

--- a/agent-control/tests/on_host/oci_registry.rs
+++ b/agent-control/tests/on_host/oci_registry.rs
@@ -47,7 +47,7 @@ fn test_download_artifact_from_local_registry_with_oci_registry() {
 
     let client = create_client_with_proxy(ProxyConfig::default());
 
-    let downloader = OCIArtifactDownloader::new(client, false);
+    let downloader = OCIArtifactDownloader::new(client, OCI_TEST_REGISTRY_URL.to_string(), false);
 
     let _ = downloader
         .download(&reference, &None, local_agent_data_dir)
@@ -108,8 +108,8 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
 
     let client = create_client_with_proxy(proxy_config);
 
-    let downloader =
-        OCIArtifactDownloader::new(client, false).with_retries(4, Duration::from_millis(100));
+    let downloader = OCIArtifactDownloader::new(client, OCI_TEST_REGISTRY_URL.to_string(), false)
+        .with_retries(4, Duration::from_millis(100));
 
     let result = downloader.download(&reference, &None, local_agent_data_dir);
     assert!(result.is_ok());

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -335,6 +335,8 @@ fleet_control:
   signature_validation:
     public_key_server_url: {}
 agents: {{}}
+oci:
+  registry: {OCI_TEST_REGISTRY_URL}
 self_update:
   enabled: true
   signature_verification_enabled: {signature_verification_enabled}

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -322,7 +322,6 @@ fn create_agent_type(
   type: {pkg_type}
   download:
     oci:
-      registry: {OCI_TEST_REGISTRY_URL}
       repository: test
       version: ${{nr-var:fake_variable}}
       public_key_url: {public_key_url}

--- a/agent-control/tests/on_host/scenarios/memory_benchmark.rs
+++ b/agent-control/tests/on_host/scenarios/memory_benchmark.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::health::check_latest_health_status;
 use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::on_host::tools::config::create_agent_control_config;
+use crate::on_host::tools::config::create_agent_control_config_with_oci_registry;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use memory_stats::memory_stats;
@@ -47,9 +47,10 @@ fn test_memory_on_agent_substitution_and_version_update() {
     let mut opamp_server = FakeServer::start_new();
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    create_agent_control_config(
+    create_agent_control_config_with_oci_registry(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
+        "non-existent:5000".to_string(),
         "{}".to_string(),
         local_dir.path().to_path_buf(),
     );

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -10,6 +10,7 @@ use newrelic_agent_control::agent_control::defaults::{
     STORE_KEY_OPAMP_DATA_CONFIG, default_capabilities,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
+use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
 use newrelic_agent_control::on_host::file_store::{FileStore, build_config_name};
 use newrelic_agent_control::values::ConfigRepo;
 use newrelic_agent_control::values::config_repository::ConfigRepository;
@@ -25,6 +26,26 @@ pub fn create_agent_control_config(
     create_agent_control_config_with_proxy(
         opamp_server_endpoint,
         jwks_endpoint,
+        OCI_TEST_REGISTRY_URL.to_string(),
+        agents,
+        local_dir,
+        None,
+    );
+}
+
+/// Creates the agent-control config given an opamp_server_endpoint
+/// and a list of agents on the specified local_dir.
+pub fn create_agent_control_config_with_oci_registry(
+    opamp_server_endpoint: String,
+    jwks_endpoint: String,
+    oci_registry: String,
+    agents: String,
+    local_dir: PathBuf,
+) {
+    create_agent_control_config_with_proxy(
+        opamp_server_endpoint,
+        jwks_endpoint,
+        oci_registry,
         agents,
         local_dir,
         None,
@@ -67,6 +88,7 @@ server:
 pub fn create_agent_control_config_with_proxy(
     opamp_server_endpoint: String,
     jwks_endpoint: String,
+    oci_registry: String,
     agents: String,
     local_dir: PathBuf,
     proxy: Option<String>,
@@ -83,10 +105,12 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     public_key_server_url: {}
+oci:
+  registry: "{}"
 agents: {}
 {}
 "#,
-        opamp_server_endpoint, jwks_endpoint, agents, proxy_config,
+        opamp_server_endpoint, jwks_endpoint, oci_registry, agents, proxy_config,
     );
     create_file(
         agent_control_config,

--- a/agent-control/tests/on_host/tools/oci_package_manager.rs
+++ b/agent-control/tests/on_host/tools/oci_package_manager.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 
 pub fn new_testing_oci_package_manager(
     base_path: PathBuf,
+    registry: String,
 ) -> OCIPackageManager<OCIArtifactDownloader, DirectoryManagerFs> {
     let client = oci::Client::try_new(
         ClientConfig {
@@ -24,7 +25,7 @@ pub fn new_testing_oci_package_manager(
         tokio_runtime(),
     )
     .unwrap();
-    let downloader = OCIArtifactDownloader::new(client, false);
+    let downloader = OCIArtifactDownloader::new(client, registry, false);
 
     OCIPackageManager::new(downloader, DirectoryManagerFs, base_path)
 }

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -191,7 +191,6 @@ deployment:
       infra-agent:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
     filesystem:
@@ -229,7 +228,6 @@ deployment:
       infra-agent:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
     filesystem:
@@ -335,7 +333,6 @@ The value yaml look like:
 ```yaml
   download:
     oci:
-      registry: ${nr-var:oci.registry}
       repository: ${nr-var:oci.repository}
       version: ${nr-var:version}
       public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
@@ -366,7 +363,6 @@ In this example:
       infra-agent:
         download:
           oci:
-            registry: ${nr-var:oci.registry}
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
     executables:


### PR DESCRIPTION
Add support for a single configurable registry.

**Context**

We decided after some discussions to simplify the solution. Initially, we wanted to have a global value to configure the registry, that could then be override in an agent-per-agent basis. This was too complex. We decided to only give support for using one registry at a time, which can be configured.

This PR does that. It adds a global option in agent control to configure the registry, and uses that option to decide from where to download the packages. This is not a final solution, but a "shortcut" to unblock following tasks.

**Technical details**

**`registry` was removed from agent types**

We no longer give support to configure the registry on the agent type configuration. It must be configured from the agent control config. In other words, all packages must be downloaded from the same registry.

**shortcut solution**

Removing the `registry` impacts several parts of the codebase. It's not a simple removal of a field. To avoid blocking other tasks, we are moving ahead with this temporal solution. Basically, we "patch" the registry before doing any operation with the oci downloader.

* The parsed references when parsing the agent type aren't the ones that we will use
* I added a `base.io` registry when templating the references that's not used but complies with the format of a reference

In a different PR, we will modify the code to reflect the correct new structure.