### PR TITLE
feat: add new pipeline control gateway config agent type and e2e test

### DIFF
--- a/.github/workflows/component_k8s_e2e.yml
+++ b/.github/workflows/component_k8s_e2e.yml
@@ -100,6 +100,7 @@ jobs:
           USE_LATEST_FLUX: ${{ inputs.use_latest_flux }}
           # Tilt configs
           ARCH: amd64
+          FEATURE_BRANCH: feat/cdEnabled
         with:
           retry_attempts: 40
           retry_seconds: 15

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,7 +131,7 @@ jobs:
       # Context:
       # We were using version 0.2.6, which downloaded the linux headers from an s3 bucket in staging.
       # This is no longer true and newer versions don't work out of the box.
-      scenarios: '["apm", "collector", "fleet-control", "dynamic", "custom-repo", "proxy"]'
+      scenarios: '["apm", "collector", "configmap-agent", "fleet-control", "dynamic", "custom-repo", "proxy"]'
       # Network policies needs calico installed,the others do not
       minikube_start_args: '--cni=calico'
       caller_workflow: nightly

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -160,7 +160,7 @@ jobs:
       # Context:
       # We were using version 0.2.6, which downloaded the linux headers from an s3 bucket in staging.
       # This is no longer true and newer versions don't work out of the box.
-      scenarios: '["infra", "apm", "collector", "fleet-control", "dynamic", "custom-repo", "proxy"]'
+      scenarios: '["infra", "apm", "configmap-agent", "collector", "fleet-control", "dynamic", "custom-repo", "proxy"]'
       # Network policies needs calico installed, the others do not
       minikube_start_args: '--cni=calico'
       caller_workflow: prerelease

--- a/.github/workflows/push_pr_test_extended_labels.yml
+++ b/.github/workflows/push_pr_test_extended_labels.yml
@@ -25,7 +25,7 @@ jobs:
       # Context:
       # We were using version 0.2.6, which downloaded the linux headers from an s3 bucket in staging.
       # This is no longer true and newer versions don't work out of the box.
-      scenarios: '["apm", "collector", "dynamic", "custom-repo", "fleet-control", "proxy"]'
+      scenarios: '["apm", "collector", "configmap-agent", "dynamic", "custom-repo", "fleet-control", "proxy"]'
       # Network policies needs calico installed, the others do not
       minikube_start_args: '--cni=calico'
       caller_workflow: push_pr_test_extended_labels

--- a/.github/workflows/push_pr_test_extended_paths_k8s.yml
+++ b/.github/workflows/push_pr_test_extended_paths_k8s.yml
@@ -36,7 +36,7 @@ jobs:
       # Context:
       # We were using version 0.2.6, which downloaded the linux headers from an s3 bucket in staging.
       # This is no longer true and newer versions don't work out of the box.
-      scenarios: '["apm", "collector", "dynamic", "custom-repo", "fleet-control", "proxy"]'
+      scenarios: '["apm", "collector", "configmap-agent", "dynamic", "custom-repo", "fleet-control", "proxy"]'
       # Network policies needs calico installed, the others do not
       minikube_start_args: '--cni=calico'
       caller_workflow: push_pr_test_extended_paths_k8s

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
@@ -24,7 +24,7 @@ deployment:
       interval: 30s
       initial_delay: 15s
       checks:
