### PR TITLE
Revert "feat: support oci auth in agent types (#2414)"

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -45,24 +45,6 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -115,24 +97,6 @@ variables:
         variants:
           ac_config_field: "oci_repository_urls"
           values: [ "newrelic/infrastructure-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -222,12 +186,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
       args:
@@ -298,12 +256,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
       args:

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -49,24 +49,6 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -113,24 +95,6 @@ variables:
         variants:
           ac_config_field: "oci_nrdot_registry_repositories"
           values: [ "newrelic/nrdot-agent-artifacts" ]
-      auth:
-        basic:
-          username:
-            description: "Username for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-          password:
-            description: "Password for HTTP Basic authentication"
-            type: string
-            required: false
-            default: ""
-        bearer:
-          token:
-            description: "Bearer token for authentication"
-            type: string
-            required: false
-            default: ""
     version:
       description: "Agent version"
       type: string
@@ -193,12 +157,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     version:
       path: ${nr-sub:packages.nrdot.dir}\\nrdot-collector.exe
       args:
@@ -232,12 +190,6 @@ deployment:
             repository: ${nr-var:oci.repository}
             version: ${nr-var:version}
             public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrdot/jwks.json
-            auth:
-              basic:
-                username: ${nr-var:oci.auth.basic.username}
-                password: ${nr-var:oci.auth.basic.password}
-              bearer:
-                token: ${nr-var:oci.auth.bearer.token}
     health:
       interval: 30s
       initial_delay: 90s

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -27,6 +27,4 @@ pub enum AgentTypeError {
     ConflictingVariableDefinition(String),
     #[error("error parsing oci reference: {0}")]
     OCIReferenceParsingError(String),
-    #[error("error with OCI auth configuration: {0}")]
-    OCIAuthError(String),
 }

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -106,8 +106,6 @@ mod tests {
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
     use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
-    use oci_client::secrets::RegistryAuth;
-    use rstest::rstest;
     use serde_yaml::Number;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -170,7 +168,6 @@ mod tests {
                     public_key_url: Some(TemplateableValue::from_template(
                         "${nr-var:public-key-url}".to_string(),
                     )),
-                    auth: package::Auth::default(),
                 },
             },
         };
@@ -179,7 +176,7 @@ mod tests {
             ("otel-first".to_string(), pkg.clone()),
             ("otel-second".to_string(), pkg),
         ]);
-        assert_eq!(on_host.packages, expected_packages);
+        assert_eq!(on_host.packages, expected_packages)
     }
 
     #[test]
@@ -719,75 +716,6 @@ executables:
         );
     }
 
-    struct AuthCredentials {
-        username: &'static str,
-        password: &'static str,
-        bearer: &'static str,
-    }
-
-    impl AuthCredentials {
-        const NONE: Self = Self {
-            username: "",
-            password: "",
-            bearer: "",
-        };
-        const BASIC: Self = Self {
-            username: "user",
-            password: "pass",
-            bearer: "",
-        };
-        const BEARER: Self = Self {
-            username: "",
-            password: "",
-            bearer: "token",
-        };
-    }
-
-    #[rstest]
-    // This case checks backwards compatibility with old agent types not defining auth.
-    #[case::no_auth(PACKAGES_NO_AUTH, AuthCredentials::NONE, RegistryAuth::Anonymous)]
-    #[case::no_credentials(PACKAGES, AuthCredentials::NONE, RegistryAuth::Anonymous)]
-    #[case::basic_credentials(PACKAGES, AuthCredentials::BASIC, RegistryAuth::Basic("user".to_string(), "pass".to_string()))]
-    #[case::bearer_credentials(PACKAGES, AuthCredentials::BEARER, RegistryAuth::Bearer("token".to_string()))]
-    fn test_auth_parsing(
-        #[case] yaml: &str,
-        #[case] creds: AuthCredentials,
-        #[case] expected_auth: RegistryAuth,
-    ) {
-        let on_host: OnHost = serde_yaml::from_str(yaml).unwrap();
-
-        let mut vars = Variables::new();
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable("/filesystem".to_string()),
-        );
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
-            Variable::new_final_string_variable("remote".to_string()),
-        );
-        vars.insert(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_SUB_AGENT_ID),
-            Variable::new_final_string_variable("agent-id".to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.basic.username".to_string(),
-            Variable::new_final_string_variable(creds.username.to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.basic.password".to_string(),
-            Variable::new_final_string_variable(creds.password.to_string()),
-        );
-        vars.insert(
-            "nr-var:oci.auth.bearer.token".to_string(),
-            Variable::new_final_string_variable(creds.bearer.to_string()),
-        );
-
-        let rendered = on_host.template_with(&vars).unwrap();
-        let pkg = rendered.packages.get("infra-agent").unwrap();
-
-        assert_eq!(pkg.download.oci.auth, expected_auth);
-    }
-
     pub const AGENT_GIVEN_YAML: &str = r#"
 health:
   interval: 3s
