### PR TITLE
feat: modify ac service on linux to restart always

### DIFF
--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -4,6 +4,7 @@
 //! performing one-shot actions or starting the main agent control process.
 #![warn(missing_docs)]
 use newrelic_agent_control::agent_control::run::AgentControlRunner;
+use newrelic_agent_control::agent_control::run::GracefulShutdownReason;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::command::{Command, Context};
 use newrelic_agent_control::utils::is_elevated::is_elevated;
@@ -56,7 +57,7 @@ fn main() -> ExitCode {
 /// could not read Agent Control config from /invalid/path: error loading the agent control config: \`error retrieving config: \`missing field \`agents\`\`\`
 /// Error: ConfigRead(LoadConfigError(ConfigError(missing field \`agents\`)))
 /// ```
-fn _main(context: Context) -> Result<(), Box<dyn Error>> {
+fn _main(context: Context) -> Result<GracefulShutdownReason, Box<dyn Error>> {
     #[cfg(not(feature = "disable-asroot"))]
     if !is_elevated()? {
         return Err("Program must run with elevated permissions".into());
@@ -86,7 +87,5 @@ fn _main(context: Context) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    // Shutdown reason is not used passed to this point.
-    run_result?;
-    Ok(())
+    run_result
 }

--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -6,6 +6,7 @@
 use crate::agent_control::config::AgentControlConfig;
 use crate::agent_control::defaults::ENVIRONMENT_VARIABLES_FILE_NAME;
 use crate::agent_control::run::Environment;
+use crate::agent_control::run::GracefulShutdownReason;
 use crate::agent_control::version_updater::on_host::verify::CommandResult;
 use crate::agent_control::{
     config_repository::{repository::AgentControlConfigLoader, store::AgentControlConfigStore},
@@ -26,6 +27,36 @@ use std::fmt::{Display, Formatter};
 use std::process::ExitCode;
 use std::sync::Arc;
 use tracing::{error, info};
+
+/// Converts the result of the main function into a process [`ExitCode`].
+///
+/// Implementations map specific outcomes (e.g. [`GracefulShutdownReason::SelfUpdate`])
+/// to non-zero exit codes that the process supervisor (e.g. systemd) can act on,
+/// while preserving the error message for logging.
+pub trait IntoExitCode {
+    /// Returns `Ok(exit_code)` on success or `Err(message)` when the process should exit
+    /// with a failure code and the message should be logged.
+    fn into_exit_code(self) -> Result<ExitCode, String>;
+}
+
+impl IntoExitCode for Result<(), Box<dyn Error>> {
+    fn into_exit_code(self) -> Result<ExitCode, String> {
+        self.map(|_| ExitCode::SUCCESS).map_err(|e| e.to_string())
+    }
+}
+
+impl IntoExitCode for Result<GracefulShutdownReason, Box<dyn Error>> {
+    fn into_exit_code(self) -> Result<ExitCode, String> {
+        match self {
+            // On Linux/Unix, exit with TEMPFAIL (75) for self-update so systemd's
+            // RestartForceExitStatus=75 triggers a restart of the newly installed binary.
+            #[cfg(target_family = "unix")]
+            Ok(GracefulShutdownReason::SelfUpdate) => Ok(ExitCode::from(75)),
+            Ok(_) => Ok(ExitCode::SUCCESS),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
 
 mod on_host_checks;
 
@@ -129,13 +160,14 @@ pub struct RunnerContext {
 
 impl Command {
     /// Runs the provided main function or shows the binary information according to commands
-    pub fn execute<F>(
+    pub fn execute<F, R>(
         running_mode: Environment,
         main_fn: F,
         #[cfg(target_os = "windows")] as_windows_service: bool,
     ) -> ExitCode
     where
-        F: FnOnce(Context) -> Result<(), Box<dyn Error>>,
+        F: FnOnce(Context) -> R,
+        R: IntoExitCode,
     {
         let parsed = Command::parse();
 
@@ -173,14 +205,15 @@ impl Command {
     }
 
     /// Handles the run command
-    fn run<F>(
+    fn run<F, R>(
         running_mode: Environment,
         main_fn: F,
         args: &Args,
         #[cfg(target_os = "windows")] as_windows_service: bool,
     ) -> ExitCode
     where
-        F: FnOnce(Context) -> Result<(), Box<dyn Error>>,
+        F: FnOnce(Context) -> R,
+        R: IntoExitCode,
     {
         match Command::build_context(
             running_mode,
@@ -194,10 +227,10 @@ impl Command {
                 eprintln!("Failed building the run context {}", err);
                 ExitCode::FAILURE
             }
-            Ok(run_context) => match main_fn(run_context) {
-                Ok(_) => {
+            Ok(run_context) => match main_fn(run_context).into_exit_code() {
+                Ok(exit_code) => {
                     info!("The agent control main process exited successfully");
-                    ExitCode::SUCCESS
+                    exit_code
                 }
                 Err(err) => {
                     error!("The agent control main process exited with an error: {err}");

--- a/build/package/newrelic-agent-control.service
+++ b/build/package/newrelic-agent-control.service
@@ -8,6 +8,7 @@ EnvironmentFile=/etc/newrelic-agent-control/systemd-env.conf
 ExecStart=/usr/bin/newrelic-agent-control
 KillMode=mixed
 Restart=on-failure
+RestartForceExitStatus=75
 Type=simple
 
 [Install]


### PR DESCRIPTION
Add RestartForceExitStatus=75 to the systemd unit and make AC exit with code 75 (POSIX TEMPFAIL) when the shutdown reason is SelfUpdate systemd treats exit codes listed in RestartForceExitStatus as "force restart regardless of the Restart= policy", so the updated binary is launched automatically.

The exit-code mapping is handled through a new IntoExitCode trait in Command, which lets each binary's _main return a typed result (Result<GracefulShutdownReason, _> for on-host, Result<(), _> for k8s) and derive the appropriate exit code without duplicating logic or using process::exit. The Windows path is unaffected — it already communicates ERROR_RESTART_APPLICATION (1467) to the SCM via teardown

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
