### PR TITLE
feat: get oci auth from the config

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -103,15 +103,14 @@ pub struct PackagesConfig {
 pub struct OciConfig {
     #[serde(default = "OciConfig::default_registry")]
     pub registry: String,
-    #[serde(default)]
-    pub auth: OciAuth,
+    pub auth: Option<OciAuth>,
 }
 
 impl Default for OciConfig {
     fn default() -> Self {
         OciConfig {
             registry: Self::default_registry(),
-            auth: OciAuth::default(),
+            auth: None,
         }
     }
 }
@@ -122,10 +121,10 @@ impl OciConfig {
     }
 }
 
-#[derive(Debug, Serialize, Default, Clone, PartialEq)]
-pub struct OciAuth {
-    pub basic: Option<BasicAuth>,
-    pub bearer: Option<BearerAuth>,
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub enum OciAuth {
+    Basic(BasicAuth),
+    Bearer(BearerAuth),
 }
 
 impl<'de> Deserialize<'de> for OciAuth {
@@ -136,15 +135,16 @@ impl<'de> Deserialize<'de> for OciAuth {
             bearer: Option<BearerAuth>,
         }
         let raw = OciAuthRaw::deserialize(deserializer)?;
-        if raw.basic.is_some() && raw.bearer.is_some() {
-            return Err(serde::de::Error::custom(
+        match (raw.basic, raw.bearer) {
+            (Some(_), Some(_)) => Err(serde::de::Error::custom(
                 "oci.auth: cannot specify both 'basic' and 'bearer' authentication",
-            ));
+            )),
+            (Some(basic), None) => Ok(OciAuth::Basic(basic)),
+            (None, Some(bearer)) => Ok(OciAuth::Bearer(bearer)),
+            (None, None) => Err(serde::de::Error::custom(
+                "oci.auth: must specify either 'basic' or 'bearer'",
+            )),
         }
-        Ok(OciAuth {
-            basic: raw.basic,
-            bearer: raw.bearer,
-        })
     }
 }
 
@@ -161,12 +161,11 @@ pub struct BearerAuth {
 
 impl From<&OciAuth> for RegistryAuth {
     fn from(auth: &OciAuth) -> Self {
-        if let Some(bearer) = &auth.bearer {
-            RegistryAuth::Bearer(bearer.token.clone())
-        } else if let Some(basic) = &auth.basic {
-            RegistryAuth::Basic(basic.username.clone(), basic.password.clone())
-        } else {
-            RegistryAuth::Anonymous
+        match auth {
+            OciAuth::Bearer(bearer) => RegistryAuth::Bearer(bearer.token.clone()),
+            OciAuth::Basic(basic) => {
+                RegistryAuth::Basic(basic.username.clone(), basic.password.clone())
+            }
         }
     }
 }
@@ -1189,17 +1188,28 @@ oci:
     }
 
     #[rstest]
-    #[case::anonymous_when_empty(OciAuth::default(), RegistryAuth::Anonymous)]
     #[case::basic_when_set(
-        OciAuth { basic: Some(BasicAuth { username: "user".to_string(), password: "pass".to_string() }), bearer: None },
+        OciAuth::Basic(BasicAuth { username: "user".to_string(), password: "pass".to_string() }),
         RegistryAuth::Basic("user".to_string(), "pass".to_string())
     )]
     #[case::bearer_when_set(
-        OciAuth { basic: None, bearer: Some(BearerAuth { token: "my-token".to_string() }) },
+        OciAuth::Bearer(BearerAuth { token: "my-token".to_string() }),
         RegistryAuth::Bearer("my-token".to_string())
     )]
     fn test_oci_auth_into_registry_auth(#[case] auth: OciAuth, #[case] expected: RegistryAuth) {
         assert_eq!(RegistryAuth::from(&auth), expected);
+    }
+
+    #[test]
+    fn test_oci_auth_rejects_empty() {
+        let result = serde_yaml::from_str::<OciAuth>("{}");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must specify either 'basic' or 'bearer'")
+        );
     }
 
     #[test]

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use http::HeaderMap;
 use kube::api::TypeMeta;