@@ -834,31 +762,5 @@ packages:
         repository: ${nr-var:repository}
         version: ${nr-var:version}
         public_key_url: ${nr-var:public-key-url}
-"#;
-
-    const PACKAGES_NO_AUTH: &str = r#"
-packages:
-  infra-agent:
-    download:
-      oci:
-        registry: docker.io
-        repository: repo/image
-        version: 0.0.1
-"#;
-
-    const PACKAGES: &str = r#"
-packages:
-  infra-agent:
-    download:
-      oci:
-        registry: docker.io
-        repository: repo/image
-        version: 0.0.1
-        auth:
-          basic:
-            username: ${nr-var:oci.auth.basic.username}
-            password: ${nr-var:oci.auth.basic.password}
-          bearer:
-            token: ${nr-var:oci.auth.bearer.token}
 "#;
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -3,10 +3,9 @@ use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
 use crate::agent_type::templates::Templateable;
 use crate::oci::reference_parser::ReferenceParser;
-use oci_client::{Reference, secrets::RegistryAuth};
+use oci_client::Reference;
 use serde::Deserialize;
 use std::str::FromStr;
-use tracing::debug;
 use url::Url;
 
 pub mod rendered;
@@ -36,26 +35,6 @@ pub struct Oci {
     pub version: TemplateableValue<String>,
     /// Public key url is expected to be a jwks.
     pub public_key_url: Option<TemplateableValue<String>>,
-    /// Authentication method for the OCI registry.
-    #[serde(default)]
-    pub auth: Auth,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct Auth {
-    pub basic: BasicAuth,
-    pub bearer: BearerAuth,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct BasicAuth {
-    pub username: TemplateableValue<String>,
-    pub password: TemplateableValue<String>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-pub struct BearerAuth {
-    pub token: TemplateableValue<String>,
 }
 
 impl Templateable for Package {
@@ -108,58 +87,10 @@ impl Templateable for Oci {
             })?,
         );
 
-        let auth = self.auth.template_with(variables)?;
-
         Ok(Self::Output {
             reference,
             public_key_url,
-            auth,
         })
-    }
-}
-
-impl Templateable for Auth {
-    type Output = RegistryAuth;
-    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        let username = self
-            .basic
-            .username
-            .template_with(variables)
-            .map_err(|err| {
-                AgentTypeError::OCIAuthError(format!("error templating username: {err}"))
-            })?;
-        let password =
-            self.basic.password.template_with(variables).map_err(|_| {
-                AgentTypeError::OCIAuthError("error templating password".to_string())
-            })?;
-        let token = self
-            .bearer
-            .token
-            .template_with(variables)
-            .map_err(|_| AgentTypeError::OCIAuthError("error templating token".to_string()))?;
-
-        match (
-            &username.is_empty(),
-            &password.is_empty(),
-            &token.is_empty(),
-        ) {
-            (true, true, true) => Ok(RegistryAuth::Anonymous),
-            (false, false, true) => {
-                debug!("Basic auth credentials provided, using basic auth");
-                Ok(RegistryAuth::Basic(username, password))
-            }
-            (true, true, false) => {
-                debug!("Bearer token provided, using bearer auth");
-                Ok(RegistryAuth::Bearer(token))
-            }
-            (false, false, false) => Err(AgentTypeError::OCIAuthError(
-                "multiple authentication methods provided, only one should be used".to_string(),
-            )),
-            (true, false, _) | (false, true, _) => Err(AgentTypeError::OCIAuthError(
-                "incomplete basic auth credentials provided, username or password is empty"
-                    .to_string(),
-            )),
-        }
     }
 }
 
