### PR TITLE
feat: adding new configuration field cd_enabled

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -23,6 +23,7 @@ use kube::api::TypeMeta;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
+use tracing::info;
 use url::Url;
 use wrapper_with_default::WrapperWithDefault;
 
@@ -398,6 +399,9 @@ pub struct K8sConfig {
     /// agent_control_cd release name. If not set and cd_enabled is true, AC expect an externally managed CD
     pub cd_release_name: Option<String>,
     /// cd_enabled indicates whether the CD utility is enabled or not.
+    /// Agent control disables health checks and automatic upgrade for the CD chart when this field is set to false.
+    /// However, it will still try to install any Agent configured without ensuring compatibility.
+    /// This responsibility is left to the user and fleet control.
     pub cd_enabled: bool,
     /// Specifies the key name within the Kubernetes Secret
     /// used to retrieve the required secret for credentials.
@@ -435,6 +439,9 @@ impl<'de> Deserialize<'de> for K8sConfig {
         if let Some(cd_enabled) = intermediate.cd_enabled
             && !cd_enabled
         {
+            info!(
+                "CD is disabled, setting cd_release_name to None, cd_remote_update to false and removing flux and instrumentation types from cr_type_meta"
+            );
             intermediate.cd_remote_update = Some(false);
             intermediate.cd_release_name = None;
             intermediate.cr_type_meta = Some(

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -326,15 +326,6 @@ pub struct OpAMPClientConfig {
     pub signature_validation: SignatureValidatorConfig,
 }
 
-/// Deserializes an empty string as None, otherwise as Some(String)
-fn deserialize_empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let maybe_string = Option::<String>::deserialize(deserializer)?;
-    Ok(maybe_string.and_then(|s| if s.is_empty() { None } else { Some(s) }))
-}
-
 impl<'de> Deserialize<'de> for OpAMPClientConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -383,7 +374,7 @@ impl<'de> Deserialize<'de> for OpAMPClientConfig {
 }
 
 /// K8sConfig represents the AgentControl configuration for K8s environments
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct K8sConfig {
     /// cluster_name is an attribute used to identify all monitored data in a particular kubernetes cluster. Required
     pub cluster_name: String,
@@ -395,27 +386,82 @@ pub struct K8sConfig {
     /// This value is passed to the agent control via Environment Variable to avoid race conditions.
     /// If set via config, after a failed upgrade we could have the "old" pod loading the new config
     /// and reading the new chart version, while the image is still the old one.
-    #[serde(default)]
     pub current_chart_version: String,
-    /// CRDs is a list of crds that AC should watch and be able to create/delete.
-    #[serde(default = "default_group_version_kinds")]
+    /// CRs is a list of resources that AC should watch and be able to create/delete.
     pub cr_type_meta: Vec<TypeMeta>,
     /// ac_remote_update enables or disables remote update for agent-control-deployment chart
-    #[serde(default)]
     pub ac_remote_update: bool,
     /// agent_control_deployment release name
-    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub ac_release_name: Option<String>,
     /// cd_remote_update enables or disables remote update for the agent-control-cd chart
-    #[serde(default)]
     pub cd_remote_update: bool,
-    /// agent_control_cd release name
-    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
+    /// agent_control_cd release name. If not set and cd_enabled is true, AC expect an externally managed CD
     pub cd_release_name: Option<String>,
+    /// cd_enabled indicates whether the CD utility is enabled or not.
+    pub cd_enabled: bool,
     /// Specifies the key name within the Kubernetes Secret
     /// used to retrieve the required secret for credentials.
-    #[serde(default)]
     pub auth_secret: AuthSecret,
+}
+
+impl<'de> Deserialize<'de> for K8sConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        struct IntermediateK8sConfig {
+            cluster_name: String,
+            namespace: String,
+            namespace_agents: String,
+            current_chart_version: Option<String>,
+            cr_type_meta: Option<Vec<TypeMeta>>,
+            ac_remote_update: Option<bool>,
+            ac_release_name: Option<String>,
+            cd_remote_update: Option<bool>,
+            cd_release_name: Option<String>,
+            cd_enabled: Option<bool>,
+            auth_secret: Option<AuthSecret>,
+        }
+
+        let mut intermediate = IntermediateK8sConfig::deserialize(deserializer)?;
+
+        // If the release names are set to empty strings we leverage None instead
+        intermediate.cd_release_name = intermediate.cd_release_name.filter(|s| !s.is_empty());
+        intermediate.ac_release_name = intermediate.ac_release_name.filter(|s| !s.is_empty());
+
+        // if cd_enabled is false, we make sure that cd_release_name is None, cd_remote_update is false
+        // and we set the cr_type_meta to a default value without flux and instrumentation types (since flux won't be installed)
+        if let Some(cd_enabled) = intermediate.cd_enabled
+            && !cd_enabled
+        {
+            intermediate.cd_remote_update = Some(false);
+            intermediate.cd_release_name = None;
+            intermediate.cr_type_meta = Some(
+                intermediate
+                    .cr_type_meta
+                    .unwrap_or_else(default_group_version_kinds_no_flux),
+            );
+        } else {
+            intermediate.cd_enabled = Some(true);
+        }
+
+        Ok(K8sConfig {
+            cluster_name: intermediate.cluster_name,
+            namespace: intermediate.namespace,
+            namespace_agents: intermediate.namespace_agents,
+            current_chart_version: intermediate.current_chart_version.unwrap_or_default(),
+            cr_type_meta: intermediate
+                .cr_type_meta
+                .unwrap_or_else(default_group_version_kinds),
+            ac_remote_update: intermediate.ac_remote_update.unwrap_or_default(),
+            ac_release_name: intermediate.ac_release_name,
+            cd_remote_update: intermediate.cd_remote_update.unwrap_or_default(),
+            cd_release_name: intermediate.cd_release_name,
+            cd_enabled: intermediate.cd_enabled.unwrap_or(true),
+            auth_secret: intermediate.auth_secret.unwrap_or_default(),
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -512,12 +558,14 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
     vec![
         // Agent Operator CRD
         instrumentation_v1beta3_type_meta(),
-        // This allows Secrets created as dynamic objects to be cleaned up by the GC
-        // This should not be needed anymore whenever the GC detection logic doesn't rely on this list.
         secret_type_meta(),
         helmrepository_type_meta(),
         helmrelease_v2_type_meta(),
     ]
+}
+
+pub fn default_group_version_kinds_no_flux() -> Vec<TypeMeta> {
+    vec![secret_type_meta()]
 }
 
 impl Default for K8sConfig {
@@ -532,6 +580,7 @@ impl Default for K8sConfig {
             ac_release_name: Default::default(),
             cd_remote_update: Default::default(),
             cd_release_name: Default::default(),
+            cd_enabled: true,
             auth_secret: AuthSecret {
                 secret_name: Default::default(),
                 secret_key_name: Default::default(),
@@ -918,6 +967,34 @@ k8s:
 
         assert_eq!(k8s.ac_release_name, expected_ac_release_name);
         assert_eq!(k8s.cd_release_name, expected_cd_release_name);
+    }
+
+    #[test]
+    fn test_cd_disabled_clears_cd_fields() {
+        let config_input = r#"
+agents: {}
+k8s:
+  namespace: some-namespace
+  namespace_agents: some-namespace-agents
+  cluster_name: some-cluster
+  cd_enabled: false
+  cd_release_name: "will-be-cleared"
+  cd_remote_update: true
+"#;
+
+        let config = serde_yaml::from_str::<AgentControlConfig>(config_input).unwrap();
+        let k8s = config.k8s.unwrap();
+
+        assert!(!k8s.cd_enabled);
+        assert_eq!(k8s.cd_release_name, None);
+        assert!(!k8s.cd_remote_update);
+        assert!(
+            k8s.cr_type_meta
+                .iter()
+                .filter(|o| o.kind == "HelmRelease" || o.kind == "Instrumentation")
+                .collect::<Vec<_>>()
+                .is_empty()
+        );
     }
 
     ////////////////////////////////////////////////////////////////////////////////////

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -434,8 +434,9 @@ impl<'de> Deserialize<'de> for K8sConfig {
         intermediate.cd_release_name = intermediate.cd_release_name.filter(|s| !s.is_empty());
         intermediate.ac_release_name = intermediate.ac_release_name.filter(|s| !s.is_empty());
 
+        let mut cr_type_meta: Vec<TypeMeta>;
         // if cd_enabled is false, we make sure that cd_release_name is None, cd_remote_update is false
-        // and we set the cr_type_meta to a default value without flux and instrumentation types (since flux won't be installed)
+        // and cr_type_meta is set to a default value without flux and instrumentation types (since flux won't be installed) unless it its set, in that case it is honored.
         if let Some(cd_enabled) = intermediate.cd_enabled
             && !cd_enabled
         {
@@ -444,13 +445,14 @@ impl<'de> Deserialize<'de> for K8sConfig {
             );
             intermediate.cd_remote_update = Some(false);
             intermediate.cd_release_name = None;
-            intermediate.cr_type_meta = Some(
-                intermediate
-                    .cr_type_meta
-                    .unwrap_or_else(default_group_version_kinds_no_flux),
-            );
+            cr_type_meta = intermediate
+                .cr_type_meta
+                .unwrap_or_else(default_group_version_kinds_no_flux);
         } else {
             intermediate.cd_enabled = Some(true);
+            cr_type_meta = intermediate
+                .cr_type_meta
+                .unwrap_or_else(default_group_version_kinds);
         }
 
         Ok(K8sConfig {
@@ -458,9 +460,7 @@ impl<'de> Deserialize<'de> for K8sConfig {
             namespace: intermediate.namespace,
             namespace_agents: intermediate.namespace_agents,
             current_chart_version: intermediate.current_chart_version.unwrap_or_default(),
-            cr_type_meta: intermediate
-                .cr_type_meta
-                .unwrap_or_else(default_group_version_kinds),
+            cr_type_meta,
             ac_remote_update: intermediate.ac_remote_update.unwrap_or_default(),
             ac_release_name: intermediate.ac_release_name,
             cd_remote_update: intermediate.cd_remote_update.unwrap_or_default(),
@@ -575,29 +575,8 @@ pub fn default_group_version_kinds_no_flux() -> Vec<TypeMeta> {
     vec![secret_type_meta()]
 }
 
-impl Default for K8sConfig {
-    fn default() -> Self {
-        Self {
-            cluster_name: Default::default(),
-            namespace: Default::default(),
-            namespace_agents: Default::default(),
-            current_chart_version: Default::default(),
-            cr_type_meta: default_group_version_kinds(),
-            ac_remote_update: Default::default(),
-            ac_release_name: Default::default(),
-            cd_remote_update: Default::default(),
-            cd_release_name: Default::default(),
-            cd_enabled: true,
-            auth_secret: AuthSecret {
-                secret_name: Default::default(),
-                secret_key_name: Default::default(),
-            },
-        }
-    }
-}
-
 #[cfg(test)]
-pub(crate) mod tests {
+pub mod tests {
     use super::*;
     use crate::opamp::remote_config::hash::Hash;
     use crate::opamp::remote_config::{AGENT_CONFIG_PREFIX, ConfigurationMap, OpampRemoteConfig};
@@ -611,6 +590,27 @@ pub(crate) mod tests {
     use assert_matches::assert_matches;
     use rstest::rstest;
     use std::path::PathBuf;
+
+    impl Default for K8sConfig {
+        fn default() -> Self {
+            Self {
+                cluster_name: Default::default(),
+                namespace: Default::default(),
+                namespace_agents: Default::default(),
+                current_chart_version: Default::default(),
+                cr_type_meta: default_group_version_kinds(),
+                ac_remote_update: Default::default(),
+                ac_release_name: Default::default(),
+                cd_remote_update: Default::default(),
+                cd_release_name: Default::default(),
+                cd_enabled: true,
+                auth_secret: AuthSecret {
+                    secret_name: Default::default(),
+                    secret_key_name: Default::default(),
+                },
+            }
+        }
+    }
 
     impl TryFrom<&str> for AgentControlDynamicConfig {
         type Error = AgentControlConfigError;
@@ -996,11 +996,9 @@ k8s:
         assert_eq!(k8s.cd_release_name, None);
         assert!(!k8s.cd_remote_update);
         assert!(
-            k8s.cr_type_meta
+            !k8s.cr_type_meta
                 .iter()
-                .filter(|o| o.kind == "HelmRelease" || o.kind == "Instrumentation")
-                .collect::<Vec<_>>()
-                .is_empty()
+                .any(|o| o.kind == "HelmRelease" || o.kind == "Instrumentation")
         );
     }
 

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -434,7 +434,7 @@ impl<'de> Deserialize<'de> for K8sConfig {
         intermediate.cd_release_name = intermediate.cd_release_name.filter(|s| !s.is_empty());
         intermediate.ac_release_name = intermediate.ac_release_name.filter(|s| !s.is_empty());
 
-        let mut cr_type_meta: Vec<TypeMeta>;
+        let cr_type_meta: Vec<TypeMeta>;
         // if cd_enabled is false, we make sure that cd_release_name is None, cd_remote_update is false
         // and cr_type_meta is set to a default value without flux and instrumentation types (since flux won't be installed) unless it its set, in that case it is honored.
         if let Some(cd_enabled) = intermediate.cd_enabled

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -344,8 +344,10 @@ pub fn agent_control_opamp_non_identifying_attributes(
             identifiers.cluster_name.clone().into(),
         ),
         (
+            // Notice that for the external flux use case there is not a specific flag for it.
+            // We rely on the fact that if there is not a CD release name and CD is enabled, then it must be the external flux use case.
             CD_EXTERNAL_ENABLED_ATTRIBUTE_KEY.to_string(),
-            (k8s_config.cd_release_name.is_none()).into(),
+            (k8s_config.cd_release_name.is_none() && k8s_config.cd_enabled).into(),
         ),
         (
             CD_REMOTE_UPDATE_ENABLED_ATTRIBUTE_KEY.to_string(),

--- a/agent-control/src/cli/k8s/uninstall/agent_control.rs
+++ b/agent-control/src/cli/k8s/uninstall/agent_control.rs
@@ -81,6 +81,7 @@ fn delete_owned_objects(
 /// objects_to_delete retrieves the static list of object known by AC, ignoring any dynamic list.
 /// Moreover, it adds ConfigMap to the list since it is not part of the default_group_version_kinds().
 /// it also filters away object that are not available in the cluster.
+/// On top of it, in the fluxless scenarios
 fn objects_to_delete(kinds_available: &HashSet<TypeMeta>) -> Vec<TypeMeta> {
     let mut tm_to_delete = default_group_version_kinds();
 

--- a/agent-control/src/cli/k8s/uninstall/agent_control.rs
+++ b/agent-control/src/cli/k8s/uninstall/agent_control.rs
@@ -81,7 +81,8 @@ fn delete_owned_objects(
 /// objects_to_delete retrieves the static list of object known by AC, ignoring any dynamic list.
 /// Moreover, it adds ConfigMap to the list since it is not part of the default_group_version_kinds().
 /// it also filters away object that are not available in the cluster.
-/// On top of it, in the fluxless scenarios
+/// On top of it, in the fluxless scenarios it loads the HelmRelease and HelmRepository CRs to be deleted,
+/// but it it a noop since they are not actually present in the cluster.
 fn objects_to_delete(kinds_available: &HashSet<TypeMeta>) -> Vec<TypeMeta> {
     let mut tm_to_delete = default_group_version_kinds();
 


### PR DESCRIPTION
Suggestions for a better name are welcomed.

The main idea is to provide a unique toggle in order to simplify the life of the user and have a clear way to detect the use-case

Notice that:
```
    /// cd_enabled indicates whether the CD utility is enabled or not.
    /// Agent control disables health checks and automatic upgrade for the CD chart when this field is set to false.
    /// However, it will still try to install any Agent configured without ensuring compatibility.
    /// This responsibility is left to the user and fleet control.
```