-        - namespace: ${nr-ac:namespace}
+        - namespace: ${nr-ac:namespace_agents}
           name: ${nr-var:deployment_name}
           kind: Deployment
           target_namespace: ${nr-ac:namespace_agents}

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
@@ -1,0 +1,47 @@
+namespace: newrelic
+name: com.newrelic.pipeline_control_gateway_config
+version: 0.1.0
+variables:
+  k8s:
+    config:
+      description: "OTel Collector configuration for the Pipeline Control Gateway"
+      type: yaml
+      required: true
+    config_map_name:
+      description: "Name of the ConfigMap that AC creates and PCG mounts as its configuration source"
+      type: string
+      required: false
+      default: "pipeline-control-gateway-custom-config"
+    deployment_name:
+      description: "Name of the pipeline control deployment for health-checks"
+      type: string
+      required: false
+      default: "pipeline-control-gateway"
+
+deployment:
+  k8s:
+    health:
+      interval: 30s
+      initial_delay: 15s
+      checks:
+        - namespace: ${nr-ac:namespace}
+          name: ${nr-var:deployment_name}
+          kind: Deployment
+          target_namespace: ${nr-ac:namespace_agents}
+    objects:
+      config:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${nr-var:config_map_name}
+          namespace: ${nr-ac:namespace_agents}
+        data:
+          deployment-config.yaml: |
+            ${nr-var:config}
+          # This is required as it is also defined in:
+          # https://github.com/newrelic/helm-charts/blob/8c3b88bdf03e600aec8a5d94bab80635b4eec671/charts/pipeline-control-gateway/templates/deployment-configmap.yaml#L7
+          gateway-config.yaml: |
+            reserved_melt_attributes:
+              Metric:
+                - interval.ms
+                - metricName

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -633,7 +633,12 @@ pub fn default_group_version_kinds() -> Vec<TypeMeta> {
 }
 
 pub fn default_group_version_kinds_no_flux() -> Vec<TypeMeta> {
-    vec![secret_type_meta()]
+    vec![
+        secret_type_meta(),
+        // This allows ConfigMaps created by sub-agents to be cleaned up by the GC.
+        // AC internal ConfigMaps (e.g. fleet-data) are handled by garbage_collect_agent_control_resources.
+        configmap_type_meta(),
+    ]
 }
 
 #[cfg(test)]

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -554,6 +554,43 @@ static AGENT_TYPE_PIPELINE_CONTROL_GATEWAY: LazyLock<AgentTypeValuesTestCase> =
         ..Default::default()
     });
 
+static AGENT_TYPE_PIPELINE_CONTROL_GATEWAY_CONFIG: LazyLock<AgentTypeValuesTestCase> =
+    LazyLock::new(|| AgentTypeValuesTestCase {
+        agent_type: "newrelic/com.newrelic.pipeline_control_gateway_config:0.1.0",
+        values_k8s: AgentTypeValues {
+            cases: HashMap::from([
+                (
+                    "mandatory fields only",
+                    r#"
+                config:
+                    receivers:
+                        otlp: {}
+                "#,
+                ),
+                (
+                    "check all value types are correct",
+                    r#"
+                config:
+                    receivers:
+                        otlp: {}
+                    exporters:
+                        otlp:
+                            endpoint: "otlp.nr-data.net:4317"
+                    service:
+                        pipelines:
+                            traces:
+                                receivers: [otlp]
+                                exporters: [otlp]
+                config_map_name: "my-otel-config"
+                "#,
+                ),
+            ]),
+            ..Default::default()
+        }
+        .into(),
+        ..Default::default()
+    });
+
 static AGENT_TYPE_EBPF: LazyLock<AgentTypeValuesTestCase> =
     LazyLock::new(|| AgentTypeValuesTestCase {
         agent_type: "newrelic/com.newrelic.ebpf:0.1.0",
@@ -608,6 +645,7 @@ fn get_agent_type_test_cases() -> impl Iterator<Item = &'static AgentTypeValuesT
         &AGENT_TYPE_OTEL_COLLECTOR,
         &AGENT_TYPE_OTEL_COLLECTOR_OLD,
         &AGENT_TYPE_PIPELINE_CONTROL_GATEWAY,
+        &AGENT_TYPE_PIPELINE_CONTROL_GATEWAY_CONFIG,
         &AGENT_TYPE_EBPF,
     ]
     .into_iter()

--- a/agent-control/src/agent_type/embedded_registry.rs
+++ b/agent-control/src/agent_type/embedded_registry.rs
@@ -135,7 +135,7 @@ pub mod tests {
         }
     }
 