@@ -227,7 +158,6 @@ mod tests {
             public_key_url: public_key_url
                 .clone()
                 .map(|_| TemplateableValue::from_template("${nr-var:public-key}".to_string())),
-            auth: Auth::default(),
         };
 
         let rendered_oci = oci.template_with(&variables);
@@ -238,110 +168,5 @@ mod tests {
         assert_eq!(rendered_oci.reference.tag(), expected_tag);
         assert_eq!(rendered_oci.reference.digest(), expected_digest);
         assert_eq!(rendered_oci.public_key_url, public_key_url);
-        assert_eq!(rendered_oci.auth, RegistryAuth::Anonymous);
-    }
-
-    #[test]
-    fn test_auth_basic_with_templated_values() {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:username".to_string(),
-            Variable::new_final_string_variable("myuser".to_string()),
-        );
-        variables.insert(
-            "nr-var:password".to_string(),
-            Variable::new_final_string_variable("mypass".to_string()),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("docker.io".to_string()),
-            repository: TemplateableValue::from_template("myrepo/myimage".to_string()),
-            version: TemplateableValue::from_template("1.0.0".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth {
-                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
-                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
-                },
-                bearer: BearerAuth::default(),
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables).unwrap();
-        assert_eq!(
-            rendered_oci.auth,
-            RegistryAuth::Basic("myuser".to_string(), "mypass".to_string())
-        );
-    }
-
-    #[test]
-    fn test_auth_bearer_with_templated_value() {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:token".to_string(),
-            Variable::new_final_string_variable("bearer-token".to_string()),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("gcr.io".to_string()),
-            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
-            version: TemplateableValue::from_template("latest".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth::default(),
-                bearer: BearerAuth {
-                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
-                },
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables).unwrap();
-        assert_eq!(
-            rendered_oci.auth,
-            RegistryAuth::Bearer("bearer-token".to_string())
-        );
-    }
-
-    #[rstest]
-    #[case::multiple_credentials_provided("myuser", "mypass", "bearer-token")]
-    #[case::no_username_in_basic_auth("", "mypass", "")]
-    #[case::no_password_in_basic_auth("myuser", "", "")]
-    fn test_auth_credentials_error(
-        #[case] username: String,
-        #[case] password: String,
-        #[case] token: String,
-    ) {
-        let mut variables = Variables::new();
-        variables.insert(
-            "nr-var:username".to_string(),
-            Variable::new_final_string_variable(username),
-        );
-        variables.insert(
-            "nr-var:password".to_string(),
-            Variable::new_final_string_variable(password),
-        );
-        variables.insert(
-            "nr-var:token".to_string(),
-            Variable::new_final_string_variable(token),
-        );
-
-        let oci = Oci {
-            registry: TemplateableValue::from_template("gcr.io".to_string()),
-            repository: TemplateableValue::from_template("myproject/myimage".to_string()),
-            version: TemplateableValue::from_template("latest".to_string()),
-            public_key_url: None,
-            auth: Auth {
-                basic: BasicAuth {
-                    username: TemplateableValue::from_template("${nr-var:username}".to_string()),
-                    password: TemplateableValue::from_template("${nr-var:password}".to_string()),
-                },
-                bearer: BearerAuth {
-                    token: TemplateableValue::from_template("${nr-var:token}".to_string()),
-                },
-            },
-        };
-
-        let rendered_oci = oci.template_with(&variables);
-        matches!(rendered_oci, Err(AgentTypeError::OCIAuthError(_)));
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -1,4 +1,4 @@
-use oci_client::{Reference, secrets::RegistryAuth};
+use oci_client::Reference;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,5 +17,4 @@ pub struct Download {
 pub struct Oci {
     pub reference: Reference,
     pub public_key_url: Option<Url>,
-    pub auth: RegistryAuth,
 }


### PR DESCRIPTION
Removes support of oci auth for agent types.

We radically changed how we are going to support mirrors for oci registries. This PR removes the introduced code.