### PR TITLE
feat(k8s): introduce explicit health-check definition [NR-552587]

### DIFF
--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -21,7 +21,6 @@ pub struct K8s {
 }
 
 /// A K8s object, usually a CR, to be managed by the agent-control.
-// TODO: at lest, the spec should be templatable.
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct K8sObject {
     #[serde(rename = "apiVersion")]
@@ -50,7 +49,10 @@ impl Templateable for K8s {
                 .into_iter()
                 .map(|(k, v)| Ok((k, v.template_with(variables)?)))
                 .collect::<Result<HashMap<String, K8sObject>, AgentTypeError>>()?,
-            health: self.health,
+            health: self
+                .health
+                .map(|h| h.template_with(variables))
+                .transpose()?,
             version: self.version,
             guid_checker: self.guid_checker,
         })
@@ -85,6 +87,43 @@ impl Templateable for K8sObjectMeta {
     }
 }
 
+/// The kind of Kubernetes resource to health-check.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub enum K8sHealthResourceKind {
+    Deployment,
+    DaemonSet,
+    StatefulSet,
+    HelmRelease,
+    Instrumentation,
+}
+
+/// A single Kubernetes resource to include in health checking.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct K8sHealthResource {
+    pub(crate) name: String,
+    pub(crate) namespace: String,
+    pub(crate) kind: K8sHealthResourceKind,
+    /// This field allows referencing related resources in a different namespace. Eg:
+    /// `HelmRelease -> Deployment`, defaults to `namespace`.
+    pub(crate) target_namespace: Option<String>,
+}
+
+impl Templateable for K8sHealthResource {
+    type Output = Self;
+    fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
+        Ok(Self {
+            name: self.name.template_with(variables)?,
+            namespace: self.namespace.template_with(variables)?,
+            kind: self.kind,
+            target_namespace: self
+                .target_namespace
+                .map(|ns| ns.template_with(variables))
+                .transpose()?,
+        })
+    }
+}
+
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct K8sHealthConfig {
     /// The duration to wait between health checks.
@@ -93,6 +132,24 @@ pub struct K8sHealthConfig {
     /// The initial delay before the first health check is performed.
     #[serde(default)]
     pub(crate) initial_delay: InitialDelay,
+    /// Explicit list of Kubernetes resources to health-check.
+    #[serde(default)]
+    pub(crate) resources: Vec<K8sHealthResource>,
+}
+
+impl Templateable for K8sHealthConfig {
+    type Output = Self;
+    fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
+        Ok(Self {
+            interval: self.interval,
+            initial_delay: self.initial_delay,
+            resources: self
+                .resources
+                .into_iter()
+                .map(|r| r.template_with(variables))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
@@ -120,7 +177,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::agent_type::definition::Variables;
-    use crate::agent_type::runtime_config::k8s::K8s;
+    use crate::agent_type::runtime_config::k8s::{K8s, K8sHealthResource, K8sHealthResourceKind};
     use crate::agent_type::templates::Templateable;
     use crate::agent_type::variable::Variable;
     use crate::agent_type::version_config::{VersionCheckerInitialDelay, VersionCheckerInterval};
@@ -254,6 +311,71 @@ objects:
         let labels = cr1.metadata.labels;
         assert_eq!(labels.get("foo").unwrap(), value);
         assert_eq!(labels.get(value).unwrap(), "bar");
+    }
+
+    #[test]
+    fn test_template_k8s_health_resources() {
+        let k8s_template: K8s = serde_yaml::from_str(
+            r#"
+objects: {}
+health:
+  interval: 30s
+  initial_delay: 10s
+  resources:
+    - namespace: ${nr-ac:namespace}
+      name: ${nr-sub:agent_id}
+      kind: HelmRelease
+      target_namespace: ${nr-ac:namespace_agents}
+    - namespace: ${nr-ac:namespace_agents}
+      name: ${nr-sub:agent_id}
+      kind: Instrumentation
+    - namespace: ${nr-ac:namespace_agents}
+      name: ${nr-sub:agent_id}
+      kind: Deployment
+"#,
+        )
+        .unwrap();
+
+        let variables = Variables::from([
+            (
+                "nr-sub:agent_id".to_string(),
+                Variable::new_final_string_variable("my-agent".to_string()),
+            ),
+            (
+                "nr-ac:namespace".to_string(),
+                Variable::new_final_string_variable("newrelic".to_string()),
+            ),
+            (
+                "nr-ac:namespace_agents".to_string(),
+                Variable::new_final_string_variable("newrelic-agents".to_string()),
+            ),
+        ]);
+
+        let k8s = k8s_template.template_with(&variables).unwrap();
+        let resources = k8s.health.unwrap().resources;
+
+        let expected = vec![
+            K8sHealthResource {
+                name: "my-agent".to_string(),
+                namespace: "newrelic".to_string(),
+                kind: K8sHealthResourceKind::HelmRelease,
+                target_namespace: Some("newrelic-agents".to_string()),
+            },
+            K8sHealthResource {
+                name: "my-agent".to_string(),
+                namespace: "newrelic-agents".to_string(),
+                kind: K8sHealthResourceKind::Instrumentation,
+                target_namespace: None,
+            },
+            K8sHealthResource {
+                name: "my-agent".to_string(),
+                namespace: "newrelic-agents".to_string(),
+                kind: K8sHealthResourceKind::Deployment,
+                target_namespace: None,
+            },
+        ];
+
+        assert_eq!(resources, expected);
     }
 
     #[test]

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -94,13 +94,13 @@ pub enum K8sHealthResourceKind {
     Deployment,
     DaemonSet,
     StatefulSet,
-    HelmRelease,
     Instrumentation,
+    HelmReleaseWorkload,
 }
 
 /// A single Kubernetes resource to include in health checking.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct K8sHealthResource {
+pub struct K8sHealthCheckDefinition {
     pub(crate) name: String,
     pub(crate) namespace: String,
     pub(crate) kind: K8sHealthResourceKind,
@@ -109,7 +109,7 @@ pub struct K8sHealthResource {
     pub(crate) target_namespace: Option<String>,
 }
 
-impl Templateable for K8sHealthResource {
+impl Templateable for K8sHealthCheckDefinition {
     type Output = Self;
     fn template_with(self, variables: &Variables) -> Result<Self, AgentTypeError> {
         Ok(Self {
@@ -132,9 +132,9 @@ pub struct K8sHealthConfig {
     /// The initial delay before the first health check is performed.
     #[serde(default)]
     pub(crate) initial_delay: InitialDelay,
-    /// Explicit list of Kubernetes resources to health-check.
+    /// Explicit list of Kubernetes check definitions
     #[serde(default)]
-    pub(crate) resources: Vec<K8sHealthResource>,
+    pub(crate) checks: Vec<K8sHealthCheckDefinition>,
 }
 
 impl Templateable for K8sHealthConfig {
@@ -143,8 +143,8 @@ impl Templateable for K8sHealthConfig {
         Ok(Self {
             interval: self.interval,
             initial_delay: self.initial_delay,
-            resources: self
-                .resources
+            checks: self
+                .checks
                 .into_iter()
                 .map(|r| r.template_with(variables))
                 .collect::<Result<Vec<_>, _>>()?,
@@ -177,7 +177,9 @@ mod tests {
     use std::time::Duration;
 
     use crate::agent_type::definition::Variables;
-    use crate::agent_type::runtime_config::k8s::{K8s, K8sHealthResource, K8sHealthResourceKind};
+    use crate::agent_type::runtime_config::k8s::{
+        K8s, K8sHealthCheckDefinition, K8sHealthResourceKind,
+    };
     use crate::agent_type::templates::Templateable;
     use crate::agent_type::variable::Variable;
     use crate::agent_type::version_config::{VersionCheckerInitialDelay, VersionCheckerInterval};
@@ -321,10 +323,10 @@ objects: {}
 health:
   interval: 30s
   initial_delay: 10s
-  resources:
+  checks:
     - namespace: ${nr-ac:namespace}
       name: ${nr-sub:agent_id}
-      kind: HelmRelease
+      kind: HelmReleaseWorkload
       target_namespace: ${nr-ac:namespace_agents}
     - namespace: ${nr-ac:namespace_agents}
       name: ${nr-sub:agent_id}
@@ -352,22 +354,22 @@ health:
         ]);
 
         let k8s = k8s_template.template_with(&variables).unwrap();
-        let resources = k8s.health.unwrap().resources;
+        let resources = k8s.health.unwrap().checks;
 
         let expected = vec![
-            K8sHealthResource {
+            K8sHealthCheckDefinition {
                 name: "my-agent".to_string(),
                 namespace: "newrelic".to_string(),
-                kind: K8sHealthResourceKind::HelmRelease,
+                kind: K8sHealthResourceKind::HelmReleaseWorkload,
                 target_namespace: Some("newrelic-agents".to_string()),
             },
-            K8sHealthResource {
+            K8sHealthCheckDefinition {
                 name: "my-agent".to_string(),
                 namespace: "newrelic-agents".to_string(),
                 kind: K8sHealthResourceKind::Instrumentation,
                 target_namespace: None,
             },
-            K8sHealthResource {
+            K8sHealthCheckDefinition {
                 name: "my-agent".to_string(),
                 namespace: "newrelic-agents".to_string(),
                 kind: K8sHealthResourceKind::Deployment,

--- a/agent-control/src/checkers/health/k8s/health_checker.rs
+++ b/agent-control/src/checkers/health/k8s/health_checker.rs
@@ -6,7 +6,7 @@ use crate::k8s::client::SyncK8sClient;
 use crate::k8s::utils::{get_name, get_namespace, get_target_namespace, get_type_meta};
 use kube::api::{DynamicObject, TypeMeta};
 use resources::{
-    daemon_set::K8sHealthDaemonSet, deployment::K8sHealthDeployment,
+    ResourceFilter, daemon_set::K8sHealthDaemonSet, deployment::K8sHealthDeployment,
     helm_release::K8sHealthHelmRelease, instrumentation::K8sHealthNRInstrumentation,
     stateful_set::K8sHealthStatefulSet,
 };
@@ -66,19 +66,19 @@ pub fn health_checkers_for_type_meta(
             )),
             K8sResourceHealthChecker::StatefulSet(K8sHealthStatefulSet::new(
                 k8s_client.clone(),
-                name.clone(),
+                ResourceFilter::ByFluxLabel(name.clone()),
                 start_time,
                 target_namespace.clone(),
             )),
             K8sResourceHealthChecker::DaemonSet(K8sHealthDaemonSet::new(
                 k8s_client.clone(),
-                name.clone(),
+                ResourceFilter::ByFluxLabel(name.clone()),
                 start_time,
                 target_namespace.clone(),
             )),
             K8sResourceHealthChecker::Deployment(K8sHealthDeployment::new(
                 k8s_client.clone(),
-                name,
+                ResourceFilter::ByFluxLabel(name),
                 start_time,
                 target_namespace,
             )),

--- a/agent-control/src/checkers/health/k8s/health_checker/resources.rs
+++ b/agent-control/src/checkers/health/k8s/health_checker/resources.rs
@@ -14,6 +14,15 @@ pub mod helm_release;
 pub mod instrumentation;
 pub mod stateful_set;
 
+/// Defines how to select Kubernetes resources for health-check purposes.
+#[derive(Debug)]
+pub enum ResourceFilter {
+    /// Match workloads by `metadata.name`.
+    ByName(String),
+    /// Match workloads carrying the Flux `helm.toolkit.fluxcd.io/name` label.
+    ByFluxLabel(String),
+}
+
 /// Executes the provided health-check function over the items provided. It expects a list
 /// of `Arc<K>` because k8s reflectors provide shared references.
 /// It returns:
@@ -54,6 +63,15 @@ where
             .as_ref()
             .is_some_and(|labels| selector.matches(labels))
     }
+}
+
+/// Returns a closure which can be used as filter predicate. It will filter objects whose
+/// `metadata.name` exactly matches the provided name.
+pub(crate) fn name_filter<K>(name: String) -> impl Fn(&Arc<K>) -> bool
+where
+    K: Metadata<Ty = ObjectMeta>,
+{
+    move |obj| obj.metadata().name.as_deref().is_some_and(|n| n == name)
 }
 
 /// Helper to return an error when an expected field in the StatefulSet object is missing.

--- a/agent-control/src/checkers/health/k8s/health_checker/resources/daemon_set.rs
+++ b/agent-control/src/checkers/health/k8s/health_checker/resources/daemon_set.rs
@@ -8,14 +8,16 @@ use crate::k8s::utils as client_utils;
 use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetStatus};
 use std::sync::Arc;
 
-use super::{check_health_for_items, flux_release_filter, missing_field_error};
+use super::{
+    ResourceFilter, check_health_for_items, flux_release_filter, missing_field_error, name_filter,
+};
 
 const ROLLING_UPDATE_UPDATE_STRATEGY: &str = "RollingUpdate";
 
 #[derive(Debug)]
 pub struct K8sHealthDaemonSet {
     k8s_client: Arc<SyncK8sClient>,
-    release_name: String,
+    filter: ResourceFilter,
     start_time: StartTime,
     namespace: String,
 }
@@ -24,12 +26,19 @@ impl HealthChecker for K8sHealthDaemonSet {
     fn check_health(&self) -> Result<HealthWithStartTime, HealthCheckerError> {
         let daemon_sets = self.k8s_client.list_daemon_set(&self.namespace)?;
 
-        let target_daemon_sets = daemon_sets
-            .into_iter()
-            .filter(flux_release_filter(self.release_name.clone()));
+        let health = match &self.filter {
+            ResourceFilter::ByName(name) => check_health_for_items(
+                daemon_sets.into_iter().filter(name_filter(name.clone())),
+                Self::check_health_single_daemon_set,
+            )?,
+            ResourceFilter::ByFluxLabel(release) => check_health_for_items(
+                daemon_sets
+                    .into_iter()
+                    .filter(flux_release_filter(release.clone())),
+                Self::check_health_single_daemon_set,
+            )?,
+        };
 
-        let health =
-            check_health_for_items(target_daemon_sets, Self::check_health_single_daemon_set)?;
         Ok(HealthWithStartTime::new(health, self.start_time))
     }
 }
@@ -37,13 +46,13 @@ impl HealthChecker for K8sHealthDaemonSet {
 impl K8sHealthDaemonSet {
     pub fn new(
         k8s_client: Arc<SyncK8sClient>,
-        release_name: String,
+        filter: ResourceFilter,
         start_time: StartTime,
         namespace: String,
     ) -> Self {
         Self {
             k8s_client,
-            release_name,
+            filter,
             start_time,
             namespace,
         }
@@ -129,10 +138,7 @@ fn is_daemon_set_update_strategy_rolling_update(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::checkers::health::{
-        health_checker::{Healthy, Unhealthy},
-        k8s::health_checker::LABEL_RELEASE_FLUX,
-    };
+    use crate::checkers::health::health_checker::{Healthy, Unhealthy};
     use crate::k8s::client::MockSyncK8sClient;
     use k8s_openapi::Resource as _; // Needed to access resource's KIND. e.g.: Deployment::KIND
     use k8s_openapi::api::apps::v1::DaemonSetUpdateStrategy;
@@ -375,30 +381,12 @@ pub mod tests {
     #[test]
     fn test_check_health() {
         let mut k8s_client = MockSyncK8sClient::new();
-        let release_name = "flux-release";
+        let name = "target-daemon-set";
 
-        let healthy_matching = DaemonSet {
+        // Matches by name — unhealthy (2 ready out of 5 desired).
+        let matching_unhealthy = DaemonSet {
             metadata: ObjectMeta {
-                name: Some("healthy-daemon-set".to_string()),
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), release_name.to_string())].into()),
-                ..Default::default()
-            },
-            spec: Some(DaemonSetSpec {
-                update_strategy: Some(DaemonSetUpdateStrategy {
-                    type_: Some(ROLLING_UPDATE_UPDATE_STRATEGY.to_string()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-            status: Some(DaemonSetStatus {
-                ..Default::default()
-            }),
-        };
-
-        let unhealthy_matching = DaemonSet {
-            metadata: ObjectMeta {
-                name: Some("unhealthy-daemon-set".to_string()),
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), release_name.to_string())].into()),
+                name: Some(name.to_string()),
                 ..Default::default()
             },
             spec: Some(DaemonSetSpec {
@@ -415,21 +403,29 @@ pub mod tests {
             }),
         };
 
+        // Does not match by name — would error if checked, but must be skipped.
+        let non_matching = DaemonSet {
+            metadata: ObjectMeta {
+                name: Some("other-daemon-set".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
         k8s_client
             .expect_list_daemon_set()
             .times(1)
             .returning(move |_| {
                 Ok(vec![
-                    Arc::new(healthy_matching.clone()),
-                    Arc::new(unhealthy_matching.clone()),
+                    Arc::new(non_matching.clone()),
+                    Arc::new(matching_unhealthy.clone()),
                 ])
             });
 
         let start_time = StartTime::now();
-
         let health_checker = K8sHealthDaemonSet::new(
             Arc::new(k8s_client),
-            release_name.to_string(),
+            ResourceFilter::ByName(name.to_string()),
             start_time,
             TEST_NAMESPACE.to_string(),
         );
@@ -438,7 +434,75 @@ pub mod tests {
         assert_eq!(
             health,
             HealthWithStartTime::from_unhealthy(
-                Unhealthy::new("DaemonSet `unhealthy-daemon-set`: the number of pods ready `2` is less that the desired `5`".into()),
+                Unhealthy::new(
+                    "DaemonSet `target-daemon-set`: the number of pods ready `2` is less that the desired `5`".into()
+                ),
+                start_time
+            )
+        );
+    }
+
+    #[test]
+    fn test_check_health_for_helm_release() {
+        let mut k8s_client = MockSyncK8sClient::new();
+        use crate::checkers::health::k8s::health_checker::LABEL_RELEASE_FLUX;
+        let release_name = "flux-release";
+
+        // Matches by Flux label.
+        let matching_unhealthy = DaemonSet {
+            metadata: ObjectMeta {
+                name: Some("chart-daemon-set".to_string()),
+                labels: Some([(LABEL_RELEASE_FLUX.to_string(), release_name.to_string())].into()),
+                ..Default::default()
+            },
+            spec: Some(DaemonSetSpec {
+                update_strategy: Some(DaemonSetUpdateStrategy {
+                    type_: Some(ROLLING_UPDATE_UPDATE_STRATEGY.to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            status: Some(DaemonSetStatus {
+                desired_number_scheduled: 3,
+                number_ready: 1,
+                ..Default::default()
+            }),
+        };
+
+        // Does not carry the Flux label — must be skipped.
+        let non_matching = DaemonSet {
+            metadata: ObjectMeta {
+                name: Some("other-daemon-set".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        k8s_client
+            .expect_list_daemon_set()
+            .times(1)
+            .returning(move |_| {
+                Ok(vec![
+                    Arc::new(non_matching.clone()),
+                    Arc::new(matching_unhealthy.clone()),
+                ])
+            });
+
+        let start_time = StartTime::now();
+        let health_checker = K8sHealthDaemonSet::new(
+            Arc::new(k8s_client),
+            ResourceFilter::ByFluxLabel(release_name.to_string()),
+            start_time,
+            TEST_NAMESPACE.to_string(),
+        );
+        let health = health_checker.check_health().unwrap();
+
+        assert_eq!(
+            health,
+            HealthWithStartTime::from_unhealthy(
+                Unhealthy::new(
+                    "DaemonSet `chart-daemon-set`: the number of pods ready `1` is less that the desired `3`".into()
+                ),
                 start_time
             )
         );

--- a/agent-control/src/checkers/health/k8s/health_checker/resources/deployment.rs
+++ b/agent-control/src/checkers/health/k8s/health_checker/resources/deployment.rs
@@ -1,4 +1,6 @@
-use super::{check_health_for_items, flux_release_filter, missing_field_error};
+use super::{
+    ResourceFilter, check_health_for_items, flux_release_filter, missing_field_error, name_filter,
+};
 use crate::checkers::health::health_checker::{
     Health, HealthChecker, HealthCheckerError, Healthy, Unhealthy,
 };
@@ -12,7 +14,7 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct K8sHealthDeployment {
     k8s_client: Arc<SyncK8sClient>,
-    release_name: String,
+    filter: ResourceFilter,
     start_time: StartTime,
     namespace: String,
 }
@@ -21,11 +23,18 @@ impl HealthChecker for K8sHealthDeployment {
     fn check_health(&self) -> Result<HealthWithStartTime, HealthCheckerError> {
         let deployments = self.k8s_client.list_deployment(&self.namespace)?;
 
-        let target_deployments = deployments
-            .into_iter()
-            .filter(flux_release_filter(self.release_name.clone()));
-
-        let health = check_health_for_items(target_deployments, Self::check_deployment_health)?;
+        let health = match &self.filter {
+            ResourceFilter::ByName(name) => check_health_for_items(
+                deployments.into_iter().filter(name_filter(name.clone())),
+                Self::check_deployment_health,
+            )?,
+            ResourceFilter::ByFluxLabel(release) => check_health_for_items(
+                deployments
+                    .into_iter()
+                    .filter(flux_release_filter(release.clone())),
+                Self::check_deployment_health,
+            )?,
+        };
 
         Ok(HealthWithStartTime::new(health, self.start_time))
     }
@@ -34,13 +43,13 @@ impl HealthChecker for K8sHealthDeployment {
 impl K8sHealthDeployment {
     pub fn new(
         k8s_client: Arc<SyncK8sClient>,
-        release_name: String,
+        filter: ResourceFilter,
         start_time: StartTime,
         namespace: String,
     ) -> Self {
         Self {
             k8s_client,
-            release_name,
+            filter,
             start_time,
             namespace,
         }
@@ -90,7 +99,6 @@ impl K8sHealthDeployment {
 mod tests {
     use super::*;
     use crate::checkers::health::health_checker::Healthy;
-    use crate::checkers::health::k8s::health_checker::LABEL_RELEASE_FLUX;
     use crate::checkers::health::k8s::health_checker::resources::daemon_set::tests::TEST_NAMESPACE;
     use crate::k8s::client::MockSyncK8sClient;
     use k8s_openapi::api::apps::v1::{
@@ -318,20 +326,47 @@ mod tests {
     }
 
     #[test]
-    fn test_health_check_unhealthy() {
-        let healthy_deployment = Deployment {
-            metadata: ObjectMeta {
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), "flux-release".to_string())].into()),
-                ..test_util_create_metadata("healthy_deployment")
-            },
+    fn test_check_health() {
+        struct TestCase {
+            name: &'static str,
+            deployments: Vec<Arc<Deployment>>,
+            expected_health: Health,
+        }
+
+        impl TestCase {
+            fn run(self) {
+                let mut k8s_client = MockSyncK8sClient::new();
+                k8s_client
+                    .expect_list_deployment()
+                    .times(1)
+                    .returning(move |_| Ok(self.deployments.clone()));
+
+                let start_time = StartTime::now();
+                let health_checker = K8sHealthDeployment::new(
+                    Arc::new(k8s_client),
+                    ResourceFilter::ByName("target-deployment".to_string()),
+                    start_time,
+                    TEST_NAMESPACE.to_string(),
+                );
+                let health = health_checker.check_health().unwrap_or_else(|_| {
+                    panic!("Unexpected error getting health for test - {}", self.name)
+                });
+                assert_eq!(
+                    health,
+                    HealthWithStartTime::new(self.expected_health, start_time),
+                    "{} failed",
+                    self.name
+                );
+            }
+        }
+
+        let matching_healthy = Deployment {
+            metadata: test_util_create_metadata("target-deployment"),
             spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
             status: Some(test_util_create_deployment_status(10)),
         };
-        let unhealthy_deployment_foo = Deployment {
-            metadata: ObjectMeta {
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), "flux-release".to_string())].into()),
-                ..test_util_create_metadata("unhealthy_deployment_foo")
-            },
+        let matching_unhealthy = Deployment {
+            metadata: test_util_create_metadata("target-deployment"),
             spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
             status: Some(DeploymentStatus {
                 available_replicas: Some(9),
@@ -339,28 +374,39 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let unhealthy_foo = Health::Unhealthy(Unhealthy {
-            last_error: "Deployment `unhealthy_deployment_foo`: has 1 unavailable replicas"
-                .to_string(),
+        // Would fail if checked — must be skipped because name doesn't match.
+        let non_matching = Deployment {
+            metadata: test_util_create_metadata("other-deployment"),
             ..Default::default()
-        });
-        let unhealthy_deployment_bar = Deployment {
-            metadata: ObjectMeta {
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), "flux-release".to_string())].into()),
-                ..test_util_create_metadata("unhealthy_deployment_bar")
-            },
-            spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
-            status: Some(DeploymentStatus {
-                available_replicas: Some(9),
-                unavailable_replicas: Some(1),
-                ..Default::default()
-            }),
         };
-        let unhealthy_bar = Health::Unhealthy(Unhealthy {
-            last_error: "Deployment `unhealthy_deployment_bar`: has 1 unavailable replicas"
-                .to_string(),
-            ..Default::default()
-        });
+
+        let test_cases = [
+            TestCase {
+                name: "Matching healthy deployment",
+                deployments: vec![Arc::new(matching_healthy.clone())],
+                expected_health: Healthy::new().into(),
+            },
+            TestCase {
+                name: "Matching unhealthy deployment",
+                deployments: vec![Arc::new(matching_unhealthy.clone())],
+                expected_health: Unhealthy::new(
+                    "Deployment `target-deployment`: has 1 unavailable replicas".into(),
+                )
+                .into(),
+            },
+            TestCase {
+                name: "Non-matching deployment is skipped",
+                deployments: vec![Arc::new(non_matching.clone())],
+                expected_health: Healthy::new().into(),
+            },
+        ];
+
+        test_cases.into_iter().for_each(|tc| tc.run());
+    }
+
+    #[test]
+    fn test_check_health_for_helm_release() {
+        use crate::checkers::health::k8s::health_checker::LABEL_RELEASE_FLUX;
 
         struct TestCase {
             name: &'static str,
@@ -379,7 +425,7 @@ mod tests {
                 let start_time = StartTime::now();
                 let health_checker = K8sHealthDeployment::new(
                     Arc::new(k8s_client),
-                    "flux-release".to_string(),
+                    ResourceFilter::ByFluxLabel("flux-release".to_string()),
                     start_time,
                     TEST_NAMESPACE.to_string(),
                 );
@@ -395,47 +441,81 @@ mod tests {
             }
         }
 
+        let flux_label =
+            || Some([(LABEL_RELEASE_FLUX.to_string(), "flux-release".to_string())].into());
+
+        let healthy = Deployment {
+            metadata: ObjectMeta {
+                labels: flux_label(),
+                ..test_util_create_metadata("chart-deployment-a")
+            },
+            spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
+            status: Some(test_util_create_deployment_status(10)),
+        };
+        let unhealthy_foo = Deployment {
+            metadata: ObjectMeta {
+                labels: flux_label(),
+                ..test_util_create_metadata("chart-deployment-foo")
+            },
+            spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
+            status: Some(DeploymentStatus {
+                available_replicas: Some(9),
+                unavailable_replicas: Some(1),
+                ..Default::default()
+            }),
+        };
+        let unhealthy_bar = Deployment {
+            metadata: ObjectMeta {
+                labels: flux_label(),
+                ..test_util_create_metadata("chart-deployment-bar")
+            },
+            spec: Some(test_util_create_deployment_spec(10, "30%", "20%")),
+            status: Some(DeploymentStatus {
+                available_replicas: Some(9),
+                unavailable_replicas: Some(1),
+                ..Default::default()
+            }),
+        };
+        // Does not carry the Flux label — must be skipped.
+        let non_matching = Deployment {
+            metadata: test_util_create_metadata("other-deployment"),
+            ..Default::default()
+        };
+
         let test_cases = [
             TestCase {
                 name: "Healthy deployments",
-                deployments: vec![
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                ],
+                deployments: vec![Arc::new(healthy.clone()), Arc::new(healthy.clone())],
                 expected_health: Healthy::new().into(),
             },
             TestCase {
-                name: "One unhealthy deployment",
-                deployments: vec![
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(unhealthy_deployment_foo.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                ],
-                expected_health: unhealthy_foo.clone(),
+                name: "Non-matching deployment is skipped",
+                deployments: vec![Arc::new(non_matching.clone()), Arc::new(healthy.clone())],
+                expected_health: Healthy::new().into(),
             },
             TestCase {
-                name: "First unhealthy deployment is reported foo",
+                name: "First unhealthy reported (foo before bar)",
                 deployments: vec![
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(unhealthy_deployment_foo.clone()),
-                    Arc::new(unhealthy_deployment_bar.clone()),
-                    Arc::new(unhealthy_deployment_bar.clone()),
+                    Arc::new(healthy.clone()),
+                    Arc::new(unhealthy_foo.clone()),
+                    Arc::new(unhealthy_bar.clone()),
                 ],
-                expected_health: unhealthy_foo.clone(),
+                expected_health: Unhealthy::new(
+                    "Deployment `chart-deployment-foo`: has 1 unavailable replicas".into(),
+                )
+                .into(),
             },
             TestCase {
-                name: "First unhealthy deployment is reported bar",
+                name: "First unhealthy reported (bar before foo)",
                 deployments: vec![
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(healthy_deployment.clone()),
-                    Arc::new(unhealthy_deployment_bar.clone()),
-                    Arc::new(unhealthy_deployment_foo.clone()),
-                    Arc::new(unhealthy_deployment_foo.clone()),
+                    Arc::new(healthy.clone()),
+                    Arc::new(unhealthy_bar.clone()),
+                    Arc::new(unhealthy_foo.clone()),
                 ],
-                expected_health: unhealthy_bar.clone(),
+                expected_health: Unhealthy::new(
+                    "Deployment `chart-deployment-bar`: has 1 unavailable replicas".into(),
+                )
+                .into(),
             },
         ];
 

--- a/agent-control/src/checkers/health/k8s/health_checker/resources/stateful_set.rs
+++ b/agent-control/src/checkers/health/k8s/health_checker/resources/stateful_set.rs
@@ -8,13 +8,15 @@ use crate::k8s::utils as client_utils;
 use k8s_openapi::api::apps::v1::StatefulSet;
 use std::sync::Arc;
 
-use super::{check_health_for_items, flux_release_filter, missing_field_error};
+use super::{
+    ResourceFilter, check_health_for_items, flux_release_filter, missing_field_error, name_filter,
+};
 
-/// Represents a health checker for the StatefulSets or a release.
+/// Represents a health checker for a StatefulSet resource.
 #[derive(Debug)]
 pub struct K8sHealthStatefulSet {
     k8s_client: Arc<SyncK8sClient>,
-    release_name: String,
+    filter: ResourceFilter,
     start_time: StartTime,
     namespace: String,
 }
@@ -23,11 +25,18 @@ impl HealthChecker for K8sHealthStatefulSet {
     fn check_health(&self) -> Result<HealthWithStartTime, HealthCheckerError> {
         let stateful_sets = self.k8s_client.list_stateful_set(&self.namespace)?;
 
-        let target_stateful_sets = stateful_sets
-            .into_iter()
-            .filter(flux_release_filter(self.release_name.clone()));
-
-        let health = check_health_for_items(target_stateful_sets, Self::stateful_set_health)?;
+        let health = match &self.filter {
+            ResourceFilter::ByName(name) => check_health_for_items(
+                stateful_sets.into_iter().filter(name_filter(name.clone())),
+                Self::stateful_set_health,
+            )?,
+            ResourceFilter::ByFluxLabel(release) => check_health_for_items(
+                stateful_sets
+                    .into_iter()
+                    .filter(flux_release_filter(release.clone())),
+                Self::stateful_set_health,
+            )?,
+        };
 
         Ok(HealthWithStartTime::new(health, self.start_time))
     }
@@ -36,13 +45,13 @@ impl HealthChecker for K8sHealthStatefulSet {
 impl K8sHealthStatefulSet {
     pub fn new(
         k8s_client: Arc<SyncK8sClient>,
-        release_name: String,
+        filter: ResourceFilter,
         start_time: StartTime,
         namespace: String,
     ) -> Self {
         Self {
             k8s_client,
-            release_name,
+            filter,
             start_time,
             namespace,
         }
@@ -81,7 +90,6 @@ impl K8sHealthStatefulSet {
 mod tests {
     use super::*;
     use crate::checkers::health::health_checker::Healthy;
-    use crate::checkers::health::k8s::health_checker::LABEL_RELEASE_FLUX;
     use crate::checkers::health::k8s::health_checker::resources::daemon_set::tests::TEST_NAMESPACE;
     use crate::k8s::client::MockSyncK8sClient;
     use assert_matches::assert_matches;
@@ -250,32 +258,21 @@ mod tests {
     #[test]
     fn test_check_health() {
         let mut k8s_client = MockSyncK8sClient::new();
-        let release_name = "flux-release";
+        let name = "target-stateful-set";
 
-        let healthy_matching = StatefulSet {
-            metadata: ObjectMeta {
-                labels: Some([(LABEL_RELEASE_FLUX.to_string(), release_name.to_string())].into()),
-                ..stateful_set_meta("name")
-            },
+        // Matches by name — healthy.
+        let matching_healthy = StatefulSet {
+            metadata: stateful_set_meta(name),
             spec: Some(StatefulSetSpec::default()),
             status: Some(StatefulSetStatus {
-                updated_replicas: Some(1),
                 ready_replicas: Some(1),
                 ..stateful_set_status()
             }),
         };
 
-        let with_err_not_matching = StatefulSet {
-            metadata: ObjectMeta {
-                labels: Some(
-                    [(
-                        LABEL_RELEASE_FLUX.to_string(),
-                        "another-release".to_string(),
-                    )]
-                    .into(),
-                ),
-                ..Default::default()
-            },
+        // Does not match by name — would error if checked, but must be skipped.
+        let non_matching = StatefulSet {
+            metadata: stateful_set_meta("other-stateful-set"),
             ..Default::default()
         };
 
@@ -284,16 +281,64 @@ mod tests {
             .times(1)
             .returning(move |_| {
                 Ok(vec![
-                    Arc::new(with_err_not_matching.clone()),
-                    Arc::new(healthy_matching.clone()),
+                    Arc::new(non_matching.clone()),
+                    Arc::new(matching_healthy.clone()),
                 ])
             });
 
         let start_time = StartTime::now();
-
         let health_checker = K8sHealthStatefulSet::new(
             Arc::new(k8s_client),
-            release_name.to_string(),
+            ResourceFilter::ByName(name.to_string()),
+            start_time,
+            TEST_NAMESPACE.to_string(),
+        );
+        let result = health_checker.check_health().unwrap();
+        assert_eq!(
+            result,
+            HealthWithStartTime::from_healthy(Healthy::new(), start_time)
+        );
+    }
+
+    #[test]
+    fn test_check_health_for_helm_release() {
+        use crate::checkers::health::k8s::health_checker::LABEL_RELEASE_FLUX;
+        let mut k8s_client = MockSyncK8sClient::new();
+        let release_name = "flux-release";
+
+        // Matches by Flux label — healthy.
+        let matching_healthy = StatefulSet {
+            metadata: ObjectMeta {
+                labels: Some([(LABEL_RELEASE_FLUX.to_string(), release_name.to_string())].into()),
+                ..stateful_set_meta("chart-stateful-set")
+            },
+            spec: Some(StatefulSetSpec::default()),
+            status: Some(StatefulSetStatus {
+                ready_replicas: Some(1),
+                ..stateful_set_status()
+            }),
+        };
+
+        // Does not carry the Flux label — would error if checked, but must be skipped.
+        let non_matching = StatefulSet {
+            metadata: stateful_set_meta("other-stateful-set"),
+            ..Default::default()
+        };
+
+        k8s_client
+            .expect_list_stateful_set()
+            .times(1)
+            .returning(move |_| {
+                Ok(vec![
+                    Arc::new(non_matching.clone()),
+                    Arc::new(matching_healthy.clone()),
+                ])
+            });
+
+        let start_time = StartTime::now();
+        let health_checker = K8sHealthStatefulSet::new(
+            Arc::new(k8s_client),
+            ResourceFilter::ByFluxLabel(release_name.to_string()),
             start_time,
             TEST_NAMESPACE.to_string(),
         );


### PR DESCRIPTION
## Summary

This PR lays the foundation for explicit K8s health-check configuration. Allowing agent type definitions to declare which K8s resources to health-check directly, rather than deriving them implicitly from the objects section.

## Background

Today, health checkers are derived implicitly from the deployment `objects`:

- When there are `HelmRelease` objects it creates HelmReleases + StatefulSet + Deployment + Daemonset health-checkers
- When there are `Instrumentation` objects it creates a single Instrumentation checker.

This coupling means the health check behavior can't be tuned per agent type, and the connection between what is deployed and what is health-checked is implicit.

More importantly, **it prevents Agent Type authors from defining health-check pointing to objects that are not directly defined by the Agent Type**. This is needed for supporting configuration-only Agent Types.

## The approach

The new approach makes health checking explicit in the agent type YAML

**HelmRelease** based agent-types:

```yaml
health:
  interval: 30s
  initial_delay: 30s
  checks:
    - namespace: ${nr-ac:namespace}
      name: ${nr-sub:agent_id}
      kind: HelmReleaseWorkload # Will keep current behavior for helm-releases (HelmRelease + Deployment + Statefulset + Daemonset)
      target_namespace: ${nr-ac:namespace_agents}  # optional; falls back to namespace
```

**Instrumentation** based agent-types:

```yaml
health:
  interval: 30s
  initial_delay: 30s
  checks:
    - namespace: ${nr-ac:namespace_agents}
      name: ${nr-sub:agent_id}
      kind: Instrumentation
```

**Config Only** based agent-types:

```yaml
health:
  interval: 30s
  initial_delay: 30s
  checks:
    - namespace: ${nr-ac:namespace_agents}
      name: ${nr-var:deployment_name}
      kind: Deployment
    - namespace: ${nr-ac:namespace_agents}
      name: ${nr-var:statefulset_name}
      kind: Statefulset
    - namespace: ${nr-ac:namespace_agents}
      name: ${nr-var:daemonset_name}
      kind: Daemonset
```

> [!NOTE]
> It will require an update of existing Agent Types but it doesn't involve a breaking change because Agent Types are still embeded.

Label selectors were also considered but won't be introduced unless we really need them (they would make the Agent Type more flexible but also the implementation slightly more complex).

## The changes

* Add support for new types in Agent Type's health-check section for K8s.
* Introduce a `ResourceFilter` with `name` support for all workload-based health-checkers: `K8sHealthDeamonSet`, `K8sHealthDeployment` and `K8sHealthStatefulSet`.

> [!NOTE]
> There are no behavioral changes, those will come in a **follow-up PR**

## 🚧 Next steps

* Wire the new definition with the health-checkers (update the supervisor and health-checker constructor to use what's defined in the `health` section of the agent type instead of inferring the health-checks from objects.
* Update the existing Agent Types and integration tests
* Update docummentation.