### PR TITLE
chore(public_key): removing null references

### DIFF
--- a/agent-control/src/signature/public_key.rs
+++ b/agent-control/src/signature/public_key.rs
@@ -160,7 +160,7 @@ pub mod tests {
         // This payload was returned by a real staging endpoint
         let signature = BASE64_STANDARD.decode("6l3Jv23SUClwCRzWuFHkZn21laEJiNUu7GXwWK+kDaVCMenLJt9Us+r7LyIqEnfRq/Z5PPJoWaalta6mn/wrDw==").unwrap();
         let message = "my-message-to-be-signed this can be anything";
-        let payload = serde_json::from_value::<PubKeyPayload>(json!({"keys":[{"kty":"OKP","alg":null,"use":"sig","kid":"869003544/1","n":null,"e":null,"x":"TpT81pA8z0vYiSK2LLhXzkWYJwrL-kxoNt93lzAb1_Q","y":null,"crv":"Ed25519"}]}))
+        let payload = serde_json::from_value::<PubKeyPayload>(json!({"keys":[{"kty":"OKP","use":"sig","kid":"869003544/1","x":"TpT81pA8z0vYiSK2LLhXzkWYJwrL-kxoNt93lzAb1_Q","crv":"Ed25519"}]}))
             .unwrap();
 
         assert_eq!(payload.keys.len(), 1);

--- a/docs/package_manager.md
+++ b/docs/package_manager.md
@@ -170,24 +170,16 @@ Public keys **MUST** be in JWKS format.
   "keys": [
     {
       "kty": "OKP",
-      "alg": null,
       "use": "sig",
       "kid": "key/0",
-      "n": null,
-      "e": null,
       "x": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "y": null,
       "crv": "Ed25519"
     },
     {
       "kty": "OKP",
-      "alg": null,
       "use": "sig",
       "kid": "key/1",
-      "n": null,
-      "e": null,
       "x": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-      "y": null,
       "crv": "Ed25519"
     }
   ]

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -317,12 +317,9 @@ async fn jwks_handler(state: web::Data<Arc<Mutex<ServerState>>>, _req: web::Byte
         "keys": [
             {
                 "kty": "OKP",
-                "alg": null,
                 "use": "sig",
                 "kid": JWKS_PUBLIC_KEY_ID,
-                "n": null,
                 "x": enc_public_key,
-                "y": null,
                 "crv": ED25519_ALG,
             }
         ]

--- a/test/crates/oci-test-utils/src/signer.rs
+++ b/test/crates/oci-test-utils/src/signer.rs
@@ -234,12 +234,9 @@ async fn jwks_handler(state: web::Data<Arc<Mutex<ServerState>>>, _req: web::Byte
         "keys": [
             {
                 "kty": "OKP",
-                "alg": null,
                 "use": "sig",
                 "kid": JWKS_PUBLIC_KEY_ID,
-                "n": null,
                 "x": enc_public_key,
-                "y": null,
                 "crv": "Ed25519"
             }
         ]


### PR DESCRIPTION
We were told that the IAM team is about to remove null values from from payload returned.

Since we were ignoring already such values nothing should change, but we are updating mocks and internal tests to reflect the change