-    const AGENT_TYPE_AMOUNT: usize = 13;
+    const AGENT_TYPE_AMOUNT: usize = 14;
 
     #[test]
     fn check_agent_type_amount_is_unchanged() {

--- a/test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml
+++ b/test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml
@@ -1,0 +1,3 @@
+# Region-specific overrides for Staging (infra scenario)
+global:
+  nrStaging: true

--- a/test/k8s-e2e/configmap-agent/ac-values-configmap-agent-us.yml
+++ b/test/k8s-e2e/configmap-agent/ac-values-configmap-agent-us.yml
@@ -1,0 +1,2 @@
+# Region-specific overrides for US/Production (infra scenario)
+# No additional overrides needed for US region

--- a/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
@@ -1,5 +1,4 @@
 subAgentsNamespace: "newrelic-agents"
-verboseLog: true
 config:
   authSecret:
     secretName: "agent-control-auth"
@@ -8,11 +7,10 @@ config:
     enabled: false
   log:
     level: debug
-  k8s:
-    cd_enabled: false
   agents:
     gateway:
       agent_type: newrelic/com.newrelic.pipeline_control_gateway_config:0.1.0
+# TODO: On mac serde is not parsing well yaml values directly and only works well with strings we should check our templating system.
 agentsConfig:
   gateway:
     config:
@@ -62,7 +60,6 @@ agentsConfig:
             level: info
           metrics:
             level: detailed
-
     config_map_name: "pcg-otel-config"
 systemIdentity:
   create: false

--- a/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
@@ -1,5 +1,6 @@
 subAgentsNamespace: "newrelic-agents"
 config:
+  cdEnabled: false
   authSecret:
     secretName: "agent-control-auth"
     secretKeyName: "private_key"
@@ -10,6 +11,10 @@ config:
   agents:
     gateway:
       agent_type: newrelic/com.newrelic.pipeline_control_gateway_config:0.1.0
+image:
+  repository: agent-control-dev
+  tag: e2e-test
+  pullPolicy: Never
 # TODO: On mac serde is not parsing well yaml values directly and only works well with strings we should check our templating system.
 agentsConfig:
   gateway:

--- a/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml
@@ -1,0 +1,68 @@
+subAgentsNamespace: "newrelic-agents"
+verboseLog: true
+config:
+  authSecret:
+    secretName: "agent-control-auth"
+    secretKeyName: "private_key"
+  fleet_control:
+    enabled: false
+  log:
+    level: debug
+  k8s:
+    cd_enabled: false
+  agents:
+    gateway:
+      agent_type: newrelic/com.newrelic.pipeline_control_gateway_config:0.1.0
+agentsConfig:
+  gateway:
+    config:
+      exporters:
+        otlp/exporter:
+          endpoint: https://otlp.nr-data.net:443
+          headers:
+            api-key: ${env:NEW_RELIC_LICENSE_KEY}
+      extensions:
+        healthcheckv2:
+          component_health:
+            include_permanent_errors: false
+            include_recoverable_errors: true
+            recovery_duration: 5m
+          http:
+            config:
+              enabled: true
+              path: /health/config
+            endpoint: ${env:MY_POD_IP}:13133
+            status:
+              enabled: true
+              path: /health/status
+          use_v2: true
+        zpages: { }
+      processors:
+        filter/Metrics: null
+      receivers:
+        otlp/receiver:
+          protocols:
+            grpc:
+              endpoint: ${env:MY_POD_IP}:4317
+            http:
+              endpoint: ${env:MY_POD_IP}:4318
+      service:
+        extensions:
+          - healthcheckv2
+        pipelines:
+          metrics/otlp:
+            exporters:
+              - otlp/exporter
+            processors:
+              - filter/Metrics
+            receivers:
+              - otlp/receiver
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            level: detailed
+
+    config_map_name: "pcg-otel-config"
+systemIdentity:
+  create: false

--- a/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
@@ -1,0 +1,39 @@
+description: E2E Test - PCG ConfigMap agent type
+
+custom_test_key: cluster_name
+
+scenarios:
+  - description: Deploy PCG configmap agent and verify ConfigMap is created with provided config and PCG running
+    before:
+      - echo The cluster name of the test is ${SCENARIO_TAG}
+      # Build AC binary and load image directly into minikube's docker registry
+      - cd ../../../ && make BUILD_MODE=release ARCH=amd64 build-agent-control-k8s
+      - cd ../../../ && eval $(minikube docker-env) && docker build -f Dockerfiles/Dockerfile_agent_control -t agent-control-dev:e2e-test .
+      # Setup namespaces and auth secret
+      - kubectl create namespace newrelic --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl create namespace newrelic-agents --dry-run=client -o yaml | kubectl apply -f -
+      - openssl genpkey -algorithm Ed25519 -out /tmp/ac-private-key.pem
+      - kubectl create secret generic agent-control-auth --from-file=private_key=/tmp/ac-private-key.pem -n newrelic
+      # Clone the helm-charts feature branch FEATURE_BRANCH that can be overridden at runtime; defaults to master.
+      - git clone --depth=1 https://github.com/newrelic/helm-charts --branch "${FEATURE_BRANCH:-master}" /tmp/helm-charts-tmp
+      # Install agent-control-deployment from the local clone
+      - cd ../../../ && helm install agent-control /tmp/helm-charts-tmp/charts/agent-control-deployment --namespace newrelic --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set image.repository=agent-control-dev --set image.tag=e2e-test --set image.pullPolicy=Never --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml --dependency-update --wait --timeout 5m
+      # Wait for AC to create the ConfigMap via the pipeline_control_gateway_config agent type
+      - timeout 120 bash -c 'until kubectl get configmap pcg-otel-config -n newrelic-agents 2>/dev/null; do sleep 5; done'
+      # Install pipeline-control-gateway from the public chart, pointing it at the ConfigMap AC created
+      - helm repo add newrelic https://helm-charts.newrelic.com && helm repo update
+      - helm install pcg newrelic/pipeline-control-gateway --namespace newrelic-agents --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set deployment.customConfigMap=pcg-otel-config --set autoscaling.minReplicas=1 --set autoscaling.maxReplicas=1 --set deployment.resources.requests.memory=256Mi --set deployment.resources.requests.cpu=100m --set deployment.resources.limits.memory=512Mi --set deployment.resources.limits.cpu=500m --wait --timeout 5m
+    after:
+      - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true -n newrelic
+      - kubectl get configmap -n newrelic-agents --show-labels
+      - kubectl get all -o wide --all-namespaces --show-labels
+      - helm uninstall pcg -n newrelic-agents || true
+      - helm uninstall agent-control -n newrelic || true
+    tests:
+      scripts:
+        # Check the config content was written under the expected key.
+        - kubectl get configmap pcg-otel-config -n newrelic-agents -o jsonpath='{.data.deployment-config\.yaml}' | grep "otlp"
+        # Check the pipeline-control-gateway deployment is running and all replicas are ready.
+        - kubectl rollout status deployment/pipeline-control-gateway -n newrelic-agents --timeout=60s
+        # Check the deployment is configured to use the pcg-otel-config ConfigMap as its config source.
+        - kubectl get deployment pipeline-control-gateway -n newrelic-agents -o yaml | grep pcg-otel-config

--- a/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
@@ -9,19 +9,17 @@ scenarios:
       # Build AC binary and load image directly into minikube's docker registry
       - cd ../../../ && make BUILD_MODE=release ARCH=amd64 build-agent-control-k8s
       - cd ../../../ && eval $(minikube docker-env) && docker build -f Dockerfiles/Dockerfile_agent_control -t agent-control-dev:e2e-test .
-      # Setup namespaces and auth secret
-      - kubectl create namespace newrelic --dry-run=client -o yaml | kubectl apply -f -
-      - kubectl create namespace newrelic-agents --dry-run=client -o yaml | kubectl apply -f -
+      # Setup auth secret
       - kubectl get secret sys-identity || kubectl create secret generic sys-identity --from-literal=CLIENT_ID="${NR_SYSTEM_IDENTITY_CLIENT_ID}" --from-literal=private_key="${NR_SYSTEM_IDENTITY_PRIVATE_KEY}"
       # Clone the helm-charts feature branch FEATURE_BRANCH that can be overridden at runtime; defaults to master.
       - git clone --depth=1 https://github.com/newrelic/helm-charts --branch "${FEATURE_BRANCH:-master}" /tmp/helm-charts-tmp
       # Install agent-control-deployment from the local clone
-      - cd ../../../ && helm install agent-control /tmp/helm-charts-tmp/charts/agent-control-deployment --namespace newrelic --set config.cdEnabled=false --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set image.repository=agent-control-dev --set image.tag=e2e-test --set image.pullPolicy=Never --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml --dependency-update --wait --timeout 5m
+      - cd ../../../ && helm install agent-control /tmp/helm-charts-tmp/charts/agent-control-deployment --namespace newrelic --create-namespace --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml --dependency-update --wait --timeout 5m
       # Wait for AC to create the ConfigMap via the pipeline_control_gateway_config agent type
       - timeout 120 bash -c 'until kubectl get configmap pcg-otel-config -n newrelic-agents 2>/dev/null; do sleep 5; done'
       # Install pipeline-control-gateway from the public chart, pointing it at the ConfigMap AC created
       - helm repo add newrelic https://helm-charts.newrelic.com && helm repo update
-      - helm install pcg newrelic/pipeline-control-gateway --namespace newrelic-agents --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set deployment.customConfigMap=pcg-otel-config --set autoscaling.minReplicas=1 --set autoscaling.maxReplicas=1 --set deployment.resources.requests.memory=256Mi --set deployment.resources.requests.cpu=100m --set deployment.resources.limits.memory=512Mi --set deployment.resources.limits.cpu=500m --wait --timeout 5m
+      - helm install pcg newrelic/pipeline-control-gateway --namespace newrelic-agents --create-namespace --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set deployment.customConfigMap=pcg-otel-config --set autoscaling.minReplicas=1 --set autoscaling.maxReplicas=1 --set deployment.resources.requests.memory=256Mi --set deployment.resources.requests.cpu=100m --set deployment.resources.limits.memory=512Mi --set deployment.resources.limits.cpu=500m --wait --timeout 5m
     after:
       - kubectl logs --tail=-1 -l app.kubernetes.io/name=agent-control --all-containers --prefix=true -n newrelic
       - kubectl get configmap -n newrelic-agents --show-labels

--- a/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
+++ b/test/k8s-e2e/configmap-agent/e2e-configmap-agent.yml
@@ -12,12 +12,11 @@ scenarios:
       # Setup namespaces and auth secret
       - kubectl create namespace newrelic --dry-run=client -o yaml | kubectl apply -f -
       - kubectl create namespace newrelic-agents --dry-run=client -o yaml | kubectl apply -f -
-      - openssl genpkey -algorithm Ed25519 -out /tmp/ac-private-key.pem
-      - kubectl create secret generic agent-control-auth --from-file=private_key=/tmp/ac-private-key.pem -n newrelic
+      - kubectl get secret sys-identity || kubectl create secret generic sys-identity --from-literal=CLIENT_ID="${NR_SYSTEM_IDENTITY_CLIENT_ID}" --from-literal=private_key="${NR_SYSTEM_IDENTITY_PRIVATE_KEY}"
       # Clone the helm-charts feature branch FEATURE_BRANCH that can be overridden at runtime; defaults to master.
       - git clone --depth=1 https://github.com/newrelic/helm-charts --branch "${FEATURE_BRANCH:-master}" /tmp/helm-charts-tmp
       # Install agent-control-deployment from the local clone
-      - cd ../../../ && helm install agent-control /tmp/helm-charts-tmp/charts/agent-control-deployment --namespace newrelic --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set image.repository=agent-control-dev --set image.tag=e2e-test --set image.pullPolicy=Never --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml --dependency-update --wait --timeout 5m
+      - cd ../../../ && helm install agent-control /tmp/helm-charts-tmp/charts/agent-control-deployment --namespace newrelic --set config.cdEnabled=false --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set image.repository=agent-control-dev --set image.tag=e2e-test --set image.pullPolicy=Never --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent.yml --values test/k8s-e2e/configmap-agent/ac-values-configmap-agent-staging.yml --dependency-update --wait --timeout 5m
       # Wait for AC to create the ConfigMap via the pipeline_control_gateway_config agent type
       - timeout 120 bash -c 'until kubectl get configmap pcg-otel-config -n newrelic-agents 2>/dev/null; do sleep 5; done'
       # Install pipeline-control-gateway from the public chart, pointing it at the ConfigMap AC created


### PR DESCRIPTION
- Adds a new com.newrelic.pipeline_control_gateway_config agent type that creates a Kubernetes ConfigMap containing a user-provided OTel collector configuration, enabling Pipeline Control Gateway to be deployed without Flux or HelmRelease objects.
- Includes an agent type validation unit test and a k8s e2e test that verifies the ConfigMap is created with the expected content and that PCG starts successfully using it as its config source.
- The e2e test installs agent-control-deployment directly from a configurable helm-charts branch (FEATURE_BRANCH, defaulting to master) and PCG from the public chart with configMap.customConfigMap pointing to the AC-managed ConfigMap.
<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
