### PR TITLE
feat: health fluxless

### DIFF
--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -165,18 +165,18 @@ where
             opamp_client.update_effective_config()?
         }
 
-        let _health_checker_thread_context =
-            (self.health_checker_builder)(self.start_time).map(|health_checker| {
-                debug!("Starting Agent Control health-checker");
-                spawn_health_checker(
-                    AgentID::AgentControl,
-                    health_checker,
-                    self.agent_control_internal_publisher.clone(),
-                    self.initial_config.health_check.interval,
-                    self.initial_config.health_check.initial_delay,
-                    self.start_time,
-                )
-            });
+        let maybe_health_checker = (self.health_checker_builder)(self.start_time);
+        let _health_checker_thread_context = maybe_health_checker.map(|health_checker| {
+            debug!("Starting Agent Control health-checker");
+            spawn_health_checker(
+                AgentID::AgentControl,
+                health_checker,
+                self.agent_control_internal_publisher.clone(),
+                self.initial_config.health_check.interval,
+                self.initial_config.health_check.initial_delay,
+                self.start_time,
+            )
+        });
 
         // This update handles scenarios where applying a remote configuration containing an updated Agent Control (AC)
         // was initiated but did not complete successfully, leaving the remote configuration un-stored.

--- a/agent-control/src/agent_control/health_checker/k8s.rs
+++ b/agent-control/src/agent_control/health_checker/k8s.rs
@@ -1,24 +1,46 @@
-use std::{sync::Arc, time::SystemTime};
-
-use crate::agent_control::config::helmrelease_v2_type_meta;
+use crate::agent_control::config::{K8sConfig, helmrelease_v2_type_meta};
+use crate::checkers::health::health_checker::{HealthChecker, HealthCheckerError};
 use crate::checkers::health::k8s::health_checker::{
     K8sHealthChecker, K8sResourceHealthChecker, health_checkers_for_type_meta,
 };
+use crate::checkers::health::noop::NoOpHealthChecker;
+use crate::checkers::health::with_start_time::HealthWithStartTime;
 use crate::k8s::client::K8sClient;
+use std::{sync::Arc, time::SystemTime};
+
+pub enum HealthCheckerVariants<C: K8sClient> {
+    K8s(K8sHealthChecker<K8sResourceHealthChecker<C>>),
+    NoOp(NoOpHealthChecker),
+}
+
+impl<C: K8sClient> HealthChecker for HealthCheckerVariants<C> {
+    fn check_health(&self) -> Result<HealthWithStartTime, HealthCheckerError> {
+        match self {
+            Self::K8s(hc) => hc.check_health(),
+            Self::NoOp(hc) => hc.check_health(),
+        }
+    }
+}
 
 /// Returns the builder function for the health-checker of Agent Control in Kubernetes.
 pub fn agent_control_health_checker_builder<C: K8sClient>(
     k8s_client: Arc<C>,
-    namespace: String,
-    ac_release_name: Option<String>,
-    cd_release_name: Option<String>,
-) -> impl Fn(SystemTime) -> Option<K8sHealthChecker<K8sResourceHealthChecker<C>>> {
+    k8s_config: &K8sConfig,
+) -> impl Fn(SystemTime) -> Option<HealthCheckerVariants<C>> {
     move |start_time: SystemTime| {
+        // If CD is not enabled, we can skip all the checks related to it and return
+        // a NoOpHealthChecker and we return always healthy if AC is up and running
+        if !k8s_config.cd_enabled {
+            return Some(HealthCheckerVariants::NoOp(NoOpHealthChecker::new(
+                start_time,
+            )));
+        }
+
         let releases = [
             // ac_release_name existing means AC is enabled
-            ac_release_name.as_ref(),
+            k8s_config.ac_release_name.as_ref(),
             // cd_release_name existing means flux is enabled
-            cd_release_name.as_ref(),
+            k8s_config.cd_release_name.as_ref(),
         ]
         .into_iter()
         .flatten();
@@ -28,14 +50,16 @@ pub fn agent_control_health_checker_builder<C: K8sClient>(
                     helmrelease_v2_type_meta(),
                     k8s_client.clone(),
                     release_name.clone(),
-                    namespace.clone(),
-                    Some(namespace.clone()),
+                    k8s_config.namespace.clone(),
+                    Some(k8s_config.namespace.clone()),
                     start_time,
                 )
             })
             .collect();
 
