### PR TITLE
test: windows e2e self-update

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -114,6 +114,7 @@ jobs:
           - wrong-config
           - remote-config
           - switch-infra-agent-version
+          - self-update-from-latest
     steps:
       - name: Record job start time
         shell: bash

--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -90,7 +90,7 @@ jobs:
             exit 1
           fi
 
-      - name: If not pre-release, set tag and SKIP_UPLOAD_RELEASE=true
+      - name: If not pre-release, set override the AC version with the tag and SKIP_UPLOAD_RELEASE=true
         if: ${{ ! inputs.pre-release }}
         run: |
           git tag ${{ inputs.tag_name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,12 +1444,16 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "fake-opamp-server",
  "glob",
+ "oci-client",
+ "oci-test-utils",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/agent-control/build.rs
+++ b/agent-control/build.rs
@@ -39,6 +39,17 @@ fn main() {
     // re-run only if the registry has changed
     println!("cargo:rerun-if-changed={REGISTRY_PATH}");
     set_git_commit();
+    set_version();
+}
+
+fn set_version() {
+    // If present NR_RELEASE_TAG env var will define the AC version, if not it will be taken from
+    // the agent-contro/cargo.toml version.
+    // This is useful to build identify nightly releases and perform e2e testing.
+    println!("cargo:rerun-if-env-changed=NR_RELEASE_TAG");
+    let version = env::var("NR_RELEASE_TAG")
+        .unwrap_or_else(|_| env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set"));
+    println!("cargo:rustc-env=AGENT_CONTROL_VERSION={version}");
 }
 
 fn set_git_commit() {

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -10,7 +10,7 @@ pub const RESERVED_AGENT_IDS: [&str; 1] = [AGENT_CONTROL_ID];
 
 pub const AGENT_CONTROL_TYPE: &str = "com.newrelic.agent_control";
 pub const AGENT_CONTROL_NAMESPACE: &str = "newrelic";
-pub const AGENT_CONTROL_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const AGENT_CONTROL_VERSION: &str = env!("AGENT_CONTROL_VERSION");
 
 // Keys identifying attributes
 pub const OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY: &str = "chart.version";

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -4,10 +4,11 @@ use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair as _};
 use base64::Engine;
 use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD};
+use opamp_client::opamp::proto::any_value::Value;
 use opamp_client::opamp::proto::{
     AgentConfigFile, AgentConfigMap, AgentDescription, AgentRemoteConfig, AgentToServer,
-    ComponentHealth, CustomMessage, EffectiveConfig, RemoteConfigStatus, ServerToAgent,
-    ServerToAgentFlags,
+    ComponentHealth, CustomMessage, EffectiveConfig, RemoteConfigStatus, RemoteConfigStatuses,
+    ServerToAgent, ServerToAgentFlags,
 };
 use opamp_client::operation::instance_uid::InstanceUid;
 use prost::Message;
@@ -249,6 +250,38 @@ impl FakeServer {
             .get(&identifier.into())
             .map(|s| s.config_status.clone())
     }
+
+    /// Returns the instance IDs of all connected agents that have an identifying attribute
+    /// matching the given key–value pair. Matches string-typed attribute values only.
+    pub fn find_agents_with_identifying_attr(&self, key: &str, value: &str) -> Vec<InstanceID> {
+        let state = self.state.lock().unwrap();
+        state
+            .agent_state
+            .iter()
+            .filter(|(_, agent_state)| has_identifying_attr(&agent_state.attributes, key, value))
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    /// Returns the string value of an identifying attribute for the given agent, or `None` if the
+    /// agent is unknown or the attribute is absent or not a string.
+    pub fn get_identifying_attr_value(
+        &self,
+        identifier: impl Into<InstanceUid>,
+        key: &str,
+    ) -> Option<String> {
+        let state = self.state.lock().unwrap();
+        state
+            .agent_state
+            .get(&identifier.into())
+            .and_then(|s| find_string_identifying_attr(&s.attributes, key))
+    }
+
+    /// Returns `true` if the agent has reported a remote config status of `Applied`.
+    pub fn is_config_status_applied(&self, identifier: impl Into<InstanceUid>) -> bool {
+        self.get_remote_config_status(identifier)
+            .is_some_and(|s| s.status == RemoteConfigStatuses::Applied as i32)
+    }
 }
 
 impl Drop for FakeServer {
@@ -349,6 +382,30 @@ fn build_response(
         ..Default::default()
     }
     .encode_to_vec()
+}
+
+fn find_string_identifying_attr(description: &AgentDescription, key: &str) -> Option<String> {
+    description
+        .identifying_attributes
+        .iter()
+        .find(|kv| kv.key == key)
+        .and_then(|kv| {
+            kv.value.as_ref()?.value.as_ref().and_then(|v| match v {
+                Value::StringValue(s) => Some(s.clone()),
+                _ => None,
+            })
+        })
+}
+
+fn has_identifying_attr(description: &AgentDescription, key: &str, value: &str) -> bool {
+    description.identifying_attributes.iter().any(|kv| {
+        kv.key == key
+            && kv
+                .value
+                .as_ref()
+                .and_then(|av| av.value.as_ref())
+                .is_some_and(|v| matches!(v, Value::StringValue(s) if s == value))
+    })
 }
 
 fn generate_key_pair() -> Ed25519KeyPair {

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -277,10 +277,16 @@ impl FakeServer {
             .and_then(|s| find_string_identifying_attr(&s.attributes, key))
     }
 
-    /// Returns `true` if the agent has reported a remote config status of `Applied`.
-    pub fn is_config_status_applied(&self, identifier: impl Into<InstanceUid>) -> bool {
-        self.get_remote_config_status(identifier)
-            .is_some_and(|s| s.status == RemoteConfigStatuses::Applied as i32)
+    /// Returns `Ok(())` if the agent has reported a remote config status of `Applied`.
+    pub fn is_config_status_applied(
+        &self,
+        identifier: impl Into<InstanceUid>,
+    ) -> Result<(), String> {
+        match self.get_remote_config_status(identifier) {
+            Some(s) if s.status == RemoteConfigStatuses::Applied as i32 => Ok(()),
+            Some(_) => Err("Config status is not Applied".to_string()),
+            None => Err("Remote config status not found".to_string()),
+        }
     }
 }
 
@@ -385,27 +391,19 @@ fn build_response(
 }
 
 fn find_string_identifying_attr(description: &AgentDescription, key: &str) -> Option<String> {
-    description
+    let kv = description
         .identifying_attributes
         .iter()
-        .find(|kv| kv.key == key)
-        .and_then(|kv| {
-            kv.value.as_ref()?.value.as_ref().and_then(|v| match v {
-                Value::StringValue(s) => Some(s.clone()),
-                _ => None,
-            })
-        })
+        .find(|kv| kv.key == key)?;
+
+    match kv.value.as_ref()?.value.as_ref()? {
+        Value::StringValue(s) => Some(s.clone()),
+        _ => None,
+    }
 }
 
 fn has_identifying_attr(description: &AgentDescription, key: &str, value: &str) -> bool {
-    description.identifying_attributes.iter().any(|kv| {
-        kv.key == key
-            && kv
-                .value
-                .as_ref()
-                .and_then(|av| av.value.as_ref())
-                .is_some_and(|v| matches!(v, Value::StringValue(s) if s == value))
-    })
+    find_string_identifying_attr(description, key).is_some_and(|v| v == value)
 }
 
 fn generate_key_pair() -> Ed25519KeyPair {

--- a/test/crates/oci-test-utils/src/lib.rs
+++ b/test/crates/oci-test-utils/src/lib.rs
@@ -6,6 +6,9 @@ mod signer;
 pub use publisher::{PackageMediaType, PackagePublisher};
 pub use signer::OCISigner;
 
+/// Port to be used for plain http testing registries
+pub const LOCAL_HTTP_REGISTRY_URL: &str = "localhost:5001";
+
 pub fn blob_digest(data: &[u8]) -> String {
     format!("sha256:{}", hex_bytes(digest(&SHA256, data).as_ref()))
 }

--- a/test/crates/oci-test-utils/src/publisher.rs
+++ b/test/crates/oci-test-utils/src/publisher.rs
@@ -1,3 +1,4 @@
+use crate::LOCAL_HTTP_REGISTRY_URL;
 use crate::blob_digest;
 use oci_client::Client;
 use oci_client::Reference;
@@ -50,7 +51,7 @@ impl PackagePublisher {
             registry_url: registry_url.into(),
             runtime_handle,
             client: Client::new(ClientConfig {
-                protocol: ClientProtocol::Http,
+                protocol: ClientProtocol::HttpsExcept(vec![LOCAL_HTTP_REGISTRY_URL.to_string()]),
                 ..Default::default()
             }),
         }
@@ -75,12 +76,16 @@ impl PackagePublisher {
     /// The artifact is structured as a manifest index (multiarch) with a single entry for the
     /// current platform.
     pub fn push(&self, file: &Path, media_type: PackageMediaType) -> Reference {
-        self.runtime_handle
-            .block_on(async { self.push_async(file, media_type).await })
+        self.push_with_tag(file, media_type, &unique_tag())
     }
 
-    async fn push_async(&self, file: &Path, media_type: PackageMediaType) -> Reference {
-        let tag = unique_tag();
+    /// Same as [`push`] but uses `tag` instead of a generated unique tag.
+    pub fn push_with_tag(&self, file: &Path, media_type: PackageMediaType, tag: &str) -> Reference {
+        self.runtime_handle
+            .block_on(async { self.push_async(file, media_type, tag).await })
+    }
+
+    async fn push_async(&self, file: &Path, media_type: PackageMediaType, tag: &str) -> Reference {
         let index_reference: Reference = format!("{}/{REPOSITORY_NAME}:{tag}", self.registry_url)
             .parse()
             .unwrap();

--- a/test/crates/oci-test-utils/src/signer.rs
+++ b/test/crates/oci-test-utils/src/signer.rs
@@ -1,11 +1,11 @@
-use crate::hex_bytes;
+use crate::{LOCAL_HTTP_REGISTRY_URL, hex_bytes};
 use actix_web::{App, HttpResponse, HttpServer, web};
 use aws_lc_rs::digest::{SHA256, digest};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair as _};
 use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD, Engine};
 use http::Uri;
-use oci_client::client::{ClientConfig, ClientProtocol::Http};
+use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_client::manifest::{OciDescriptor, OciImageManifest, OciManifest::Image};
 use oci_client::secrets::RegistryAuth;
 use oci_client::secrets::RegistryAuth::Anonymous;
@@ -48,7 +48,7 @@ impl OCISigner {
         let server_handle = runtime_handle.spawn(Self::run_http_server(listener, state.clone()));
 
         let oci_client = Client::new(ClientConfig {
-            protocol: Http,
+            protocol: ClientProtocol::HttpsExcept(vec![LOCAL_HTTP_REGISTRY_URL.to_string()]),
             ..Default::default()
         });
 

--- a/test/e2e-runner/Cargo.toml
+++ b/test/e2e-runner/Cargo.toml
@@ -12,11 +12,15 @@ repository.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 glob = "0.3"
+fake-opamp-server = { path = "../crates/fake-opamp-server" }
+oci-test-utils = { path = "../crates/oci-test-utils" }
+oci-client = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/test/e2e-runner/src/common.rs
+++ b/test/e2e-runner/src/common.rs
@@ -1,12 +1,15 @@
 use std::path::PathBuf;
 
+pub mod cert;
 pub mod config;
 pub mod exec;
 pub mod file;
 pub mod fleet_control_api;
 pub mod logs;
 pub mod nrql;
+pub mod oci;
 pub mod on_drop;
+pub mod runtime;
 pub mod test;
 
 /// Common Fleet Control arguments shared across different commands

--- a/test/e2e-runner/src/common/cert.rs
+++ b/test/e2e-runner/src/common/cert.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+use tracing::info;
+
+const CERT_FILENAME: &str = "localhost.crt";
+const KEY_FILENAME: &str = "localhost.key";
+
+/// A self-signed TLS certificate for `localhost` that is installed in the system root store.
+/// Removes itself from the root store on drop.
+pub struct SelfSignedCert {
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+    _temp_dir: TempDir,
+}
+
+impl SelfSignedCert {
+    /// Generates a self-signed certificate for `localhost` using `openssl`, adds it to the
+    /// system root store, and returns the struct holding paths to the cert and key files.
+    pub fn generate() -> Self {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir for cert");
+        let cert_path = temp_dir.path().join(CERT_FILENAME);
+        let key_path = temp_dir.path().join(KEY_FILENAME);
+
+        generate_cert(&cert_path, &key_path);
+        add_to_root_store(&cert_path);
+
+        Self {
+            cert_path,
+            key_path,
+            _temp_dir: temp_dir,
+        }
+    }
+}
+
+fn generate_cert(cert_path: &std::path::Path, key_path: &std::path::Path) {
+    info!("Generating self-signed certificate for localhost");
+    let output = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            &key_path.to_string_lossy(),
+            "-out",
+            &cert_path.to_string_lossy(),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        ])
+        .output()
+        .expect("failed to run openssl");
+    assert!(
+        output.status.success(),
+        "openssl req failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(target_os = "windows")]
+fn add_to_root_store(cert_path: &std::path::Path) {
+    info!("Adding certificate to Windows root store");
+    let output = Command::new("certutil")
+        .args(["-addstore", "-f", "Root", &cert_path.to_string_lossy()])
+        .output()
+        .expect("failed to run certutil");
+    assert!(
+        output.status.success(),
+        "certutil -addstore failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(target_family = "unix")]
+fn add_to_root_store(_cert_path: &std::path::Path) {
+    unimplemented!()
+}

--- a/test/e2e-runner/src/common/oci.rs
+++ b/test/e2e-runner/src/common/oci.rs
@@ -1,11 +1,11 @@
 use crate::common::InstallationArgs;
 use crate::common::cert::SelfSignedCert;
 use crate::common::runtime::tokio_runtime;
+use crate::common::test::retry;
 use oci_client::Reference;
 use oci_test_utils::{OCISigner, PackageMediaType, PackagePublisher};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
 use std::time::Duration;
 use tracing::info;
 
@@ -94,17 +94,13 @@ fn script_command() -> Command {
 
 fn wait_for_registry() {
     let url = format!("https://localhost:{LOCAL_REGISTRY_PORT}/v2/");
-    for _ in 0..30 {
-        info!("Checking registry at {url}");
-        if reqwest::blocking::get(&url)
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
-        {
-            return;
-        }
-        thread::sleep(Duration::from_secs(1));
-    }
-    panic!("OCI registry did not become ready within 30 seconds");
+    info!("Checking registry at {url}");
+    retry(30, Duration::from_secs(1), "Checking registry", || {
+        reqwest::blocking::get(&url)
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| e.into())
+    })
+    .expect("OCI registry did not become ready within 30 seconds");
 }
 
 /// Holds a pushed and signed AC package artifact for the duration of a test.

--- a/test/e2e-runner/src/common/oci.rs
+++ b/test/e2e-runner/src/common/oci.rs
@@ -1,0 +1,178 @@
+use crate::common::InstallationArgs;
+use crate::common::cert::SelfSignedCert;
+use crate::common::runtime::tokio_runtime;
+use oci_client::Reference;
+use oci_test_utils::{OCISigner, PackageMediaType, PackagePublisher};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+use tracing::info;
+
+const REGISTRY_SCRIPT_PATH: &str = "../../tools/oci-registry.sh";
+// 5001 is assumed by the helpers to be http so we use 5002
+const LOCAL_REGISTRY_PORT: &str = "5002";
+
+pub struct OciRegistry {
+    run_process: Child,
+    _cert: SelfSignedCert,
+}
+
+impl OciRegistry {
+    pub fn start() -> Self {
+        // AC can only connect to https registries so we generate certificates to enable TLS
+        let cert = SelfSignedCert::generate();
+
+        info!("Installing OCI registry");
+        run_script_step("install");
+
+        info!(
+            "Starting OCI registry on port {LOCAL_REGISTRY_PORT} with tls_cert: '{}' and tls_key: '{}'",
+            cert.cert_path.display(),
+            cert.key_path.display()
+        );
+
+        // Sanitize path for windows
+        let cert_path = cert.cert_path.display().to_string().replace("\\", "\\\\");
+        let key_path = cert.key_path.display().to_string().replace("\\", "\\\\");
+
+        let run_process = script_command()
+            .arg("run")
+            .env("PORT", LOCAL_REGISTRY_PORT)
+            .env("TLS_CERT", cert_path)
+            .env("TLS_KEY", key_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn oci-registry.sh run: {e}"));
+
+        wait_for_registry();
+        info!("OCI registry is ready on port {LOCAL_REGISTRY_PORT}");
+
+        Self {
+            run_process,
+            _cert: cert,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("localhost:{LOCAL_REGISTRY_PORT}")
+    }
+}
+
+impl Drop for OciRegistry {
+    fn drop(&mut self) {
+        let _ = self.run_process.kill();
+    }
+}
+
+fn run_script_step(step: &str) {
+    let output = script_command()
+        .arg(step)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run oci-registry.sh {step}: {e}"));
+    assert!(
+        output.status.success(),
+        "oci-registry.sh {step} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn script_command() -> Command {
+    let script_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(REGISTRY_SCRIPT_PATH);
+
+    #[cfg(target_os = "windows")]
+    let bash = PathBuf::from(r"C:\Program Files\Git\bin\bash.exe");
+    #[cfg(target_family = "unix")]
+    let bash = PathBuf::from("bash");
+
+    let mut cmd = Command::new(bash);
+    cmd.arg(script_path);
+    cmd
+}
+
+fn wait_for_registry() {
+    let url = format!("https://localhost:{LOCAL_REGISTRY_PORT}/v2/");
+    for _ in 0..30 {
+        info!("Checking registry at {url}");
+        if reqwest::blocking::get(&url)
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    panic!("OCI registry did not become ready within 30 seconds");
+}
+
+/// Holds a pushed and signed AC package artifact for the duration of a test.
+///
+/// Keeps the JWKS HTTP server alive so that signature verification against
+/// `jwks_url` continues to work while the test runs.
+pub struct PushedPackage {
+    /// OCI image index reference.
+    pub reference: Reference,
+    /// URL of the JWKS endpoint serving the public signing key.
+    pub jwks_url: String,
+    _signer: OCISigner,
+}
+
+/// Finds the AC release archive in `args.artifacts_package_dir`,
+/// pushes it to `registry`, and signs it.
+///
+/// The archive name follows the goreleaser convention:
+/// `newrelic-agent-control_{version}_{os}_{arch}.{ext}`.
+/// On Linux: `.tar.gz`; on Windows: `.zip` (always `amd64`)
+pub fn push_ac_package(args: &InstallationArgs) -> PushedPackage {
+    let package_dir = args
+        .artifacts_package_dir
+        .as_deref()
+        .expect("local artifacts are expected");
+
+    let (file, media_type) = find_package(package_dir, &args.agent_control_version);
+
+    let publisher = PackagePublisher::new(
+        tokio_runtime().handle().clone(),
+        format!("localhost:{LOCAL_REGISTRY_PORT}"),
+    );
+
+    let reference = publisher.push_with_tag(&file, media_type, &args.agent_control_version);
+
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+
+    signer.sign_artifact(&reference);
+
+    let jwks_url = signer.jwks_url().to_string();
+
+    info!("AC package pushed and signed: {reference} (JWKS: {jwks_url})");
+
+    PushedPackage {
+        reference,
+        jwks_url,
+        _signer: signer,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn find_package(dir: &Path, version: &str) -> (PathBuf, PackageMediaType) {
+    // we currently don't generate the arm64 package.
+    let name = format!("newrelic-agent-control_{version}_windows_amd64.zip");
+    let path = dir.join(name);
+    assert!(path.exists(), "package not found: {}", path.display());
+    (path, PackageMediaType::Zip)
+}
+
+#[cfg(target_family = "unix")]
+fn find_package(dir: &Path, version: &str) -> (PathBuf, PackageMediaType) {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => panic!("unsupported arch: {other}"),
+    };
+    let name = format!("newrelic-agent-control_{version}_linux_{arch}.tar.gz");
+    let path = dir.join(name);
+    assert!(path.exists(), "package not found: {}", path.display());
+    (path, PackageMediaType::TarGz)
+}

--- a/test/e2e-runner/src/common/runtime.rs
+++ b/test/e2e-runner/src/common/runtime.rs
@@ -1,0 +1,16 @@
+use std::sync::{Arc, OnceLock};
+
+pub fn tokio_runtime() -> Arc<tokio::runtime::Runtime> {
+    static RUNTIME: OnceLock<Arc<tokio::runtime::Runtime>> = OnceLock::new();
+    RUNTIME
+        .get_or_init(|| {
+            Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            )
+        })
+        .clone()
+}

--- a/test/e2e-runner/src/main.rs
+++ b/test/e2e-runner/src/main.rs
@@ -58,6 +58,9 @@ enum WindowsScenarios {
     /// Starts with a local-only installation of AC, then updates the installation to include fleet configuration that should
     /// trigger a sub-agent update.
     SwitchInfraAgentVersion(InstallationArgs),
+    /// Tests the self-update, install the latest released AC and tries to self update to compiled version that has locally
+    /// been pushed to a registry.
+    SelfUpdateFromLatest(InstallationArgs),
     /// Simple installation of Agent Control on Windows with update to wrong and correct config
     /// to test service stop and start.
     WrongConfig(InstallationArgs),

--- a/test/e2e-runner/src/windows.rs
+++ b/test/e2e-runner/src/windows.rs
@@ -49,6 +49,9 @@ pub fn run_windows_e2e() {
         WindowsScenarios::SwitchInfraAgentVersion(args) => {
             scenarios::switch_infra_agent_version::switch_infra_agent_version(args);
         }
+        WindowsScenarios::SelfUpdateFromLatest(args) => {
+            scenarios::self_update::test_self_update_from_latest(args);
+        }
         WindowsScenarios::WrongConfig(args) => {
             scenarios::service_wrong_config::test_service_restart_depending_on_config_correctness(
                 args,

--- a/test/e2e-runner/src/windows/install.rs
+++ b/test/e2e-runner/src/windows/install.rs
@@ -14,8 +14,6 @@ use crate::{common::test::retry, windows::powershell::exec_ps};
 pub const SERVICE_NAME: &str = "newrelic-agent-control";
 
 /// Installs Agent Control using the recipe as configured in the provided [RecipeData].
-///
-///
 pub fn install_agent_control_from_recipe(data: &RecipeData) {
     info!("Installing Agent Control from recipe");
 
@@ -32,14 +30,7 @@ pub fn install_agent_control_from_recipe(data: &RecipeData) {
     let _ = exec_ps(&git_command)
         .unwrap_or_else(|err| panic!("could not checkout recipes repository: {err}"));
 
-    let install_newrelic_cli_command = r#"
-(New-Object System.Net.WebClient).DownloadFile("https://github.com/newrelic/newrelic-cli/releases/latest/download/NewRelicCLIInstaller.msi", "$env:TEMP\NewRelicCLIInstaller.msi"); `
-msiexec.exe /qn /i "$env:TEMP\NewRelicCLIInstaller.msi" | Out-Null;
-"#;
-    info!("Installing newrelic cli",);
-    debug!("Running command: \n{install_newrelic_cli_command}");
-    let _ = exec_ps(install_newrelic_cli_command)
-        .unwrap_or_else(|err| panic!("could not install New Relic CLI: {err}"));
+    install_newrelic_cli();
 
     // By default, the windows recipe will download the zip file from https://download.newrelic.com and put it
     // in "$env:TEMP\newrelic-agent-control-{version}.zip". If the zip file already exists, the recipe will skip the
@@ -105,11 +96,57 @@ $env:NEW_RELIC_AGENT_CONTROL_SKIP_BINARY_SIGNATURE_VALIDATION='true'; `
         data.recipe_list,
     );
 
-    // Create a temporary .ps1 file for the installation command
-    //
-    // There's an option that allows running commands directly. That is "-Command". The
-    // issue with that is that "-ExecutionPolicy" won't bypass all the checks. It seems
-    // to only work properly using a ps1 script. We are forced to create a temporary script file.
+    run_newrelic_install(install_command);
+}
+
+pub fn install_latest_agent_control(data: &RecipeData) {
+    install_newrelic_cli();
+
+    let install_command = format!(
+        r#"
+$env:NEW_RELIC_CLI_SKIP_CORE='1'; `
+$env:NEW_RELIC_LICENSE_KEY='{}'; `
+$env:NEW_RELIC_API_KEY='{}'; `
+$env:NEW_RELIC_ACCOUNT_ID='{}'; `
+$env:NEW_RELIC_AUTH_PROVISIONED_CLIENT_ID='{}'; `
+$env:NEW_RELIC_AUTH_PRIVATE_KEY_PATH='{}'; `
+$env:NEW_RELIC_REGION='{}'; `
+$env:NR_CLI_FLEET_ID='{}'; `
+$env:NEW_RELIC_AGENT_CONTROL_FLEET_ENABLED='{}'; `
+$env:NEW_RELIC_AGENT_CONTROL='true'; `
+& "C:\Program Files\New Relic\New Relic CLI\newrelic.exe" install `
+-n {}
+"#,
+        data.args.nr_license_key,
+        data.args.nr_api_key,
+        data.args.nr_account_id,
+        data.args.system_identity_client_id,
+        data.args.agent_control_private_key,
+        data.args.nr_region,
+        data.fleet_id,
+        data.fleet_enabled,
+        data.recipe_list,
+    );
+
+    run_newrelic_install(install_command);
+}
+
+fn install_newrelic_cli() {
+    let command = r#"
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/newrelic/newrelic-cli/releases/latest/download/NewRelicCLIInstaller.msi", "$env:TEMP\NewRelicCLIInstaller.msi"); `
+msiexec.exe /qn /i "$env:TEMP\NewRelicCLIInstaller.msi" | Out-Null;
+"#;
+    info!("Installing newrelic cli");
+    debug!("Running command: \n{command}");
+    let _ = exec_ps(command).unwrap_or_else(|err| panic!("could not install New Relic CLI: {err}"));
+}
+
+// Create a temporary .ps1 file for the installation command
+//
+// There's an option that allows running commands directly. That is "-Command". The
+// issue with that is that "-ExecutionPolicy" won't bypass all the checks. It seems
+// to only work properly using a ps1 script. We are forced to create a temporary script file.
+fn run_newrelic_install(install_command: String) {
     info!("Creating install script");
     info!("Install script content: \n{install_command}");
     let script_dir = tempdir().expect("failed to create temp dir for script");

--- a/test/e2e-runner/src/windows/scenarios.rs
+++ b/test/e2e-runner/src/windows/scenarios.rs
@@ -3,6 +3,7 @@ pub mod installation_infra_agent;
 pub mod installation_nrdot;
 pub mod proxy;
 pub mod remote_config;
+pub mod self_update;
 pub mod service_wrong_config;
 pub mod switch_infra_agent_version;
 

--- a/test/e2e-runner/src/windows/scenarios/self_update.rs
+++ b/test/e2e-runner/src/windows/scenarios/self_update.rs
@@ -100,11 +100,9 @@ self_update:
         Duration::from_secs(2),
         "waiting for remote config Applied status",
         || {
-            if opamp_server.is_config_status_applied(instance_id.clone()) {
-                Ok(())
-            } else {
-                Err("remote config status not yet Applied".into())
-            }
+            opamp_server
+                .is_config_status_applied(instance_id.clone())
+                .map_err(|e| e.into())
         },
     );
 
@@ -114,15 +112,15 @@ self_update:
         Duration::from_secs(2),
         "verifying updated agent.version attribute",
         || {
-            let Some(version) =
+            let Some(reported_version) =
                 opamp_server.get_identifying_attr_value(instance_id.clone(), AGENT_VERSION_ATTR)
             else {
                 return Err("agent.version attribute not set yet".into());
             };
-            if version == new_version {
-                Ok(version)
+            if reported_version == new_version {
+                Ok(())
             } else {
-                Err(format!("expected version {new_version}, got {version}").into())
+                Err(format!("expected version {new_version}, got {reported_version}").into())
             }
         },
     );

--- a/test/e2e-runner/src/windows/scenarios/self_update.rs
+++ b/test/e2e-runner/src/windows/scenarios/self_update.rs
@@ -1,0 +1,142 @@
+use crate::common::oci::{OciRegistry, push_ac_package};
+use crate::common::on_drop::CleanUp;
+use crate::common::runtime::tokio_runtime;
+use crate::common::test::{TestResult, retry_panic};
+use crate::common::{InstallationArgs, RecipeData, config};
+use crate::windows::install::{SERVICE_NAME, install_latest_agent_control, tear_down_test};
+use crate::windows::service::{STATUS_RUNNING, restart_service};
+use crate::windows::{self};
+use fake_opamp_server::{FakeServer, InstanceID};
+use std::time::Duration;
+use tracing::info;
+
+const AGENT_VERSION_ATTR: &str = "agent.version";
+const SUPERVISOR_KEY_ATTR: &str = "supervisor.key";
+const AGENT_CONTROL_SUPERVISOR_KEY: &str = "agent-control";
+
+pub fn test_self_update_from_latest(args: InstallationArgs) {
+    info!("Starting self-update scenario");
+
+    let registry = OciRegistry::start();
+    let pushed_package = push_ac_package(&args);
+
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+    info!("Fake OpAMP server started at {}", opamp_server.endpoint());
+
+    let _clean_up = CleanUp::new(tear_down_test);
+
+    install_latest_agent_control(&RecipeData {
+        args: args.clone(),
+        ..Default::default()
+    });
+
+    let self_update_config = format!(
+        r#"
+fleet_control:
+  endpoint: {}
+  signature_validation:
+    public_key_server_url: {}
+oci:
+  registry: {}
+log:
+  file: 
+    enabled: true
+  level: debug
+self_update:
+  enabled: true
+  signature_verification_enabled: true
+  package:
+    download:
+      oci:
+        repository: test
+        public_key_url: {}
+"#,
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        registry.url(),
+        pushed_package.jwks_url,
+    );
+    config::update_config(windows::DEFAULT_AC_CONFIG_PATH, &self_update_config);
+
+    restart_service(SERVICE_NAME, STATUS_RUNNING);
+    info!("AC service restarted with fleet and self-update configuration");
+
+    let instance_id = retry_panic(
+        20,
+        Duration::from_secs(2),
+        "AC connecting to OpAMP server",
+        || find_ac_instance_id(&opamp_server),
+    );
+    info!("AC connected to fake OpAMP server");
+
+    let initial_version = retry_panic(
+        30,
+        Duration::from_secs(2),
+        "reading initial agent.version attribute",
+        || -> TestResult<_> {
+            opamp_server
+                .get_identifying_attr_value(instance_id.clone(), AGENT_VERSION_ATTR)
+                .ok_or_else(|| "agent.version attribute not set yet".into())
+        },
+    );
+    info!(
+        version = initial_version,
+        "Verified initial AC version before self-update"
+    );
+
+    let new_version = pushed_package.reference.tag().unwrap();
+    assert_ne!(
+        initial_version, new_version,
+        "initial and new version must differ for self-update to be meaningful"
+    );
+
+    let update_config = format!("version: \"{new_version}\"\nagents: {{}}");
+    opamp_server.set_config_response(instance_id.clone(), update_config);
+    info!(tag = new_version, "Sent self-update remote config");
+
+    info!("Verifying remote config status is Applied");
+    retry_panic(
+        120,
+        Duration::from_secs(2),
+        "waiting for remote config Applied status",
+        || {
+            if opamp_server.is_config_status_applied(instance_id.clone()) {
+                Ok(())
+            } else {
+                Err("remote config status not yet Applied".into())
+            }
+        },
+    );
+
+    info!("Verifying agent.version attribute reflects the updated version");
+    retry_panic(
+        120,
+        Duration::from_secs(2),
+        "verifying updated agent.version attribute",
+        || {
+            let Some(version) =
+                opamp_server.get_identifying_attr_value(instance_id.clone(), AGENT_VERSION_ATTR)
+            else {
+                return Err("agent.version attribute not set yet".into());
+            };
+            if version == new_version {
+                Ok(version)
+            } else {
+                Err(format!("expected version {new_version}, got {version}").into())
+            }
+        },
+    );
+    info!(version = new_version, "AC version updated successfully");
+
+    info!("Self-update test completed successfully");
+}
+
+fn find_ac_instance_id(server: &FakeServer) -> TestResult<InstanceID> {
+    let agents =
+        server.find_agents_with_identifying_attr(SUPERVISOR_KEY_ATTR, AGENT_CONTROL_SUPERVISOR_KEY);
+    match agents.len() {
+        0 => Err("no agent-control connected to OpAMP server yet".into()),
+        1 => Ok(agents.into_iter().next().unwrap()),
+        n => Err(format!("expected exactly one agent-control, found {n}").into()),
+    }
+}

--- a/tools/oci-registry.sh
+++ b/tools/oci-registry.sh
@@ -123,6 +123,18 @@ EOF
 )
     fi
 
+    local http_tls_block=""
+    if [ -n "${TLS_CERT:-}" ] && [ -n "${TLS_KEY:-}" ]; then
+        http_tls_block=$(cat << EOF
+,
+        "tls": {
+            "cert": "$TLS_CERT",
+            "key": "$TLS_KEY"
+        }
+EOF
+)
+    fi
+
     cat > "$CONFIG_FILE" << EOF
 {
     "distSpecVersion": "1.0.1",
@@ -131,7 +143,7 @@ EOF
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "$PORT"${http_auth_block}
+        "port": "$PORT"${http_auth_block}${http_tls_block}
     },
     "log": {
         "level": "debug",

--- a/tools/oci-registry.sh
+++ b/tools/oci-registry.sh
@@ -123,6 +123,7 @@ EOF
 )
     fi
 
+    # TLS_CERT and TLS_KEY are paths to a PEM cert and its matching key; both must be set to enable HTTPS.
     local http_tls_block=""
     if [ -n "${TLS_CERT:-}" ] && [ -n "${TLS_KEY:-}" ]; then
         http_tls_block=$(cat << EOF


### PR DESCRIPTION
Adds a windows self-update e2e test. The test basically installs latest AC from the recipe and self-update to the compiled version. It leverages a fake OpAMP server to send the remote config and spawn the same local registry (but with TLS so AC compiled in release mode can connect) as the integration test to store the compiled package.

Other:
- Our `component_packages.yml` was not overriding the AC version when using a specific tag, probably because we never need it to be correct. You could see the nightlies having the cargo toml version. As for the self update to work this needed to be changed so new != current version.

Pending:
- We need AC 1.13.0 or greater (that has self-update capabilities) in order to activate this test. For now there is a special commit that forces to install 1.13.0
