### PR TITLE
fix: garbage collection of configmaps

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -609,6 +609,13 @@ pub fn secret_type_meta() -> TypeMeta {
     }
 }
 
+pub fn configmap_type_meta() -> TypeMeta {
+    TypeMeta {
+        api_version: "v1".to_string(),
+        kind: "ConfigMap".to_string(),
+    }
+}
+
 pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     // In flux health check we are currently supporting just a single helm_release_type_meta
     // Each time we support a new version we should decide if and how to support retrieving its health
@@ -617,6 +624,9 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
         // Agent Operator CRD
         instrumentation_v1beta3_type_meta(),
         secret_type_meta(),
+        // This allows ConfigMaps created by sub-agents to be cleaned up by the GC.
+        // AC internal ConfigMaps (e.g. fleet-data) are handled by garbage_collect_agent_control_resources.
+        configmap_type_meta(),
         helmrepository_type_meta(),
         helmrelease_v2_type_meta(),
     ]

--- a/agent-control/src/agent_control/config_repository/repository.rs
+++ b/agent-control/src/agent_control/config_repository/repository.rs
@@ -82,7 +82,7 @@ pub(crate) mod tests {
 
         fn store(&self, config: &RemoteConfig) -> Result<(), AgentControlConfigError> {
             self.values_repository
-                .store_remote(&AgentID::AgentControl, config)
+                .store_remote(&AgentID::AgentControl, None, config)
                 .map_err(|e| AgentControlConfigError(e.to_string()))
         }
 

--- a/agent-control/src/agent_control/config_repository/repository.rs
+++ b/agent-control/src/agent_control/config_repository/repository.rs
@@ -34,6 +34,7 @@ pub(crate) mod tests {
     use super::{AgentControlConfigError, AgentControlDynamicConfigRepository};
     use crate::agent_control::agent_id::AgentID;
     use crate::opamp::remote_config::hash::ConfigState;
+    use crate::resource_ownership::ResourceOwnership;
     use crate::values::config::RemoteConfig;
     use crate::values::config_repository::ConfigRepository;
     use crate::{
@@ -82,13 +83,21 @@ pub(crate) mod tests {
 
         fn store(&self, config: &RemoteConfig) -> Result<(), AgentControlConfigError> {
             self.values_repository
-                .store_remote(&AgentID::AgentControl, None, config)
+                .store_remote(
+                    &AgentID::AgentControl,
+                    ResourceOwnership::AgentControl,
+                    config,
+                )
                 .map_err(|e| AgentControlConfigError(e.to_string()))
         }
 
         fn update_state(&self, state: ConfigState) -> Result<(), AgentControlConfigError> {
             self.values_repository
-                .update_state(&AgentID::AgentControl, state)
+                .update_state(
+                    &AgentID::AgentControl,
+                    ResourceOwnership::AgentControl,
+                    state,
+                )
                 .map_err(|e| AgentControlConfigError(e.to_string()))
         }
 

--- a/agent-control/src/agent_control/config_repository/store.rs
+++ b/agent-control/src/agent_control/config_repository/store.rs
@@ -7,6 +7,7 @@ use crate::agent_control::config_repository::repository::{
 };
 use crate::agent_control::defaults::{AGENT_CONTROL_CONFIG_ENV_VAR_PREFIX, default_capabilities};
 use crate::opamp::remote_config::hash::ConfigState;
+use crate::resource_ownership::ResourceOwnership;
 use crate::values::config::RemoteConfig;
 use crate::values::config_repository::ConfigRepository;
 use crate::values::yaml_config::YAMLConfigError;
@@ -45,13 +46,21 @@ where
 
     fn store(&self, config: &RemoteConfig) -> Result<(), AgentControlConfigError> {
         self.values_repository
-            .store_remote(&self.agent_control_id, None, config)
+            .store_remote(
+                &self.agent_control_id,
+                ResourceOwnership::AgentControl,
+                config,
+            )
             .map_err(|e| AgentControlConfigError(format!("storing Agent Control config: {e}")))
     }
 
     fn update_state(&self, state: ConfigState) -> Result<(), AgentControlConfigError> {
         self.values_repository
-            .update_state(&self.agent_control_id, state)
+            .update_state(
+                &self.agent_control_id,
+                ResourceOwnership::AgentControl,
+                state,
+            )
             .map_err(|e| AgentControlConfigError(format!("updating Agent Control config: {e}")))
     }
 
@@ -166,6 +175,7 @@ pub(crate) mod tests {
     use crate::agent_control::config_repository::repository::AgentControlConfigLoader;
     use crate::agent_control::config_repository::store::AgentControlConfigStore;
     use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::resource_ownership::ResourceOwnership;
     use crate::values::config_repository::ConfigRepository;
     use crate::values::config_repository::tests::InMemoryConfigRepository;
     use crate::values::yaml_config::YAMLConfig;
@@ -225,7 +235,11 @@ pub(crate) mod tests {
         .unwrap();
 
         config_repository
-            .store_remote(&AgentID::AgentControl, None, &remote_config.clone().into())
+            .store_remote(
+                &AgentID::AgentControl,
+                ResourceOwnership::AgentControl,
+                &remote_config.clone().into(),
+            )
             .unwrap();
 
         let store = AgentControlConfigStore::new(Arc::new(config_repository));

--- a/agent-control/src/agent_control/config_repository/store.rs
+++ b/agent-control/src/agent_control/config_repository/store.rs
@@ -45,7 +45,7 @@ where
 
     fn store(&self, config: &RemoteConfig) -> Result<(), AgentControlConfigError> {
         self.values_repository
-            .store_remote(&self.agent_control_id, config)
+            .store_remote(&self.agent_control_id, None, config)
             .map_err(|e| AgentControlConfigError(format!("storing Agent Control config: {e}")))
     }
 
@@ -225,7 +225,7 @@ pub(crate) mod tests {
         .unwrap();
 
         config_repository
-            .store_remote(&AgentID::AgentControl, &remote_config.clone().into())
+            .store_remote(&AgentID::AgentControl, None, &remote_config.clone().into())
             .unwrap();
 
         let store = AgentControlConfigStore::new(Arc::new(config_repository));

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -208,7 +208,9 @@ impl K8sGarbageCollectorMode<'_> {
                     // Objects without the annotation (e.g. fleet-data ConfigMaps) are not
                     // supervisor-created resources and should not be deleted here.
                     match Self::retrieve_annotated_agent_type_id(obj_meta) {
-                        Ok(annotated_agent_type_id) => Ok(&annotated_agent_type_id != agent_type_id),
+                        Ok(annotated_agent_type_id) => {
+                            Ok(&annotated_agent_type_id != agent_type_id)
+                        }
                         Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
                         Err(e) => Err(e),
                     }
@@ -223,7 +225,9 @@ impl K8sGarbageCollectorMode<'_> {
                     // Objects without the annotation (e.g. fleet-data ConfigMaps) are not
                     // supervisor-created resources and should not be deleted here.
                     match Self::retrieve_annotated_agent_type_id(obj_meta) {
-                        Ok(annotated_agent_type_id) => Ok(annotated_agent_type_id == **agent_type_id),
+                        Ok(annotated_agent_type_id) => {
+                            Ok(annotated_agent_type_id == **agent_type_id)
+                        }
                         Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
                         Err(e) => Err(e),
                     }
@@ -375,7 +379,10 @@ mod tests {
         })
     }
 
-    fn dynamic_object_without_annotation(agent_id: &AgentID, namespace: &str) -> Arc<DynamicObject> {
+    fn dynamic_object_without_annotation(
+        agent_id: &AgentID,
+        namespace: &str,
+    ) -> Arc<DynamicObject> {
         Arc::new(DynamicObject {
             types: None,
             metadata: ObjectMeta {

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -202,11 +202,19 @@ impl K8sGarbageCollectorMode<'_> {
         match self {
             K8sGarbageCollectorMode::RetainConfig(agent_identities) => {
                 if let Some(agent_type_id) = agent_identities.get(agent_id) {
-                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
-                    // Check if the agent type is different from the one in the config.
-                    // This is to support the case where the agent id exists in the config,
-                    // but it's a different agent type. See PR#655 for some details.
-                    Ok(&annotated_agent_type_id != agent_type_id)
+                    // Objects without the annotation (e.g. fleet-data ConfigMaps from
+                    // ConfigMapStore) are not supervisor-created and should not be deleted here;
+                    // they are handled by garbage_collection_config_maps via label selector.
+                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
+                        Ok(annotated_agent_type_id) => {
+                            // Check if the agent type is different from the one in the config.
+                            // This is to support the case where the agent id exists in the config,
+                            // but it's a different agent type. See PR#655 for some details.
+                            Ok(&annotated_agent_type_id != agent_type_id)
+                        }
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(e) => Err(e),
+                    }
                 } else {
                     // Delete if the agent id does not exist in the passed config
                     Ok(true)
@@ -215,8 +223,14 @@ impl K8sGarbageCollectorMode<'_> {
 
             K8sGarbageCollectorMode::Collect(id, agent_type_id) => {
                 if agent_id == *id {
-                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
-                    Ok(annotated_agent_type_id == **agent_type_id)
+                    // Same as above: objects without the annotation are not supervisor-created.
+                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
+                        Ok(annotated_agent_type_id) => {
+                            Ok(annotated_agent_type_id == **agent_type_id)
+                        }
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(e) => Err(e),
+                    }
                 } else {
                     Ok(false)
                 }
@@ -272,6 +286,7 @@ impl From<K8sGarbageCollectorError> for ResourceCleanerError {
 mod tests {
     use super::*;
     use crate::k8s::client::tests::MockK8sClient;
+    use kube::api::{DynamicObject, ObjectMeta};
     use mockall::predicate;
 
     const TEST_NAMESPACE: &str = "test-namespace";
@@ -339,5 +354,57 @@ mod tests {
         let agent_type_id = &AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
 
         assert!(garbage_collector.collect(ac_id, agent_type_id).is_ok());
+    }
+
+    #[test]
+    fn skips_dynamic_objects_without_agent_type_id_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+
+        // Fleet-data ConfigMap: has managed-by + agent-id labels, but no agent-type-id annotation
+        let fleet_data_cm = Arc::new(DynamicObject {
+            types: None,
+            metadata: ObjectMeta {
+                name: Some("fleet-data-foo-agent".to_string()),
+                namespace: Some(TEST_NAMESPACE.to_string()),
+                labels: Some(Labels::new(&agent_id).get()),
+                ..Default::default()
+            },
+            data: serde_json::Value::Null,
+        });
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![fleet_data_cm]));
+        // The fleet-data CM must never be deleted by the dynamic-object path
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let garbage_collector = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+
+        let agent_type_id = &AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        assert!(garbage_collector.collect(&agent_id, agent_type_id).is_ok());
     }
 }

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -281,6 +281,8 @@ impl From<K8sGarbageCollectorError> for ResourceCleanerError {
 
 #[cfg(test)]
 mod tests {
+    use crate::k8s::annotations::Annotations;
+
     use super::*;
     use crate::k8s::client::tests::MockK8sClient;
     use kube::api::{DynamicObject, ObjectMeta};
@@ -353,9 +355,9 @@ mod tests {
         assert!(garbage_collector.collect(ac_id, agent_type_id).is_ok());
     }
 
-    fn dynamic_object_with_annotation(
+    fn new_dynamic_object(
         agent_id: &AgentID,
-        agent_type_id: &AgentTypeID,
+        agent_type_id: Option<&AgentTypeID>,
         namespace: &str,
     ) -> Arc<DynamicObject> {
         Arc::new(DynamicObject {
@@ -364,29 +366,9 @@ mod tests {
                 name: Some(format!("fleet-data-{agent_id}")),
                 namespace: Some(namespace.to_string()),
                 labels: Some(Labels::new(agent_id).get()),
-                annotations: Some(
-                    crate::k8s::annotations::Annotations::new_agent_type_id_annotation(
-                        agent_type_id,
-                    )
-                    .get(),
-                ),
-                ..Default::default()
-            },
-            data: serde_json::Value::Null,
-        })
-    }
-
-    fn dynamic_object_without_annotation(
-        agent_id: &AgentID,
-        namespace: &str,
-    ) -> Arc<DynamicObject> {
-        Arc::new(DynamicObject {
-            types: None,
-            metadata: ObjectMeta {
-                name: Some(format!("fleet-data-{agent_id}")),
-                namespace: Some(namespace.to_string()),
-                labels: Some(Labels::new(agent_id).get()),
-                annotations: None,
+                annotations: agent_type_id
+                    .map(Annotations::new_agent_type_id_annotation)
+                    .map(|anns| anns.get()),
                 ..Default::default()
             },
             data: serde_json::Value::Null,
@@ -399,7 +381,7 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = dynamic_object_with_annotation(&agent_id, &agent_type_id, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, Some(&agent_type_id), TEST_NAMESPACE);
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
@@ -441,7 +423,7 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = dynamic_object_with_annotation(&agent_id, &agent_type_id, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, Some(&agent_type_id), TEST_NAMESPACE);
 
         let mut k8s_client = MockK8sClient::default();
         k8s_client
@@ -484,7 +466,7 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
@@ -526,7 +508,7 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
 
         let mut k8s_client = SyncK8sClient::default();
         k8s_client
@@ -567,7 +549,7 @@ mod tests {
     fn retain_deletes_dynamic_object_for_inactive_agent_without_annotation() {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
-        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
@@ -616,7 +598,7 @@ mod tests {
         let old_type = AgentTypeID::try_from("newrelic/com.example.bar:0.0.1").unwrap();
 
         // The object on the cluster carries the OLD type annotation.
-        let cm = dynamic_object_with_annotation(&agent_id, &old_type, TEST_NAMESPACE);
+        let cm = new_dynamic_object(&agent_id, Some(&old_type), TEST_NAMESPACE);
 
         let active_agents = HashMap::from([(agent_id, active_type)]);
 

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -84,7 +84,7 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
             .filter(|cm| {
                 let empty_map = BTreeMap::new();
                 let annotations = cm.metadata.annotations.as_ref().unwrap_or(&empty_map);
-                annotations::is_owned_by_agent_control(annotations) // should we log the skips?
+                annotations::is_owned_by_agent_control(annotations)
             })
             .try_for_each(|cm| {
                 let name = cm.metadata.name.as_deref().unwrap_or("unknown");

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -202,11 +202,16 @@ impl K8sGarbageCollectorMode<'_> {
         match self {
             K8sGarbageCollectorMode::RetainConfig(agent_identities) => {
                 if let Some(agent_type_id) = agent_identities.get(agent_id) {
-                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
                     // Check if the agent type is different from the one in the config.
                     // This is to support the case where the agent id exists in the config,
                     // but it's a different agent type. See PR#655 for some details.
-                    Ok(&annotated_agent_type_id != agent_type_id)
+                    // Objects without the annotation (e.g. fleet-data ConfigMaps) are not
+                    // supervisor-created resources and should not be deleted here.
+                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
+                        Ok(annotated_agent_type_id) => Ok(&annotated_agent_type_id != agent_type_id),
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(e) => Err(e),
+                    }
                 } else {
                     // Delete if the agent id does not exist in the passed config
                     Ok(true)
@@ -215,8 +220,13 @@ impl K8sGarbageCollectorMode<'_> {
 
             K8sGarbageCollectorMode::Collect(id, agent_type_id) => {
                 if agent_id == *id {
-                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
-                    Ok(annotated_agent_type_id == **agent_type_id)
+                    // Objects without the annotation (e.g. fleet-data ConfigMaps) are not
+                    // supervisor-created resources and should not be deleted here.
+                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
+                        Ok(annotated_agent_type_id) => Ok(annotated_agent_type_id == **agent_type_id),
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(e) => Err(e),
+                    }
                 } else {
                     Ok(false)
                 }
@@ -365,6 +375,20 @@ mod tests {
         })
     }
 
+    fn dynamic_object_without_annotation(agent_id: &AgentID, namespace: &str) -> Arc<DynamicObject> {
+        Arc::new(DynamicObject {
+            types: None,
+            metadata: ObjectMeta {
+                name: Some(format!("fleet-data-{agent_id}")),
+                namespace: Some(namespace.to_string()),
+                labels: Some(Labels::new(agent_id).get()),
+                annotations: None,
+                ..Default::default()
+            },
+            data: serde_json::Value::Null,
+        })
+    }
+
     // RetainConfig mode: object with a matching annotation for an active agent is retained.
     #[test]
     fn retain_skips_dynamic_object_with_matching_annotation() {
@@ -448,6 +472,134 @@ mod tests {
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
         };
         assert!(gc.collect(&agent_id, &agent_type_id).is_ok());
+    }
+
+    // RetainConfig mode: object for active agent with NO annotation (fleet-data CM) is skipped.
+    #[test]
+    fn retain_skips_dynamic_object_without_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+
+        let active_agents = HashMap::from([(agent_id, agent_type_id)]);
+
+        let mut k8s_client = SyncK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.retain(active_agents).is_ok());
+    }
+
+    // Collect mode: object for matching agent with NO annotation (fleet-data CM) is skipped.
+    #[test]
+    fn collect_skips_dynamic_object_without_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+
+        let mut k8s_client = SyncK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.collect(&agent_id, &agent_type_id).is_ok());
+    }
+
+    // RetainConfig mode: object for INACTIVE agent with NO annotation is deleted.
+    // The inactive-agent branch (else { Ok(true) }) never reads annotations, so absence of
+    // the annotation must not prevent deletion.
+    #[test]
+    fn retain_deletes_dynamic_object_for_inactive_agent_without_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let cm = dynamic_object_without_annotation(&agent_id, TEST_NAMESPACE);
+
+        let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
+
+        let mut k8s_client = SyncK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client
+            .expect_delete_dynamic_object()
+            .once()
+            .returning(|_, _| Ok(either::Either::Right(kube::core::Status::default())));
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.retain(active_agents).is_ok());
     }
 
     // RetainConfig mode: object whose annotation names a different type than the active one

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -31,15 +31,6 @@ pub struct K8sGarbageCollector<C: K8sClient = SyncK8sClient> {
     pub cr_type_meta: Vec<TypeMeta>,
 }
 
-impl K8sGarbageCollector {
-    pub fn active_config_ids(active_config: &SubAgentsMap) -> HashMap<AgentID, AgentTypeID> {
-        active_config
-            .iter()
-            .map(|(id, config)| (id.clone(), config.agent_type.clone()))
-            .collect()
-    }
-}
-
 impl<C: K8sClient> K8sGarbageCollector<C> {
     /// Remove all the Kubernetes resources managed by Agent Control that are not included in the
     /// map passed as parameter.
@@ -519,7 +510,7 @@ mod tests {
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
-        let mut k8s_client = SyncK8sClient::default();
+        let mut k8s_client = MockK8sClient::default();
         k8s_client
             .expect_list_configmaps()
             .once()
@@ -559,7 +550,7 @@ mod tests {
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
         let cm = new_dynamic_object_without_owned_by(&agent_id, None, TEST_NAMESPACE);
 
-        let mut k8s_client = SyncK8sClient::default();
+        let mut k8s_client = MockK8sClient::default();
         k8s_client
             .expect_list_configmaps()
             .once()
@@ -601,7 +592,7 @@ mod tests {
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
-        let mut k8s_client = SyncK8sClient::default();
+        let mut k8s_client = MockK8sClient::default();
         k8s_client
             .expect_list_configmaps()
             .once()
@@ -643,7 +634,7 @@ mod tests {
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
-        let mut k8s_client = SyncK8sClient::default();
+        let mut k8s_client = MockK8sClient::default();
         k8s_client
             .expect_list_configmaps()
             .once()

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -115,7 +115,7 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
                         })
                 }
                 Err(K8sError::MissingAPIResource(e)) => {
-                    debug!(error = %e, "GC skipping for TypeMeta {}", tm.kind);
+                    debug!(error = %e, "skipping GC for TypeMeta {}", tm.kind);
                     Ok(())
                 }
                 Err(e) => Err(e.into()),
@@ -150,7 +150,11 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
             Err(AgentIDError::Reserved(_)) => Ok(false),
             // We should also be conservative, so we do not delete an object if we cannot retrieve a valid AgentID from it
             Err(e) => {
-                warn!("invalid agent id: {e}");
+                warn!(
+                    namespace = self.namespace,
+                    error = %e,
+                    "invalid agent id with name {agent_id_from_labels}"
+                );
                 Ok(false)
             }
         }

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -49,9 +49,9 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
         active_agents: HashMap<AgentID, AgentTypeID>,
     ) -> Result<(), K8sGarbageCollectorError> {
         let mode = K8sGarbageCollectorMode::RetainConfig(&active_agents);
-        self.garbage_collection_config_maps(&mode)?;
-        self.garbage_collection_dynamic_object(&mode, &self.namespace_agents)?;
-        self.garbage_collection_dynamic_object(&mode, &self.namespace)
+        self.garbage_collect_agent_control_resources(&mode)?;
+        self.garbage_collect_sub_agent_resources(&mode, &self.namespace_agents)?;
+        self.garbage_collect_sub_agent_resources(&mode, &self.namespace)
     }
 
     /// Garbage collect resources managed by AC associated to a certain
@@ -68,25 +68,56 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
         }
 
         let mode = K8sGarbageCollectorMode::Collect(id, agent_type_id);
-        self.garbage_collection_config_maps(&mode)?;
-        self.garbage_collection_dynamic_object(&mode, &self.namespace_agents)?;
-        self.garbage_collection_dynamic_object(&mode, &self.namespace)
+        self.garbage_collect_agent_control_resources(&mode)?;
+        self.garbage_collect_sub_agent_resources(&mode, &self.namespace_agents)?;
+        self.garbage_collect_sub_agent_resources(&mode, &self.namespace)
     }
 
-    fn garbage_collection_config_maps(
+    pub fn active_config_ids(active_config: &SubAgentsMap) -> HashMap<AgentID, AgentTypeID> {
+        active_config
+            .iter()
+            .map(|(id, config)| (id.clone(), config.agent_type.clone()))
+            .collect()
+    }
+
+    fn garbage_collect_agent_control_resources(
         &self,
         mode: &K8sGarbageCollectorMode,
     ) -> Result<(), K8sGarbageCollectorError> {
-        // Delete configmaps depending on mode
+        // List ConfigMaps by label selector and delete only those owned by Agent Control
         let label_selector_query = mode.label_selector_query();
-        debug!("deleting ConfigMaps using label selector: `{label_selector_query}`");
+        debug!("listing ConfigMaps using label selector: `{label_selector_query}`");
         self.k8s_client
-            .delete_configmap_collection(&self.namespace, &label_selector_query)?;
+            .list_configmaps(&self.namespace, &label_selector_query)?
+            .into_iter()
+            .filter(|cm| {
+                let empty_map = BTreeMap::new();
+                let annotations = cm.metadata.annotations.as_ref().unwrap_or(&empty_map);
+                annotations::is_owned_by_agent_control(annotations) // should we log the skips?
+            })
+            .try_for_each(|cm| {
+                let name = cm.metadata.name.as_deref().unwrap_or("unknown");
+                debug!("deleting agent-control ConfigMap: `{name}`");
+                self.k8s_client.delete_configmap(&self.namespace, name)?;
+                Ok(())
+            })
 
-        Ok(())
+        // for cm in configmaps {
+        //     let empty_map = BTreeMap::new();
+        //     let annotations = cm.metadata.annotations.as_ref().unwrap_or(&empty_map);
+        //     if annotations::is_owned_by_agent_control(annotations) {
+        //         let name = cm.metadata.name.as_deref().unwrap_or("unknown");
+        //         debug!("deleting agent-control ConfigMap: `{name}`");
+        //         self.k8s_client.delete_configmap(&self.namespace, name)?;
+        //     } else {
+        //         warn!("skipping ConfigMap without owned-by=agent-control annotation");
+        //     }
+        // }
+
+        // Ok(())
     }
 
-    fn garbage_collection_dynamic_object(
+    fn garbage_collect_sub_agent_resources(
         &self,
         mode: &K8sGarbageCollectorMode,
         namespace: &str,
@@ -102,7 +133,7 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
                                 let name = get_name(&d)?;
                                 let namespace = get_namespace(&d)?;
 
-                                debug!("deleting dynamic_resource: `{}/{}`", tm.kind, name);
+                                debug!("deleting sub-agent resource: `{}/{}`", tm.kind, name);
                                 self.k8s_client.delete_dynamic_object(
                                     tm,
                                     K8sObjectKey {
@@ -134,9 +165,18 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
         // in case any of them are None.
         let empty_map = BTreeMap::new();
         let labels = obj_meta.labels.as_ref().unwrap_or(&empty_map);
+        let annotations = obj_meta.annotations.as_ref().unwrap_or(&empty_map);
 
         // We delete resources only if they are managed by Agent Control
         if !labels::is_managed_by_agent_control(labels) {
+            return Ok(false);
+        }
+
+        // We only delete dynamic objects that are owned by a sub-agent.
+        // Agent Control internal resources (e.g. fleet-data ConfigMaps) are handled
+        // by garbage_collect_agent_control_resources.
+        if !annotations::is_owned_by_sub_agent(annotations) {
+            warn!("dynamic object missing owned-by=sub-agent annotation, skipping");
             return Ok(false);
         }
 
@@ -299,7 +339,7 @@ mod tests {
     fn errors_if_ac_id() {
         let mut k8s_client = MockK8sClient::default();
         // collect should return immediately on AC ID, and return with an error
-        k8s_client.expect_delete_configmap_collection().never();
+        k8s_client.expect_list_configmaps().never();
         k8s_client.expect_list_dynamic_objects().never();
         k8s_client.expect_delete_dynamic_object().never();
 
@@ -325,10 +365,10 @@ mod tests {
         let mut k8s_client = MockK8sClient::default();
         // collect should return immediately on AC ID, and return with an error
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
             .with(predicate::eq(TEST_NAMESPACE), predicate::eq("app.kubernetes.io/managed-by==newrelic-agent-control, newrelic.io/agent-id in (foo-agent)"))
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -364,15 +404,34 @@ mod tests {
         agent_type_id: Option<&AgentTypeID>,
         namespace: &str,
     ) -> Arc<DynamicObject> {
+        let annotations = agent_type_id.map(|id| Annotations::new_sub_agent_owned(id).get());
         Arc::new(DynamicObject {
             types: None,
             metadata: ObjectMeta {
                 name: Some(format!("fleet-data-{agent_id}")),
                 namespace: Some(namespace.to_string()),
                 labels: Some(Labels::new(agent_id).get()),
-                annotations: agent_type_id
-                    .map(Annotations::new_agent_type_id_annotation)
-                    .map(|anns| anns.get()),
+                annotations,
+                ..Default::default()
+            },
+            data: serde_json::Value::Null,
+        })
+    }
+
+    fn new_dynamic_object_without_owned_by(
+        agent_id: &AgentID,
+        agent_type_id: Option<&AgentTypeID>,
+        namespace: &str,
+    ) -> Arc<DynamicObject> {
+        let annotations =
+            agent_type_id.map(|id| Annotations::new_agent_type_id_annotation(id).get());
+        Arc::new(DynamicObject {
+            types: None,
+            metadata: ObjectMeta {
+                name: Some(format!("fleet-data-{agent_id}")),
+                namespace: Some(namespace.to_string()),
+                labels: Some(Labels::new(agent_id).get()),
+                annotations,
                 ..Default::default()
             },
             data: serde_json::Value::Null,
@@ -391,9 +450,9 @@ mod tests {
 
         let mut k8s_client = MockK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -431,9 +490,9 @@ mod tests {
 
         let mut k8s_client = MockK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -470,15 +529,15 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
+        let cm = new_dynamic_object_without_owned_by(&agent_id, None, TEST_NAMESPACE);
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
         let mut k8s_client = SyncK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -512,13 +571,13 @@ mod tests {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
+        let cm = new_dynamic_object_without_owned_by(&agent_id, None, TEST_NAMESPACE);
 
         let mut k8s_client = SyncK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -546,22 +605,63 @@ mod tests {
         assert!(gc.collect(&agent_id, &agent_type_id).is_ok());
     }
 
-    // RetainConfig mode: object for INACTIVE agent with NO annotation is deleted.
-    // The inactive-agent branch (else { Ok(true) }) never reads annotations, so absence of
-    // the annotation must not prevent deletion.
+    // RetainConfig mode: object for INACTIVE agent without owned-by annotation is skipped.
+    // We are conservative: objects without owned-by=sub-agent are not sub-agent resources.
     #[test]
-    fn retain_deletes_dynamic_object_for_inactive_agent_without_annotation() {
+    fn retain_skips_dynamic_object_for_inactive_agent_without_owned_by() {
         let type_meta = TypeMeta::default();
         let agent_id = AgentID::try_from("foo-agent").unwrap();
-        let cm = new_dynamic_object(&agent_id, None, TEST_NAMESPACE);
+        let cm = new_dynamic_object_without_owned_by(&agent_id, None, TEST_NAMESPACE);
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
         let mut k8s_client = SyncK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.retain(active_agents).is_ok());
+    }
+
+    // RetainConfig mode: object for INACTIVE agent with owned-by=sub-agent is deleted.
+    #[test]
+    fn retain_deletes_dynamic_object_for_inactive_agent_with_sub_agent_owned_by() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let cm = new_dynamic_object(&agent_id, Some(&agent_type_id), TEST_NAMESPACE);
+
+        let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
+
+        let mut k8s_client = SyncK8sClient::default();
+        k8s_client
+            .expect_list_configmaps()
+            .once()
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()
@@ -608,9 +708,9 @@ mod tests {
 
         let mut k8s_client = MockK8sClient::default();
         k8s_client
-            .expect_delete_configmap_collection()
+            .expect_list_configmaps()
             .once()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(vec![]));
         k8s_client
             .expect_list_dynamic_objects()
             .once()

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -79,7 +79,7 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
     ) -> Result<(), K8sGarbageCollectorError> {
         // Delete configmaps depending on mode
         let label_selector_query = mode.label_selector_query();
-        debug!("Deleting configmaps using label selector: `{label_selector_query}`",);
+        debug!("deleting ConfigMaps using label selector: `{label_selector_query}`");
         self.k8s_client
             .delete_configmap_collection(&self.namespace, &label_selector_query)?;
 

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -87,9 +87,12 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
                 annotations::is_owned_by_agent_control(annotations)
             })
             .try_for_each(|cm| {
-                let name = cm.metadata.name.as_deref().unwrap_or("unknown");
-                debug!("deleting agent-control ConfigMap: `{name}`");
-                self.k8s_client.delete_configmap(&self.namespace, name)?;
+                if let Some(name) = cm.metadata.name.as_deref() {
+                    debug!("deleting agent-control ConfigMap: `{name}`");
+                    self.k8s_client.delete_configmap(&self.namespace, name)?;
+                } else {
+                    warn!("found ConfigMap without name. Skipping deletion.");
+                }
                 Ok(())
             })
     }

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -385,7 +385,8 @@ mod tests {
         agent_type_id: Option<&AgentTypeID>,
         namespace: &str,
     ) -> Arc<DynamicObject> {
-        let annotations = agent_type_id.map(|id| Annotations::new_sub_agent_owned(id).get());
+        let annotations =
+            agent_type_id.map(|id| Annotations::new_sub_agent_owned_with_type(id).get());
         Arc::new(DynamicObject {
             types: None,
             metadata: ObjectMeta {

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -309,6 +309,7 @@ mod tests {
 
     use super::*;
     use crate::k8s::client::tests::MockK8sClient;
+    use k8s_openapi::api::core::v1::ConfigMap;
     use kube::api::{DynamicObject, ObjectMeta};
     use mockall::predicate;
 
@@ -418,6 +419,30 @@ mod tests {
         })
     }
 
+    fn mock_k8s_client_listing_objects(
+        configmaps: Vec<Arc<ConfigMap>>,
+        namespace_agents_objects: Vec<Arc<DynamicObject>>,
+        namespace_objects: Vec<Arc<DynamicObject>>,
+    ) -> MockK8sClient {
+        let type_meta = TypeMeta::default();
+        let mut mock = MockK8sClient::default();
+        mock.expect_list_configmaps()
+            .once()
+            .return_once(move |_, _| Ok(configmaps));
+        mock.expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .return_once(move |_, _| Ok(namespace_agents_objects));
+        mock.expect_list_dynamic_objects()
+            .once()
+            .with(predicate::eq(type_meta), predicate::eq(TEST_NAMESPACE))
+            .return_once(move |_, _| Ok(namespace_objects));
+        mock
+    }
+
     // RetainConfig mode: object with a matching annotation for an active agent is retained.
     #[test]
     fn retain_skips_dynamic_object_with_matching_annotation() {
@@ -428,27 +453,7 @@ mod tests {
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client.expect_delete_dynamic_object().never();
 
         let gc = K8sGarbageCollector {
@@ -468,27 +473,7 @@ mod tests {
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
         let cm = new_dynamic_object(&agent_id, Some(&agent_type_id), TEST_NAMESPACE);
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client
             .expect_delete_dynamic_object()
             .once()
@@ -513,27 +498,7 @@ mod tests {
 
         let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client.expect_delete_dynamic_object().never();
 
         let gc = K8sGarbageCollector {
@@ -553,27 +518,7 @@ mod tests {
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
         let cm = new_dynamic_object_without_owned_by(&agent_id, None, TEST_NAMESPACE);
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client.expect_delete_dynamic_object().never();
 
         let gc = K8sGarbageCollector {
@@ -595,27 +540,7 @@ mod tests {
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client.expect_delete_dynamic_object().never();
 
         let gc = K8sGarbageCollector {
@@ -637,27 +562,7 @@ mod tests {
 
         let active_agents: HashMap<AgentID, AgentTypeID> = HashMap::new();
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client
             .expect_delete_dynamic_object()
             .once()
@@ -686,27 +591,7 @@ mod tests {
 
         let active_agents = HashMap::from([(agent_id, active_type)]);
 
-        let mut k8s_client = MockK8sClient::default();
-        k8s_client
-            .expect_list_configmaps()
-            .once()
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE_AGENTS),
-            )
-            .returning(|_, _| Ok(vec![]));
-        k8s_client
-            .expect_list_dynamic_objects()
-            .once()
-            .with(
-                predicate::eq(type_meta.clone()),
-                predicate::eq(TEST_NAMESPACE),
-            )
-            .return_once(move |_, _| Ok(vec![cm]));
+        let mut k8s_client = mock_k8s_client_listing_objects(vec![], vec![], vec![cm]);
         k8s_client
             .expect_delete_dynamic_object()
             .once()

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -101,20 +101,6 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
                 self.k8s_client.delete_configmap(&self.namespace, name)?;
                 Ok(())
             })
-
-        // for cm in configmaps {
-        //     let empty_map = BTreeMap::new();
-        //     let annotations = cm.metadata.annotations.as_ref().unwrap_or(&empty_map);
-        //     if annotations::is_owned_by_agent_control(annotations) {
-        //         let name = cm.metadata.name.as_deref().unwrap_or("unknown");
-        //         debug!("deleting agent-control ConfigMap: `{name}`");
-        //         self.k8s_client.delete_configmap(&self.namespace, name)?;
-        //     } else {
-        //         warn!("skipping ConfigMap without owned-by=agent-control annotation");
-        //     }
-        // }
-
-        // Ok(())
     }
 
     fn garbage_collect_sub_agent_resources(

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -342,22 +342,38 @@ mod tests {
         assert!(garbage_collector.collect(ac_id, agent_type_id).is_ok());
     }
 
-    #[test]
-    fn skips_dynamic_objects_without_agent_type_id_annotation() {
-        let type_meta = TypeMeta::default();
-        let agent_id = AgentID::try_from("foo-agent").unwrap();
-
-        // Fleet-data ConfigMap: has managed-by + agent-id labels, but no agent-type-id annotation
-        let fleet_data_cm = Arc::new(DynamicObject {
+    fn dynamic_object_with_annotation(
+        agent_id: &AgentID,
+        agent_type_id: &AgentTypeID,
+        namespace: &str,
+    ) -> Arc<DynamicObject> {
+        Arc::new(DynamicObject {
             types: None,
             metadata: ObjectMeta {
-                name: Some("fleet-data-foo-agent".to_string()),
-                namespace: Some(TEST_NAMESPACE.to_string()),
-                labels: Some(Labels::new(&agent_id).get()),
+                name: Some(format!("fleet-data-{agent_id}")),
+                namespace: Some(namespace.to_string()),
+                labels: Some(Labels::new(agent_id).get()),
+                annotations: Some(
+                    crate::k8s::annotations::Annotations::new_agent_type_id_annotation(
+                        agent_type_id,
+                    )
+                    .get(),
+                ),
                 ..Default::default()
             },
             data: serde_json::Value::Null,
-        });
+        })
+    }
+
+    // RetainConfig mode: object with a matching annotation for an active agent is retained.
+    #[test]
+    fn retain_skips_dynamic_object_with_matching_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let cm = dynamic_object_with_annotation(&agent_id, &agent_type_id, TEST_NAMESPACE);
+
+        let active_agents = HashMap::from([(agent_id, agent_type_id)]);
 
         let mut k8s_client = MockK8sClient::default();
         k8s_client
@@ -379,18 +395,107 @@ mod tests {
                 predicate::eq(type_meta.clone()),
                 predicate::eq(TEST_NAMESPACE),
             )
-            .return_once(move |_, _| Ok(vec![fleet_data_cm]));
-        // The fleet-data CM must never be deleted by the dynamic-object path
+            .return_once(move |_, _| Ok(vec![cm]));
         k8s_client.expect_delete_dynamic_object().never();
 
-        let garbage_collector = K8sGarbageCollector {
+        let gc = K8sGarbageCollector {
             k8s_client: Arc::new(k8s_client),
             cr_type_meta: vec![type_meta],
             namespace: TEST_NAMESPACE.to_string(),
             namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
         };
+        assert!(gc.retain(active_agents).is_ok());
+    }
 
-        let agent_type_id = &AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        assert!(garbage_collector.collect(&agent_id, agent_type_id).is_ok());
+    // Collect mode: dynamic object whose annotation matches the target type is deleted.
+    #[test]
+    fn collect_deletes_dynamic_object_with_matching_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let cm = dynamic_object_with_annotation(&agent_id, &agent_type_id, TEST_NAMESPACE);
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client
+            .expect_delete_dynamic_object()
+            .once()
+            .returning(|_, _| Ok(either::Either::Right(kube::core::Status::default())));
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.collect(&agent_id, &agent_type_id).is_ok());
+    }
+
+    // RetainConfig mode: object whose annotation names a different type than the active one
+    // must be deleted (the agent type was replaced).
+    #[test]
+    fn retain_deletes_dynamic_object_with_mismatched_annotation() {
+        let type_meta = TypeMeta::default();
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let active_type = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let old_type = AgentTypeID::try_from("newrelic/com.example.bar:0.0.1").unwrap();
+
+        // The object on the cluster carries the OLD type annotation.
+        let cm = dynamic_object_with_annotation(&agent_id, &old_type, TEST_NAMESPACE);
+
+        let active_agents = HashMap::from([(agent_id, active_type)]);
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_delete_configmap_collection()
+            .once()
+            .returning(|_, _| Ok(()));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE_AGENTS),
+            )
+            .returning(|_, _| Ok(vec![]));
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .with(
+                predicate::eq(type_meta.clone()),
+                predicate::eq(TEST_NAMESPACE),
+            )
+            .return_once(move |_, _| Ok(vec![cm]));
+        k8s_client
+            .expect_delete_dynamic_object()
+            .once()
+            .returning(|_, _| Ok(either::Either::Right(kube::core::Status::default())));
+
+        let gc = K8sGarbageCollector {
+            k8s_client: Arc::new(k8s_client),
+            cr_type_meta: vec![type_meta],
+            namespace: TEST_NAMESPACE.to_string(),
+            namespace_agents: TEST_NAMESPACE_AGENTS.to_string(),
+        };
+        assert!(gc.retain(active_agents).is_ok());
     }
 }

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -17,7 +17,7 @@ use kube::api::{ObjectMeta, TypeMeta};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 /// The K8sGarbageCollector is responsible for cleaning up resources in Kubernetes that are
 /// no longer needed. In practice, this actually performs the stop and deletion of a sub-agent
@@ -202,19 +202,11 @@ impl K8sGarbageCollectorMode<'_> {
         match self {
             K8sGarbageCollectorMode::RetainConfig(agent_identities) => {
                 if let Some(agent_type_id) = agent_identities.get(agent_id) {
-                    // Objects without the annotation (e.g. fleet-data ConfigMaps from
-                    // ConfigMapStore) are not supervisor-created and should not be deleted here;
-                    // they are handled by garbage_collection_config_maps via label selector.
-                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
-                        Ok(annotated_agent_type_id) => {
-                            // Check if the agent type is different from the one in the config.
-                            // This is to support the case where the agent id exists in the config,
-                            // but it's a different agent type. See PR#655 for some details.
-                            Ok(&annotated_agent_type_id != agent_type_id)
-                        }
-                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
-                        Err(e) => Err(e),
-                    }
+                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
+                    // Check if the agent type is different from the one in the config.
+                    // This is to support the case where the agent id exists in the config,
+                    // but it's a different agent type. See PR#655 for some details.
+                    Ok(&annotated_agent_type_id != agent_type_id)
                 } else {
                     // Delete if the agent id does not exist in the passed config
                     Ok(true)
@@ -223,14 +215,8 @@ impl K8sGarbageCollectorMode<'_> {
 
             K8sGarbageCollectorMode::Collect(id, agent_type_id) => {
                 if agent_id == *id {
-                    // Same as above: objects without the annotation are not supervisor-created.
-                    match Self::retrieve_annotated_agent_type_id(obj_meta) {
-                        Ok(annotated_agent_type_id) => {
-                            Ok(annotated_agent_type_id == **agent_type_id)
-                        }
-                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
-                        Err(e) => Err(e),
-                    }
+                    let annotated_agent_type_id = Self::retrieve_annotated_agent_type_id(obj_meta)?;
+                    Ok(annotated_agent_type_id == **agent_type_id)
                 } else {
                     Ok(false)
                 }

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -2,6 +2,7 @@ use super::{ResourceCleaner, ResourceCleanerError};
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::config::SubAgentsMap;
 use crate::agent_control::defaults::AGENT_CONTROL_ID;
+use crate::agent_control::{agent_id::AgentIDError, config::AgentControlConfigError};
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::k8s::annotations;
 use crate::k8s::client::K8sObjectKey;
@@ -9,10 +10,6 @@ use crate::k8s::client::{K8sClient, SyncK8sClient};
 use crate::k8s::error::K8sError;
 use crate::k8s::labels::{self, AGENT_ID_LABEL_KEY, Labels};
 use crate::k8s::utils::{get_name, get_namespace};
-use crate::{
-    agent_control::{agent_id::AgentIDError, config::AgentControlConfigError},
-    agent_type::agent_type_id::AgentTypeIDError,
-};
 use kube::api::{ObjectMeta, TypeMeta};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -147,14 +144,16 @@ impl<C: K8sClient> K8sGarbageCollector<C> {
             .ok_or(K8sGarbageCollectorError::MissingLabels)?
             .as_str();
 
-        let agent_id_from_labels = match AgentID::try_from(agent_id_from_labels) {
-            Ok(id) => id,
+        match AgentID::try_from(agent_id_from_labels) {
+            Ok(id) => mode.should_delete_agent_id(&id, obj_meta),
             // We must not delete anything with reserved AgentIDs (currently only Agent Control)
-            Err(AgentIDError::Reserved(_)) => return Ok(false),
-            Err(e) => return Err(e.into()),
-        };
-
-        mode.should_delete_agent_id(&agent_id_from_labels, obj_meta)
+            Err(AgentIDError::Reserved(_)) => Ok(false),
+            // We should also be conservative, so we do not delete an object if we cannot retrieve a valid AgentID from it
+            Err(e) => {
+                warn!("invalid agent id: {e}");
+                Ok(false)
+            }
+        }
     }
 }
 
@@ -209,9 +208,12 @@ impl K8sGarbageCollectorMode<'_> {
                     // supervisor-created resources and should not be deleted here.
                     match Self::retrieve_annotated_agent_type_id(obj_meta) {
                         Ok(annotated_agent_type_id) => {
-                            Ok(&annotated_agent_type_id != agent_type_id)
+                            Ok(annotated_agent_type_id != agent_type_id.to_string())
                         }
-                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => {
+                            warn!("object missing agent type id annotations, skipping");
+                            Ok(false)
+                        }
                         Err(e) => Err(e),
                     }
                 } else {
@@ -226,9 +228,12 @@ impl K8sGarbageCollectorMode<'_> {
                     // supervisor-created resources and should not be deleted here.
                     match Self::retrieve_annotated_agent_type_id(obj_meta) {
                         Ok(annotated_agent_type_id) => {
-                            Ok(annotated_agent_type_id == **agent_type_id)
+                            Ok(annotated_agent_type_id == agent_type_id.to_string())
                         }
-                        Err(K8sGarbageCollectorError::MissingAnnotations) => Ok(false),
+                        Err(K8sGarbageCollectorError::MissingAnnotations) => {
+                            warn!("object missing agent type id annotations, skipping");
+                            Ok(false)
+                        }
                         Err(e) => Err(e),
                     }
                 } else {
@@ -240,14 +245,12 @@ impl K8sGarbageCollectorMode<'_> {
 
     fn retrieve_annotated_agent_type_id(
         obj_meta: &ObjectMeta,
-    ) -> Result<AgentTypeID, K8sGarbageCollectorError> {
+    ) -> Result<String, K8sGarbageCollectorError> {
         let empty_map = BTreeMap::new();
         let annotations = obj_meta.annotations.as_ref().unwrap_or(&empty_map);
-        let annotated_agent_type_id = AgentTypeID::try_from(
-            annotations::get_agent_type_id_value(annotations)
-                .ok_or(K8sGarbageCollectorError::MissingAnnotations)?
-                .as_str(),
-        )?;
+        let annotated_agent_type_id = annotations::get_agent_type_id_value(annotations)
+            .ok_or(K8sGarbageCollectorError::MissingAnnotations)?
+            .to_owned();
         Ok(annotated_agent_type_id)
     }
 }
@@ -265,12 +268,6 @@ pub enum K8sGarbageCollectorError {
 
     #[error("garbage collector fetched resources without required annotations")]
     MissingAnnotations,
-
-    #[error("unable to parse AgentTypeID: {0}")]
-    ParsingAgentType(#[from] AgentTypeIDError),
-
-    #[error("unable to parse AgentID: {0}")]
-    ParsingAgentId(#[from] AgentIDError),
 
     #[error("attempted to clean up resources for Agent Control")]
     AgentControlId,

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -211,7 +211,7 @@ impl AgentControlRunner {
         // Cleanup of the existing resources managed by Agent Control but not existing in the
         // config loaded from the first time, for example from previous executions.
         garbage_collector
-            .retain(K8sGarbageCollector::active_config_ids(
+            .retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
                 &agent_control_config.dynamic.agents,
             ))
             .map_err(|err| RunError(format!("failure on K8s garbage collector: {err}")))?;

--- a/agent-control/src/cli/k8s/install.rs
+++ b/agent-control/src/cli/k8s/install.rs
@@ -455,16 +455,10 @@ mod tests {
                         agent_identity.id.to_string(),
                     ),
                 ])),
-                annotations: Some(BTreeMap::from_iter(vec![
-                    (
-                        "newrelic.io/agent-type-id".to_string(),
-                        agent_identity.agent_type_id.to_string(),
-                    ),
-                    (
-                        "newrelic.io/owned-by".to_string(),
-                        "agent-control".to_string(),
-                    ),
-                ])),
+                annotations: Some(
+                    Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id)
+                        .get(),
+                ),
                 ..ObjectMeta::default()
             },
             data: serde_json::json!({
@@ -501,16 +495,10 @@ mod tests {
                         source.to_string(),
                     ),
                 ])),
-                annotations: Some(BTreeMap::from_iter(vec![
-                    (
-                        "newrelic.io/agent-type-id".to_string(),
-                        agent_identity.agent_type_id.to_string(),
-                    ),
-                    (
-                        "newrelic.io/owned-by".to_string(),
-                        "agent-control".to_string(),
-                    ),
-                ])),
+                annotations: Some(
+                    Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id)
+                        .get(),
+                ),
                 ..Default::default()
             },
             data: serde_json::json!({

--- a/agent-control/src/cli/k8s/install.rs
+++ b/agent-control/src/cli/k8s/install.rs
@@ -410,7 +410,10 @@ mod tests {
     use super::*;
     use crate::{
         agent_control::config::helmrepository_type_meta,
-        k8s::labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL},
+        k8s::{
+            annotations::Annotations,
+            labels::{AGENT_CONTROL_VERSION_SET_FROM, LOCAL_VAL, REMOTE_VAL},
+        },
         sub_agent::identity::AgentIdentity,
     };
 
@@ -732,18 +735,7 @@ mod tests {
         .collect();
 
         let annotations = Some(
-            [
-                (
-                    "newrelic.io/agent-type-id".to_string(),
-                    agent_identity.agent_type_id.to_string(),
-                ),
-                (
-                    "newrelic.io/owned-by".to_string(),
-                    "agent-control".to_string(),
-                ),
-            ]
-            .into_iter()
-            .collect(),
+            Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id).get(),
         );
 
         let mut expected_repository_object = repository_object();

--- a/agent-control/src/cli/k8s/install.rs
+++ b/agent-control/src/cli/k8s/install.rs
@@ -452,10 +452,16 @@ mod tests {
                         agent_identity.id.to_string(),
                     ),
                 ])),
-                annotations: Some(BTreeMap::from_iter(vec![(
-                    "newrelic.io/agent-type-id".to_string(),
-                    agent_identity.agent_type_id.to_string(),
-                )])),
+                annotations: Some(BTreeMap::from_iter(vec![
+                    (
+                        "newrelic.io/agent-type-id".to_string(),
+                        agent_identity.agent_type_id.to_string(),
+                    ),
+                    (
+                        "newrelic.io/owned-by".to_string(),
+                        "agent-control".to_string(),
+                    ),
+                ])),
                 ..ObjectMeta::default()
             },
             data: serde_json::json!({
@@ -492,10 +498,16 @@ mod tests {
                         source.to_string(),
                     ),
                 ])),
-                annotations: Some(BTreeMap::from_iter(vec![(
-                    "newrelic.io/agent-type-id".to_string(),
-                    agent_identity.agent_type_id.to_string(),
-                )])),
+                annotations: Some(BTreeMap::from_iter(vec![
+                    (
+                        "newrelic.io/agent-type-id".to_string(),
+                        agent_identity.agent_type_id.to_string(),
+                    ),
+                    (
+                        "newrelic.io/owned-by".to_string(),
+                        "agent-control".to_string(),
+                    ),
+                ])),
                 ..Default::default()
             },
             data: serde_json::json!({
@@ -720,10 +732,16 @@ mod tests {
         .collect();
 
         let annotations = Some(
-            vec![(
-                "newrelic.io/agent-type-id".to_string(),
-                agent_identity.agent_type_id.to_string(),
-            )]
+            [
+                (
+                    "newrelic.io/agent-type-id".to_string(),
+                    agent_identity.agent_type_id.to_string(),
+                ),
+                (
+                    "newrelic.io/owned-by".to_string(),
+                    "agent-control".to_string(),
+                ),
+            ]
             .into_iter()
             .collect(),
         );

--- a/agent-control/src/cli/k8s/install/agent_control.rs
+++ b/agent-control/src/cli/k8s/install/agent_control.rs
@@ -47,7 +47,8 @@ impl DynamicObjectListBuilder for InstallAgentControl {
         let labels = labels.get();
         debug!("Parsed labels: {:?}", labels);
 
-        let annotations = Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id);
+        let annotations =
+            Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id);
         let annotations = annotations.get();
 
         let helm_repository_obj_meta_data = obj_meta_data(

--- a/agent-control/src/cli/k8s/install/agent_control.rs
+++ b/agent-control/src/cli/k8s/install/agent_control.rs
@@ -47,7 +47,7 @@ impl DynamicObjectListBuilder for InstallAgentControl {
         let labels = labels.get();
         debug!("Parsed labels: {:?}", labels);
 
-        let annotations = Annotations::new_agent_control_owned(Some(&agent_identity.agent_type_id));
+        let annotations = Annotations::new_agent_control_owned_with_type(&agent_identity.agent_type_id);
         let annotations = annotations.get();
 
         let helm_repository_obj_meta_data = obj_meta_data(

--- a/agent-control/src/cli/k8s/install/agent_control.rs
+++ b/agent-control/src/cli/k8s/install/agent_control.rs
@@ -47,7 +47,7 @@ impl DynamicObjectListBuilder for InstallAgentControl {
         let labels = labels.get();
         debug!("Parsed labels: {:?}", labels);
 
-        let annotations = Annotations::new_agent_type_id_annotation(&agent_identity.agent_type_id);
+        let annotations = Annotations::new_agent_control_owned(Some(&agent_identity.agent_type_id));
         let annotations = annotations.get();
 
         let helm_repository_obj_meta_data = obj_meta_data(

--- a/agent-control/src/data_store.rs
+++ b/agent-control/src/data_store.rs
@@ -2,7 +2,10 @@ use std::error::Error;
 
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{agent_control::agent_id::AgentID, opamp::instance_id::storer::StorerError};
+use crate::{
+    agent_control::agent_id::AgentID, agent_type::agent_type_id::AgentTypeID,
+    opamp::instance_id::storer::StorerError,
+};
 
 /// The key used to identify the data in the OpAMP Data Store.
 pub type StoreKey = str;
@@ -29,6 +32,7 @@ pub trait DataStore {
     fn set_remote_data<T>(
         &self,
         agent_id: &AgentID,
+        agent_type_id: Option<AgentTypeID>,
         key: &str,
         data: &T,
     ) -> Result<(), Self::Error>

--- a/agent-control/src/data_store.rs
+++ b/agent-control/src/data_store.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
-    agent_control::agent_id::AgentID, agent_type::agent_type_id::AgentTypeID,
-    opamp::instance_id::storer::StorerError,
+    agent_control::agent_id::AgentID, opamp::instance_id::storer::StorerError,
+    resource_ownership::ResourceOwnership,
 };
 
 /// The key used to identify the data in the OpAMP Data Store.
@@ -32,7 +32,7 @@ pub trait DataStore {
     fn set_remote_data<T>(
         &self,
         agent_id: &AgentID,
-        agent_type_id: Option<AgentTypeID>,
+        ownership: ResourceOwnership,
         key: &str,
         data: &T,
     ) -> Result<(), Self::Error>

--- a/agent-control/src/k8s/annotations.rs
+++ b/agent-control/src/k8s/annotations.rs
@@ -2,6 +2,10 @@ use crate::agent_type::agent_type_id::AgentTypeID;
 use std::collections::BTreeMap;
 
 const AGENT_TYPE_ID_ANNOTATION_KEY: &str = "newrelic.io/agent-type-id";
+const OWNED_BY_ANNOTATION_KEY: &str = "newrelic.io/owned-by";
+
+const OWNED_BY_AGENT_CONTROL: &str = "agent-control";
+const OWNED_BY_SUB_AGENT: &str = "sub-agent";
 
 /// Collection of annotations used to identify agent control resources.
 #[derive(PartialEq, Default)]
@@ -15,6 +19,33 @@ impl Annotations {
         )]))
     }
 
+    pub fn new_agent_control_owned(agent_type_id: Option<&AgentTypeID>) -> Self {
+        let mut map = BTreeMap::from([(
+            OWNED_BY_ANNOTATION_KEY.to_string(),
+            OWNED_BY_AGENT_CONTROL.to_string(),
+        )]);
+        agent_type_id.inspect(|agent_type_id| {
+            map.insert(
+                AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
+                agent_type_id.to_string(),
+            );
+        });
+        Self(map)
+    }
+
+    pub fn new_sub_agent_owned(agent_type_id: &AgentTypeID) -> Self {
+        Self(BTreeMap::from([
+            (
+                OWNED_BY_ANNOTATION_KEY.to_string(),
+                OWNED_BY_SUB_AGENT.to_string(),
+            ),
+            (
+                AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
+                agent_type_id.to_string(),
+            ),
+        ]))
+    }
+
     pub fn get(&self) -> BTreeMap<String, String> {
         self.0.clone()
     }
@@ -22,4 +53,16 @@ impl Annotations {
 
 pub fn get_agent_type_id_value(annotations: &BTreeMap<String, String>) -> Option<&String> {
     annotations.get(AGENT_TYPE_ID_ANNOTATION_KEY)
+}
+
+pub fn get_owned_by_value(annotations: &BTreeMap<String, String>) -> Option<&String> {
+    annotations.get(OWNED_BY_ANNOTATION_KEY)
+}
+
+pub fn is_owned_by_agent_control(annotations: &BTreeMap<String, String>) -> bool {
+    get_owned_by_value(annotations).is_some_and(|v| v == OWNED_BY_AGENT_CONTROL)
+}
+
+pub fn is_owned_by_sub_agent(annotations: &BTreeMap<String, String>) -> bool {
+    get_owned_by_value(annotations).is_some_and(|v| v == OWNED_BY_SUB_AGENT)
 }

--- a/agent-control/src/k8s/annotations.rs
+++ b/agent-control/src/k8s/annotations.rs
@@ -26,30 +26,25 @@ impl Annotations {
         )]))
     }
 
-    pub fn new_agent_control_owned_with_type(agent_type_id: &AgentTypeID) -> Self {
-        let base = Self::new_agent_control_owned().0;
-        let with_agent_type_id = std::iter::chain(
-            base,
-            [(
-                AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
-                agent_type_id.to_string(),
-            )],
-        )
-        .collect();
-        Self(with_agent_type_id)
+    fn new_subagent_owned() -> Self {
+        Self(BTreeMap::from([(
+            OWNED_BY_ANNOTATION_KEY.to_string(),
+            OWNED_BY_SUB_AGENT.to_string(),
+        )]))
     }
 
-    pub fn new_sub_agent_owned(agent_type_id: &AgentTypeID) -> Self {
-        Self(BTreeMap::from([
-            (
-                OWNED_BY_ANNOTATION_KEY.to_string(),
-                OWNED_BY_SUB_AGENT.to_string(),
-            ),
-            (
-                AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
-                agent_type_id.to_string(),
-            ),
-        ]))
+    pub fn new_agent_control_owned_with_type(agent_type_id: &AgentTypeID) -> Self {
+        let base = Self::new_agent_control_owned().0;
+        let with_agent_id = Self::new_agent_type_id_annotation(agent_type_id).0;
+        let merged = std::iter::chain(base, with_agent_id).collect();
+        Self(merged)
+    }
+
+    pub fn new_sub_agent_owned_with_type(agent_type_id: &AgentTypeID) -> Self {
+        let base = Self::new_subagent_owned().0;
+        let with_agent_id = Self::new_agent_type_id_annotation(agent_type_id).0;
+        let merged = std::iter::chain(base, with_agent_id).collect();
+        Self(merged)
     }
 
     pub fn get(&self) -> BTreeMap<String, String> {

--- a/agent-control/src/k8s/annotations.rs
+++ b/agent-control/src/k8s/annotations.rs
@@ -9,12 +9,10 @@ pub struct Annotations(BTreeMap<String, String>);
 
 impl Annotations {
     pub fn new_agent_type_id_annotation(agent_type: &AgentTypeID) -> Self {
-        let mut annotations = Self::default();
-        annotations.0.insert(
+        Self(BTreeMap::from([(
             AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
             agent_type.to_string(),
-        );
-        annotations
+        )]))
     }
 
     pub fn get(&self) -> BTreeMap<String, String> {

--- a/agent-control/src/k8s/annotations.rs
+++ b/agent-control/src/k8s/annotations.rs
@@ -19,18 +19,24 @@ impl Annotations {
         )]))
     }
 
-    pub fn new_agent_control_owned(agent_type_id: Option<&AgentTypeID>) -> Self {
-        let mut map = BTreeMap::from([(
+    pub fn new_agent_control_owned() -> Self {
+        Self(BTreeMap::from([(
             OWNED_BY_ANNOTATION_KEY.to_string(),
             OWNED_BY_AGENT_CONTROL.to_string(),
-        )]);
-        agent_type_id.inspect(|agent_type_id| {
-            map.insert(
+        )]))
+    }
+
+    pub fn new_agent_control_owned_with_type(agent_type_id: &AgentTypeID) -> Self {
+        let base = Self::new_agent_control_owned().0;
+        let with_agent_type_id = std::iter::chain(
+            base,
+            [(
                 AGENT_TYPE_ID_ANNOTATION_KEY.to_string(),
                 agent_type_id.to_string(),
-            );
-        });
-        Self(map)
+            )],
+        )
+        .collect();
+        Self(with_agent_type_id)
     }
 
     pub fn new_sub_agent_owned(agent_type_id: &AgentTypeID) -> Self {

--- a/agent-control/src/k8s/client.rs
+++ b/agent-control/src/k8s/client.rs
@@ -211,6 +211,24 @@ impl SyncK8sClient {
         )
     }
 
+    pub fn list_configmaps(
+        &self,
+        namespace: &str,
+        label_selector: &str,
+    ) -> Result<Vec<Arc<ConfigMap>>, K8sError> {
+        self.runtime
+            .block_on(self.async_client.list_configmaps(namespace, label_selector))
+    }
+
+    pub fn delete_configmap(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Either<ConfigMap, Status>, K8sError> {
+        self.runtime
+            .block_on(self.async_client.delete_configmap(namespace, name))
+    }
+
     pub fn get_configmap_key(
         &self,
         name: &str,
@@ -487,6 +505,30 @@ impl AsyncK8sClient {
 
         delete_collection(&api, label_selector).await?;
         Ok(())
+    }
+
+    pub async fn list_configmaps(
+        &self,
+        namespace: &str,
+        label_selector: &str,
+    ) -> Result<Vec<Arc<ConfigMap>>, K8sError> {
+        let api: Api<ConfigMap> = Api::<ConfigMap>::namespaced(self.client.clone(), namespace);
+        let list = api
+            .list(&ListParams {
+                label_selector: Some(label_selector.to_string()),
+                ..Default::default()
+            })
+            .await?;
+        Ok(list.iter().map(|cm| Arc::new(cm.clone())).collect())
+    }
+
+    pub async fn delete_configmap(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Either<ConfigMap, Status>, K8sError> {
+        let api: Api<ConfigMap> = Api::<ConfigMap>::namespaced(self.client.clone(), namespace);
+        Ok(api.delete(name, &DeleteParams::default()).await?)
     }
 
     pub async fn get_configmap_key(

--- a/agent-control/src/k8s/client.rs
+++ b/agent-control/src/k8s/client.rs
@@ -68,6 +68,16 @@ pub trait K8sClient: Debug + Send + Sync + 'static {
         namespace: &str,
         label_selector: &str,
     ) -> Result<(), K8sError>;
+    fn list_configmaps(
+        &self,
+        namespace: &str,
+        label_selector: &str,
+    ) -> Result<Vec<Arc<ConfigMap>>, K8sError>;
+    fn delete_configmap(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Either<ConfigMap, Status>, K8sError>;
     fn get_configmap_key(
         &self,
         name: &str,
@@ -85,6 +95,7 @@ pub trait K8sClient: Debug + Send + Sync + 'static {
         name: &str,
         namespace: &str,
         labels: BTreeMap<String, String>,
+        annotations: BTreeMap<String, String>,
         key: &str,
         value: &str,
     ) -> Result<(), K8sError>;
@@ -383,10 +394,11 @@ impl K8sClient for SyncK8sClient {
         name: &str,
         namespace: &str,
         labels: BTreeMap<String, String>,
+        annotations: BTreeMap<String, String>,
         key: &str,
         value: &str,
     ) -> Result<(), K8sError> {
-        self.set_configmap_key(name, namespace, labels, key, value)
+        self.set_configmap_key(name, namespace, labels, annotations, key, value)
     }
 
     fn delete_configmap_key(&self, name: &str, namespace: &str, key: &str) -> Result<(), K8sError> {
@@ -403,6 +415,22 @@ impl K8sClient for SyncK8sClient {
 
     fn list_deployment(&self, ns: &str) -> Result<Vec<Arc<Deployment>>, K8sError> {
         self.list_deployment(ns)
+    }
+
+    fn list_configmaps(
+        &self,
+        namespace: &str,
+        label_selector: &str,
+    ) -> Result<Vec<Arc<ConfigMap>>, K8sError> {
+        self.list_configmaps(namespace, label_selector)
+    }
+
+    fn delete_configmap(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Either<ConfigMap, Status>, K8sError> {
+        self.delete_configmap(namespace, name)
     }
 }
 
@@ -843,6 +871,16 @@ pub(crate) mod tests {
                 namespace: &str,
                 label_selector: &str,
             ) -> Result<(), K8sError>;
+            fn list_configmaps(
+                &self,
+                namespace: &str,
+                label_selector: &str,
+            ) -> Result<Vec<Arc<ConfigMap>>, K8sError>;
+            fn delete_configmap(
+                &self,
+                namespace: &str,
+                name: &str,
+            ) -> Result<Either<ConfigMap, Status>, K8sError>;
             fn get_configmap_key(
                 &self,
                 name: &str,
@@ -860,6 +898,7 @@ pub(crate) mod tests {
                 name: &str,
                 namespace: &str,
                 labels: BTreeMap<String, String>,
+                 annotations: BTreeMap<String, String>,
                 key: &str,
                 value: &str,
             ) -> Result<(), K8sError>;

--- a/agent-control/src/k8s/client.rs
+++ b/agent-control/src/k8s/client.rs
@@ -237,13 +237,18 @@ impl SyncK8sClient {
         name: &str,
         namespace: &str,
         labels: BTreeMap<String, String>,
+        annotations: BTreeMap<String, String>,
         key: &str,
         value: &str,
     ) -> Result<(), K8sError> {
-        self.runtime.block_on(
-            self.async_client
-                .set_configmap_key(name, namespace, labels, key, value),
-        )
+        self.runtime.block_on(self.async_client.set_configmap_key(
+            name,
+            namespace,
+            labels,
+            annotations,
+            key,
+            value,
+        ))
     }
 
     pub fn delete_configmap_key(
@@ -516,6 +521,7 @@ impl AsyncK8sClient {
         name: &str,
         namespace: &str,
         labels: BTreeMap<String, String>,
+        annotations: BTreeMap<String, String>,
         key: &str,
         value: &str,
     ) -> Result<(), K8sError> {
@@ -534,8 +540,12 @@ impl AsyncK8sClient {
             })
             .and_modify(|cm| {
                 cm.metadata.labels = Some(labels);
+                cm.metadata
+                    .annotations
+                    .get_or_insert_default()
+                    .extend(annotations);
                 cm.data
-                    .get_or_insert_with(BTreeMap::default)
+                    .get_or_insert_default()
                     .insert(key.to_string(), value.to_string());
             })
             .commit(&PostParams::default())

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -107,6 +107,7 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
 
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
+        let annotations = Annotations::new_agent_control_owned(agent_type_id.as_ref()).get();
         self.k8s_client.set_configmap_key(
             &configmap_name,
             self.namespace.as_str(),
@@ -160,6 +161,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
 
+        let expected_annotations_no_type = Annotations::new_agent_control_owned(None).get();
         k8s_client
             .expect_set_configmap_key()
             .once()
@@ -170,6 +172,7 @@ pub mod tests {
                 )),
                 predicate::eq(TEST_NAMESPACE),
                 predicate::eq(Labels::new(&AgentID::try_from(AGENT_NAME).unwrap()).get()),
+                predicate::eq(expected_annotations_no_type),
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
@@ -348,7 +351,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let expected_annotations = Annotations::new_agent_type_id_annotation(&agent_type_id).get();
+        let expected_annotations = Annotations::new_agent_control_owned(Some(&agent_type_id)).get();
 
         k8s_client
             .expect_set_configmap_key()

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -7,8 +7,9 @@ use super::client::{K8sClient, SyncK8sClient};
 use super::labels::Labels;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::{FOLDER_NAME_FLEET_DATA, FOLDER_NAME_LOCAL_DATA};
+use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::data_store::{DataStore, StoreKey};
-use crate::k8s;
+use crate::k8s::{self, annotations::Annotations};
 use std::sync::{Arc, RwLock};
 
 /// Represents a Kubernetes persistent store of Agents data such as instance id and configs.
@@ -93,6 +94,7 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
     fn set_remote_data<T>(
         &self,
         agent_id: &AgentID,
+        agent_type_id: Option<AgentTypeID>,
         key: &StoreKey,
         data: &T,
     ) -> Result<(), Self::Error>
@@ -105,10 +107,14 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
 
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
+        let annotations = agent_type_id
+            .map(|id| Annotations::new_agent_type_id_annotation(&id).get())
+            .unwrap_or_default();
         self.k8s_client.set_configmap_key(
             &configmap_name,
             self.namespace.as_str(),
             Labels::new(agent_id).get(),
+            annotations,
             key,
             &data_as_string,
         )
@@ -136,6 +142,7 @@ pub mod tests {
     use crate::k8s::labels::Labels;
     use mockall::predicate;
     use serde::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     const AGENT_NAME: &str = "agent1";
@@ -166,10 +173,11 @@ pub mod tests {
                 )),
                 predicate::eq(TEST_NAMESPACE),
                 predicate::eq(Labels::new(&AgentID::try_from(AGENT_NAME).unwrap()).get()),
+                predicate::eq(BTreeMap::default()),
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
-            .returning(move |_, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _, _| Ok(()));
         k8s_client
             .expect_delete_configmap_key()
             .once()
@@ -187,6 +195,7 @@ pub mod tests {
 
         let _ = k8s_store.set_remote_data(
             &agent_id,
+            None,
             STORE_KEY_TEST,
             &DataToBeStored {
                 test: "foo".to_string(),
@@ -307,13 +316,14 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _| {
+            .returning(move |_, _, _, _, _, _| {
                 Err(K8sError::KubeRs(Box::new(kube::Error::TlsRequired)))
             });
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
 
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
+            None,
             STORE_KEY_TEST,
             &DataToBeStored::default(),
         );
@@ -326,10 +336,11 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _, _| Ok(()));
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
+            None,
             STORE_KEY_TEST,
             &DataToBeStored::default(),
         );

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -107,7 +107,10 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
 
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
-        let annotations = Annotations::new_agent_control_owned(agent_type_id.as_ref()).get();
+        let annotations = match agent_type_id {
+            Some(agent_type_id) => Annotations::new_agent_control_owned_with_type(&agent_type_id).get(),
+            None => Annotations::new_agent_control_owned().get(),
+        };
         self.k8s_client.set_configmap_key(
             &configmap_name,
             self.namespace.as_str(),
@@ -161,7 +164,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
 
-        let expected_annotations_no_type = Annotations::new_agent_control_owned(None).get();
+        let expected_annotations_no_type = Annotations::new_agent_control_owned().get();
         k8s_client
             .expect_set_configmap_key()
             .once()
@@ -351,7 +354,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let expected_annotations = Annotations::new_agent_control_owned(Some(&agent_type_id)).get();
+        let expected_annotations = Annotations::new_agent_control_owned_with_type(&agent_type_id).get();
 
         k8s_client
             .expect_set_configmap_key()

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -109,15 +109,16 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
         let annotations = match ownership {
             ResourceOwnership::SubAgent(agent_type_id) => {
-                Annotations::new_sub_agent_owned_with_type(&agent_type_id).get()
+                Annotations::new_sub_agent_owned_with_type(&agent_type_id)
             }
-            ResourceOwnership::AgentControl => Annotations::new_agent_control_owned().get(),
+            ResourceOwnership::AgentControl => Annotations::new_agent_control_owned(),
         };
+
         self.k8s_client.set_configmap_key(
             &configmap_name,
             self.namespace.as_str(),
             Labels::new(agent_id).get(),
-            annotations,
+            annotations.get(),
             key,
             &data_as_string,
         )

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -117,6 +117,7 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
             &configmap_name,
             self.namespace.as_str(),
             Labels::new(agent_id).get(),
+            annotations,
             key,
             &data_as_string,
         )
@@ -181,7 +182,7 @@ pub mod tests {
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
-            .returning(move |_, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _, _| Ok(()));
         k8s_client
             .expect_delete_configmap_key()
             .once()
@@ -320,7 +321,7 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _| {
+            .returning(move |_, _, _, _, _, _| {
                 Err(K8sError::KubeRs(Box::new(kube::Error::TlsRequired)))
             });
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
@@ -340,7 +341,7 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _, _| Ok(()));
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
@@ -368,10 +369,11 @@ pub mod tests {
                 )),
                 predicate::eq(TEST_NAMESPACE),
                 predicate::eq(Labels::new(&agent_id).get()),
+                predicate::eq(expected_annotations),
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
-            .returning(move |_, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _, _| Ok(()));
 
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let result = k8s_store.set_remote_data(

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -109,7 +109,7 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
         let annotations = match ownership {
             ResourceOwnership::SubAgent(agent_type_id) => {
-                Annotations::new_sub_agent_owned(&agent_type_id).get()
+                Annotations::new_sub_agent_owned_with_type(&agent_type_id).get()
             }
             ResourceOwnership::AgentControl => Annotations::new_agent_control_owned().get(),
         };
@@ -357,7 +357,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let expected_annotations = Annotations::new_sub_agent_owned(&agent_type_id).get();
+        let expected_annotations = Annotations::new_sub_agent_owned_with_type(&agent_type_id).get();
 
         k8s_client
             .expect_set_configmap_key()

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -107,14 +107,10 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
 
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
-        let annotations = agent_type_id
-            .map(|id| Annotations::new_agent_type_id_annotation(&id).get())
-            .unwrap_or_default();
         self.k8s_client.set_configmap_key(
             &configmap_name,
             self.namespace.as_str(),
             Labels::new(agent_id).get(),
-            annotations,
             key,
             &data_as_string,
         )
@@ -137,12 +133,13 @@ pub mod tests {
     use super::*;
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_control::defaults::{FOLDER_NAME_FLEET_DATA, FOLDER_NAME_LOCAL_DATA};
+    use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::k8s::annotations::Annotations;
     use crate::k8s::client::tests::MockK8sClient;
     use crate::k8s::error::K8sError;
     use crate::k8s::labels::Labels;
     use mockall::predicate;
     use serde::{Deserialize, Serialize};
-    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     const AGENT_NAME: &str = "agent1";
@@ -173,11 +170,10 @@ pub mod tests {
                 )),
                 predicate::eq(TEST_NAMESPACE),
                 predicate::eq(Labels::new(&AgentID::try_from(AGENT_NAME).unwrap()).get()),
-                predicate::eq(BTreeMap::default()),
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
-            .returning(move |_, _, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _| Ok(()));
         k8s_client
             .expect_delete_configmap_key()
             .once()
@@ -316,7 +312,7 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _, _| {
+            .returning(move |_, _, _, _, _| {
                 Err(K8sError::KubeRs(Box::new(kube::Error::TlsRequired)))
             });
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
@@ -336,7 +332,7 @@ pub mod tests {
         k8s_client
             .expect_set_configmap_key()
             .once()
-            .returning(move |_, _, _, _, _, _| Ok(()));
+            .returning(move |_, _, _, _, _| Ok(()));
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
@@ -345,6 +341,40 @@ pub mod tests {
             &DataToBeStored::default(),
         );
         assert!(id.is_ok())
+    }
+
+    #[test]
+    fn test_set_with_agent_type_id_includes_annotation() {
+        let mut k8s_client = MockK8sClient::default();
+        let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let expected_annotations = Annotations::new_agent_type_id_annotation(&agent_type_id).get();
+
+        k8s_client
+            .expect_set_configmap_key()
+            .once()
+            .with(
+                predicate::eq(ConfigMapStore::build_cm_name(
+                    &agent_id,
+                    FOLDER_NAME_FLEET_DATA,
+                )),
+                predicate::eq(TEST_NAMESPACE),
+                predicate::eq(Labels::new(&agent_id).get()),
+                predicate::eq(STORE_KEY_TEST),
+                predicate::eq(DATA_STORED),
+            )
+            .returning(move |_, _, _, _, _| Ok(()));
+
+        let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
+        let result = k8s_store.set_remote_data(
+            &agent_id,
+            Some(agent_type_id),
+            STORE_KEY_TEST,
+            &DataToBeStored {
+                test: "foo".to_string(),
+            },
+        );
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -108,7 +108,9 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
         let annotations = match agent_type_id {
-            Some(agent_type_id) => Annotations::new_agent_control_owned_with_type(&agent_type_id).get(),
+            Some(agent_type_id) => {
+                Annotations::new_agent_control_owned_with_type(&agent_type_id).get()
+            }
             None => Annotations::new_agent_control_owned().get(),
         };
         self.k8s_client.set_configmap_key(
@@ -354,7 +356,8 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let expected_annotations = Annotations::new_agent_control_owned_with_type(&agent_type_id).get();
+        let expected_annotations =
+            Annotations::new_agent_control_owned_with_type(&agent_type_id).get();
 
         k8s_client
             .expect_set_configmap_key()

--- a/agent-control/src/k8s/configmap_store.rs
+++ b/agent-control/src/k8s/configmap_store.rs
@@ -7,9 +7,9 @@ use super::client::{K8sClient, SyncK8sClient};
 use super::labels::Labels;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::{FOLDER_NAME_FLEET_DATA, FOLDER_NAME_LOCAL_DATA};
-use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::data_store::{DataStore, StoreKey};
 use crate::k8s::{self, annotations::Annotations};
+use crate::resource_ownership::ResourceOwnership;
 use std::sync::{Arc, RwLock};
 
 /// Represents a Kubernetes persistent store of Agents data such as instance id and configs.
@@ -94,7 +94,7 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
     fn set_remote_data<T>(
         &self,
         agent_id: &AgentID,
-        agent_type_id: Option<AgentTypeID>,
+        ownership: ResourceOwnership,
         key: &StoreKey,
         data: &T,
     ) -> Result<(), Self::Error>
@@ -107,11 +107,11 @@ impl<C: K8sClient> DataStore for ConfigMapStore<C> {
 
         let data_as_string = serde_yaml::to_string(data)?;
         let configmap_name = ConfigMapStore::build_cm_name(agent_id, FOLDER_NAME_FLEET_DATA);
-        let annotations = match agent_type_id {
-            Some(agent_type_id) => {
-                Annotations::new_agent_control_owned_with_type(&agent_type_id).get()
+        let annotations = match ownership {
+            ResourceOwnership::SubAgent(agent_type_id) => {
+                Annotations::new_sub_agent_owned(&agent_type_id).get()
             }
-            None => Annotations::new_agent_control_owned().get(),
+            ResourceOwnership::AgentControl => Annotations::new_agent_control_owned().get(),
         };
         self.k8s_client.set_configmap_key(
             &configmap_name,
@@ -166,7 +166,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
 
-        let expected_annotations_no_type = Annotations::new_agent_control_owned().get();
+        let expected_annotations = Annotations::new_agent_control_owned().get();
         k8s_client
             .expect_set_configmap_key()
             .once()
@@ -177,7 +177,7 @@ pub mod tests {
                 )),
                 predicate::eq(TEST_NAMESPACE),
                 predicate::eq(Labels::new(&AgentID::try_from(AGENT_NAME).unwrap()).get()),
-                predicate::eq(expected_annotations_no_type),
+                predicate::eq(expected_annotations),
                 predicate::eq(STORE_KEY_TEST),
                 predicate::eq(DATA_STORED),
             )
@@ -199,7 +199,7 @@ pub mod tests {
 
         let _ = k8s_store.set_remote_data(
             &agent_id,
-            None,
+            ResourceOwnership::AgentControl,
             STORE_KEY_TEST,
             &DataToBeStored {
                 test: "foo".to_string(),
@@ -327,7 +327,7 @@ pub mod tests {
 
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
-            None,
+            ResourceOwnership::AgentControl,
             STORE_KEY_TEST,
             &DataToBeStored::default(),
         );
@@ -344,7 +344,7 @@ pub mod tests {
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let id = k8s_store.set_remote_data(
             &AgentID::try_from(AGENT_NAME).unwrap(),
-            None,
+            ResourceOwnership::AgentControl,
             STORE_KEY_TEST,
             &DataToBeStored::default(),
         );
@@ -356,8 +356,7 @@ pub mod tests {
         let mut k8s_client = MockK8sClient::default();
         let agent_id = AgentID::try_from(AGENT_NAME).unwrap();
         let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
-        let expected_annotations =
-            Annotations::new_agent_control_owned_with_type(&agent_type_id).get();
+        let expected_annotations = Annotations::new_sub_agent_owned(&agent_type_id).get();
 
         k8s_client
             .expect_set_configmap_key()
@@ -377,7 +376,7 @@ pub mod tests {
         let k8s_store = ConfigMapStore::new(Arc::new(k8s_client), TEST_NAMESPACE.to_string());
         let result = k8s_store.set_remote_data(
             &agent_id,
-            Some(agent_type_id),
+            ResourceOwnership::SubAgent(agent_type_id.clone()),
             STORE_KEY_TEST,
             &DataToBeStored {
                 test: "foo".to_string(),

--- a/agent-control/src/lib.rs
+++ b/agent-control/src/lib.rs
@@ -18,6 +18,7 @@ pub mod oci;
 pub mod on_host;
 pub mod opamp;
 pub mod package;
+pub mod resource_ownership;
 pub mod secret_retriever;
 pub mod secrets_provider;
 pub mod signature;

--- a/agent-control/src/on_host/file_store.rs
+++ b/agent-control/src/on_host/file_store.rs
@@ -18,8 +18,8 @@ use crate::{
         agent_id::AgentID,
         defaults::{FOLDER_NAME_FLEET_DATA, FOLDER_NAME_LOCAL_DATA},
     },
-    agent_type::agent_type_id::AgentTypeID,
     data_store::{DataStore, StoreKey},
+    resource_ownership::ResourceOwnership,
 };
 
 pub struct FileStore<F, D>
@@ -162,7 +162,7 @@ where
     fn set_remote_data<T>(
         &self,
         agent_id: &AgentID,
-        _agent_type_id: Option<AgentTypeID>,
+        _ownership: ResourceOwnership,
         key: &str,
         data: &T,
     ) -> Result<(), Self::Error>
@@ -664,7 +664,9 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        repo.store_remote(&agent_id, None, &remote_config).unwrap();
+        // using agent control as ownership but this test does not care
+        repo.store_remote(&agent_id, ResourceOwnership::AgentControl, &remote_config)
+            .unwrap();
     }
 
     #[rstest]
@@ -692,7 +694,8 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        let result = repo.store_remote(&agent_id, None, &remote_config);
+        // using agent control as ownership but this test does not care
+        let result = repo.store_remote(&agent_id, ResourceOwnership::AgentControl, &remote_config);
         assert_matches!(result, Err(ConfigRepositoryError::StoreError(_)));
     }
 
@@ -725,7 +728,8 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        let result = repo.store_remote(&agent_id, None, &remote_config);
+        // using agent control as ownership but this test does not care
+        let result = repo.store_remote(&agent_id, ResourceOwnership::AgentControl, &remote_config);
         assert_matches!(result, Err(ConfigRepositoryError::StoreError(_)));
     }
 

--- a/agent-control/src/on_host/file_store.rs
+++ b/agent-control/src/on_host/file_store.rs
@@ -18,6 +18,7 @@ use crate::{
         agent_id::AgentID,
         defaults::{FOLDER_NAME_FLEET_DATA, FOLDER_NAME_LOCAL_DATA},
     },
+    agent_type::agent_type_id::AgentTypeID,
     data_store::{DataStore, StoreKey},
 };
 
@@ -158,7 +159,13 @@ where
         self.get(self.local_dir.get_file_path(agent_id, key))
     }
 
-    fn set_remote_data<T>(&self, agent_id: &AgentID, key: &str, data: &T) -> Result<(), Self::Error>
+    fn set_remote_data<T>(
+        &self,
+        agent_id: &AgentID,
+        _agent_type_id: Option<AgentTypeID>,
+        key: &str,
+        data: &T,
+    ) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
@@ -657,7 +664,7 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        repo.store_remote(&agent_id, &remote_config).unwrap();
+        repo.store_remote(&agent_id, None, &remote_config).unwrap();
     }
 
     #[rstest]
@@ -685,7 +692,7 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        let result = repo.store_remote(&agent_id, &remote_config);
+        let result = repo.store_remote(&agent_id, None, &remote_config);
         assert_matches!(result, Err(ConfigRepositoryError::StoreError(_)));
     }
 
@@ -718,7 +725,7 @@ state: applied
             hash: Hash::from("a-hash"),
             state: ConfigState::Applying,
         };
-        let result = repo.store_remote(&agent_id, &remote_config);
+        let result = repo.store_remote(&agent_id, None, &remote_config);
         assert_matches!(result, Err(ConfigRepositoryError::StoreError(_)));
     }
 

--- a/agent-control/src/opamp/instance_id/storer.rs
+++ b/agent-control/src/opamp/instance_id/storer.rs
@@ -64,7 +64,7 @@ where
         debug!("storer: setting Instance ID of agent_id: {}", agent_id);
 
         self.opamp_data_store
-            .set_remote_data(agent_id, STORE_KEY_INSTANCE_ID, data)?;
+            .set_remote_data(agent_id, None, STORE_KEY_INSTANCE_ID, data)?;
 
         Ok(())
     }

--- a/agent-control/src/opamp/instance_id/storer.rs
+++ b/agent-control/src/opamp/instance_id/storer.rs
@@ -9,6 +9,7 @@ use crate::{
     data_store::DataStore,
     k8s,
     opamp::instance_id::getter::DataStored,
+    resource_ownership::ResourceOwnership,
 };
 
 use super::definition::InstanceIdentifiers;
@@ -63,8 +64,12 @@ where
     fn set(&self, agent_id: &AgentID, data: &DataStored<I>) -> Result<(), StorerError> {
         debug!("storer: setting Instance ID of agent_id: {}", agent_id);
 
-        self.opamp_data_store
-            .set_remote_data(agent_id, None, STORE_KEY_INSTANCE_ID, data)?;
+        self.opamp_data_store.set_remote_data(
+            agent_id,
+            ResourceOwnership::AgentControl,
+            STORE_KEY_INSTANCE_ID,
+            data,
+        )?;
 
         Ok(())
     }

--- a/agent-control/src/resource_ownership.rs
+++ b/agent-control/src/resource_ownership.rs
@@ -19,23 +19,3 @@ pub enum ResourceOwnership {
     /// Resource is owned by a sub-agent (e.g., sub-agent's fleet-data ConfigMap, supervisor-created objects)
     SubAgent(AgentTypeID),
 }
-
-impl ResourceOwnership {
-    /// Returns the agent type ID if this is a sub-agent-owned resource
-    pub fn agent_type_id(&self) -> Option<&AgentTypeID> {
-        match self {
-            ResourceOwnership::AgentControl => None,
-            ResourceOwnership::SubAgent(agent_type_id) => Some(agent_type_id),
-        }
-    }
-
-    /// Returns true if this resource is owned by Agent Control
-    pub fn is_agent_control(&self) -> bool {
-        matches!(self, ResourceOwnership::AgentControl)
-    }
-
-    /// Returns true if this resource is owned by a sub-agent
-    pub fn is_sub_agent(&self) -> bool {
-        matches!(self, ResourceOwnership::SubAgent(_))
-    }
-}

--- a/agent-control/src/resource_ownership.rs
+++ b/agent-control/src/resource_ownership.rs
@@ -1,0 +1,41 @@
+use crate::agent_type::agent_type_id::AgentTypeID;
+
+/// Represents ownership of a resource in Agent Control's data store.
+///
+/// This type is used to distinguish between resources owned by Agent Control itself
+/// (internal resources like fleet-data ConfigMaps for AC, instance IDs) and resources
+/// owned by sub-agents (fleet-data ConfigMaps for sub-agents, supervisor-created K8s objects).
+///
+/// The ownership determines which annotations are applied to the resource:
+/// - `AgentControl`: applies `owned-by=agent-control` annotation
+/// - `SubAgent`: applies `owned-by=sub-agent` + `agent-type-id=<type>` annotations
+///
+/// This type-safe approach prevents bugs where the wrong ownership could be accidentally
+/// applied, which would cause resources to be incorrectly handled by the garbage collector.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResourceOwnership {
+    /// Resource is owned by Agent Control itself (e.g., AC's own fleet-data ConfigMap, instance IDs)
+    AgentControl,
+    /// Resource is owned by a sub-agent (e.g., sub-agent's fleet-data ConfigMap, supervisor-created objects)
+    SubAgent(AgentTypeID),
+}
+
+impl ResourceOwnership {
+    /// Returns the agent type ID if this is a sub-agent-owned resource
+    pub fn agent_type_id(&self) -> Option<&AgentTypeID> {
+        match self {
+            ResourceOwnership::AgentControl => None,
+            ResourceOwnership::SubAgent(agent_type_id) => Some(agent_type_id),
+        }
+    }
+
+    /// Returns true if this resource is owned by Agent Control
+    pub fn is_agent_control(&self) -> bool {
+        matches!(self, ResourceOwnership::AgentControl)
+    }
+
+    /// Returns true if this resource is owned by a sub-agent
+    pub fn is_sub_agent(&self) -> bool {
+        matches!(self, ResourceOwnership::SubAgent(_))
+    }
+}

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -462,7 +462,11 @@ where
                 if let Some(remote_config) = maybe_remote_config {
                     let _ = self
                         .config_repository
-                        .store_remote(&self.identity.id, remote_config)
+                        .store_remote(
+                            &self.identity.id,
+                            Some(self.identity.agent_type_id.clone()),
+                            remote_config,
+                        )
                         .inspect_err(|err| {
                             warn!("Failed to store remote configuration: {err}");
                         });
@@ -1532,7 +1536,7 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &old_remote_config)
+            .store_remote(&TestAgent::id(), None, &old_remote_config)
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1583,7 +1587,7 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &old_remote_config)
+            .store_remote(&TestAgent::id(), None, &old_remote_config)
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1633,7 +1637,7 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &remote_config)
+            .store_remote(&TestAgent::id(), None, &remote_config)
             .unwrap();
 
         let supervisor_builder = expect_supervisor_do_not_build();
@@ -1685,7 +1689,7 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &old_remote_config)
+            .store_remote(&TestAgent::id(), None, &old_remote_config)
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1738,7 +1742,7 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &old_remote_config)
+            .store_remote(&TestAgent::id(), None, &old_remote_config)
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1789,7 +1793,7 @@ deployment:
         };
 
         config_repository
-            .store_remote(&TestAgent::id(), &old_remote_config)
+            .store_remote(&TestAgent::id(), None, &old_remote_config)
             .unwrap();
 
         let supervisor_builder = expect_supervisor_do_not_build();
@@ -1902,7 +1906,7 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &remote_config)
+            .store_remote(&TestAgent::id(), None, &remote_config)
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1935,7 +1939,7 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &remote_config)
+            .store_remote(&TestAgent::id(), None, &remote_config)
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1968,7 +1972,7 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &remote_config)
+            .store_remote(&TestAgent::id(), None, &remote_config)
             .unwrap();
 
         let supervisor_builder = expect_fail_to_build_supervisor();
@@ -2010,7 +2014,7 @@ deployment:
             state,
         };
         config_repository
-            .store_remote(&TestAgent::id(), &input_remote_config)
+            .store_remote(&TestAgent::id(), None, &input_remote_config)
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -24,6 +24,7 @@ use crate::opamp::operations::stop_opamp_client;
 use crate::opamp::remote_config::OpampRemoteConfig;
 use crate::opamp::remote_config::hash::{ConfigState, Hash};
 use crate::opamp::remote_config::report::report_state;
+use crate::resource_ownership::ResourceOwnership;
 use crate::utils::threads::spawn_named_thread;
 use crate::values::config::{Config, RemoteConfig};
 use crate::values::config_repository::ConfigRepository;
@@ -464,7 +465,7 @@ where
                         .config_repository
                         .store_remote(
                             &self.identity.id,
-                            Some(self.identity.agent_type_id.clone()),
+                            ResourceOwnership::SubAgent(self.identity.agent_type_id.clone()),
                             remote_config,
                         )
                         .inspect_err(|err| {
@@ -702,7 +703,11 @@ where
         self.report_state(state.clone(), hash);
         let _ = self
             .config_repository
-            .update_state(&self.identity.id, state)
+            .update_state(
+                &self.identity.id,
+                ResourceOwnership::SubAgent(self.identity.agent_type_id.clone()),
+                state,
+            )
             .inspect_err(|err| {
                 warn!("Could not update the config state: {err}");
             });
@@ -1536,7 +1541,11 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &old_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &old_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1587,7 +1596,11 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &old_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &old_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1637,7 +1650,11 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_supervisor_do_not_build();
@@ -1689,7 +1706,11 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &old_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &old_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1742,7 +1763,11 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &old_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &old_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = MockSupervisorBuilder::new();
@@ -1793,7 +1818,11 @@ deployment:
         };
 
         config_repository
-            .store_remote(&TestAgent::id(), None, &old_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &old_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_supervisor_do_not_build();
@@ -1906,7 +1935,11 @@ deployment:
             state: ConfigState::Applied,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1939,7 +1972,11 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());
@@ -1972,7 +2009,11 @@ deployment:
             state: ConfigState::Applying,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_fail_to_build_supervisor();
@@ -2014,7 +2055,11 @@ deployment:
             state,
         };
         config_repository
-            .store_remote(&TestAgent::id(), None, &input_remote_config)
+            .store_remote(
+                &TestAgent::id(),
+                ResourceOwnership::SubAgent(TestAgent::agent_type_definition().agent_type_id),
+                &input_remote_config,
+            )
             .unwrap();
 
         let supervisor_builder = expect_build_supervisor_with(TestAgent::valid_config_value());

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -124,8 +124,7 @@ impl<C: K8sClient> NotStartedSupervisorK8s<C> {
         // Merge default labels with the ones coming from the config with default labels taking precedence.
         labels.append_extra_labels(&k8s_obj.metadata.labels);
 
-        let annotations =
-            Annotations::new_agent_type_id_annotation(&self.agent_identity.agent_type_id);
+        let annotations = Annotations::new_sub_agent_owned(&self.agent_identity.agent_type_id);
 
         let metadata = ObjectMeta {
             name: Some(k8s_obj.metadata.name.clone()),
@@ -381,7 +380,7 @@ pub mod tests {
 
         let mut labels = Labels::new(&agent_identity.id);
         labels.append_extra_labels(&k8s_object().metadata.labels);
-        let annotations = Annotations::new_agent_type_id_annotation(&agent_identity.agent_type_id);
+        let annotations = Annotations::new_sub_agent_owned(&agent_identity.agent_type_id);
 
         let expected = DynamicObject {
             types: Some(TypeMeta {

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -124,7 +124,8 @@ impl<C: K8sClient> NotStartedSupervisorK8s<C> {
         // Merge default labels with the ones coming from the config with default labels taking precedence.
         labels.append_extra_labels(&k8s_obj.metadata.labels);
 
-        let annotations = Annotations::new_sub_agent_owned(&self.agent_identity.agent_type_id);
+        let annotations =
+            Annotations::new_sub_agent_owned_with_type(&self.agent_identity.agent_type_id);
 
         let metadata = ObjectMeta {
             name: Some(k8s_obj.metadata.name.clone()),
@@ -380,7 +381,7 @@ pub mod tests {
 
         let mut labels = Labels::new(&agent_identity.id);
         labels.append_extra_labels(&k8s_object().metadata.labels);
-        let annotations = Annotations::new_sub_agent_owned(&agent_identity.agent_type_id);
+        let annotations = Annotations::new_sub_agent_owned_with_type(&agent_identity.agent_type_id);
 
         let expected = DynamicObject {
             types: Some(TypeMeta {

--- a/agent-control/src/values.rs
+++ b/agent-control/src/values.rs
@@ -8,9 +8,9 @@ use crate::{
         agent_id::AgentID,
         defaults::{STORE_KEY_LOCAL_DATA_CONFIG, STORE_KEY_OPAMP_DATA_CONFIG},
     },
-    agent_type::agent_type_id::AgentTypeID,
     data_store::DataStore,
     opamp::remote_config::hash::ConfigState,
+    resource_ownership::ResourceOwnership,
     values::{
         config::{Config, RemoteConfig},
         config_repository::{ConfigRepository, ConfigRepositoryError},
@@ -77,7 +77,7 @@ where
     fn store_remote(
         &self,
         agent_id: &AgentID,
-        agent_type_id: Option<AgentTypeID>,
+        ownership: ResourceOwnership,
         remote_config: &RemoteConfig,
     ) -> Result<(), ConfigRepositoryError> {
         debug!(agent_id = agent_id.to_string(), "saving remote config");
@@ -85,7 +85,7 @@ where
         self.opamp_data_store
             .set_remote_data(
                 agent_id,
-                agent_type_id,
+                ownership,
                 STORE_KEY_OPAMP_DATA_CONFIG,
                 remote_config,
             )
@@ -106,6 +106,7 @@ where
     fn update_state(
         &self,
         agent_id: &AgentID,
+        ownership: ResourceOwnership,
         state: ConfigState,
     ) -> Result<(), ConfigRepositoryError> {
         debug!(
@@ -125,7 +126,7 @@ where
                 .opamp_data_store
                 .set_remote_data(
                     agent_id,
-                    None,
+                    ownership,
                     STORE_KEY_OPAMP_DATA_CONFIG,
                     &remote_config.with_state(state),
                 )

--- a/agent-control/src/values.rs
+++ b/agent-control/src/values.rs
@@ -8,6 +8,7 @@ use crate::{
         agent_id::AgentID,
         defaults::{STORE_KEY_LOCAL_DATA_CONFIG, STORE_KEY_OPAMP_DATA_CONFIG},
     },
+    agent_type::agent_type_id::AgentTypeID,
     data_store::DataStore,
     opamp::remote_config::hash::ConfigState,
     values::{
@@ -76,12 +77,18 @@ where
     fn store_remote(
         &self,
         agent_id: &AgentID,
+        agent_type_id: Option<AgentTypeID>,
         remote_config: &RemoteConfig,
     ) -> Result<(), ConfigRepositoryError> {
         debug!(agent_id = agent_id.to_string(), "saving remote config");
 
         self.opamp_data_store
-            .set_remote_data(agent_id, STORE_KEY_OPAMP_DATA_CONFIG, remote_config)
+            .set_remote_data(
+                agent_id,
+                agent_type_id,
+                STORE_KEY_OPAMP_DATA_CONFIG,
+                remote_config,
+            )
             .map_err(|e| ConfigRepositoryError::StoreError(format!("storing remote config: {}", e)))
     }
 
@@ -118,6 +125,7 @@ where
                 .opamp_data_store
                 .set_remote_data(
                     agent_id,
+                    None,
                     STORE_KEY_OPAMP_DATA_CONFIG,
                     &remote_config.with_state(state),
                 )

--- a/agent-control/src/values/config_repository.rs
+++ b/agent-control/src/values/config_repository.rs
@@ -1,4 +1,5 @@
 use crate::agent_control::agent_id::AgentID;
+use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::values::config::{Config, RemoteConfig};
 
 use crate::opamp::remote_config::hash::ConfigState;
@@ -47,6 +48,7 @@ pub trait ConfigRepository: Send + Sync + 'static {
     fn store_remote(
         &self,
         agent_id: &AgentID,
+        agent_type_id: Option<AgentTypeID>,
         remote_config: &RemoteConfig,
     ) -> Result<(), ConfigRepositoryError>;
 
@@ -70,6 +72,7 @@ pub mod tests {
     use std::sync::Mutex;
 
     use crate::agent_control::agent_id::AgentID;
+    use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::opamp::remote_config::hash::ConfigState;
     use crate::values::config::{Config, RemoteConfig};
     use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
@@ -107,6 +110,7 @@ pub mod tests {
         fn store_remote(
             &self,
             agent_id: &AgentID,
+            _agent_type_id: Option<AgentTypeID>,
             remote_config: &RemoteConfig,
         ) -> Result<(), ConfigRepositoryError> {
             self.remote_config.lock().unwrap().insert(
@@ -203,6 +207,7 @@ pub mod tests {
             fn store_remote(
                 &self,
                 agent_id: &AgentID,
+                agent_type_id: Option<AgentTypeID>,
                 remote_config: &RemoteConfig,
             ) -> Result<(), ConfigRepositoryError>;
 

--- a/agent-control/src/values/config_repository.rs
+++ b/agent-control/src/values/config_repository.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_type::agent_type_id::AgentTypeID;
+use crate::resource_ownership::ResourceOwnership;
 use crate::values::config::{Config, RemoteConfig};
 
 use crate::opamp::remote_config::hash::ConfigState;
@@ -48,7 +48,7 @@ pub trait ConfigRepository: Send + Sync + 'static {
     fn store_remote(
         &self,
         agent_id: &AgentID,
-        agent_type_id: Option<AgentTypeID>,
+        ownership: ResourceOwnership,
         remote_config: &RemoteConfig,
     ) -> Result<(), ConfigRepositoryError>;
 
@@ -60,6 +60,7 @@ pub trait ConfigRepository: Send + Sync + 'static {
     fn update_state(
         &self,
         agent_id: &AgentID,
+        ownership: ResourceOwnership,
         state: ConfigState,
     ) -> Result<(), ConfigRepositoryError>;
 
@@ -72,8 +73,8 @@ pub mod tests {
     use std::sync::Mutex;
 
     use crate::agent_control::agent_id::AgentID;
-    use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::opamp::remote_config::hash::ConfigState;
+    use crate::resource_ownership::ResourceOwnership;
     use crate::values::config::{Config, RemoteConfig};
     use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
     use crate::values::yaml_config::YAMLConfig;
@@ -110,7 +111,7 @@ pub mod tests {
         fn store_remote(
             &self,
             agent_id: &AgentID,
-            _agent_type_id: Option<AgentTypeID>,
+            _ownership: ResourceOwnership,
             remote_config: &RemoteConfig,
         ) -> Result<(), ConfigRepositoryError> {
             self.remote_config.lock().unwrap().insert(
@@ -157,6 +158,7 @@ pub mod tests {
         fn update_state(
             &self,
             agent_id: &AgentID,
+            _ownership: ResourceOwnership,
             state: ConfigState,
         ) -> Result<(), ConfigRepositoryError> {
             let updated_remote_config =
@@ -207,7 +209,7 @@ pub mod tests {
             fn store_remote(
                 &self,
                 agent_id: &AgentID,
-                agent_type_id: Option<AgentTypeID>,
+                ownership: ResourceOwnership,
                 remote_config: &RemoteConfig,
             ) -> Result<(), ConfigRepositoryError>;
 
@@ -219,6 +221,7 @@ pub mod tests {
             fn update_state(
                 &self,
                 agent_id: &AgentID,
+                ownership: ResourceOwnership,
                 state: ConfigState,
             ) -> Result<(), ConfigRepositoryError>;
 

--- a/agent-control/tests/k8s/README.md
+++ b/agent-control/tests/k8s/README.md
@@ -3,10 +3,9 @@
 Requirements:
 
 - Docker
-- [Install minikube](https://minikube.sigs.k8s.io/docs/start/) 
+- [Install minikube](https://minikube.sigs.k8s.io/docs/start/)
   No external registry should be configured and docker driver must be used so Tilt uses minikube docker engine
   for image building.
-
 
 On the repo root directory Run:
 
@@ -29,8 +28,8 @@ Notes:
   test module or expose them in the agent-control crate, outside the `test` feature flag).
 - You can run test manually dumping the minikube context to the dev kubecontext:
 
-```bash
-$ KUBECONFIG='./.kubeconfig-dev' minikube update-context
+```sh
+KUBECONFIG='./.kubeconfig-dev' minikube update-context
 ```
 
 ## sync / async integration tests
@@ -39,7 +38,7 @@ Some tests use the `SyncK8sClient` which encapsulates calls to `runtime.block_on
 When this client is used, `#[tokio::test]` cannot be used because `runtime.block_on` would be executing in a tokio
 runtime context, leading to a panic:
 
-```
+```txt
 'Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.'
 ```
 

--- a/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
+++ b/agent-control/tests/k8s/agent_control_cli/dynamic_objects.rs
@@ -153,10 +153,18 @@ fn k8s_cli_install_agent_control_creates_resources() {
     assert_eq!(
         release.metadata.annotations,
         Some(
-            vec![("newrelic.io/agent-type-id", agent_identity.agent_type_id)]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect()
+            [
+                (
+                    "newrelic.io/agent-type-id".to_string(),
+                    agent_identity.agent_type_id.to_string()
+                ),
+                (
+                    "newrelic.io/owned-by".to_string(),
+                    "agent-control".to_string()
+                ),
+            ]
+            .into_iter()
+            .collect()
         )
     );
 }

--- a/agent-control/tests/k8s/client.rs
+++ b/agent-control/tests/k8s/client.rs
@@ -9,7 +9,7 @@ use crate::k8s::tools::test_crd::{
 };
 use assert_matches::assert_matches;
 use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec};
-use k8s_openapi::api::core::v1::{ConfigMap, PodTemplateSpec};
+use k8s_openapi::api::core::v1::{ConfigMap, Container, PodSpec, PodTemplateSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use kube::api::PostParams;
 use kube::core::DynamicObject;
@@ -59,7 +59,14 @@ fn k8s_create_statefulset_retrieve_dynamic_via_reflector_and_trasform_it_back() 
                         labels: Some([("app".to_string(), "test".to_string())].into()),
                         ..Default::default()
                     }),
-                    spec: None,
+                    spec: Some(PodSpec {
+                        containers: vec![Container {
+                            name: "test-container".to_string(),
+                            image: Some("busybox:latest".to_string()),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
                 },
                 ..Default::default()
             }),

--- a/agent-control/tests/k8s/data/k8s_config_map_type_gc_does_not_fail_on_restart/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_config_map_type_gc_does_not_fail_on_restart/local-data-agent-control.template
@@ -1,0 +1,17 @@
+fleet_control:
+  endpoint: <opamp-endpoint>
+  poll_interval: 5s
+  signature_validation:
+    public_key_server_url: <jwks-endpoint>
+k8s:
+  namespace: <ns>
+  namespace_agents: <agents-ns>
+  cluster_name: <cluster-name>
+  auth_secret:
+    secret_name: agent-control-auth
+    secret_key_name: private_key
+  # Add ConfigMap to the list of supported k8s object types
+  cr_type_meta:
+    - apiVersion: v1
+      kind: ConfigMap
+agents: {}

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -260,8 +260,10 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
         removed_agent_id,
         Some(Labels::new(&AgentID::try_from(removed_agent_id.to_string()).unwrap()).get()),
         Some(
-            Annotations::new_sub_agent_owned(&AgentTypeID::try_from("ns/removed:1.0.0").unwrap())
-                .get(),
+            Annotations::new_sub_agent_owned_with_type(
+                &AgentTypeID::try_from("ns/removed:1.0.0").unwrap(),
+            )
+            .get(),
         ),
     ));
 
@@ -353,7 +355,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "not-deleted",
         Some(Labels::new(agent_id).get()),
-        Some(Annotations::new_sub_agent_owned(fqn).get()),
+        Some(Annotations::new_sub_agent_owned_with_type(fqn).get()),
     ));
 
     block_on(create_foo_cr(
@@ -377,7 +379,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "old-fqn",
         Some(Labels::new(agent_id).get()),
-        Some(Annotations::new_sub_agent_owned(fqn_old).get()),
+        Some(Annotations::new_sub_agent_owned_with_type(fqn_old).get()),
     ));
 
     block_on(create_foo_cr(
@@ -385,7 +387,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "id-unknown",
         Some(Labels::new(agent_id_unknonw).get()),
-        Some(Annotations::new_sub_agent_owned(fqn).get()),
+        Some(Annotations::new_sub_agent_owned_with_type(fqn).get()),
     ));
 
     let config = format!(

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -7,14 +7,15 @@ use super::tools::{
     k8s_env::K8sEnv,
     test_crd::{Foo, create_foo_cr, foo_type_meta},
 };
-use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::{api::Api, core::TypeMeta};
 use mockall::mock;
 use newrelic_agent_control::opamp::remote_config::hash::ConfigState;
 use newrelic_agent_control::sub_agent::k8s::supervisor::NotStartedSupervisorK8s;
 use newrelic_agent_control::values::config::RemoteConfig;
 use newrelic_agent_control::{
-    agent_control::config::default_group_version_kinds, agent_type::agent_type_id::AgentTypeID,
+    agent_control::config::{configmap_type_meta, default_group_version_kinds},
+    agent_type::agent_type_id::AgentTypeID,
 };
 use newrelic_agent_control::{
     agent_control::config_repository::repository::AgentControlDynamicConfigRepository,
@@ -85,6 +86,7 @@ fn k8s_garbage_collector_cleans_removed_agent_resources() {
 
     let resource_name = "test-different-from-agent-id";
     let secret_name = "test-secret-name";
+    let configmap_name = "test-configmap-name";
 
     let s = NotStartedSupervisorK8s::new(
         agent_identity.clone(),
@@ -133,6 +135,26 @@ fn k8s_garbage_collector_cleans_removed_agent_resources() {
                     )
                     .unwrap(),
                 ),
+                (
+                    "fooConfigMap".to_string(),
+                    serde_yaml::from_str::<K8sObject>(
+                        format!(
+                            r#"
+    apiVersion: {}
+    kind: {}
+    data:
+      values.yaml: |
+        nameOverride: "override-by-configmap"
+    metadata:
+      namespace: {}
+      name: {}
+            "#,
+                            "v1", "ConfigMap", test_ns, configmap_name,
+                        )
+                        .as_str(),
+                    )
+                    .unwrap(),
+                ),
             ]),
             ..K8s::default()
         },
@@ -173,10 +195,11 @@ agents:
                 api_version: "v1".to_string(),
                 kind: "Secret".to_string(),
             },
+            configmap_type_meta(),
         ],
     };
 
-    // Expects the GC to keep the agent cr and secret from the config, event if looking for multiple kinds or that
+    // Expects the GC to keep the agent cr, secret, and configmap from the config, even if looking for multiple kinds or that
     // are missing in the cluster.
     let first_agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>(config.as_str())
         .unwrap()
@@ -187,13 +210,15 @@ agents:
     block_on(api_foo.get(resource_name)).expect("CR should exist");
     let api_secret: Api<Secret> = Api::namespaced(test.client.clone(), &test_ns);
     block_on(api_secret.get(secret_name)).expect("Secret should exist");
+    let api_configmap: Api<ConfigMap> = Api::namespaced(test.client.clone(), &test_ns);
+    block_on(api_configmap.get(configmap_name)).expect("ConfigMap should exist");
     assert_eq!(
         agent_instance_id,
         instance_id_getter.get(&agent_identity.id).unwrap(),
         "Expects the Instance ID keeps the same since is get from the CM"
     );
 
-    // Expect that the current_agent and secret to be removed on the second call.
+    // Expect that the current_agent, secret, and configmap to be removed on the second call.
     let second_agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>("agents: {}")
         .unwrap()
         .agents;
@@ -203,12 +228,14 @@ agents:
     .unwrap();
     retry(120, Duration::from_secs(1), || {
         if block_on(api_foo.get(resource_name)).is_ok() {
-            return Err("CR should be removed".into());
-        };
-        if block_on(api_secret.get(secret_name)).is_ok() {
-            return Err("Secret should be removed".into());
-        };
-        Ok(())
+            Err("CR should be removed".into())
+        } else if block_on(api_secret.get(secret_name)).is_ok() {
+            Err("Secret should be removed".into())
+        } else if block_on(api_configmap.get(configmap_name)).is_ok() {
+            Err("ConfigMap should be removed".into())
+        } else {
+            Ok(())
+        }
     });
     assert_ne!(
         agent_instance_id,
@@ -271,7 +298,7 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
         test_ns.as_str(),
         ac_id.as_str(),
         Some(Labels::new(ac_id).get()),
-        Some(Annotations::new_agent_control_owned(None).get()),
+        Some(Annotations::new_agent_control_owned().get()),
     ));
 
     let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
@@ -328,7 +355,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "sa-id",
         Some(Labels::new(&AgentID::AgentControl).get()),
-        Some(Annotations::new_agent_control_owned(None).get()),
+        Some(Annotations::new_agent_control_owned().get()),
     ));
 
     block_on(create_foo_cr(

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -230,7 +230,10 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
         test_ns.as_str(),
         removed_agent_id,
         Some(Labels::new(&AgentID::try_from(removed_agent_id.to_string()).unwrap()).get()),
-        None,
+        Some(
+            Annotations::new_sub_agent_owned(&AgentTypeID::try_from("ns/removed:1.0.0").unwrap())
+                .get(),
+        ),
     ));
 
     // This kind is not present in the cluster.
@@ -262,13 +265,13 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
     let mut test = block_on(K8sEnv::new());
     let test_ns = block_on(test.test_namespace());
 
-    let sa_id = &AgentID::AgentControl;
+    let ac_id = &AgentID::AgentControl;
     block_on(create_foo_cr(
         test.client.to_owned(),
         test_ns.as_str(),
-        sa_id.as_str(),
-        Some(Labels::new(sa_id).get()),
-        None,
+        ac_id.as_str(),
+        Some(Labels::new(ac_id).get()),
+        Some(Annotations::new_agent_control_owned(None).get()),
     ));
 
     let k8s_client = Arc::new(SyncK8sClient::try_new(tokio_runtime()).unwrap());
@@ -278,7 +281,7 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
     let instance_id_getter =
         InstanceIDWithIdentifiersGetter::new(instance_id_storer, Identifiers::default());
 
-    let sa_instance_id = instance_id_getter.get(sa_id).unwrap();
+    let ac_instance_id = instance_id_getter.get(ac_id).unwrap();
 
     let gc = K8sGarbageCollector {
         k8s_client,
@@ -296,8 +299,8 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
     let api: Api<Foo> = Api::namespaced(test.client.clone(), &test_ns);
     block_on(api.get(AGENT_CONTROL_ID)).expect("CR should exist");
     assert_eq!(
-        sa_instance_id,
-        instance_id_getter.get(sa_id).unwrap(),
+        ac_instance_id,
+        instance_id_getter.get(ac_id).unwrap(),
         "Expects the Instance ID keeps the same since is get from the CM"
     );
 }
@@ -317,7 +320,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "not-deleted",
         Some(Labels::new(agent_id).get()),
-        Some(Annotations::new_agent_type_id_annotation(fqn).get()),
+        Some(Annotations::new_sub_agent_owned(fqn).get()),
     ));
 
     block_on(create_foo_cr(
@@ -325,7 +328,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "sa-id",
         Some(Labels::new(&AgentID::AgentControl).get()),
-        None,
+        Some(Annotations::new_agent_control_owned(None).get()),
     ));
 
     block_on(create_foo_cr(
@@ -341,7 +344,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "old-fqn",
         Some(Labels::new(agent_id).get()),
-        Some(Annotations::new_agent_type_id_annotation(fqn_old).get()),
+        Some(Annotations::new_sub_agent_owned(fqn_old).get()),
     ));
 
     block_on(create_foo_cr(
@@ -349,7 +352,7 @@ fn k8s_garbage_collector_deletes_only_expected_resources() {
         test_ns.as_str(),
         "id-unknown",
         Some(Labels::new(agent_id_unknonw).get()),
-        Some(Annotations::new_agent_type_id_annotation(fqn).get()),
+        Some(Annotations::new_sub_agent_owned(fqn).get()),
     ));
 
     let config = format!(

--- a/agent-control/tests/k8s/garbage_collector.rs
+++ b/agent-control/tests/k8s/garbage_collector.rs
@@ -204,8 +204,10 @@ agents:
     let first_agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>(config.as_str())
         .unwrap()
         .agents;
-    gc.retain(K8sGarbageCollector::active_config_ids(&first_agents_config))
-        .unwrap();
+    gc.retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
+        &first_agents_config,
+    ))
+    .unwrap();
     let api_foo: Api<Foo> = Api::namespaced(test.client.clone(), &test_ns);
     block_on(api_foo.get(resource_name)).expect("CR should exist");
     let api_secret: Api<Secret> = Api::namespaced(test.client.clone(), &test_ns);
@@ -222,7 +224,7 @@ agents:
     let second_agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>("agents: {}")
         .unwrap()
         .agents;
-    gc.retain(K8sGarbageCollector::active_config_ids(
+    gc.retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
         &second_agents_config,
     ))
     .unwrap();
@@ -280,8 +282,10 @@ fn k8s_garbage_collector_with_missing_and_extra_kinds() {
         .unwrap()
         .agents;
     // Expects the GC to clean the "removed" agent CR.
-    gc.retain(K8sGarbageCollector::active_config_ids(&agents_config))
-        .unwrap();
+    gc.retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
+        &agents_config,
+    ))
+    .unwrap();
     let api: Api<Foo> = Api::namespaced(test.client.clone(), &test_ns);
     block_on(api.get(removed_agent_id)).expect_err("fail garbage collecting removed agent");
 }
@@ -321,8 +325,10 @@ fn k8s_garbage_collector_does_not_remove_agent_control() {
     let agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>("agents: {}")
         .unwrap()
         .agents;
-    gc.retain(K8sGarbageCollector::active_config_ids(&agents_config))
-        .unwrap();
+    gc.retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
+        &agents_config,
+    ))
+    .unwrap();
     let api: Api<Foo> = Api::namespaced(test.client.clone(), &test_ns);
     block_on(api.get(AGENT_CONTROL_ID)).expect("CR should exist");
     assert_eq!(
@@ -401,8 +407,10 @@ agents:
     let agents_config = serde_yaml::from_str::<AgentControlDynamicConfig>(config.as_str())
         .unwrap()
         .agents;
-    gc.retain(K8sGarbageCollector::active_config_ids(&agents_config))
-        .unwrap();
+    gc.retain(K8sGarbageCollector::<SyncK8sClient>::active_config_ids(
+        &agents_config,
+    ))
+    .unwrap();
     let api: Api<Foo> = Api::namespaced(test.client.clone(), &test_ns);
 
     block_on(api.get("not-deleted")).expect("CR should exist");

--- a/agent-control/tests/k8s/scenarios/garbage_collector.rs
+++ b/agent-control/tests/k8s/scenarios/garbage_collector.rs
@@ -40,7 +40,7 @@ fn k8s_garbage_collector_triggers_on_ac_startup() {
         removed_agent_id,
         Some(Labels::new(&AgentID::try_from(removed_agent_id.to_string()).unwrap()).get()),
         Some(
-            Annotations::new_sub_agent_owned(
+            Annotations::new_sub_agent_owned_with_type(
                 &AgentTypeID::try_from("newrelic/com.newrelic.removed:0.0.1").unwrap(),
             )
             .get(),

--- a/agent-control/tests/k8s/scenarios/garbage_collector.rs
+++ b/agent-control/tests/k8s/scenarios/garbage_collector.rs
@@ -1,7 +1,11 @@
 use std::time::Duration;
 
 use kube::Api;
-use newrelic_agent_control::{agent_control::agent_id::AgentID, k8s::labels::Labels};
+use newrelic_agent_control::{
+    agent_control::agent_id::AgentID,
+    agent_type::agent_type_id::AgentTypeID,
+    k8s::{annotations::Annotations, labels::Labels},
+};
 use tempfile::tempdir;
 
 use crate::{
@@ -35,7 +39,12 @@ fn k8s_garbage_collector_triggers_on_ac_startup() {
         &test_ns,
         removed_agent_id,
         Some(Labels::new(&AgentID::try_from(removed_agent_id.to_string()).unwrap()).get()),
-        None,
+        Some(
+            Annotations::new_sub_agent_owned(
+                &AgentTypeID::try_from("newrelic/com.newrelic.removed:0.0.1").unwrap(),
+            )
+            .get(),
+        ),
     ));
 
     // start Agent Control, so the objects above should be removed by the GC.

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -4,7 +4,7 @@
 use crate::common::retry::retry;
 use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::start_agent_control_with_testdata_config;
-use crate::k8s::tools::k8s_api::check_config_map_exist;
+use crate::k8s::tools::k8s_api::{check_config_map_exist, check_config_map_has_annotation};
 use crate::k8s::tools::k8s_env::K8sEnv;
 use crate::k8s::tools::{agent_control, instance_id};
 use fake_opamp_server::FakeServer;
@@ -129,21 +129,21 @@ agents: {}
     });
 }
 
-/// This test exposes a GC labelling bug: when ConfigMap is included in `cr_type_meta`,
-/// the `retain` function at AC startup fails because fleet-data ConfigMaps (created by
-/// the ConfigMapStore with managed-by + agent-id labels but no agent-type-id annotation)
-/// are listed by `garbage_collection_dynamic_object`. When the agent is still active,
-/// `should_delete_agent_id` tries to read the missing annotation and returns a
-/// MissingAnnotations error, crashing AC on startup.
+/// This test verifies that GC handles the fleet-data ConfigMap correctly on AC restart.
+///
+/// When ConfigMap is included in `cr_type_meta`, the `retain` function at AC startup
+/// lists fleet-data ConfigMaps via `garbage_collection_dynamic_object`. Each fleet-data
+/// ConfigMap must carry the `newrelic.io/agent-type-id` annotation so that GC can decide
+/// whether to retain or delete it.
 ///
 /// The test:
-/// 1. Starts AC and deploys the config-map-type agent via remote config, which causes AC
-///    to create a fleet-data ConfigMap for that agent.
-/// 2. Stops and restarts AC while the agent is still active.
-/// 3. On restart, `retain` is called with the active agent in the config. The fleet-data
-///    ConfigMap (which has no agent-type-id annotation) triggers the bug.
-/// 4. The test passes only if AC starts successfully, meaning GC handled the fleet-data
-///    ConfigMap correctly without erroring on the missing annotation.
+/// 1. Starts AC and deploys the config-map-type agent via OpAMP remote config.
+/// 2. Sends a remote config to the sub-agent, which causes AC to store the remote config
+///    and write the agent-type-id annotation onto the fleet-data ConfigMap.
+/// 3. Waits for the annotation to be present, then stops and restarts AC.
+/// 4. On restart, `retain` finds the annotated fleet-data ConfigMap, reads the annotation,
+///    verifies the type matches the active agent, and correctly retains it.
+/// 5. The test passes only if AC starts successfully.
 #[test]
 #[ignore = "needs k8s cluster"]
 fn k8s_config_map_type_gc_does_not_fail_on_restart() {
@@ -175,8 +175,7 @@ fn k8s_config_map_type_gc_does_not_fail_on_restart() {
     let instance_id =
         instance_id::get_instance_id(k8s.client.clone(), &namespace, &AgentID::AgentControl);
 
-    // Deploy the config-map-type agent. This causes AC to create a fleet-data ConfigMap
-    // for the agent (with managed-by + agent-id labels but no agent-type-id annotation).
+    // Deploy the config-map-type agent via the fleet-level config.
     server.set_config_response(
         instance_id.clone(),
         r#"
@@ -186,8 +185,7 @@ agents:
     "#,
     );
 
-    // Wait for the fleet-data ConfigMap to be created, confirming the agent is running
-    // and the fleet-data ConfigMap (without agent-type-id annotation) now exists.
+    // Wait for the fleet-data ConfigMap to be created (instance-ID written by the storer).
     let fleet_data_cm_name = "fleet-data-test-config-map";
     println!("Waiting for fleet-data ConfigMap to be created...");
     retry(120, Duration::from_secs(1), || {
@@ -197,15 +195,41 @@ agents:
             &namespace,
         ))
     });
-    println!("fleet-data ConfigMap exists — stopping AC to simulate a restart.");
 
-    // Stop AC while the agent is still active. The fleet-data ConfigMap persists.
+    // Send a remote config to the sub-agent. This causes AC to call `store_remote` for the
+    // sub-agent, which writes the agent-type-id annotation onto the fleet-data ConfigMap.
+    let subagent_instance_id = instance_id::get_instance_id(
+        k8s.client.clone(),
+        &namespace,
+        &AgentID::try_from("test-config-map").unwrap(),
+    );
+    server.set_config_response(
+        subagent_instance_id,
+        r#"
+chart_values:
+  cm_content: {}
+    "#,
+    );
+
+    // Wait for the annotation to be written
+    println!("Waiting for agent-type-id annotation on fleet-data ConfigMap...");
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_has_annotation(
+            k8s.client.clone(),
+            fleet_data_cm_name,
+            &namespace,
+            "newrelic.io/agent-type-id",
+        ))
+    });
+    println!("Annotation present — stopping AC to simulate a restart.");
+
+    // Stop AC while the agent is still active. The annotated fleet-data ConfigMap persists.
     drop(_ac);
 
     // Restart AC with the same configuration. On startup, `retain` is called with the
-    // active agent ({test-config-map: ...}) and cr_type_meta includes ConfigMap.
-    // Without the fix, `garbage_collection_dynamic_object` finds the fleet-data ConfigMap,
-    // tries to read its missing agent-type-id annotation, and crashes with MissingAnnotations.
+    // active agent ({test-config-map: newrelic/com.newrelic.test_config_map:0.1.0}) and
+    // cr_type_meta includes ConfigMap. GC finds the fleet-data ConfigMap, reads the
+    // agent-type-id annotation, and correctly retains it.
     let _ac = start_agent_control_with_testdata_config(
         test_name,
         CONFIG_AGENT_TYPE_PATH,
@@ -218,8 +242,9 @@ agents:
         tmp_dir.path(),
     );
 
-    // If GC correctly handles fleet-data ConfigMaps on restart, AC starts successfully.
-    // If not, this will time out because AC crashes before creating fleet-data-agent-control.
+    // If GC correctly handles the annotated fleet-data ConfigMap on restart, AC starts
+    // successfully. If not, this will time out because AC crashes before creating
+    // fleet-data-agent-control.
     agent_control::wait_until_agent_control_with_opamp_is_started(
         k8s.client.clone(),
         namespace.as_str(),

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -166,7 +166,7 @@ agents: {}
 fn k8s_config_map_type_gc_does_not_fail_on_restart() {
     let test_name = "k8s_config_map_type_gc_does_not_fail_on_restart";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -128,3 +128,100 @@ agents: {}
         Ok(())
     });
 }
+
+/// This test exposes a GC labelling bug: when ConfigMap is included in `cr_type_meta`,
+/// the `retain` function at AC startup fails because fleet-data ConfigMaps (created by
+/// the ConfigMapStore with managed-by + agent-id labels but no agent-type-id annotation)
+/// are listed by `garbage_collection_dynamic_object`. When the agent is still active,
+/// `should_delete_agent_id` tries to read the missing annotation and returns a
+/// MissingAnnotations error, crashing AC on startup.
+///
+/// The test:
+/// 1. Starts AC and deploys the config-map-type agent via remote config, which causes AC
+///    to create a fleet-data ConfigMap for that agent.
+/// 2. Stops and restarts AC while the agent is still active.
+/// 3. On restart, `retain` is called with the active agent in the config. The fleet-data
+///    ConfigMap (which has no agent-type-id annotation) triggers the bug.
+/// 4. The test passes only if AC starts successfully, meaning GC handled the fleet-data
+///    ConfigMap correctly without erroring on the missing annotation.
+#[test]
+#[ignore = "needs k8s cluster"]
+fn k8s_config_map_type_gc_does_not_fail_on_restart() {
+    let test_name = "k8s_config_map_type_gc_does_not_fail_on_restart";
+
+    let mut server = FakeServer::start_new();
+
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    let _ac = start_agent_control_with_testdata_config(
+        test_name,
+        CONFIG_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        &namespace,
+        Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+
+    agent_control::wait_until_agent_control_with_opamp_is_started(
+        k8s.client.clone(),
+        namespace.as_str(),
+    );
+
+    let instance_id =
+        instance_id::get_instance_id(k8s.client.clone(), &namespace, &AgentID::AgentControl);
+
+    // Deploy the config-map-type agent. This causes AC to create a fleet-data ConfigMap
+    // for the agent (with managed-by + agent-id labels but no agent-type-id annotation).
+    server.set_config_response(
+        instance_id.clone(),
+        r#"
+agents:
+  test-config-map:
+    agent_type: "newrelic/com.newrelic.test_config_map:0.1.0"
+    "#,
+    );
+
+    // Wait for the fleet-data ConfigMap to be created, confirming the agent is running
+    // and the fleet-data ConfigMap (without agent-type-id annotation) now exists.
+    let fleet_data_cm_name = "fleet-data-test-config-map";
+    println!("Waiting for fleet-data ConfigMap to be created...");
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_exist(
+            k8s.client.clone(),
+            fleet_data_cm_name,
+            &namespace,
+        ))
+    });
+    println!("fleet-data ConfigMap exists — stopping AC to simulate a restart.");
+
+    // Stop AC while the agent is still active. The fleet-data ConfigMap persists.
+    drop(_ac);
+
+    // Restart AC with the same configuration. On startup, `retain` is called with the
+    // active agent ({test-config-map: ...}) and cr_type_meta includes ConfigMap.
+    // Without the fix, `garbage_collection_dynamic_object` finds the fleet-data ConfigMap,
+    // tries to read its missing agent-type-id annotation, and crashes with MissingAnnotations.
+    let _ac = start_agent_control_with_testdata_config(
+        test_name,
+        CONFIG_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        &namespace,
+        Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+
+    // If GC correctly handles fleet-data ConfigMaps on restart, AC starts successfully.
+    // If not, this will time out because AC crashes before creating fleet-data-agent-control.
+    agent_control::wait_until_agent_control_with_opamp_is_started(
+        k8s.client.clone(),
+        namespace.as_str(),
+    );
+}

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -112,6 +112,18 @@ chart_values:
         "deployment-config.yaml should contain the configured values"
     );
 
+    // Wait for the annotation to be written
+    println!("Waiting for agent-type-id annotation on fleet-data ConfigMap...");
+    retry(120, Duration::from_secs(1), || {
+        block_on(check_config_map_has_annotation(
+            k8s.client.clone(),
+            expected_configmap_name,
+            &namespace,
+            "newrelic.io/agent-type-id",
+        ))
+    });
+    println!("Annotation present.");
+
     // Test removal: remove the agent and verify the ConfigMap is deleted
     server.set_config_response(
         instance_id.clone(),

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -143,18 +143,23 @@ agents: {}
 
 /// This test verifies that GC handles the fleet-data ConfigMap correctly on AC restart.
 ///
-/// When ConfigMap is included in `cr_type_meta`, the `retain` function at AC startup
-/// lists fleet-data ConfigMaps via `garbage_collection_dynamic_object`. Each fleet-data
-/// ConfigMap must carry the `newrelic.io/agent-type-id` annotation so that GC can decide
-/// whether to retain or delete it.
+/// Fleet-data ConfigMaps are Agent Control internal resources and carry the
+/// `newrelic.io/owned-by: agent-control` annotation. They are handled by
+/// `garbage_collect_agent_control_resources`, which lists ConfigMaps by label and
+/// deletes only those with the `owned-by: agent-control` annotation.
+///
+/// Sub-agent dynamic objects (e.g. supervisor-created resources) carry the
+/// `newrelic.io/owned-by: sub-agent` annotation and are handled by
+/// `garbage_collect_sub_agent_resources`.
 ///
 /// The test:
 /// 1. Starts AC and deploys the config-map-type agent via OpAMP remote config.
 /// 2. Sends a remote config to the sub-agent, which causes AC to store the remote config
-///    and write the agent-type-id annotation onto the fleet-data ConfigMap.
+///    and write the `owned-by: agent-control` and `agent-type-id` annotations onto the
+///    fleet-data ConfigMap.
 /// 3. Waits for the annotation to be present, then stops and restarts AC.
-/// 4. On restart, `retain` finds the annotated fleet-data ConfigMap, reads the annotation,
-///    verifies the type matches the active agent, and correctly retains it.
+/// 4. On restart, `retain` finds the annotated fleet-data ConfigMap, recognises it as an
+///    Agent Control internal resource, and correctly retains it.
 /// 5. The test passes only if AC starts successfully.
 #[test]
 #[ignore = "needs k8s cluster"]

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -101,7 +101,7 @@ fn k8s_hash_in_config_map() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id_1, &remote_config_1)
+        .store_remote(&agent_id_1, None, &remote_config_1)
         .unwrap();
     let loaded_hash_1 = config_repository
         .get_remote_config(&agent_id_1)
@@ -117,7 +117,7 @@ fn k8s_hash_in_config_map() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id_2, &remote_config_2)
+        .store_remote(&agent_id_2, None, &remote_config_2)
         .unwrap();
     let loaded_hash_2 = config_repository
         .get_remote_config(&agent_id_2)
@@ -173,7 +173,7 @@ fn k8s_value_repository_config_map() {
         state: ConfigState::Applied,
     };
     value_repository
-        .store_remote(&agent_id_1, &remote_values)
+        .store_remote(&agent_id_1, None, &remote_values)
         .unwrap();
     let res = value_repository.load_remote_fallback_local(&agent_id_1, &capabilities);
     assert_eq!(
@@ -207,7 +207,7 @@ fn k8s_value_repository_config_map() {
     };
 
     value_repository
-        .store_remote(&agent_id_2, &remote_values_agent_2)
+        .store_remote(&agent_id_2, None, &remote_values_agent_2)
         .unwrap();
     let res = value_repository
         .load_remote_fallback_local(&agent_id_1, &capabilities)
@@ -314,7 +314,7 @@ fn k8s_multiple_store_entries() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id, &remote_config)
+        .store_remote(&agent_id, None, &remote_config)
         .unwrap();
     let instance_id_created = instance_id_getter.get(&agent_id).unwrap();
 

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -12,6 +12,7 @@ use newrelic_agent_control::agent_control::defaults::{
 use newrelic_agent_control::agent_control::defaults::{
     FOLDER_NAME_LOCAL_DATA, default_capabilities,
 };
+use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
 use newrelic_agent_control::data_store::StoreKey;
 use newrelic_agent_control::k8s::client::SyncK8sClient;
 use newrelic_agent_control::k8s::configmap_store::ConfigMapStore;
@@ -22,6 +23,7 @@ use newrelic_agent_control::opamp::instance_id::getter::{
 use newrelic_agent_control::opamp::instance_id::k8s::identifiers::Identifiers;
 use newrelic_agent_control::opamp::instance_id::storer::Storer;
 use newrelic_agent_control::opamp::remote_config::hash::{ConfigState, Hash};
+use newrelic_agent_control::resource_ownership::ResourceOwnership;
 use newrelic_agent_control::values::ConfigRepo;
 use newrelic_agent_control::values::config::RemoteConfig;
 use newrelic_agent_control::values::config_repository::ConfigRepository;
@@ -101,7 +103,13 @@ fn k8s_hash_in_config_map() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id_1, None, &remote_config_1)
+        .store_remote(
+            &agent_id_1,
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+            ),
+            &remote_config_1,
+        )
         .unwrap();
     let loaded_hash_1 = config_repository
         .get_remote_config(&agent_id_1)
@@ -117,7 +125,13 @@ fn k8s_hash_in_config_map() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id_2, None, &remote_config_2)
+        .store_remote(
+            &agent_id_2,
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.2").unwrap(),
+            ),
+            &remote_config_2,
+        )
         .unwrap();
     let loaded_hash_2 = config_repository
         .get_remote_config(&agent_id_2)
@@ -173,7 +187,13 @@ fn k8s_value_repository_config_map() {
         state: ConfigState::Applied,
     };
     value_repository
-        .store_remote(&agent_id_1, None, &remote_values)
+        .store_remote(
+            &agent_id_1,
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+            ),
+            &remote_values,
+        )
         .unwrap();
     let res = value_repository.load_remote_fallback_local(&agent_id_1, &capabilities);
     assert_eq!(
@@ -207,7 +227,13 @@ fn k8s_value_repository_config_map() {
     };
 
     value_repository
-        .store_remote(&agent_id_2, None, &remote_values_agent_2)
+        .store_remote(
+            &agent_id_2,
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+            ),
+            &remote_values_agent_2,
+        )
         .unwrap();
     let res = value_repository
         .load_remote_fallback_local(&agent_id_1, &capabilities)
@@ -314,7 +340,13 @@ fn k8s_multiple_store_entries() {
         state: ConfigState::Applying,
     };
     config_repository
-        .store_remote(&agent_id, None, &remote_config)
+        .store_remote(
+            &agent_id,
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+            ),
+            &remote_config,
+        )
         .unwrap();
     let instance_id_created = instance_id_getter.get(&agent_id).unwrap();
 

--- a/agent-control/tests/k8s/tools/k8s_api.rs
+++ b/agent-control/tests/k8s/tools/k8s_api.rs
@@ -38,6 +38,29 @@ pub async fn check_config_map_exist(
     Ok(())
 }
 
+pub async fn check_config_map_has_annotation(
+    k8s_client: Client,
+    name: &str,
+    namespace: &str,
+    annotation_key: &str,
+) -> Result<(), Box<dyn Error>> {
+    let api: Api<ConfigMap> = Api::namespaced(k8s_client.clone(), namespace);
+    let cm = api
+        .get(name)
+        .await
+        .map_err(|err| format!("ConfigMap {name} not found: {err}"))?;
+    let has_annotation = cm
+        .metadata
+        .annotations
+        .as_ref()
+        .is_some_and(|a| a.contains_key(annotation_key));
+    if has_annotation {
+        Ok(())
+    } else {
+        Err(format!("ConfigMap {name} does not have annotation {annotation_key}").into())
+    }
+}
+
 /// Check if the `HelmRelease` with the provided name has the the expected value in the `spec.values` field.
 pub async fn check_helmrelease_spec_values(
     k8s_client: Client,

--- a/agent-control/tests/k8s/tools/k8s_api.rs
+++ b/agent-control/tests/k8s/tools/k8s_api.rs
@@ -33,7 +33,7 @@ pub async fn check_config_map_exist(
 
     api.get(name)
         .await
-        .map_err(|err| format!("ConfigMap {name} not found: {err}"))?;
+        .map_err(|err| format!("resource ConfigMap {name} not found: {err}"))?;
 
     Ok(())
 }
@@ -48,7 +48,7 @@ pub async fn check_config_map_has_annotation(
     let cm = api
         .get(name)
         .await
-        .map_err(|err| format!("ConfigMap {name} not found: {err}"))?;
+        .map_err(|err| format!("resource ConfigMap {name} not found: {err}"))?;
     let has_annotation = cm
         .metadata
         .annotations
@@ -57,7 +57,7 @@ pub async fn check_config_map_has_annotation(
     if has_annotation {
         Ok(())
     } else {
-        Err(format!("ConfigMap {name} does not have annotation {annotation_key}").into())
+        Err(format!("resource ConfigMap {name} does not have annotation {annotation_key}").into())
     }
 }
 

--- a/agent-control/tests/on_host/config_repository.rs
+++ b/agent-control/tests/on_host/config_repository.rs
@@ -47,7 +47,7 @@ fn test_store_remote_no_mocks() {
     };
 
     values_repo
-        .store_remote(&agent_id.clone(), &agent_values)
+        .store_remote(&agent_id.clone(), None, &agent_values)
         .unwrap();
 
     assert_eq!(

--- a/agent-control/tests/on_host/config_repository.rs
+++ b/agent-control/tests/on_host/config_repository.rs
@@ -4,8 +4,10 @@ use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
     FOLDER_NAME_FLEET_DATA, STORE_KEY_OPAMP_DATA_CONFIG,
 };
+use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
 use newrelic_agent_control::on_host::file_store::{FileStore, build_config_name};
 use newrelic_agent_control::opamp::remote_config::hash::{ConfigState, Hash};
+use newrelic_agent_control::resource_ownership::ResourceOwnership;
 use newrelic_agent_control::values::ConfigRepo;
 use newrelic_agent_control::values::config::RemoteConfig;
 use newrelic_agent_control::values::config_repository::ConfigRepository;
@@ -47,7 +49,13 @@ fn test_store_remote_no_mocks() {
     };
 
     values_repo
-        .store_remote(&agent_id.clone(), None, &agent_values)
+        .store_remote(
+            &agent_id.clone(),
+            ResourceOwnership::SubAgent(
+                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+            ),
+            &agent_values,
+        )
         .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
  On Agent Control restart, the Kubernetes garbage collector (`retain`) listed all dynamic objects
including fleet-data ConfigMaps. These ConfigMaps share the same agent-ID label as
supervisor-created resources, so they were included in the GC pass — but they lack the
`newrelic.io/agent-type-id` annotation that GC uses to decide whether to retain or delete.

This caused two problems:
1. **Missing annotation → wrong deletion decision**: In `RetainConfig` mode, if an active
   agent's fleet-data ConfigMap had no annotation, the GC would error out.
2. **No annotation was ever written**: `store_remote` / `set_remote_data` never wrote the
   `agent-type-id` annotation onto fleet-data ConfigMaps in the first place.

### Solution

**Write the annotation at creation time**: `ConfigMapStore::set_remote_data` now accepts an
optional `AgentTypeID`. When a sub-agent stores its remote config, the annotation
`newrelic.io/agent-type-id` is written onto the fleet-data ConfigMap. The K8s client's
`set_configmap_key` is extended to accept and merge an annotations map.

**Make GC conservative on missing annotations**: In both `RetainConfig` and `Collect` modes,
if `retrieve_annotated_agent_type_id` returns `MissingAnnotations`, GC now logs a warning and
returns `Ok(false)` (skip) instead of propagating an error. Objects without the annotation are
never accidentally deleted.

**Simplify annotation comparison**: `retrieve_annotated_agent_type_id` returns a raw `String`
instead of a parsed `AgentTypeID`, and comparisons use `.to_string()`. This removes
`AgentTypeIDError` and `AgentIDError` as error variants from `K8sGarbageCollectorError` —
invalid agent IDs in labels are now also logged and skipped rather than surfaced as errors.

### Changes

- `k8s_garbage_collector.rs` — conservative GC logic for missing annotations and invalid agent
  IDs; string-based type comparison; 6 new unit tests covering all retain/collect ×
  annotation-present/absent/mismatch combinations
- `configmap_store.rs` — `set_remote_data` accepts `Option<AgentTypeID>` and forwards the
  annotation to the K8s client
- `client.rs` — `set_configmap_key` (sync + async) accepts an annotations map and merges it
  into the ConfigMap metadata
- `sub_agent.rs` — passes `agent_type_id` from identity when calling `store_remote`
- `config_repository.rs` / `store.rs` — `store_remote` trait and implementations updated to
  thread through `Option<AgentTypeID>`
- `without_flux.rs` — new integration test `k8s_config_map_type_gc_does_not_fail_on_restart`
  that validates the full restart scenario; existing test extended to assert the annotation
  is written