### PR TITLE
chore(releaseName): threat empty string as None

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -326,6 +326,15 @@ pub struct OpAMPClientConfig {
     pub signature_validation: SignatureValidatorConfig,
 }
 
+/// Deserializes an empty string as None, otherwise as Some(String)
+fn deserialize_empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let maybe_string = Option::<String>::deserialize(deserializer)?;
+    Ok(maybe_string.and_then(|s| if s.is_empty() { None } else { Some(s) }))
+}
+
 impl<'de> Deserialize<'de> for OpAMPClientConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -395,14 +404,14 @@ pub struct K8sConfig {
     #[serde(default)]
     pub ac_remote_update: bool,
     /// agent_control_deployment release name
-    #[serde(default)]
-    pub ac_release_name: String,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
+    pub ac_release_name: Option<String>,
     /// cd_remote_update enables or disables remote update for the agent-control-cd chart
     #[serde(default)]
     pub cd_remote_update: bool,
     /// agent_control_cd release name
-    #[serde(default)]
-    pub cd_release_name: String,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
+    pub cd_release_name: Option<String>,
     /// Specifies the key name within the Kubernetes Secret
     /// used to retrieve the required secret for credentials.
     #[serde(default)]
@@ -883,6 +892,35 @@ k8s:
     #[test]
     fn test_default_package_compiles() {
         let _ = AgentControlPackage::default();
+    }
+
+    #[rstest]
+    #[case::empty_strings("", "", None, None)]
+    #[case::non_empty_strings("my-ac-release", "my-cd-release", Some("my-ac-release".to_string()), Some("my-cd-release".to_string()))]
+    fn test_release_names_deserialization(
+        #[case] ac_release_name: &str,
+        #[case] cd_release_name: &str,
+        #[case] expected_ac_release_name: Option<String>,
+        #[case] expected_cd_release_name: Option<String>,
+    ) {
+        let config_input = format!(
+            r#"
+agents: {{}}
+k8s:
+  namespace: some-namespace
+  namespace_agents: some-namespace-agents
+  cluster_name: some-cluster
+  ac_release_name: "{}"
+  cd_release_name: "{}"
+"#,
+            ac_release_name, cd_release_name
+        );
+
+        let config = serde_yaml::from_str::<AgentControlConfig>(&config_input).unwrap();
+        let k8s = config.k8s.unwrap();
+
+        assert_eq!(k8s.ac_release_name, expected_ac_release_name);
+        assert_eq!(k8s.cd_release_name, expected_cd_release_name);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////

--- a/agent-control/src/agent_control/config_validator/k8s.rs
+++ b/agent-control/src/agent_control/config_validator/k8s.rs
@@ -6,8 +6,8 @@ use super::{DynamicConfigValidator, DynamicConfigValidatorError};
 /// to avoid modification of agent CRs during AC self-update
 pub struct K8sReleaseNamesConfigValidator<V: DynamicConfigValidator> {
     inner: V,
-    ac_release_name: String,
-    cd_release_name: String,
+    ac_release_name: Option<String>,
+    cd_release_name: Option<String>,
 }
 
 impl<V: DynamicConfigValidator> DynamicConfigValidator for K8sReleaseNamesConfigValidator<V> {
@@ -17,25 +17,34 @@ impl<V: DynamicConfigValidator> DynamicConfigValidator for K8sReleaseNamesConfig
     ) -> Result<(), DynamicConfigValidatorError> {
         self.inner.validate(dynamic_config)?;
 
-        dynamic_config
-            .agents
-            .keys()
-            .try_for_each(|agent_id| match agent_id.as_str() {
-                agent_id if agent_id == self.ac_release_name => Err(validation_error(
-                    agent_id,
+        dynamic_config.agents.keys().try_for_each(|agent_id| {
+            if self
+                .ac_release_name
+                .clone()
+                .is_some_and(|name| agent_id.as_str() == name)
+            {
+                return Err(validation_error(
+                    agent_id.as_str(),
                     "Agent Control itself (agent-control-deployment)",
-                )),
-                agent_id if agent_id == self.cd_release_name => Err(validation_error(
-                    agent_id,
+                ));
+            }
+            if self
+                .cd_release_name
+                .clone()
+                .is_some_and(|name| agent_id.as_str() == name)
+            {
+                return Err(validation_error(
+                    agent_id.as_str(),
                     "Agent Control CD (agent-control-cd)",
-                )),
-                _ => Ok(()),
-            })
+                ));
+            }
+            Ok(())
+        })
     }
 }
 
 impl<V: DynamicConfigValidator> K8sReleaseNamesConfigValidator<V> {
-    pub fn new(inner: V, ac_release_name: String, cd_release_name: String) -> Self {
+    pub fn new(inner: V, ac_release_name: Option<String>, cd_release_name: Option<String>) -> Self {
         Self {
             inner,
             ac_release_name,
@@ -66,8 +75,8 @@ mod tests {
 
         let validator = K8sReleaseNamesConfigValidator {
             inner,
-            ac_release_name: "agent-control-deployment".to_string(),
-            cd_release_name: "agent-control-cd".to_string(),
+            ac_release_name: Some("agent-control-deployment".to_string()),
+            cd_release_name: Some("agent-control-cd".to_string()),
         };
 
         let dynamic_config = AgentControlDynamicConfig {
@@ -89,8 +98,8 @@ mod tests {
 
         let validator = K8sReleaseNamesConfigValidator {
             inner,
-            ac_release_name: "agent-control-deployment".to_string(),
-            cd_release_name: "agent-control-cd".to_string(),
+            ac_release_name: Some("agent-control-deployment".to_string()),
+            cd_release_name: Some("agent-control-cd".to_string()),
         };
 
         let dynamic_config = AgentControlDynamicConfig {
@@ -111,8 +120,8 @@ mod tests {
 
         let validator = K8sReleaseNamesConfigValidator {
             inner,
-            ac_release_name: "nrdot".to_string(),
-            cd_release_name: "agent-control-cd".to_string(),
+            ac_release_name: Some("nrdot".to_string()),
+            cd_release_name: Some("agent-control-cd".to_string()),
         };
 
         let dynamic_config = AgentControlDynamicConfig {
@@ -133,8 +142,8 @@ mod tests {
 
         let validator = K8sReleaseNamesConfigValidator {
             inner,
-            ac_release_name: "random-release-name".to_string(),
-            cd_release_name: "infra-agent".to_string(),
+            ac_release_name: Some("random-release-name".to_string()),
+            cd_release_name: Some("infra-agent".to_string()),
         };
 
         let dynamic_config = AgentControlDynamicConfig {

--- a/agent-control/src/agent_control/health_checker/k8s.rs
+++ b/agent-control/src/agent_control/health_checker/k8s.rs
@@ -16,7 +16,7 @@ pub fn agent_control_health_checker_builder(
 ) -> impl Fn(SystemTime) -> Option<K8sHealthChecker> {
     move |start_time: SystemTime| {
         let releases = [
-            // ac_release_name existing means AC is enable
+            // ac_release_name existing means AC is enabled
             ac_release_name.as_ref(),
             // cd_release_name existing means flux is enabled
             cd_release_name.as_ref(),

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -52,7 +52,7 @@ use resource_detection::system::hostname::get_hostname;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub const NAMESPACE_VARIABLE_NAME: &str = "namespace";
 pub const NAMESPACE_AGENTS_VARIABLE_NAME: &str = "namespace_agents";
@@ -203,7 +203,7 @@ impl AgentControlRunner {
             k8s_client: k8s_client.clone(),
             namespace: k8s_config.namespace.clone(),
             namespace_agents: k8s_config.namespace_agents.clone(),
-            cr_type_meta: k8s_config.cr_type_meta,
+            cr_type_meta: k8s_config.cr_type_meta.clone(),
         };
 
         info!("Initiating cleanup of outdated resources from previous Agent Control executions");
@@ -220,8 +220,8 @@ impl AgentControlRunner {
 
         let dynamic_config_validator = K8sReleaseNamesConfigValidator::new(
             registry_config_validator,
-            k8s_config.ac_release_name.to_string(),
-            k8s_config.cd_release_name.to_string(),
+            k8s_config.ac_release_name.clone(),
+            k8s_config.cd_release_name.clone(),
         );
 
         // The http server stops on Drop. We need to keep it while the agent control is running.
@@ -231,15 +231,11 @@ impl AgentControlRunner {
             .transpose()
             .map_err(|err| RunError(format!("failed to start HTTP server: {err}")))?;
 
-        let cd_remote_updates_enabled =
-            k8s_config.cd_remote_update && !k8s_config.cd_release_name.is_empty();
-        let ac_release_name_exists = !k8s_config.ac_release_name.is_empty();
-
         let health_checker_builder = agent_control_health_checker_builder(
             k8s_client.clone(),
             k8s_config.namespace.to_string(),
-            ac_release_name_exists.then(|| k8s_config.ac_release_name.clone()),
-            cd_remote_updates_enabled.then(|| k8s_config.cd_release_name.clone()),
+            k8s_config.clone().ac_release_name,
+            k8s_config.clone().cd_release_name,
         );
 
         let k8s_ac_updater = K8sACUpdater::new(
@@ -248,19 +244,24 @@ impl AgentControlRunner {
             k8s_client.clone(),
             k8s_config.namespace.clone(),
             k8s_config.current_chart_version.clone(),
-            k8s_config.ac_release_name,
-            k8s_config.cd_release_name.clone(),
+            k8s_config.clone().ac_release_name,
+            k8s_config.clone().cd_release_name,
         );
         let (agent_control_internal_publisher, agent_control_internal_consumer) = pub_sub();
 
-        let _cd_version_checker = cd_remote_updates_enabled.then(|| {
-            start_cd_version_checker(
+        let _cd_version_checker = if let Some(cd_release_name) = k8s_config.clone().cd_release_name
+            && k8s_config.cd_remote_update
+        {
+            Some(start_cd_version_checker(
                 k8s_client,
                 k8s_config.namespace.clone(),
-                k8s_config.cd_release_name.clone(),
+                cd_release_name,
                 agent_control_internal_publisher.clone(),
-            )
-        });
+            ))
+        } else {
+            debug!("Skipping CD version checker thread startup");
+            None
+        };
 
         AgentControl::new(
             maybe_client,
@@ -344,7 +345,7 @@ pub fn agent_control_opamp_non_identifying_attributes(
         ),
         (
             CD_EXTERNAL_ENABLED_ATTRIBUTE_KEY.to_string(),
-            (k8s_config.cd_release_name.is_empty()).into(),
+            (k8s_config.cd_release_name.is_none()).into(),
         ),
         (
             CD_REMOTE_UPDATE_ENABLED_ATTRIBUTE_KEY.to_string(),

--- a/agent-control/src/agent_control/version_updater/k8s.rs
+++ b/agent-control/src/agent_control/version_updater/k8s.rs
@@ -32,31 +32,42 @@ pub struct K8sACUpdater {
     // It is loaded at startup, and it is populated by the HelmChart.
     current_chart_version: String,
     // release name for agent control deployment loaded from config
-    ac_release_name: String,
+    ac_release_name: Option<String>,
     // release name for agent control cd loaded from config
-    cd_release_name: String,
+    cd_release_name: Option<String>,
 }
 
 impl VersionUpdater for K8sACUpdater {
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError> {
         if self.ac_remote_update_enabled {
-            self.update_helm_release_version(
-                Component::AgentControl,
-                config.chart_version.as_ref(),
-                &self.ac_release_name,
-                || Ok(self.current_chart_version.clone()),
-            )?;
+            if let Some(release_name) = &self.ac_release_name {
+                self.update_helm_release_version(
+                    Component::AgentControl,
+                    config.chart_version.as_ref(),
+                    release_name,
+                    || Ok(self.current_chart_version.clone()),
+                )?;
+            } else {
+                debug!("Agent Control release name is not set. Skipping AC update.");
+            }
         } else {
             debug!("Remote updates for Agent Control are disabled. Nothing to do.");
         }
 
         if self.cd_remote_update_enabled {
-            self.update_helm_release_version(
-                Component::FluxCD,
-                config.cd_chart_version.as_ref(),
-                self.cd_release_name.as_str(),
-                || self.get_cd_helm_release_version(),
-            )?;
+            if let Some(release_name) = &self.cd_release_name {
+                self.update_helm_release_version(
+                    Component::FluxCD,
+                    config.cd_chart_version.as_ref(),
+                    release_name,
+                    || self.get_cd_helm_release_version(release_name),
+                )?;
+            } else {
+                debug!(
+                    "Agent Control CD release name is not set. Skipping Agent Control CD update."
+                );
+                return Ok(());
+            };
         } else {
             debug!("Remote updates for Agent Control cd are disabled. Nothing to do.");
         }
@@ -72,8 +83,8 @@ impl K8sACUpdater {
         k8s_client: Arc<SyncK8sClient>,
         namespace: String,
         current_chart_version: String,
-        ac_release_name: String,
-        cd_release_name: String,
+        ac_release_name: Option<String>,
+        cd_release_name: Option<String>,
     ) -> Self {
         Self {
             ac_remote_update_enabled: ac_remote_update,
@@ -174,27 +185,24 @@ impl K8sACUpdater {
         Ok(())
     }
 
-    fn get_cd_helm_release_version(&self) -> Result<String, UpdaterError> {
+    fn get_cd_helm_release_version(&self, release_name: &str) -> Result<String, UpdaterError> {
         let helm_release = self
             .k8s_client
             .get_dynamic_object(
                 &helmrelease_v2_type_meta(),
                 K8sObjectKey {
-                    name: &self.cd_release_name,
+                    name: release_name,
                     namespace: &self.namespace,
                 },
             )
             .map_err(|k8s_err| {
                 UpdaterError::UpdateFailed(format!(
                     "Failed to fetch HelmRelease '{}': {}",
-                    &self.cd_release_name, k8s_err
+                    release_name, k8s_err
                 ))
             })?
             .ok_or_else(|| {
-                UpdaterError::UpdateFailed(format!(
-                    "HelmRelease '{}' not found",
-                    &self.cd_release_name
-                ))
+                UpdaterError::UpdateFailed(format!("HelmRelease '{}' not found", release_name))
             })?;
 
         let version = helm_release
@@ -208,7 +216,7 @@ impl K8sACUpdater {
             .ok_or_else(|| {
                 UpdaterError::UpdateFailed(format!(
                     "Could not find version at 'spec.chart.spec.version' in HelmRelease '{}'",
-                    &self.cd_release_name
+                    release_name
                 ))
             })?;
 
@@ -314,8 +322,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(Some(NEW_AC_VERSION), None));
@@ -371,8 +379,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(None, Some(NEW_CD_VERSION)));
@@ -421,8 +429,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(Some(NEW_AC_VERSION), Some(NEW_CD_VERSION)));
@@ -440,8 +448,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(Some(NEW_AC_VERSION), Some(NEW_CD_VERSION)));
@@ -459,8 +467,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(None, None));
@@ -493,8 +501,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         // We pass the current versions, not the new ones
@@ -519,8 +527,8 @@ mod tests {
             Arc::new(mock_client),
             TEST_NAMESPACE.to_string(),
             CURRENT_AC_VERSION.to_string(),
-            TEST_AC_RELEASE_NAME.to_string(),
-            TEST_CD_RELEASE_NAME.to_string(),
+            Some(TEST_AC_RELEASE_NAME.to_string()),
+            Some(TEST_CD_RELEASE_NAME.to_string()),
         );
 
         let result = updater.update(&test_config(Some(NEW_AC_VERSION), None));

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 const POLL_INTERVAL: u64 = 5;
 
-const SECRET_NAME: &str = "ac-values";
+const AC_VALUES_SECRET_NAME: &str = "ac-values";
 const VALUES_KEY: &str = "values.yaml";
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -367,7 +367,7 @@ fn bootstrap_ac(
     create_values_secret(
         client.clone(),
         namespace,
-        SECRET_NAME,
+        AC_VALUES_SECRET_NAME,
         VALUES_KEY,
         ac_chart_values(opamp_endpoint, namespace),
     );
@@ -393,7 +393,7 @@ fn install_ac_with_cli(namespace: &str, chart_version: &str, release_name: &str)
     cmd.arg("--release-name").arg(release_name);
     cmd.arg("--namespace").arg(namespace);
     cmd.arg("--secrets")
-        .arg(format!("{SECRET_NAME}={VALUES_KEY}"));
+        .arg(format!("{AC_VALUES_SECRET_NAME}={VALUES_KEY}"));
     cmd.arg("--skip-installation-check");
     cmd.assert().success();
 }
@@ -411,6 +411,9 @@ fn ac_chart_values(opamp_endpoint: Url, name_override: &str) -> String {
             },
             "acRemoteUpdate": true,
             "cdRemoteUpdate": false,
+            // This is needed since the chart has a default cdReleaseName defined that is different from the one specified in the tiltfile.
+            // We do not want to monitor on control that, therefore we are unsetting it.
+            "cdReleaseName": "",
             "authSecret": {
                 "secretName": K8S_PRIVATE_KEY_SECRET,
                 "secretKeyName": K8S_KEY_SECRET,

--- a/agent-control/tests/k8s/updater.rs
+++ b/agent-control/tests/k8s/updater.rs
@@ -36,8 +36,8 @@ fn k8s_run_updater_for_cd_and_ac() {
         k8s_client.clone(),
         test_ns.clone(),
         CURRENT_AC_VERSION.to_string(),
-        TEST_AC_RELEASE_NAME.to_string(),
-        TEST_CD_RELEASE_NAME.to_string(),
+        Some(TEST_AC_RELEASE_NAME.to_string()),
+        Some(TEST_CD_RELEASE_NAME.to_string()),
     );
 
     let config_to_update = &AgentControlDynamicConfig {


### PR DESCRIPTION
This PRs make explicit the fact that the cd and ac release names could be not set.
The previous approach (managing empty strings) was not consistent around the code, possibly hiding subtle bugs

For example I think we had a bug or a confusing logic with the flux health. We were doing the following:
```
        let cd_remote_updates_enabled =
            k8s_config.cd_remote_update && !k8s_config.cd_release_name.is_empty();
let health_checker_builder = agent_control_health_checker_builder([...] 
            cd_remote_updates_enabled.then(|| k8s_config.cd_release_name.clone()),
        );
```
IMO the fact that the cd_remote_update is disabled should not disable as well the health monitoring
