### PR TITLE
refactor: extract fake opamp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-opamp-server"
+version = "0.1.0"
+dependencies = [
+ "actix-web",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "opamp-client",
+ "prost",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2947,7 @@ dependencies = [
  "duration-str",
  "either",
  "fake",
+ "fake-opamp-server",
  "flate2",
  "fs",
  "futures",
@@ -2956,7 +2971,6 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "predicates",
- "prost",
  "rcgen",
  "regex",
  "reqwest 0.13.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 
 members = [
   "agent-control",
+  "test/crates/fake-opamp-server",
   "resource-detection",
   "fs",
   "wrapper_with_default",
@@ -44,6 +45,10 @@ reqwest = { version = "0.13.3", features = ["blocking", "socks"] }
 rstest = "0.26.1"
 windows = "0.62.2"
 windows-sys = "0.61.2"
+aws-lc-rs = "1.16.3"
+base64 = "0.22.1"
+opamp-client = { git = "https://github.com/newrelic/newrelic-opamp-rs.git", tag = "0.0.37" }
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 
 [profile.release-debug]
 inherits = "release"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -864,6 +864,11 @@ Distributed under the following license(s):
 * Apache-2.0
 * MIT
 
+## fake-opamp-server <file:///home/runner/work/newrelic-agent-control/newrelic-agent-control/test/crates/fake-opamp-server>
+
+Distributed under the following license(s):
+
+
 ## fastrand <https://crates.io/crates/fastrand>
 
 Distributed under the following license(s):

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = { version = "3.5.2", features = ["termination"] }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
 futures = { version = "0.3.32" }
-tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { workspace = true, features = ["sync"] }
 console-subscriber = { version = "0.5.0", optional = true }
 duration-str = "0.21.0"
 http = { workspace = true }
@@ -30,10 +30,10 @@ actix-web = "4.13.0"
 serde_json = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
-base64 = { version = "0.22.1" }
+base64 = { workspace = true }
 # New Relic dependencies (external repos)
+opamp-client = { workspace = true }
 nr-auth = { git = "https://github.com/newrelic/newrelic-auth-rs.git", tag = "0.4.2" }
-opamp-client = { git = "https://github.com/newrelic/newrelic-opamp-rs.git", tag = "0.0.37" }
 # local dependencies
 fs = { path = "../fs" }
 wrapper_with_default = { path = "../wrapper_with_default" }
@@ -44,12 +44,12 @@ self-replacer = { path = "../self-replacer" }
 
 # K8S subagent dependencies
 kube = { version = "3.1.0", default-features = false, features = [
-  "config",
-  "runtime",
-  "derive",
-  "ws",
-  "rustls-tls",
-  "aws-lc-rs",
+    "config",
+    "runtime",
+    "derive",
+    "ws",
+    "rustls-tls",
+    "aws-lc-rs",
 ] }
 k8s-openapi = { version = "0.27.1", features = ["v1_31"] }
 either = { version = "1.15.0" }
@@ -60,11 +60,11 @@ cfg-if = "1.0.4"
 # HOST_ID and HOST_NAME attributes are experimental fields and after 0.26.0 are not included by default.
 # Check <https://github.com/open-telemetry/opentelemetry-rust/pull/2098> for details.
 opentelemetry-semantic-conventions = { version = "0.31.0", features = [
-  "semconv_experimental",
+    "semconv_experimental",
 ] }
 http-serde = "2.1.1"
 config = { version = "0.15.22", features = ["yaml"] }
-aws-lc-rs = "1.16.3"
+aws-lc-rs = { workspace = true }
 bytes = "1.11.1"
 opentelemetry = { version = "0.31.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
@@ -72,14 +72,14 @@ tracing-opentelemetry = "0.32.1"
 opentelemetry-otlp = { version = "0.31.1", features = ["reqwest-rustls"] }
 opentelemetry-http = { version = "0.31.0" }
 opentelemetry-appender-tracing = { version = "0.31.1", features = [
-  "experimental_use_tracing_span_context",
+    "experimental_use_tracing_span_context",
 ] }
 async-trait = "0.1.89"
 flate2 = "1.1.9"
 tar = "0.4.45"
 zip = "8.6.0"
 oci-client = { version = "0.16.1", features = [
-  "rustls-tls",
+    "rustls-tls",
 ], default-features = false }
 rustls-pki-types = { version = "1.14.1", features = ["std"] }
 dhat = { version = "0.3.3", optional = true }
@@ -89,10 +89,10 @@ nix = { workspace = true, features = ["signal", "user", "hostname"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 windows = { workspace = true, features = [
-  "Win32_System_Console",
-  "Win32_System_Threading",
-  "Win32_System_JobObjects",
-  "Win32_Security",
+    "Win32_System_Console",
+    "Win32_System_Threading",
+    "Win32_System_JobObjects",
+    "Win32_Security",
 ] }
 windows-service = "0.8.0"
 
@@ -100,6 +100,7 @@ windows-service = "0.8.0"
 windows-sys = { workspace = true }
 
 [dev-dependencies]
+fake-opamp-server = { path = "../test/crates/fake-opamp-server" }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tower-test = { workspace = true }
@@ -111,9 +112,8 @@ assert_matches = { workspace = true }
 tracing-test = { workspace = true }
 jsonwebtoken = { workspace = true }
 fs = { path = "../fs", features = ["mocks"] }
-tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true }
 fake = { version = "5.1.0", features = ["derive", "http"] }
-prost = "0.14.3"
 httpmock = { version = "0.8.3", features = ["proxy"] }
 serial_test = "3.4.0"
 futures = "0.3.32"

--- a/agent-control/build.rs
+++ b/agent-control/build.rs
@@ -24,7 +24,8 @@ const LOGGING_ENABLED_CRATES: &[&str] = &[
 // Workspace crates whose logs are explicitly disabled.
 // Every workspace member must appear in exactly one of the two lists — the build
 // fails otherwise, forcing an explicit decision when a new crate is added.
-const LOGGING_DISABLED_CRATES: &[&str] = &["wrapper_with_default", "e2e_runner"];
+const LOGGING_DISABLED_CRATES: &[&str] =
+    &["wrapper_with_default", "e2e_runner", "fake_opamp_server"];
 
 fn main() {
     generate_agent_type_registry();

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -1,4 +1,4 @@
-use crate::common::opamp::FakeServer;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 
 use opamp_client::opamp::proto::any_value::Value;
@@ -10,7 +10,7 @@ pub fn check_latest_identifying_attributes_match_expected(
     expected_identifying_attributes: Vec<KeyValue>,
 ) -> Result<(), String> {
     let current_attributes = opamp_server
-        .get_attributes(instance_id)
+        .get_attributes(instance_id.clone())
         .ok_or_else(|| "Identifying attributes not found".to_string())?;
 
     check_opamp_attributes(
@@ -26,7 +26,7 @@ pub fn check_latest_non_identifying_attributes_match_expected(
     expected_non_identifying_attributes: Vec<KeyValue>,
 ) -> Result<(), String> {
     let current_attributes = opamp_server
-        .get_attributes(instance_id)
+        .get_attributes(instance_id.clone())
         .ok_or_else(|| "Non identifying attributes not found".to_string())?;
 
     check_opamp_attributes(
@@ -42,7 +42,7 @@ pub fn check_identifying_attributes_contains_expected(
     expected_subset: Vec<KeyValue>,
 ) -> Result<(), String> {
     let current_attributes = opamp_server
-        .get_attributes(instance_id)
+        .get_attributes(instance_id.clone())
         .ok_or_else(|| "Identifying attributes not found".to_string())?;
 
     check_opamp_attributes_contains(

--- a/agent-control/tests/common/effective_config.rs
+++ b/agent-control/tests/common/effective_config.rs
@@ -1,4 +1,4 @@
-use crate::common::opamp::FakeServer;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 use std::error::Error;
 

--- a/agent-control/tests/common/health.rs
+++ b/agent-control/tests/common/health.rs
@@ -1,4 +1,4 @@
-use crate::common::opamp::FakeServer;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 use opamp_client::opamp::proto::ComponentHealth;
 use std::error::Error;
@@ -17,7 +17,7 @@ pub fn check_latest_health_status(
     instance_id: &InstanceID,
     check_fn: impl FnOnce(&ComponentHealth) -> bool,
 ) -> Result<(), Box<dyn Error>> {
-    let health_status = server.get_health_status(instance_id);
+    let health_status = server.get_health_status(instance_id.clone());
     match health_status.as_ref() {
         Some(status) if check_fn(status) => Ok(()),
         None => Err("Health status not available".into()),

--- a/agent-control/tests/common/mod.rs
+++ b/agent-control/tests/common/mod.rs
@@ -6,7 +6,6 @@ pub(super) mod global_logger;
 pub(super) mod health;
 pub(super) mod http_port;
 pub(super) mod oci;
-pub(super) mod opamp;
 pub(super) mod process_finder;
 pub(super) mod remote_config_status;
 pub(super) mod retry;

--- a/agent-control/tests/common/oci_signer.rs
+++ b/agent-control/tests/common/oci_signer.rs
@@ -1,6 +1,5 @@
-use super::runtime::tokio_runtime;
 use crate::common::oci::{hex_bytes, push_empty_config_descriptor};
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use actix_web::{App, HttpResponse, HttpServer, web};
 use aws_lc_rs::digest::SHA256;
 use aws_lc_rs::digest::digest;

--- a/agent-control/tests/common/remote_config_status.rs
+++ b/agent-control/tests/common/remote_config_status.rs
@@ -1,4 +1,4 @@
-use crate::common::opamp::FakeServer;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 use opamp_client::opamp::proto::RemoteConfigStatus;
 use std::error::Error;

--- a/agent-control/tests/k8s/agent_control_cli/installation.rs
+++ b/agent-control/tests/k8s/agent_control_cli/installation.rs
@@ -1,5 +1,4 @@
-use crate::common::opamp::FakeServer;
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::{DUMMY_PRIVATE_KEY, K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET};
 use crate::k8s::tools::cmd::{assert_stderr_contains, print_cli_output};
 use crate::k8s::tools::k8s_api::create_values_secret;
@@ -11,6 +10,7 @@ use crate::k8s::tools::local_chart::{
 use crate::k8s::tools::opamp::get_minikube_opamp_url_from_fake_server;
 use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
+use fake_opamp_server::FakeServer;
 use kube::Client;
 use std::time::Duration;
 // NOTE: The tests below are using the latest '*' chart version, and they will likely fail
@@ -26,7 +26,7 @@ fn k8s_cli_install_agent_control_installation_with_invalid_chart_version() {
     let mut k8s_env = block_on(K8sEnv::new());
     let ac_namespace = block_on(k8s_env.test_namespace());
     let subagents_namespace = block_on(k8s_env.test_namespace());
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     create_simple_values_secret(
         k8s_env.client.clone(),
@@ -96,7 +96,7 @@ fn k8s_cli_install_agent_control_installation_failed_upgrade() {
     let mut k8s_env = block_on(K8sEnv::new());
     let ac_namespace = block_on(k8s_env.test_namespace());
     let subagents_namespace = block_on(k8s_env.test_namespace());
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     create_simple_values_secret(
         k8s_env.client.clone(),

--- a/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
+++ b/agent-control/tests/k8s/agent_control_cli/upgrade_local_vs_remote.rs
@@ -1,4 +1,3 @@
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
 use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::agent_control_cli::installation::{ac_install_cmd, create_simple_values_secret};
@@ -11,6 +10,7 @@ use crate::k8s::tools::local_chart::agent_control_deploymet::{
     CHART_VERSION_DEV_1, CHART_VERSION_DEV_2, CHART_VERSION_LATEST_RELEASE,
 };
 use crate::k8s::tools::logs::print_pod_logs;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::config::helmrelease_v2_type_meta;
 use newrelic_agent_control::checkers::version::VersionCheckError;
@@ -29,7 +29,7 @@ const CLI_AC_LABEL_SELECTOR: &str = "app.kubernetes.io/name=agent-control-deploy
 // a similar workaround than the one we use in the tiltfile.
 // The test is checking how local and remote upgrade are interacting
 fn k8s_cli_local_and_remote_updates() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s_env = block_on(K8sEnv::new());
     let ac_namespace = block_on(k8s_env.test_namespace());
     let subagents_namespace = block_on(k8s_env.test_namespace());

--- a/agent-control/tests/k8s/flux_self_update.rs
+++ b/agent-control/tests/k8s/flux_self_update.rs
@@ -8,10 +8,9 @@ use crate::common::attributes::{
 /// special setup that differs from other integration tests and is managed by
 /// the Makefile and Tiltfile for CI environments.
 use crate::common::health::{check_latest_health_status, check_latest_health_status_was_healthy};
-use crate::common::opamp::FakeServer;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::retry::{DeferredCommand, retry};
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::{
     CUSTOM_AGENT_TYPE_SPLIT_NS_PATH, start_agent_control_with_testdata_config,
 };
@@ -24,6 +23,7 @@ use crate::k8s::tools::local_chart::agent_control_cd::{
     CHART_VERSION_UPSTREAM_1, CHART_VERSION_UPSTREAM_1_PKG, CHART_VERSION_UPSTREAM_2,
 };
 use crate::k8s::tools::local_chart::agent_control_deploymet::MISSING_VERSION;
+use fake_opamp_server::FakeServer;
 use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
 use kube::api::PostParams;
 use kube::{Api, Client};
@@ -68,7 +68,7 @@ fn k8s_cli_install_and_update_flux_resources_success() {
 #[ignore = "needs k8s cluster"]
 fn k8s_remote_flux_update() {
     let test_name = "k8s_remote_flux_update";
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 
@@ -152,7 +152,7 @@ cd_chart_version: {CHART_VERSION_UPSTREAM_2}
 #[ignore = "needs k8s cluster"]
 fn k8s_remote_flux_update_with_wrong_version_causes_unhealthy() {
     let test_name = "k8s_remote_flux_update";
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 

--- a/agent-control/tests/k8s/scenarios/ac_restarts.rs
+++ b/agent-control/tests/k8s/scenarios/ac_restarts.rs
@@ -1,8 +1,7 @@
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::check_latest_health_status_was_healthy;
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::{
     CUSTOM_AGENT_TYPE_PATH, start_agent_control_with_testdata_config,
     wait_until_agent_control_with_opamp_is_started,
@@ -10,6 +9,7 @@ use crate::k8s::tools::agent_control::{
 use crate::k8s::tools::instance_id;
 use crate::k8s::tools::k8s_api::check_helmrelease_spec_values;
 use crate::k8s::tools::k8s_env::K8sEnv;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -26,7 +26,7 @@ use tempfile::tempdir;
 fn k8s_opamp_subagent_configuration_change_after_ac_restarts() {
     let test_name = "k8s_opamp_subagent_configuration_change_after_ac_restarts";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -4,11 +4,12 @@ use crate::common::attributes::{
     check_latest_non_identifying_attributes_match_expected, convert_to_vec_key_value,
 };
 use crate::common::retry::retry;
-use crate::common::{opamp::FakeServer, runtime::block_on};
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::CUSTOM_AGENT_TYPE_PATH;
 use crate::k8s::tools::{
     agent_control::start_agent_control_with_testdata_config, instance_id, k8s_env::K8sEnv,
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_VERSION, CD_EXTERNAL_ENABLED_ATTRIBUTE_KEY,
@@ -29,7 +30,7 @@ fn k8s_test_attributes_from_existing_agent_type() {
     let test_name = "k8s_opamp_attributes_existing_agent_type";
 
     // setup the fake-opamp-server, with empty configuration for agents in local config should be used.
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/config_signature.rs
+++ b/agent-control/tests/k8s/scenarios/config_signature.rs
@@ -1,5 +1,9 @@
-use crate::common::{opamp::FakeServer, retry::retry, runtime::block_on};
+use crate::common::{
+    retry::retry,
+    runtime::{block_on, tokio_runtime},
+};
 use crate::k8s::tools::agent_control::CUSTOM_AGENT_TYPE_PATH;
+use fake_opamp_server::FakeServer;
 
 use crate::k8s::tools::{
     agent_control::start_agent_control_with_testdata_config, instance_id,
@@ -18,7 +22,7 @@ use tempfile::tempdir;
 fn k8s_signature_disabled() {
     let test_name = "k8s_signature_disabled";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/cr_based_agents.rs
+++ b/agent-control/tests/k8s/scenarios/cr_based_agents.rs
@@ -9,9 +9,13 @@ use crate::k8s::tools::{
     k8s_env::K8sEnv,
 };
 use crate::{
-    common::{opamp::FakeServer, retry::retry, runtime::block_on},
+    common::{
+        retry::retry,
+        runtime::{block_on, tokio_runtime},
+    },
     k8s::tools::agent_control::FOO_CR_AGENT_TYPE_PATH,
 };
+use fake_opamp_server::FakeServer;
 use kube::{Api, CustomResource, CustomResourceExt};
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use schemars::JsonSchema;
@@ -27,7 +31,7 @@ fn k8s_opamp_foo_cr_subagent() {
     let test_name = "k8s_opamp_foo_cr_subagent";
 
     // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());
@@ -100,7 +104,7 @@ fn k8s_opamp_cr_subagent_installed_before_crd() {
     let test_name = "k8s_opamp_cr_subagent_installed_before_crd";
 
     // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/fail_remote_config.rs
+++ b/agent-control/tests/k8s/scenarios/fail_remote_config.rs
@@ -1,11 +1,13 @@
 use crate::common::{
-    effective_config::check_latest_effective_config_is_expected, opamp::FakeServer,
-    remote_config_status::check_latest_remote_config_status_is_expected, retry::retry,
-    runtime::block_on,
+    effective_config::check_latest_effective_config_is_expected,
+    remote_config_status::check_latest_remote_config_status_is_expected,
+    retry::retry,
+    runtime::{block_on, tokio_runtime},
 };
 use crate::k8s::tools::{
     agent_control::start_agent_control_with_testdata_config, instance_id, k8s_env::K8sEnv,
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use opamp_client::opamp::proto::RemoteConfigStatuses;
 use std::time::Duration;
@@ -16,7 +18,7 @@ use tempfile::tempdir;
 fn k8s_fail_remote_config_missing_required_values() {
     let test_name = "k8s_fail_remote_config_missing_required_values";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/garbage_collector.rs
+++ b/agent-control/tests/k8s/scenarios/garbage_collector.rs
@@ -5,7 +5,10 @@ use newrelic_agent_control::{agent_control::agent_id::AgentID, k8s::labels::Labe
 use tempfile::tempdir;
 
 use crate::{
-    common::{opamp::FakeServer, retry::retry, runtime::block_on},
+    common::{
+        retry::retry,
+        runtime::{block_on, tokio_runtime},
+    },
     k8s::tools::{
         agent_control::{
             CUSTOM_AGENT_TYPE_PATH, start_agent_control_with_testdata_config,
@@ -15,6 +18,7 @@ use crate::{
         test_crd::{Foo, create_foo_cr},
     },
 };
+use fake_opamp_server::FakeServer;
 
 #[test]
 #[ignore = "needs k8s cluster"]
@@ -36,7 +40,7 @@ fn k8s_garbage_collector_triggers_on_ac_startup() {
 
     // start Agent Control, so the objects above should be removed by the GC.
     let tmp_dir = tempdir().expect("failed to create local temp dir");
-    let server = FakeServer::start_new();
+    let server = FakeServer::start(tokio_runtime().handle());
     let _sa = start_agent_control_with_testdata_config(
         test_name,
         CUSTOM_AGENT_TYPE_PATH,

--- a/agent-control/tests/k8s/scenarios/health_checks.rs
+++ b/agent-control/tests/k8s/scenarios/health_checks.rs
@@ -1,12 +1,12 @@
 use crate::{
     common::{
         health::{check_latest_health_status, check_latest_health_status_was_healthy},
-        opamp::FakeServer,
         retry::retry,
-        runtime::block_on,
+        runtime::{block_on, tokio_runtime},
     },
     k8s::tools::agent_control::CUSTOM_AGENT_TYPE_DIRECT_CHECKS_PATH,
 };
+use fake_opamp_server::FakeServer;
 
 use crate::k8s::tools::{
     agent_control::start_agent_control_with_testdata_config, instance_id, k8s_env::K8sEnv,
@@ -30,7 +30,7 @@ use tempfile::tempdir;
 fn k8s_direct_workload_health_checks() {
     let test_name = "k8s_direct_workload_health_checks";
 
-    let server = FakeServer::start_new();
+    let server = FakeServer::start(tokio_runtime().handle());
 
     let mut k8s = block_on(K8sEnv::new());
     let ac_ns = block_on(k8s.test_namespace());
@@ -80,7 +80,7 @@ fn k8s_direct_workload_health_checks() {
 fn k8s_direct_workload_health_checks_unhealthy() {
     let test_name = "k8s_direct_workload_health_checks";
 
-    let server = FakeServer::start_new();
+    let server = FakeServer::start(tokio_runtime().handle());
 
     let mut k8s = block_on(K8sEnv::new());
     let ac_ns = block_on(k8s.test_namespace());

--- a/agent-control/tests/k8s/scenarios/http_status_server.rs
+++ b/agent-control/tests/k8s/scenarios/http_status_server.rs
@@ -1,8 +1,7 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::http_port::{available_port, status_server_url};
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::{
     CUSTOM_AGENT_TYPE_PATH, DUMMY_PRIVATE_KEY, DYNAMIC_AGENT_TYPE_FILENAME, K8S_KEY_SECRET,
     K8S_PRIVATE_KEY_SECRET, TEST_CLUSTER_NAME, create_config_map,
@@ -10,6 +9,7 @@ use crate::k8s::tools::agent_control::{
 };
 use crate::k8s::tools::k8s_api::create_values_secret;
 use crate::k8s::tools::k8s_env::K8sEnv;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_ID, AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
     CLUSTER_NAME_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
@@ -31,7 +31,7 @@ fn test_k8s_http_status_endpoint_response() {
     const AGENT_ID: &str = "hello-world";
     const AGENT_TYPE: &str = "newrelic/com.newrelic.custom_agent:0.0.1";
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
     let tmp_dir = tempdir().expect("failed to create local temp dir");

--- a/agent-control/tests/k8s/scenarios/opamp.rs
+++ b/agent-control/tests/k8s/scenarios/opamp.rs
@@ -1,11 +1,13 @@
 use crate::{
     common::{
         effective_config::check_latest_effective_config_is_expected,
-        health::check_latest_health_status_was_healthy, opamp::FakeServer, retry::retry,
-        runtime::block_on,
+        health::check_latest_health_status_was_healthy,
+        retry::retry,
+        runtime::{block_on, tokio_runtime},
     },
     k8s::tools::agent_control::CUSTOM_AGENT_TYPE_SPLIT_NS_PATH,
 };
+use fake_opamp_server::FakeServer;
 
 use crate::k8s::tools::k8s_api::{check_helmrelease_exists, delete_helm_release};
 use crate::k8s::tools::{
@@ -27,7 +29,7 @@ use tempfile::tempdir;
 fn k8s_opamp_remove_subagent() {
     let test_name = "k8s_opamp_remove_subagent";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());
@@ -132,7 +134,7 @@ fn k8s_opamp_add_subagent() {
     let test_name = "k8s_opamp_add_sub_agent";
 
     // setup the fake-opamp-server, with empty configuration for agents in local config local config should be used.
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());
@@ -194,7 +196,7 @@ agents:
 fn k8s_opamp_modify_subagent_config() {
     let test_name = "k8s_opamp_modify_subagent_config";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     // setup the k8s environment
     let mut k8s = block_on(K8sEnv::new());

--- a/agent-control/tests/k8s/scenarios/without_flux.rs
+++ b/agent-control/tests/k8s/scenarios/without_flux.rs
@@ -1,13 +1,13 @@
 //! Integration tests for k8s without Flux
 //! These tests use a simplified environment with just agent-control binary and image.
 
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::start_agent_control_with_testdata_config;
 use crate::k8s::tools::k8s_api::check_config_map_exist;
 use crate::k8s::tools::k8s_env::K8sEnv;
 use crate::k8s::tools::{agent_control, instance_id};
+use fake_opamp_server::FakeServer;
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::Api;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
@@ -23,7 +23,7 @@ const CONFIG_AGENT_TYPE_PATH: &str = "tests/k8s/data/config_map_type.yml";
 fn k8s_config_map_type_creates_configmap() {
     let test_name = "k8s_config_map_type_creates_configmap";
 
-    let mut server = FakeServer::start_new();
+    let mut server = FakeServer::start(tokio_runtime().handle());
 
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());

--- a/agent-control/tests/k8s/self_update.rs
+++ b/agent-control/tests/k8s/self_update.rs
@@ -2,16 +2,16 @@ use super::tools::k8s_api::create_values_secret;
 use super::tools::k8s_env::K8sEnv;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::{check_latest_health_status, check_latest_health_status_was_healthy};
-use crate::common::opamp::FakeServer;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::retry::retry;
-use crate::common::runtime::block_on;
+use crate::common::runtime::{block_on, tokio_runtime};
 use crate::k8s::tools::agent_control::{DUMMY_PRIVATE_KEY, K8S_KEY_SECRET, K8S_PRIVATE_KEY_SECRET};
 use crate::k8s::tools::instance_id;
 use crate::k8s::tools::local_chart::{LOCAL_CHART_REPOSITORY, agent_control_deploymet::*};
 use crate::k8s::tools::logs::{AC_LABEL_SELECTOR, print_pod_logs};
 use crate::k8s::tools::opamp::get_minikube_opamp_url_from_fake_server;
 use assert_cmd::cargo::cargo_bin_cmd;
+use fake_opamp_server::FakeServer;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::ListParams;
 use kube::{Api, Client};
@@ -33,7 +33,7 @@ const VALUES_KEY: &str = "values.yaml";
 /// This test installs AC using the image from our public repository,
 /// then sends a RemoteConfig with an AC chart version update to the local build image.
 fn k8s_self_update_bump_chart_version_from_last_release_to_local_new_config() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 
@@ -58,7 +58,7 @@ chart_version: {CHART_VERSION_DEV_1}
     // Also the rest of the config with the new agent has been effectevely applied.
     retry(60, Duration::from_secs(5), || {
         let current_attributes = opamp_server
-            .get_attributes(&ac_instance_id)
+            .get_attributes(ac_instance_id.clone())
             .ok_or_else(|| "Identifying attributes not found".to_string())?;
 
         if !current_attributes
@@ -95,7 +95,7 @@ chart_version: {CHART_VERSION_DEV_1}
 /// This test installs AC using the CLI, then sends a RemoteConfig with an AC chart version update
 /// and asserts that the new AC version is sending OpAmp messages.
 fn k8s_self_update_bump_chart_version() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 
@@ -120,7 +120,7 @@ chart_version: {CHART_VERSION_DEV_2}
     // Assert that opamp server receives Agent description with updated version.
     retry(60, Duration::from_secs(5), || {
         let current_attributes = opamp_server
-            .get_attributes(&ac_instance_id)
+            .get_attributes(ac_instance_id.clone())
             .ok_or_else(|| "Identifying attributes not found".to_string())?;
 
         if !current_attributes
@@ -147,7 +147,7 @@ chart_version: {CHART_VERSION_DEV_2}
 /// This test installs AC using the CLI, then sends a RemoteConfig with an AC chart version update
 /// also introducing a change in the AC config which should be applied to the new AC version.
 fn k8s_self_update_bump_chart_version_with_new_config() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 
@@ -178,7 +178,7 @@ chart_version: {CHART_VERSION_DEV_2}
     // Also the rest of the config with the new agent has been effectevely applied.
     retry(60, Duration::from_secs(5), || {
         let current_attributes = opamp_server
-            .get_attributes(&ac_instance_id)
+            .get_attributes(ac_instance_id.clone())
             .ok_or_else(|| "Identifying attributes not found".to_string())?;
 
         if !current_attributes
@@ -216,7 +216,7 @@ chart_version: {CHART_VERSION_DEV_2}
 /// pointing to a version that doesn't exist. It expects that current AC keeps working and reports
 /// unhealthy status then a new correct remote config arrives, it's applied and the new ac reports healthy.
 fn k8s_self_update_new_version_fails_to_start_next_receives_correct_version() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 
@@ -283,7 +283,7 @@ chart_version: {CHART_VERSION_DEV_2}
 /// pointing to a version that contains an image. It expects that current AC keeps working and reports
 /// unhealthy status.
 fn k8s_self_update_new_version_failing_image() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let mut k8s = block_on(K8sEnv::new());
     let namespace = block_on(k8s.test_namespace());
 

--- a/agent-control/tests/on_host/proxy.rs
+++ b/agent-control/tests/on_host/proxy.rs
@@ -1,8 +1,9 @@
 #![cfg(target_family = "unix")]
+use fake_opamp_server::FakeServer;
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::check_latest_health_status_was_healthy;
-use crate::common::{opamp::FakeServer, retry::retry};
+use crate::common::{runtime::tokio_runtime, retry::retry};
 use crate::on_host::tools::config::create_agent_control_config_with_proxy;
 use crate::on_host::tools::instance_id::get_instance_id;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
@@ -27,7 +28,7 @@ use tempfile::tempdir;
 fn proxy_onhost_opamp_agent_control_local_effective_config() {
     // Given a agent-control without agents and opamp configured.
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -1,10 +1,10 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::oci_signer::OCISigner;
-use crate::common::opamp::FakeServer;
 use crate::common::remote_config_status::check_latest_remote_config_status;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::retry::retry;
 use crate::common::retry::retry_never;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::create_local_config;
 use crate::on_host::tools::fake_binary::assert_is_fake_binary;
 use crate::on_host::tools::fake_binary::build_fake_ac_binary;
@@ -12,6 +12,7 @@ use crate::on_host::tools::fake_binary::build_invalid_fake_ac_binary;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_artifact::push_agent_package;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_VERSION;
@@ -33,7 +34,7 @@ use tempfile::{TempDir, tempdir};
 /// should be executed sequentially.
 fn test_ac_self_update_with_oci_registry() {
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -91,7 +92,7 @@ agents: {{}}
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_ac_self_update_fails_for_unsigned_package_with_oci_registry() {
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -154,7 +155,7 @@ agents: {{}}
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_ac_self_update_does_nothing_for_same_version_with_oci_registry() {
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -204,7 +205,7 @@ agents: {{}}
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_ac_self_update_fails_for_missing_version_with_oci_registry() {
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -265,7 +266,7 @@ agents: {}
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_ac_self_update_fails_when_binary_verification_fails_with_oci_registry() {
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -3,12 +3,13 @@ use crate::common::attributes::{
     check_latest_identifying_attributes_match_expected,
     check_latest_non_identifying_attributes_match_expected, convert_to_vec_key_value,
 };
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
 use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_NAMESPACE, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
@@ -33,7 +34,7 @@ const DEFAULT_NAME: &str = "name";
 /// identifying and non identifying attributes are what we expect.
 #[test]
 fn test_attributes_from_non_existing_agent_type() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let agent_id = "test-agent";
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -122,7 +123,7 @@ fn test_attributes_from_non_existing_agent_type() {
 #[cfg_attr(target_family = "unix", case::without_regex(|local_dir| {CustomAgentType::default().with_version(Some(r#"{"path": "echo", "args": ["-n","1.0.0"]}"#)).build(local_dir)}))]
 #[cfg_attr(target_family = "windows", case::without_regex(|local_dir| {CustomAgentType::default().with_version(Some(r#"{"path": "cmd", "args": ["/C","set","/p=1.0.0<nul"]}"#)).build(local_dir)}))]
 fn test_attributes_from_an_existing_agent_type(#[case] get_agent_type: impl Fn(PathBuf) -> String) {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -2,8 +2,8 @@ use crate::on_host::tools::config::create_remote_config;
 use crate::{
     common::{
         agent_control::start_agent_control_with_custom_config,
-        effective_config::check_latest_effective_config_is_expected, opamp::FakeServer,
-        retry::retry,
+        effective_config::check_latest_effective_config_is_expected, retry::retry,
+        runtime::tokio_runtime,
     },
     on_host::tools::{
         config::{create_agent_control_config, create_local_config},
@@ -11,6 +11,7 @@ use crate::{
         instance_id::get_instance_id,
     },
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_control::{agent_id::AgentID, run::BasePaths};
 use opamp_client::opamp::proto::RemoteConfigStatuses;
@@ -23,7 +24,7 @@ use tempfile::tempdir;
 #[test]
 fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -100,7 +101,7 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 #[test]
 fn onhost_opamp_sub_agent_with_no_local_config() {
     // Given a agent-control with a custom-agent with opamp configured.
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -141,7 +142,7 @@ fn onhost_opamp_sub_agent_with_no_local_config() {
     retry(60, Duration::from_secs(1), || {
         // The agent attributes should be informed even if there is no supervisor
         let _ = opamp_server
-            .get_attributes(&sub_agent_instance_id.clone())
+            .get_attributes(sub_agent_instance_id.clone())
             .ok_or("no attributes informed")?;
         Ok(())
     });

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -2,7 +2,7 @@ use std::{fs, io, path::Path, time::Duration};
 
 use crate::{
     common::{
-        agent_control::start_agent_control_with_custom_config, opamp::FakeServer, retry::retry,
+        agent_control::start_agent_control_with_custom_config, retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
         config::{create_agent_control_config, create_file, create_local_config},
@@ -10,6 +10,7 @@ use crate::{
         instance_id::get_instance_id,
     },
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_control::{
@@ -103,7 +104,7 @@ fn run_file_logging_scenario(
     reload_file_logging: bool,
     reload_message: &str,
 ) -> (tempfile::TempDir, String) {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let tempdir = tempdir().expect("failed to create temp dir");
     let local_dir = tempdir.path().join("local");

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -3,13 +3,14 @@ use std::{fs::read_to_string, path::Path, time::Duration};
 use crate::on_host::consts::NO_CONFIG;
 use crate::{
     common::{
-        agent_control::start_agent_control_with_custom_config, opamp::FakeServer, retry::retry,
+        agent_control::start_agent_control_with_custom_config, retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
         config::{create_agent_control_config, create_file, create_local_config},
         custom_agent_type::DYNAMIC_AGENT_TYPE_FILENAME,
     },
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_control::{
     defaults::AGENT_FILESYSTEM_FOLDER_NAME, run::BasePaths,
@@ -20,7 +21,7 @@ use tempfile::tempdir;
 /// created in the appropriate location under the remote directory.
 #[test]
 fn writes_filesystem_entries() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let tempdir = tempdir().expect("failed to create temp dir");
     let local_dir = tempdir.path().join("local");
@@ -97,7 +98,7 @@ deployment:
 /// rendered from the defined variables.
 #[test]
 fn complete_render_and_and_write_files_and_dirs() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let tempdir = tempdir().expect("failed to create temp dir");
     let local_dir = tempdir.path().join("local");
@@ -289,7 +290,7 @@ some_mapstringyaml:
 /// are not deleted when agent control restarts, ensuring persistent storage across restarts.
 #[test]
 fn filesystem_persists_across_restarts() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let tempdir = tempdir().expect("failed to create temp dir");
     let local_dir = tempdir.path().join("local");

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -1,12 +1,13 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
 use crate::on_host::tools::config::{
     create_agent_control_config, create_file, create_local_config,
 };
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use httpmock::Method::GET;
 use httpmock::MockServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
@@ -19,7 +20,7 @@ use tempfile::tempdir;
 /// read the health status from the file and send it to the opamp server.
 #[test]
 fn test_file_health_without_supervisor() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -84,7 +85,8 @@ status_time_unix_nano: 1725444200
     retry(30, Duration::from_secs(1), || {
         // health_status.start_time_unix_nano and health_status.status_time_unix_nano are not going
         // to match the ones from the file because they will be the ones from the aggregated checker
-        if let Some(health_status) = opamp_server.get_health_status(&agent_control_instance_id)
+        if let Some(health_status) =
+            opamp_server.get_health_status(agent_control_instance_id.clone())
             && health_status.healthy
             && health_status.status == "healthy-message"
         {
@@ -106,7 +108,8 @@ status_time_unix_nano: 1725444500
     );
 
     retry(30, Duration::from_secs(1), || {
-        if let Some(health_status) = opamp_server.get_health_status(&agent_control_instance_id)
+        if let Some(health_status) =
+            opamp_server.get_health_status(agent_control_instance_id.clone())
             && !health_status.healthy
             && health_status.status == "unhealthy-message"
             && health_status.last_error == "error-message"
@@ -123,7 +126,7 @@ status_time_unix_nano: 1725444500
 /// read the health status from http endpoint and send it to the opamp server.
 #[test]
 fn test_http_health_without_supervisor() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let health_server = MockServer::start();
 
@@ -184,7 +187,8 @@ http:
     let agent_control_instance_id = get_instance_id(&sub_agent_id, base_paths);
 
     retry(30, Duration::from_secs(1), || {
-        if let Some(health_status) = opamp_server.get_health_status(&agent_control_instance_id)
+        if let Some(health_status) =
+            opamp_server.get_health_status(agent_control_instance_id.clone())
             && health_status.healthy
             && health_status.status == "healthy-message"
         {
@@ -201,7 +205,8 @@ http:
     });
 
     retry(30, Duration::from_secs(1), || {
-        if let Some(health_status) = opamp_server.get_health_status(&agent_control_instance_id)
+        if let Some(health_status) =
+            opamp_server.get_health_status(agent_control_instance_id.clone())
             && !health_status.healthy
             && health_status.status == "unhealthy-message"
         {

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -1,12 +1,13 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::http_port::{available_port, status_server_url};
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
 use crate::on_host::tools::config::{
     create_agent_control_config_with_status_server, create_local_config,
 };
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_ID, AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
     HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
@@ -28,7 +29,7 @@ fn test_http_status_endpoint_response() {
     const AGENT_ID: &str = "nr-sleep-agent";
     const HOST_ID: &str = "integration-test";
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -4,14 +4,15 @@ use crate::common::attributes::{
 };
 use crate::common::health::check_latest_health_status_was_healthy;
 use crate::common::oci_signer::OCISigner;
-use crate::common::opamp::FakeServer;
 use crate::common::remote_config_status::check_latest_remote_config_status;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_artifact::push_agent_package;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -72,7 +73,7 @@ fn test_install_and_update_agent_remote_package_with_oci_registry() {
     let version = push_testing_package_platform(&platform, PCK_VERSION_1, Some(&signer));
     let updated_version = push_testing_package_platform(&platform, PCK_VERSION_2, Some(&signer));
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     create_agent_control_config(
@@ -183,7 +184,7 @@ fn test_unsigned_artifact_makes_remote_config_fail_with_oci_registry() {
     // Push unsigned package
     let version = push_testing_package_platform(&platform, VERSION, None);
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     create_agent_control_config(

--- a/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
@@ -1,11 +1,12 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
-use crate::common::{opamp::FakeServer, retry::retry};
+use crate::common::{retry::retry, runtime::tokio_runtime};
 use crate::on_host::tools::config::load_remote_config_content;
 use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::STORE_KEY_OPAMP_DATA_CONFIG;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -24,7 +25,7 @@ use tempfile::tempdir;
 fn onhost_opamp_sub_agent_invalid_remote_config() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -104,7 +105,7 @@ fn onhost_opamp_sub_agent_invalid_remote_config() {
 /// - That latest effective configuration reported is the local one (which is valid).
 #[test]
 fn test_invalid_config_executable_less_supervisor() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -188,7 +189,7 @@ fn test_invalid_config_executable_less_supervisor() {
 fn onhost_opamp_sub_agent_invalid_remote_config_rollback_previous_remote() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/memory_benchmark.rs
+++ b/agent-control/tests/on_host/scenarios/memory_benchmark.rs
@@ -1,10 +1,11 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::health::check_latest_health_status;
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::create_agent_control_config_with_oci_registry;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use memory_stats::memory_stats;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -44,7 +45,7 @@ fn test_memory_on_agent_substitution_and_version_update() {
         .with_packages(Some(&packages_config))
         .build(local_dir.path().to_path_buf());
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     create_agent_control_config_with_oci_registry(

--- a/agent-control/tests/on_host/scenarios/multiple_executables.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_executables.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use crate::{
     common::{
         agent_control::start_agent_control_with_custom_config, health::check_latest_health_status,
-        opamp::FakeServer, retry::retry,
+        retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
         config::create_agent_control_config, custom_agent_type::CustomAgentType,
         instance_id::get_instance_id,
     },
 };
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::{
     agent_id::AgentID,
     run::{BasePaths, on_host::AGENT_CONTROL_MODE_ON_HOST},
@@ -18,7 +19,7 @@ use tempfile::tempdir;
 
 #[test]
 fn onhost_subagent_multiple_executables_some_failed_launching() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -74,7 +75,7 @@ agents:
 
 #[test]
 fn onhost_subagent_multiple_executables_some_commands_failed_after_max_retries() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
@@ -1,10 +1,11 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
-use crate::common::{opamp::FakeServer, retry::retry};
+use crate::common::{retry::retry, runtime::tokio_runtime};
 use crate::on_host::tools::config::create_agent_control_config;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -16,7 +17,7 @@ use tempfile::tempdir;
 
 #[test]
 fn onhost_ac_multiconfig_agents_append() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -67,7 +68,7 @@ fn onhost_ac_multiconfig_agents_append() {
     );
 
     opamp_server.set_multi_config_response(
-        &ac_instance_id,
+        ac_instance_id.clone(),
         HashMap::from([
             (format!("{AGENT_CONFIG_PREFIX}-a"), agent_a),
             (format!("{AGENT_CONFIG_PREFIX}-b"), agent_b),
@@ -92,7 +93,7 @@ fn onhost_ac_multiconfig_agents_append() {
 
 #[test]
 fn onhost_ac_multiconfig_agents_append_fails() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -125,7 +126,7 @@ fn onhost_ac_multiconfig_agents_append_fails() {
     );
 
     opamp_server.set_multi_config_response(
-        &ac_instance_id,
+        ac_instance_id.clone(),
         HashMap::from([
             // Both configs define agent-a, causing a conflict.
             (format!("{AGENT_CONFIG_PREFIX}-a"), config.clone()),
@@ -146,7 +147,7 @@ fn onhost_ac_multiconfig_agents_append_fails() {
 
 #[test]
 fn onhost_sub_agent_multiconfig() {
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -196,7 +197,7 @@ fn onhost_sub_agent_multiconfig() {
     let expected_config = "var_a: a\nvar_b: b";
 
     opamp_server.set_multi_config_response(
-        &sub_agent_instance_id,
+        sub_agent_instance_id.clone(),
         HashMap::from([
             (format!("{AGENT_CONFIG_PREFIX}-a"), var_a),
             (format!("{AGENT_CONFIG_PREFIX}-b"), var_b),

--- a/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
+++ b/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
@@ -2,10 +2,11 @@
 // there should be no orphan processes left behind.
 
 use crate::common::agent_control::start_agent_control_with_custom_config;
-use crate::common::opamp::FakeServer;
 use crate::common::process_finder::find_processes_by_pattern;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use std::thread;
@@ -16,7 +17,7 @@ use tempfile::tempdir;
 /// This test works on both Unix and Windows platforms.
 #[test]
 fn test_no_orphan_processes_after_agent_control_stops() {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/oci_auth.rs
+++ b/agent-control/tests/on_host/scenarios/oci_auth.rs
@@ -1,7 +1,7 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::oci_signer::OCISigner;
-use crate::common::opamp::FakeServer;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::create_local_config;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
@@ -10,6 +10,7 @@ use crate::on_host::tools::oci_artifact::{
     OCI_TEST_REGISTRY_BASIC_AUTH_PASSWORD, OCI_TEST_REGISTRY_BASIC_AUTH_USERNAME,
 };
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -38,7 +39,7 @@ fn test_agent_remote_package_with_auth_oci_registry() {
     let remote_dir = tempdir().unwrap();
 
     let signer = OCISigner::start();
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let agent_type = CustomAgentType::default()
         .with_packages(Some(
@@ -94,7 +95,7 @@ fn test_ac_self_update_with_auth_oci_registry() {
     let remote_dir = tempdir().unwrap();
 
     let signer = OCISigner::start();
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let package_reference = push_fake_package_with_basic_auth(&signer);
     let package_tag = package_reference.tag().unwrap().to_string();

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::check_latest_health_status_was_healthy;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
-use crate::common::{opamp::FakeServer, retry::retry};
+use crate::common::{retry::retry, runtime::tokio_runtime};
 use crate::on_host::consts::NO_CONFIG;
 use crate::on_host::tools::config::{
     create_agent_control_config, create_file, create_local_config,
@@ -10,6 +10,7 @@ use crate::on_host::tools::config::{
 use crate::on_host::tools::config::{create_remote_config, load_remote_config_content};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_ID, AGENT_FILESYSTEM_FOLDER_NAME, FOLDER_NAME_FLEET_DATA,
@@ -33,7 +34,7 @@ use tempfile::tempdir;
 #[test]
 fn onhost_opamp_agent_control_local_effective_config() {
     // Given a agent-control without agents and opamp configured.
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -80,7 +81,7 @@ fn onhost_opamp_agent_control_local_effective_config() {
 fn onhost_opamp_agent_control_remote_effective_config() {
     // Given a agent-control without agents and opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -171,7 +172,7 @@ agents:
 fn onhost_opamp_agent_control_accepts_unknown_fields_on_remote_config() {
     // Given a agent-control without agents and opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -233,7 +234,7 @@ non-existing: {}
 fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -305,7 +306,7 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
 fn onhost_opamp_sub_agent_remote_effective_config() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -374,7 +375,7 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
 fn onhost_opamp_sub_agent_empty_local_effective_config() {
     // Given a agent-control with a custom-agent running a sleep command with opamp configured.
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -440,7 +441,7 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
 fn onhost_executable_less_reports_local_effective_config() {
     // Given a agent-control without agents and opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -553,7 +554,7 @@ status_time_unix_nano: 1725444001
 fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
     // Given a agent-control without agents and opamp configured.
 
-    let mut opamp_server = FakeServer::start_new();
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
 
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");

--- a/agent-control/tests/on_host/scenarios/restarting_processes.rs
+++ b/agent-control/tests/on_host/scenarios/restarting_processes.rs
@@ -1,9 +1,10 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
-use crate::common::opamp::FakeServer;
 use crate::common::process_finder::find_processes_by_pattern;
 use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use std::thread;
@@ -20,7 +21,7 @@ use nix::{
 /// a process gets restarted as expected when killing it externally.
 #[test]
 fn killing_subprocess_with_signal_restarts() -> Result<(), Box<dyn std::error::Error>> {
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let local_dir = tempdir()?;
     let remote_dir = tempdir()?;
 

--- a/agent-control/tests/on_host/verify_executor.rs
+++ b/agent-control/tests/on_host/verify_executor.rs
@@ -11,9 +11,10 @@ use opamp_client::opamp::proto::any_value::Value;
 use tempfile::tempdir;
 
 use crate::{
-    common::opamp::FakeServer, on_host::tools::config::create_agent_control_config,
+    common::runtime::tokio_runtime, on_host::tools::config::create_agent_control_config,
     on_host::tools::instance_id::get_instance_id,
 };
+use fake_opamp_server::FakeServer;
 
 /// Returns the path to the newrelic-agent-control binary under test
 fn binary_path() -> &'static Path {
@@ -25,7 +26,7 @@ fn test_verify_executor() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let opamp_server = FakeServer::start_new();
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
     let agents = "{}".to_string();
 
     create_agent_control_config(
@@ -61,7 +62,7 @@ fn test_verify_executor() {
     // Verify that execution.mode attribute was sent to OpAMP server
     let agent_control_instance_id = get_instance_id(&AgentID::AgentControl, base_paths);
     let attributes = opamp_server
-        .get_attributes(&agent_control_instance_id)
+        .get_attributes(agent_control_instance_id.clone())
         .expect("Agent Control attributes not found in OpAMP server");
 
     let execution_mode_attr = attributes

--- a/test/crates/fake-opamp-server/Cargo.toml
+++ b/test/crates/fake-opamp-server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fake-opamp-server"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[dependencies]
+actix-web = "4.13.0"
+aws-lc-rs = { workspace = true }
+base64 = { workspace = true }
+opamp-client = { workspace = true }
+prost = "0.14.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -1,16 +1,9 @@
-use super::runtime::tokio_runtime;
 use actix_web::{App, HttpResponse, HttpServer, web};
 use aws_lc_rs::digest;
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair as _};
 use base64::Engine;
 use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD};
-use newrelic_agent_control::opamp::instance_id::InstanceID;
-use newrelic_agent_control::opamp::remote_config::AGENT_CONFIG_PREFIX;
-use newrelic_agent_control::opamp::remote_config::signature::{
-    SIGNATURE_CUSTOM_CAPABILITY, SIGNATURE_CUSTOM_MESSAGE_TYPE, SignatureFields,
-};
-use newrelic_agent_control::signature::public_key::SigningAlgorithm::ED25519;
 use opamp_client::opamp::proto::{
     AgentConfigFile, AgentConfigMap, AgentDescription, AgentRemoteConfig, AgentToServer,
     ComponentHealth, CustomMessage, EffectiveConfig, RemoteConfigStatus, ServerToAgent,
@@ -18,20 +11,26 @@ use opamp_client::opamp::proto::{
 };
 use opamp_client::operation::instance_uid::InstanceUid;
 use prost::Message;
+use serde::Serialize;
 use serde_json::json;
+use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::Mutex;
-use std::{collections::HashMap, net, sync::Arc};
+use std::net;
+use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
+
+pub use opamp_client::operation::instance_uid::InstanceUid as InstanceID;
 
 const FAKE_SERVER_PATH: &str = "/opamp-fake-server";
 const JWKS_SERVER_PATH: &str = "/jwks";
 const JWKS_PUBLIC_KEY_ID: &str = "fakeKeyName/0";
+const AGENT_CONFIG_PREFIX: &str = "agentConfig";
+const SIGNATURE_CUSTOM_CAPABILITY: &str = "com.newrelic.security.configSignature";
+const SIGNATURE_CUSTOM_MESSAGE_TYPE: &str = "newrelicRemoteConfigSignature";
+const ED25519_ALG: &str = "ED25519";
 
-/// Represents the state of the FakeServer.
 struct ServerState {
-    agent_state: HashMap<InstanceID, AgentState>,
-    // Key pair to sign remote configuration
+    agent_state: HashMap<InstanceUid, AgentState>,
     key_pair: Ed25519KeyPair,
 }
 
@@ -54,13 +53,12 @@ impl ServerState {
     }
 }
 
-#[derive(Clone, Debug, Default)]
 /// Represents a remote configuration that can be sent to the agent.
+#[derive(Clone, Debug, Default)]
 pub struct RemoteConfig(AgentRemoteConfig);
 
 impl RemoteConfig {
     pub fn new(config_map: HashMap<String, String>) -> Self {
-        // Build an AgentConfigMap from raw entries (keys and YAML bodies as &str)
         let built_map: HashMap<String, AgentConfigFile> = config_map
             .into_iter()
             .map(|(key, body)| {
@@ -84,7 +82,7 @@ impl RemoteConfig {
         })
     }
 
-    // Do not assume this replicate FC hashing.
+    // Do not assume this replicates FC hashing.
     fn compute_hash(map: &HashMap<String, AgentConfigFile>) -> Vec<u8> {
         let mut hasher = DefaultHasher::new();
         for agent_config_file in map.values() {
@@ -94,20 +92,26 @@ impl RemoteConfig {
     }
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SignatureFields {
+    signature: String,
+    signing_algorithm: String,
+    key_id: String,
+}
+
+/// Represents a remote configuration signature custom message.
 #[derive(Clone, Debug, Default)]
-/// Represents a remote configuration signature custom message
 pub struct RemoteConfigSignature(CustomMessage);
+
 impl RemoteConfigSignature {
     pub fn new(key_pair: &Ed25519KeyPair, remote_config: RemoteConfig) -> Self {
-        let mut custom_message_data = HashMap::new();
+        let mut custom_message_data: HashMap<String, Vec<SignatureFields>> = HashMap::new();
 
         let config_map = remote_config.0.config.unwrap_or_default().config_map;
 
         for (cfg_key, cfg_content) in config_map {
-            // Actual implementation from FC side signs the Base64 representation of the SHA256 digest
-            // of the message (i.e. the remote configs). Hence, to verify the signature, we need to
-            // compute the SHA256 digest of the message, then Base64 encode it, and finally verify
-            // the signature against that.
+            // FC signs the Base64 representation of the SHA256 digest of the message body.
             let digest = digest::digest(&digest::SHA256, &cfg_content.body);
             let msg = BASE64_STANDARD.encode(digest);
             let signature = key_pair.sign(msg.as_bytes());
@@ -116,11 +120,12 @@ impl RemoteConfigSignature {
                 cfg_key,
                 vec![SignatureFields {
                     signature: BASE64_STANDARD.encode(signature),
-                    signing_algorithm: ED25519.as_ref().to_string(),
+                    signing_algorithm: ED25519_ALG.to_string(),
                     key_id: JWKS_PUBLIC_KEY_ID.to_string(),
                 }],
             );
         }
+
         Self(CustomMessage {
             capability: SIGNATURE_CUSTOM_CAPABILITY.to_string(),
             r#type: SIGNATURE_CUSTOM_MESSAGE_TYPE.to_string(),
@@ -129,8 +134,7 @@ impl RemoteConfigSignature {
     }
 }
 
-/// FakeServer represents a OpAMP mock server that can be used for testing purposed.
-/// The underlying http server will be aborted when the object is dropped.
+/// OpAMP mock server for testing. The underlying HTTP server is aborted when dropped.
 pub struct FakeServer {
     handle: JoinHandle<()>,
     state: Arc<Mutex<ServerState>>,
@@ -139,31 +143,27 @@ pub struct FakeServer {
 }
 
 impl FakeServer {
-    /// Gets the endpoint to be used in the Super-Agent static configuration.
+    /// Starts the server on a random port, spawning the HTTP task on the provided runtime handle.
+    pub fn start(handle: &tokio::runtime::Handle) -> Self {
+        let listener = net::TcpListener::bind("0.0.0.0:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state = Arc::new(Mutex::new(ServerState::generate()));
+        let join_handle = handle.spawn(Self::run_http_server(listener, state.clone()));
+
+        Self {
+            handle: join_handle,
+            state,
+            port,
+            path: FAKE_SERVER_PATH.to_string(),
+        }
+    }
+
     pub fn endpoint(&self) -> String {
         format!("http://localhost:{}{}", self.port, self.path)
     }
 
     pub fn jwks_endpoint(&self) -> String {
         format!("http://localhost:{}{}", self.port, JWKS_SERVER_PATH)
-    }
-
-    /// Starts and returns new FakeServer in a random port.
-    pub fn start_new() -> Self {
-        // While binding to port 0, the kernel gives you a free ephemeral port.
-        let listener = net::TcpListener::bind("0.0.0.0:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        let state = Arc::new(Mutex::new(ServerState::generate()));
-
-        let handle = tokio_runtime().spawn(Self::run_http_server(listener, state.clone()));
-
-        Self {
-            handle,
-            state,
-            port,
-            path: FAKE_SERVER_PATH.to_string(),
-        }
     }
 
     async fn run_http_server(listener: net::TcpListener, state: Arc<Mutex<ServerState>>) {
@@ -180,15 +180,17 @@ impl FakeServer {
         .unwrap_or_else(|err| panic!("Failed to run the HTTP server: {err}"))
     }
 
-    /// Sets a response for the provided identifier. If a response already existed, it is overwritten.
-    /// It will be returned by the server until the agent informs that the remote configuration has been applied,
-    /// then the server will return a `None` (no-changes) configuration in following requests.
-    /// The identifier should be a valid UUID.
-    pub fn set_config_response(&mut self, identifier: InstanceID, response: impl AsRef<str>) {
+    /// Sets the remote config for the given agent. Overwrites any existing config.
+    /// The server stops sending it once the agent acknowledges the hash.
+    pub fn set_config_response(
+        &mut self,
+        identifier: impl Into<InstanceUid>,
+        response: impl AsRef<str>,
+    ) {
         let mut state = self.state.lock().unwrap();
         state
             .agent_state
-            .entry(identifier)
+            .entry(identifier.into())
             .or_default()
             .remote_config = Some(RemoteConfig::new(HashMap::from([(
             AGENT_CONFIG_PREFIX.to_string(),
@@ -196,67 +198,68 @@ impl FakeServer {
         )])));
     }
 
-    /// Same as `set_config_response` but accepts multiple configurations.
+    /// Same as `set_config_response` but accepts multiple config keys.
     pub fn set_multi_config_response(
         &mut self,
-        identifier: &InstanceID,
+        identifier: impl Into<InstanceUid>,
         config_map: HashMap<String, String>,
     ) {
         let mut state = self.state.lock().unwrap();
         state
             .agent_state
-            .entry(identifier.clone())
+            .entry(identifier.into())
             .or_default()
             .remote_config = Some(RemoteConfig::new(config_map));
     }
 
-    pub fn get_health_status(&self, identifier: &InstanceID) -> Option<ComponentHealth> {
+    pub fn get_health_status(&self, identifier: impl Into<InstanceUid>) -> Option<ComponentHealth> {
         let state = self.state.lock().unwrap();
         state
             .agent_state
-            .get(identifier)
+            .get(&identifier.into())
             .and_then(|s| s.health_status.clone())
     }
-    pub fn get_attributes(&self, identifier: &InstanceID) -> Option<AgentDescription> {
+
+    pub fn get_attributes(&self, identifier: impl Into<InstanceUid>) -> Option<AgentDescription> {
         let state = self.state.lock().unwrap();
         state
             .agent_state
-            .get(identifier)
+            .get(&identifier.into())
             .map(|s| s.attributes.clone())
     }
 
-    pub fn get_effective_config(&self, identifier: InstanceID) -> Option<EffectiveConfig> {
+    pub fn get_effective_config(
+        &self,
+        identifier: impl Into<InstanceUid>,
+    ) -> Option<EffectiveConfig> {
         let state = self.state.lock().unwrap();
         state
             .agent_state
-            .get(&identifier)
+            .get(&identifier.into())
             .map(|s| s.effective_config.clone())
     }
 
-    pub fn get_remote_config_status(&self, identifier: InstanceID) -> Option<RemoteConfigStatus> {
+    pub fn get_remote_config_status(
+        &self,
+        identifier: impl Into<InstanceUid>,
+    ) -> Option<RemoteConfigStatus> {
         let state = self.state.lock().unwrap();
         state
             .agent_state
-            .get(&identifier)
+            .get(&identifier.into())
             .map(|s| s.config_status.clone())
-    }
-
-    fn stop(&self) {
-        self.handle.abort();
     }
 }
 
 impl Drop for FakeServer {
     fn drop(&mut self) {
-        self.stop();
+        self.handle.abort();
     }
 }
 
 async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Bytes) -> HttpResponse {
     let message = AgentToServer::decode(req).unwrap();
-    let identifier: InstanceID = InstanceUid::try_from(message.clone().instance_uid)
-        .unwrap()
-        .into();
+    let identifier = InstanceUid::try_from(message.clone().instance_uid).unwrap();
 
     let mut server_state = state.lock().unwrap();
 
@@ -265,16 +268,11 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
         .entry(identifier.clone())
         .or_default();
 
-    // Check sequence number
     let mut flags = ServerToAgentFlags::Unspecified as u64;
     if message.sequence_num == (agent_state.sequence_number + 1) {
-        // case 1: first opamp connection start with seq number 1
-        // case 2: Any valid new sequence number
         agent_state.sequence_number += 1;
     } else {
         flags = ServerToAgentFlags::ReportFullState as u64;
-        // upon report full state the opamp client will send a new AgentToServer
-        // increasing the seq number so current should be the valid
         agent_state.sequence_number = message.sequence_num;
     }
 
@@ -290,9 +288,6 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
         agent_state.effective_config = effective_cfg;
     }
 
-    // Process config status:
-    // Stop sending the RemoteConfig once we got a RemoteConfigStatus response associated with the hash.
-    // emulating what FC currently does.
     if let Some(cfg_status) = message.remote_config_status {
         if agent_state
             .remote_config
@@ -308,7 +303,7 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
 
     let remote_config = agent_state.remote_config.clone();
 
-    let _ = agent_state; // We need to get rid of the mutable reference before leveraging another immutable.
+    let _ = agent_state; // drop mutable ref before taking immutable one
 
     let server_to_agent = build_response(identifier, remote_config, &server_state.key_pair, flags);
     HttpResponse::Ok().body(server_to_agent)
@@ -328,7 +323,7 @@ async fn jwks_handler(state: web::Data<Arc<Mutex<ServerState>>>, _req: web::Byte
                 "n": null,
                 "x": enc_public_key,
                 "y": null,
-                "crv": ED25519.as_ref(),
+                "crv": ED25519_ALG,
             }
         ]
     });
@@ -336,7 +331,7 @@ async fn jwks_handler(state: web::Data<Arc<Mutex<ServerState>>>, _req: web::Byte
 }
 
 fn build_response(
-    instance_id: InstanceID,
+    instance_id: InstanceUid,
     maybe_remote_config: Option<RemoteConfig>,
     key_pair: &Ed25519KeyPair,
     flags: u64,
@@ -348,8 +343,9 @@ fn build_response(
         maybe_custom_message = Some(RemoteConfigSignature::new(key_pair, remote_config.clone()).0);
         maybe_agent_remote_config = Some(remote_config.0);
     }
+
     ServerToAgent {
-        instance_uid: instance_id.into(),
+        instance_uid: Vec::<u8>::from(instance_id),
         remote_config: maybe_agent_remote_config,
         custom_message: maybe_custom_message,
         flags,


### PR DESCRIPTION
- Moves the fake OpAMP server implementation out of agent-control's integration test helpers and into a dedicated crate at test/fake-opamp-server/, following the same convention that test/e2e-runner/ uses. 

- test/fake-opamp-server does not depend on newrelic_agent_control — that would create a circular dependency, since newrelic_agent_control dev-depends on fake-opamp-server. Instead, fake-opamp-server exposes InstanceUid directly from opamp-client

- agent-control/tests/common/opamp.rs is kept as a thin wrapper — it bridges the InstanceID type used across AC integration tests with the InstanceUid key the new crate uses. Removing it would require changing every integration test that calls FakeServer.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