+use oci_client::secrets::RegistryAuth;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -121,12 +122,30 @@ impl OciConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+#[derive(Debug, Serialize, Default, Clone, PartialEq)]
 pub struct OciAuth {
-    #[serde(default)]
-    pub basic: BasicAuth,
-    #[serde(default)]
-    pub bearer: BearerAuth,
+    pub basic: Option<BasicAuth>,
+    pub bearer: Option<BearerAuth>,
+}
+
+impl<'de> Deserialize<'de> for OciAuth {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct OciAuthRaw {
+            basic: Option<BasicAuth>,
+            bearer: Option<BearerAuth>,
+        }
+        let raw = OciAuthRaw::deserialize(deserializer)?;
+        if raw.basic.is_some() && raw.bearer.is_some() {
+            return Err(serde::de::Error::custom(
+                "oci.auth: cannot specify both 'basic' and 'bearer' authentication",
+            ));
+        }
+        Ok(OciAuth {
+            basic: raw.basic,
+            bearer: raw.bearer,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
@@ -138,6 +157,18 @@ pub struct BasicAuth {
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct BearerAuth {
     pub token: String,
+}
+
+impl From<&OciAuth> for RegistryAuth {
+    fn from(auth: &OciAuth) -> Self {
+        if let Some(bearer) = &auth.bearer {
+            RegistryAuth::Bearer(bearer.token.clone())
+        } else if let Some(basic) = &auth.basic {
+            RegistryAuth::Basic(basic.username.clone(), basic.password.clone())
+        } else {
+            RegistryAuth::Anonymous
+        }
+    }
 }
 
 const DEFAULT_SIGNATURE_VERIFICATION_ENABLED: bool = true;
@@ -1155,5 +1186,32 @@ oci:
         agents.extend(infra());
         agents.extend(nrdot());
         agents
+    }
+
+    #[rstest]
+    #[case::anonymous_when_empty(OciAuth::default(), RegistryAuth::Anonymous)]
+    #[case::basic_when_set(
+        OciAuth { basic: Some(BasicAuth { username: "user".to_string(), password: "pass".to_string() }), bearer: None },
+        RegistryAuth::Basic("user".to_string(), "pass".to_string())
+    )]
+    #[case::bearer_when_set(
+        OciAuth { basic: None, bearer: Some(BearerAuth { token: "my-token".to_string() }) },
+        RegistryAuth::Bearer("my-token".to_string())
+    )]
+    fn test_oci_auth_into_registry_auth(#[case] auth: OciAuth, #[case] expected: RegistryAuth) {
+        assert_eq!(RegistryAuth::from(&auth), expected);
+    }
+
+    #[test]
+    fn test_oci_auth_rejects_both_basic_and_bearer() {
+        let yaml = "basic:\n  username: user\n  password: pass\nbearer:\n  token: my-token";
+        let result = serde_yaml::from_str::<OciAuth>(yaml);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot specify both")
+        );
     }
 }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -177,6 +177,7 @@ impl AgentControlRunner {
             OCIArtifactDownloader::new(
                 oci_client.clone(),
                 self.bootstrap_config.oci.registry.clone(),
+                self.bootstrap_config.oci.auth.clone(),
                 agent_control_config
                     .agent_packages
                     .signature_verification_enabled
@@ -228,6 +229,7 @@ impl AgentControlRunner {
             OCIArtifactDownloader::new(
                 oci_client.clone(),
                 self.bootstrap_config.oci.registry.clone(),
+                self.bootstrap_config.oci.auth.clone(),
                 agent_control_config
                     .self_update
                     .signature_verification_enabled

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -26,7 +26,6 @@ pub use error::OciClientError;
 #[derive(Clone)]
 pub struct Client {
     client: oci_client::Client,
-    auth: RegistryAuth,
     runtime: Arc<Runtime>,
     public_key_fetcher: PublicKeyFetcher,
 }
@@ -41,7 +40,6 @@ impl Client {
         let public_key_fetcher = Self::try_build_public_key_fetcher(proxy_config)?;
         Ok(Self {
             client: oci_client::Client::new(client_config),
-            auth: RegistryAuth::Anonymous,
             public_key_fetcher,
             runtime,
         })
@@ -51,9 +49,10 @@ impl Client {
     pub fn pull_image_manifest(
         &self,
         reference: &Reference,
+        auth: &RegistryAuth,
     ) -> Result<(OciImageManifest, String), OciClientError> {
         self.runtime
-            .block_on(self.client.pull_image_manifest(reference, &self.auth))
+            .block_on(self.client.pull_image_manifest(reference, auth))
             .map_err(|err| OciClientError::PullManifest(err.into()))
     }
 
@@ -109,13 +108,14 @@ impl Client {
         &self,
         reference: &Reference,
         public_key_url: &Url,
+        auth: &RegistryAuth,
     ) -> Result<Reference, OciClientError> {
         let public_keys = self
             .public_key_fetcher
             .fetch(public_key_url)
             .map_err(|err| OciClientError::Verify(format!("could not fetch public keys: {err}")))?;
         self.runtime
-            .block_on(self.verify_signature_with_public_keys(reference, &public_keys))
+            .block_on(self.verify_signature_with_public_keys(reference, &public_keys, auth))
     }
 }
 
@@ -178,7 +178,8 @@ pub mod tests {
         let image_ref = mock_server.reference();
         assert!(image_ref.digest().is_none()); // The reference to be verified doesn't have digest
 
-        let result = client.verify_signature(&image_ref, &jwks_server.url);
+        let result =
+            client.verify_signature(&image_ref, &jwks_server.url, &RegistryAuth::Anonymous);
 
         if signer_position.is_some() {
             let verified_ref = result.expect("verification should succeed");
@@ -206,7 +207,8 @@ pub mod tests {
         let client = create_test_client();
         let image_ref = mock_server.reference();
 
-        let result = client.verify_signature(&image_ref, &jwks_server.url);
+        let result =
+            client.verify_signature(&image_ref, &jwks_server.url, &RegistryAuth::Anonymous);
 
         assert_matches!(result, Err(OciClientError::Verify(_)));
     }
@@ -219,7 +221,9 @@ pub mod tests {
 
         let client = create_test_client();
         let reference = &server.reference();
-        let (image_manifest, _) = client.pull_image_manifest(reference).unwrap();
+        let (image_manifest, _) = client
+            .pull_image_manifest(reference, &RegistryAuth::Anonymous)
+            .unwrap();
         let layer = &image_manifest.layers[0];
         assert_eq!(layer.media_type, "fake-media_type");
 

--- a/agent-control/src/oci/signature_verification.rs
+++ b/agent-control/src/oci/signature_verification.rs
@@ -7,7 +7,7 @@ use crate::{
     signature::{public_key::PublicKey, public_key_fetcher::PublicKeyFetcher},
 };
 use base64::Engine;
-use oci_client::{Reference, manifest::OciDescriptor};
+use oci_client::{Reference, manifest::OciDescriptor, secrets::RegistryAuth};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, time::Duration};
 use tracing::debug;
@@ -77,6 +77,7 @@ impl Client {
         &self,
         reference: &Reference,
         public_keys: &[PublicKey],
+        auth: &RegistryAuth,
     ) -> Result<Reference, OciClientError> {
         // Resolve manifest digest
         let digest = match reference.digest() {
@@ -90,7 +91,7 @@ impl Client {
                 // instead.
                 let digest = self
                     .client
-                    .fetch_manifest_digest(reference, &self.auth)
+                    .fetch_manifest_digest(reference, auth)
                     .await
                     .map_err(|err| {
                         OciClientError::Verify(format!("could not fetch manifest: {err}"))
@@ -107,7 +108,7 @@ impl Client {
         // Get the corresponding manifest
         let (signature_manifest, _) = self
             .client
-            .pull_image_manifest(&signature_ref, &self.auth)
+            .pull_image_manifest(&signature_ref, auth)
             .await
             .map_err(|err| {
                 OciClientError::Verify(format!("could not fetch signature manifest: {err}"))
@@ -415,9 +416,12 @@ mod tests {
 
         let reference = ref_fn(&mock_server);
 
-        let result = tokio_runtime().block_on(
-            create_test_client().verify_signature_with_public_keys(&reference, &[kp.public_key()]),
-        );
+        let result =
+            tokio_runtime().block_on(create_test_client().verify_signature_with_public_keys(
+                &reference,
+                &[kp.public_key()],
+                &RegistryAuth::Anonymous,
+            ));
 
         let expected_digest = mock_server.manifest_digest();
         let verified_ref = result.expect("verification should succeed");
@@ -435,9 +439,12 @@ mod tests {
             .with_signature(&kp)
             .build();
 
-        let result = tokio_runtime().block_on(
-            create_test_client().verify_signature_with_public_keys(&mock_server.reference(), &[]),
-        );
+        let result =
+            tokio_runtime().block_on(create_test_client().verify_signature_with_public_keys(
+                &mock_server.reference(),
+                &[],
+                &RegistryAuth::Anonymous,
+            ));
         assert_matches!(result, Err(OciClientError::Verify(_)));
     }
 
@@ -459,10 +466,12 @@ mod tests {
             expected_digest.clone(),
         );
 
-        let result = tokio_runtime().block_on(
-            create_test_client()
-                .verify_signature_with_public_keys(&ref_with_digest, &[kp.public_key()]),
-        );
+        let result =
+            tokio_runtime().block_on(create_test_client().verify_signature_with_public_keys(
+                &ref_with_digest,
+                &[kp.public_key()],
+                &RegistryAuth::Anonymous,
+            ));
 
         assert_matches!(result, Err(OciClientError::Verify(_)));
     }

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -1,7 +1,9 @@
+use crate::agent_control::config::OciAuth;
 use crate::oci::{Client, reference_parser::ReferenceParser};
 use crate::package::oci::artifact_definitions::LocalAgentPackage;
 use crate::utils::retry::retry;
 use oci_client::Reference;
+use oci_client::secrets::RegistryAuth;
 use std::path::Path;
 use std::time::Duration;
 use thiserror::Error;
@@ -27,6 +29,7 @@ pub trait OCIAgentDownloader: Send + Sync {
 // This implementation avoids that since each download is expected to be done in a separate package directory.
 pub struct OCIArtifactDownloader {
     client: Client,
+    auth: RegistryAuth,
     signature_verification_enabled: bool,
     max_retries: usize,
     retry_interval: Duration,
@@ -69,9 +72,15 @@ const DEFAULT_RETRIES: usize = 0;
 
 impl OCIArtifactDownloader {
     /// Returns an artifact downloader with default retries setup.
-    pub fn new(client: Client, registry: String, signature_verification_enabled: bool) -> Self {
+    pub fn new(
+        client: Client,
+        registry: String,
+        auth: OciAuth,
+        signature_verification_enabled: bool,
+    ) -> Self {
         OCIArtifactDownloader {
             client,
+            auth: RegistryAuth::from(&auth),
             signature_verification_enabled,
             max_retries: DEFAULT_RETRIES,
             retry_interval: Duration::default(),
@@ -111,7 +120,7 @@ impl OCIArtifactDownloader {
     ) -> Result<Reference, OCIDownloaderError> {
         let reference = &reference_with_registry(reference, &self.registry);
         self.client
-            .verify_signature(reference, public_key_url)
+            .verify_signature(reference, public_key_url, &self.auth)
             .map_err(|err| OCIDownloaderError(err.to_string()))
     }
 
@@ -123,7 +132,7 @@ impl OCIArtifactDownloader {
         let reference = &reference_with_registry(reference, &self.registry);
         let (image_manifest, _) = self
             .client
-            .pull_image_manifest(reference)
+            .pull_image_manifest(reference, &self.auth)
             .map_err(|err| OCIDownloaderError(format!("pull artifact manifest failure: {err}")))?;
 
         let (layer, media_type) = LocalAgentPackage::get_layer(&image_manifest)
@@ -164,6 +173,7 @@ pub mod tests {
     use crate::utils::test_runtime::tokio_runtime;
 
     use super::*;
+    use crate::agent_control::config::OciAuth;
     use assert_matches::assert_matches;
     use httpmock::prelude::*;
     use mockall::mock;
@@ -462,6 +472,11 @@ pub mod tests {
             tokio_runtime(),
         )
         .unwrap();
-        OCIArtifactDownloader::new(client, registry, signature_verification_enabled)
+        OCIArtifactDownloader::new(
+            client,
+            registry,
+            OciAuth::default(),
+            signature_verification_enabled,
+        )
     }
 }

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -75,12 +75,15 @@ impl OCIArtifactDownloader {
     pub fn new(
         client: Client,
         registry: String,
-        auth: OciAuth,
+        auth: Option<OciAuth>,
         signature_verification_enabled: bool,
     ) -> Self {
         OCIArtifactDownloader {
             client,
-            auth: RegistryAuth::from(&auth),
+            auth: auth
+                .as_ref()
+                .map(RegistryAuth::from)
+                .unwrap_or(RegistryAuth::Anonymous),
             signature_verification_enabled,
             max_retries: DEFAULT_RETRIES,
             retry_interval: Duration::default(),
@@ -173,7 +176,6 @@ pub mod tests {
     use crate::utils::test_runtime::tokio_runtime;
 
     use super::*;
-    use crate::agent_control::config::OciAuth;
     use assert_matches::assert_matches;
     use httpmock::prelude::*;
     use mockall::mock;
@@ -459,6 +461,34 @@ pub mod tests {
         assert_eq!(reference_with_registry.registry(), registry);
     }
 
+    #[test]
+    fn test_none_auth_defaults_to_anonymous() {
+        let server = FakeOciServer::new("test-repo", "v1.0.0")
+            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
+            .with_layer(
+                b"content",
+                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
+            )
+            .build();
+
+        let client = Client::try_new(
+            ClientConfig {
+                protocol: ClientProtocol::Http,
+                ..Default::default()
+            },
+            ProxyConfig::default(),
+            tokio_runtime(),
+        )
+        .unwrap();
+        let downloader = OCIArtifactDownloader::new(client, server.registry(), None, false);
+        let dest_dir = tempdir().unwrap();
+        assert!(
+            downloader
+                .download(&server.reference(), &None, dest_dir.path())
+                .is_ok()
+        );
+    }
+
     fn create_downloader(
         registry: String,
         signature_verification_enabled: bool,
@@ -472,11 +502,6 @@ pub mod tests {
             tokio_runtime(),
         )
         .unwrap();
-        OCIArtifactDownloader::new(
-            client,
-            registry,
-            OciAuth::default(),
-            signature_verification_enabled,
-        )
+        OCIArtifactDownloader::new(client, registry, None, signature_verification_enabled)
     }
 }

--- a/agent-control/tests/on_host/oci_registry.rs
+++ b/agent-control/tests/on_host/oci_registry.rs
@@ -47,7 +47,12 @@ fn test_download_artifact_from_local_registry_with_oci_registry() {
 
     let client = create_client_with_proxy(ProxyConfig::default());
 
-    let downloader = OCIArtifactDownloader::new(client, OCI_TEST_REGISTRY_URL.to_string(), false);
+    let downloader = OCIArtifactDownloader::new(
+        client,
+        OCI_TEST_REGISTRY_URL.to_string(),
+        Default::default(),
+        false,
+    );
 
     let _ = downloader
         .download(&reference, &None, local_agent_data_dir)
@@ -108,8 +113,13 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
 
     let client = create_client_with_proxy(proxy_config);
 
-    let downloader = OCIArtifactDownloader::new(client, OCI_TEST_REGISTRY_URL.to_string(), false)
-        .with_retries(4, Duration::from_millis(100));
+    let downloader = OCIArtifactDownloader::new(
+        client,
+        OCI_TEST_REGISTRY_URL.to_string(),
+        Default::default(),
+        false,
+    )
+    .with_retries(4, Duration::from_millis(100));
 
     let result = downloader.download(&reference, &None, local_agent_data_dir);
     assert!(result.is_ok());

--- a/agent-control/tests/on_host/tools/oci_package_manager.rs
+++ b/agent-control/tests/on_host/tools/oci_package_manager.rs
@@ -25,7 +25,7 @@ pub fn new_testing_oci_package_manager(
         tokio_runtime(),
     )
     .unwrap();
-    let downloader = OCIArtifactDownloader::new(client, registry, false);
+    let downloader = OCIArtifactDownloader::new(client, registry, Default::default(), false);
 
     OCIPackageManager::new(downloader, DirectoryManagerFs, base_path)
 }


### PR DESCRIPTION
Use OCI registry auth from config instead of anonymous access.

- The auth is added to OCIArtifactDownloader rather than the client so the client remains reusable across different credential contexts, allowing to use a single client if we support multiple registries with different auth in the  future.                                           
- OciAuth now uses Option fields for basic and bearer, and deserialization actively rejects configurations that set both — ensuring users must choose one or the other rather than relying on silent precedence rules.           
                                                                                                                      

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
