### PR TITLE
fix: use custom tracing for verify command

### DIFF
--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -15,7 +15,10 @@ use crate::command::on_host_checks::config::check_config;
 use crate::command::on_host_checks::opamp::check_connectivity;
 use crate::event::ApplicationEvent;
 use crate::event::channel::{EventConsumer, EventPublisher, pub_sub};
-use crate::instrumentation::tracing::{TracingConfig, TracingGuardBox, try_init_tracing};
+use crate::instrumentation::config::logs::config::LoggingConfig;
+use crate::instrumentation::tracing::{
+    TracingConfig, TracingGuardBox, try_init_stderr_tracing, try_init_tracing,
+};
 use crate::on_host::file_store::FileStore;
 use crate::utils::binary_metadata::binary_metadata;
 use crate::utils::env_var::load_env_yaml_file;
@@ -104,6 +107,14 @@ pub struct Args {
     logs_dir: Option<std::path::PathBuf>,
 }
 
+/// Minimal context shared by all commands
+pub struct BootstrapContext {
+    /// Agent Control bootstrap configuration (built with runtime information but with no remote)
+    pub bootstrap_config: AgentControlConfig,
+    /// Agent Control directories where configuration and logs are stored
+    pub base_paths: BasePaths,
+}
+
 /// Context passed to the main loop, containing all initialized components.
 pub struct Context {
     /// Context used to build and start [crate::agent_control::AgentControl]
@@ -142,7 +153,7 @@ impl Command {
         match parsed.subcommand {
             Some(SubCommand::Version) => Command::print_version(running_mode),
             Some(SubCommand::Verify) => {
-                let (exit_code, message) = match Command::verify(running_mode, &parsed.args) {
+                let (exit_code, message) = match Command::verify(&parsed.args) {
                     Ok(_) => (ExitCode::SUCCESS, "Verification succeeded".to_string()),
                     Err(err) => (ExitCode::FAILURE, err.to_string()),
                 };
@@ -207,17 +218,36 @@ impl Command {
         }
     }
 
+    fn build_bootstrap_context(args: &Args) -> Result<BootstrapContext, Box<dyn Error>> {
+        let base_paths = BasePaths::default();
+
+        #[cfg(debug_assertions)]
+        let base_paths = set_debug_dirs(base_paths, args);
+
+        let env_file_path = base_paths.local_dir.join(ENVIRONMENT_VARIABLES_FILE_NAME);
+        if env_file_path.exists() {
+            load_env_yaml_file(env_file_path.as_path())
+                .map_err(|e| format!("Failed to load environment: {e}"))?;
+        }
+
+        let bootstrap_config = Self::build_bootstrap_config(&base_paths)?;
+
+        Ok(BootstrapContext {
+            bootstrap_config,
+            base_paths,
+        })
+    }
+
     /// Builds the complete context required to execute the application
     fn build_context(
         running_mode: Environment,
         args: &Args,
         #[cfg(target_os = "windows")] as_windows_service: bool,
     ) -> Result<Context, Box<dyn Error>> {
-        let base_paths = BasePaths::default();
-
-        // Initialize debug directories (if set)
-        #[cfg(debug_assertions)]
-        let base_paths = set_debug_dirs(base_paths, args);
+        let BootstrapContext {
+            base_paths,
+            bootstrap_config,
+        } = Self::build_bootstrap_context(args)?;
 
         // We need to create the pub_sub here so the Windows Service Stop handler is capable
         // of publishing a stop signal to the application for a Graceful Shutdown.
@@ -232,14 +262,7 @@ impl Command {
             .transpose()
             .map_err(|e| format!("Failed to setup Windows service: {e}"))?;
 
-        let env_file_path = base_paths.local_dir.join(ENVIRONMENT_VARIABLES_FILE_NAME);
-        if env_file_path.exists() {
-            load_env_yaml_file(env_file_path.as_path())
-                .map_err(|e| format!("Failed to load environment: {e}"))?;
-        }
-
         let config_folder_name = base_paths.local_dir.display().to_string();
-        let bootstrap_config = Self::build_bootstrap_config(&base_paths)?;
 
         let tracing_config = TracingConfig::from_logging_path(base_paths.log_dir.clone())
             .with_logging_config(bootstrap_config.log.clone())
@@ -302,9 +325,12 @@ impl Command {
         Ok(agent_control_config)
     }
 
-    fn verify(running_mode: Environment, args: &Args) -> Result<(), Box<dyn std::error::Error>> {
-        let verified_config = check_config(running_mode, args)
-            .map_err(|err| format!("Configuration check failed: {err}"))?;
+    fn verify(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+        try_init_stderr_tracing(&LoggingConfig::default())
+            .map_err(|e| format!("failed to initialize tracing: {e}"))?;
+
+        let verified_config =
+            check_config(args).map_err(|err| format!("configuration check failed: {err}"))?;
 
         if verified_config.maybe_opamp.is_some() {
             check_connectivity(verified_config)

--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -244,23 +244,23 @@ impl Command {
         args: &Args,
         #[cfg(target_os = "windows")] as_windows_service: bool,
     ) -> Result<Context, Box<dyn Error>> {
-        let BootstrapContext {
-            base_paths,
-            bootstrap_config,
-        } = Self::build_bootstrap_context(args)?;
-
         // We need to create the pub_sub here so the Windows Service Stop handler is capable
         // of publishing a stop signal to the application for a Graceful Shutdown.
         let (application_event_publisher, application_event_consumer) = pub_sub();
 
-        create_shutdown_signal_handler(application_event_publisher.clone())
-            .map_err(|e| format!("Failed to create shutdown signal handler: {e}"))?;
-
         #[cfg(target_family = "windows")]
         let stop_handler = as_windows_service
-            .then(|| windows::setup_windows_service(application_event_publisher))
+            .then(|| windows::setup_windows_service(application_event_publisher.clone()))
             .transpose()
             .map_err(|e| format!("Failed to setup Windows service: {e}"))?;
+
+        create_shutdown_signal_handler(application_event_publisher)
+            .map_err(|e| format!("Failed to create shutdown signal handler: {e}"))?;
+
+        let BootstrapContext {
+            base_paths,
+            bootstrap_config,
+        } = Self::build_bootstrap_context(args)?;
 
         let config_folder_name = base_paths.local_dir.display().to_string();
 

--- a/agent-control/src/command/on_host_checks/config.rs
+++ b/agent-control/src/command/on_host_checks/config.rs
@@ -7,9 +7,9 @@ use crate::{
     agent_control::{
         config::{AgentControlConfig, OpAMPClientConfig},
         config_repository::repository::AgentControlConfigLoader,
-        run::{Environment, setup_config_repository_and_store},
+        run::setup_config_repository_and_store,
     },
-    command::{Args, Command},
+    command::{Args, BootstrapContext, Command},
     http::config::ProxyConfig,
     on_host::file_store::FileStore,
     values::ConfigRepo,
@@ -24,26 +24,21 @@ pub struct VerifiedConfig {
     pub yaml_config_repository: Arc<ConfigRepo<FileStore<LocalFile, DirectoryManagerFs>>>,
 }
 
-pub fn check_config(
-    running_mode: Environment,
-    args: &Args,
-) -> Result<VerifiedConfig, Box<dyn std::error::Error>> {
-    let context = Command::build_context(
-        running_mode,
-        args,
-        #[cfg(target_os = "windows")]
-        false,
-    )
-    .map_err(|err| format!("failed to build context: {err}"))?;
+pub fn check_config(args: &Args) -> Result<VerifiedConfig, Box<dyn std::error::Error>> {
+    let BootstrapContext {
+        base_paths,
+        bootstrap_config,
+    } = Command::build_bootstrap_context(args)
+        .map_err(|err| format!("failed to build context: {err}"))?;
 
-    let local_dir = context.ac_runner_context.base_paths.local_dir;
-    let remote_dir = context.ac_runner_context.base_paths.remote_dir;
+    let local_dir = base_paths.local_dir;
+    let remote_dir = base_paths.remote_dir;
     let file_store = Arc::new(FileStore::new_local_fs(
         local_dir.clone(),
         remote_dir.clone(),
     ));
 
-    let maybe_opamp = context.ac_runner_context.bootstrap_config.fleet_control;
+    let maybe_opamp = bootstrap_config.fleet_control;
     let (yaml_config_repository, config_storer) =
         setup_config_repository_and_store(file_store.clone(), maybe_opamp.is_some());
     let agent_control_config = config_storer
@@ -52,7 +47,7 @@ pub fn check_config(
 
     info!("Config validation check successful");
 
-    let proxy_config = context.ac_runner_context.bootstrap_config.proxy.clone();
+    let proxy_config = bootstrap_config.proxy.clone();
 
     Ok(VerifiedConfig {
         local_dir,

--- a/agent-control/src/instrumentation/tracing.rs
+++ b/agent-control/src/instrumentation/tracing.rs
@@ -75,6 +75,14 @@ impl TracingConfig {
     }
 }
 
+/// Initializes tracing with stderr output only, without file or OpenTelemetry layers.
+///
+/// Intended for short-lived commands (e.g. verify) that must not write to the running AC log files.
+pub fn try_init_stderr_tracing(config: &LoggingConfig) -> Result<(), TracingError> {
+    let layers = vec![stderr(config)?];
+    try_init_tracing_subscriber(layers)
+}
+
 /// This function allows initializing tracing as setup in the provided configuration.
 ///
 /// Depending on the configuration, the tracer might be shutdown on drop, therefore the corresponding


### PR DESCRIPTION
The `verify` subcommand was sharing `build_context` with the run path, which unconditionally initializes file-based and OTel tracing, causing verify's logs to land in the running AC's log files.

The fix extracts a `BootstrapContext` (base paths + bootstrap config, no tracing/pub-sub/signal handlers) so verify can initialize only a stderr layer via the new try_init_stderr_tracing.