-        Some(K8sHealthChecker::new(checkers, start_time))
+        Some(HealthCheckerVariants::K8s(K8sHealthChecker::new(
+            checkers, start_time,
+        )))
     }
 }
 
@@ -53,20 +77,28 @@ mod tests {
         let agent_control_release_name = "ac-deployment".to_string();
         let cd_release_name = "flux-cd".to_string();
 
-        let builder_fn = agent_control_health_checker_builder(
-            mock_k8s_client,
-            namespace,
-            Some(agent_control_release_name),
-            Some(cd_release_name),
-        );
+        let k8s_config = K8sConfig {
+            namespace: namespace.clone(),
+            ac_release_name: Some(agent_control_release_name.clone()),
+            cd_release_name: Some(cd_release_name.clone()),
+            cd_enabled: true,
+            ..Default::default()
+        };
 
+        let builder_fn = agent_control_health_checker_builder(mock_k8s_client, &k8s_config);
         let health_checker = builder_fn(SystemTime::now()).expect("Builder should not return None");
 
-        assert_eq!(
-            health_checker.checkers_count(),
-            8,
-            "There should be 8 checkers (4 for AC, 4 for Flux) when Flux is enabled"
-        );
+        match health_checker {
+            HealthCheckerVariants::K8s(hc) => {
+                // Assuming each release (AC and Flux) contributes 4 checkers, we expect 8 total
+                assert_eq!(
+                    hc.checkers_count(),
+                    8,
+                    "There should be 8 checkers (4 for AC, 4 for Flux) when Flux is enabled"
+                );
+            }
+            _ => panic!("Expected K8sHealthChecker variant"),
+        }
     }
 
     #[test]
@@ -75,18 +107,46 @@ mod tests {
         let namespace = "test-ns".to_string();
         let agent_control_release_name = "ac-deployment".to_string();
 
-        let builder_fn = agent_control_health_checker_builder(
-            mock_k8s_client,
-            namespace,
-            Some(agent_control_release_name),
-            None,
-        );
+        let k8s_config = K8sConfig {
+            namespace: namespace.clone(),
+            ac_release_name: Some(agent_control_release_name.clone()),
+            cd_enabled: true,
+            ..Default::default()
+        };
+
+        let builder_fn = agent_control_health_checker_builder(mock_k8s_client, &k8s_config);
         let health_checker = builder_fn(SystemTime::now()).expect("Builder should not return None");
 
-        assert_eq!(
-            health_checker.checkers_count(),
-            4,
-            "There should only be 4 checkers (all for AC) when Flux is disabled"
+        match health_checker {
+            HealthCheckerVariants::K8s(hc) => {
+                // Assuming each release (AC and Flux) contributes 4 checkers, we expect 8 total
+                assert_eq!(
+                    hc.checkers_count(),
+                    4,
+                    "There should only be 4 checkers (all for AC) when Flux is disabled"
+                );
+            }
+            _ => panic!("Expected K8sHealthChecker variant"),
+        }
+    }
+
+    #[test]
+    fn test_builder_returns_noop_when_cd_disabled() {
+        let mock_k8s_client = Arc::new(MockK8sClient::new());
+
+        let k8s_config = K8sConfig {
+            namespace: "test-ns".to_string(),
+            ac_release_name: Some("ac-deployment".to_string()),
+            cd_enabled: false,
+            ..Default::default()
+        };
+
+        let builder_fn = agent_control_health_checker_builder(mock_k8s_client, &k8s_config);
+        let health_checker = builder_fn(SystemTime::now()).expect("Builder should not return None");
+
+        assert!(
+            matches!(health_checker, HealthCheckerVariants::NoOp(_)),
+            "Expected NoOpHealthChecker variant when cd_enabled is false"
         );
     }
 }

--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -230,12 +230,8 @@ impl AgentControlRunner {
             .transpose()
             .map_err(|err| RunError(format!("failed to start HTTP server: {err}")))?;
 
-        let health_checker_builder = agent_control_health_checker_builder(
-            k8s_client.clone(),
-            k8s_config.namespace.to_string(),
-            k8s_config.clone().ac_release_name,
-            k8s_config.clone().cd_release_name,
-        );
+        let health_checker_builder =
+            agent_control_health_checker_builder(k8s_client.clone(), &k8s_config);
 
         let k8s_ac_updater = K8sACUpdater::new(
             k8s_config.ac_remote_update,


### PR DESCRIPTION
This PR add a NOOP for the agent control health check whenever flux is not enabled. Due to rust I needed to include a new enum to return either one or the other implementation to avoid a box of a box