### PR TITLE
test: add e2e for self-update in linux

### DIFF
--- a/.github/workflows/component_onhost_e2e.yaml
+++ b/.github/workflows/component_onhost_e2e.yaml
@@ -53,6 +53,7 @@ jobs:
           - infra-agent
           - nrdot-agent
           - proxy
+          - self-update-from-latest
     steps:
       - name: Record job start time
         run: echo "JOB_START_TIME=$(date +%s)" >> "$GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ### 🚀 Enhancements
 - Added support for JP endpoints
 
+### 🧪 Testing
+- Added e2e test for self-update functionality on Linux
+
 ## 1.14.1 - 2026-05-13
 
 ### 🚀 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ### 🚀 Enhancements
 - Added support for JP endpoints
 
-### 🧪 Testing
-- Added e2e test for self-update functionality on Linux
-
 ## 1.14.1 - 2026-05-13
 
 ### 🚀 Enhancements

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -263,6 +263,17 @@ impl FakeServer {
             .collect()
     }
 
+    /// Finds the Agent Control instance ID connected to this OpAMP server.
+    /// Returns an error if no agent-control is connected or if more than one is found.
+    pub fn find_agent_control_instance(&self) -> Result<InstanceID, String> {
+        let agents = self.find_agents_with_identifying_attr("supervisor.key", "agent-control");
+        match agents.len() {
+            0 => Err("no agent-control connected to OpAMP server yet".to_string()),
+            1 => Ok(agents.into_iter().next().unwrap()),
+            n => Err(format!("expected exactly one agent-control, found {n}")),
+        }
+    }
+
     /// Returns the string value of an identifying attribute for the given agent, or `None` if the
     /// agent is unknown or the attribute is absent or not a string.
     pub fn get_identifying_attr_value(

--- a/test/e2e-runner/src/common/cert.rs
+++ b/test/e2e-runner/src/common/cert.rs
@@ -56,10 +56,6 @@ fn generate_cert(cert_path: &std::path::Path, key_path: &std::path::Path) {
         "/CN=localhost",
         "-addext",
         "subjectAltName=DNS:localhost,IP:127.0.0.1",
-    ]);
-
-    #[cfg(target_family = "unix")]
-    cmd.args([
         "-addext",
         "basicConstraints=critical,CA:FALSE",
         "-addext",
@@ -109,17 +105,4 @@ fn add_to_root_store(cert_path: &std::path::Path) {
         "update-ca-certificates failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-}
-
-impl Drop for SelfSignedCert {
-    fn drop(&mut self) {
-        #[cfg(target_family = "unix")]
-        {
-            // Remove certificate from system store on Linux
-            let system_cert_path =
-                std::path::Path::new("/usr/local/share/ca-certificates/localhost-test.crt");
-            let _ = std::fs::remove_file(system_cert_path);
-            let _ = Command::new("update-ca-certificates").output();
-        }
-    }
 }

--- a/test/e2e-runner/src/common/cert.rs
+++ b/test/e2e-runner/src/common/cert.rs
@@ -35,26 +35,38 @@ impl SelfSignedCert {
 
 fn generate_cert(cert_path: &std::path::Path, key_path: &std::path::Path) {
     info!("Generating self-signed certificate for localhost");
-    let output = Command::new("openssl")
-        .args([
-            "req",
-            "-x509",
-            "-newkey",
-            "rsa:2048",
-            "-keyout",
-            &key_path.to_string_lossy(),
-            "-out",
-            &cert_path.to_string_lossy(),
-            "-days",
-            "1",
-            "-nodes",
-            "-subj",
-            "/CN=localhost",
-            "-addext",
-            "subjectAltName=DNS:localhost,IP:127.0.0.1",
-        ])
-        .output()
-        .expect("failed to run openssl");
+
+    let key_path_str = key_path.to_string_lossy();
+    let cert_path_str = cert_path.to_string_lossy();
+
+    let mut cmd = Command::new("openssl");
+    cmd.args([
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        &key_path_str,
+        "-out",
+        &cert_path_str,
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    ]);
+
+    #[cfg(target_family = "unix")]
+    cmd.args([
+        "-addext",
+        "basicConstraints=critical,CA:FALSE",
+        "-addext",
+        "keyUsage=critical,digitalSignature,keyEncipherment",
+    ]);
+
+    let output = cmd.output().expect("failed to run openssl");
     assert!(
         output.status.success(),
         "openssl req failed: {}",
@@ -77,6 +89,37 @@ fn add_to_root_store(cert_path: &std::path::Path) {
 }
 
 #[cfg(target_family = "unix")]
-fn add_to_root_store(_cert_path: &std::path::Path) {
-    unimplemented!()
+fn add_to_root_store(cert_path: &std::path::Path) {
+    info!("Adding certificate to system root store (Linux)");
+
+    // Copy certificate to /usr/local/share/ca-certificates/
+    let system_cert_dir = std::path::Path::new("/usr/local/share/ca-certificates");
+    let system_cert_path = system_cert_dir.join("localhost-test.crt");
+
+    std::fs::copy(cert_path, &system_cert_path)
+        .expect("failed to copy certificate to /usr/local/share/ca-certificates");
+
+    // Update CA certificates
+    let output = Command::new("update-ca-certificates")
+        .output()
+        .expect("failed to run update-ca-certificates");
+
+    assert!(
+        output.status.success(),
+        "update-ca-certificates failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+impl Drop for SelfSignedCert {
+    fn drop(&mut self) {
+        #[cfg(target_family = "unix")]
+        {
+            // Remove certificate from system store on Linux
+            let system_cert_path =
+                std::path::Path::new("/usr/local/share/ca-certificates/localhost-test.crt");
+            let _ = std::fs::remove_file(system_cert_path);
+            let _ = Command::new("update-ca-certificates").output();
+        }
+    }
 }

--- a/test/e2e-runner/src/linux.rs
+++ b/test/e2e-runner/src/linux.rs
@@ -47,5 +47,8 @@ pub fn run_linux_e2e() {
         LinuxScenarios::FleetControlApi(args) => {
             fleet_control_api::run_fleet_control_api(&args.fleet_control);
         }
+        LinuxScenarios::SelfUpdateFromLatest(args) => {
+            scenarios::self_update::test_self_update_from_latest(args);
+        }
     };
 }

--- a/test/e2e-runner/src/linux/install.rs
+++ b/test/e2e-runner/src/linux/install.rs
@@ -107,6 +107,44 @@ curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh |
     info!("Output:\n{output}");
 }
 
+pub fn install_latest_agent_control(data: &RecipeData) {
+    let install_command = format!(
+        r#"
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | \
+  bash && sudo \
+  NEW_RELIC_CLI_SKIP_CORE=1 \
+  NEW_RELIC_LICENSE_KEY={} \
+  NEW_RELIC_API_KEY={} \
+  NEW_RELIC_ACCOUNT_ID={} \
+  NEW_RELIC_AUTH_PROVISIONED_CLIENT_ID={} \
+  NEW_RELIC_AUTH_PRIVATE_KEY_PATH={} \
+  NEW_RELIC_REGION={} \
+  NR_CLI_FLEET_ID={} \
+  NEW_RELIC_AGENT_CONTROL_FLEET_ENABLED={} \
+  NEW_RELIC_AGENT_CONTROL=true \
+  NEW_RELIC_AGENT_VERSION=1.13.0 \
+  /usr/local/bin/newrelic install \
+  -n {}
+"#,
+        data.args.nr_license_key,
+        data.args.nr_api_key,
+        data.args.nr_account_id,
+        data.args.system_identity_client_id,
+        data.args.agent_control_private_key,
+        data.args.nr_region,
+        data.fleet_id,
+        data.fleet_enabled,
+        data.recipe_list,
+    );
+
+    info!("Executing recipe to install Agent Control version 1.13.0");
+    let output = retry(3, Duration::from_secs(30), "recipe installation", || {
+        exec_bash_command(&install_command)
+    })
+    .unwrap_or_else(|err| panic!("failure executing recipe after retries: {err}"));
+    info!("Output:\n{output}");
+}
+
 pub fn tear_down_test() {
     let _ = show_logs(DEFAULT_LOG_PATH);
 }

--- a/test/e2e-runner/src/linux/install.rs
+++ b/test/e2e-runner/src/linux/install.rs
@@ -122,7 +122,6 @@ curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh |
   NR_CLI_FLEET_ID={} \
   NEW_RELIC_AGENT_CONTROL_FLEET_ENABLED={} \
   NEW_RELIC_AGENT_CONTROL=true \
-  NEW_RELIC_AGENT_VERSION=1.13.0 \
   /usr/local/bin/newrelic install \
   -n {}
 "#,
@@ -137,7 +136,7 @@ curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh |
         data.recipe_list,
     );
 
-    info!("Executing recipe to install Agent Control version 1.13.0");
+    info!("Executing recipe to install latest Agent Control");
     let output = retry(3, Duration::from_secs(30), "recipe installation", || {
         exec_bash_command(&install_command)
     })

--- a/test/e2e-runner/src/linux/scenarios.rs
+++ b/test/e2e-runner/src/linux/scenarios.rs
@@ -4,3 +4,4 @@ pub mod infra_agent;
 pub mod nrdot_agent;
 pub mod proxy;
 pub mod remote_config;
+pub mod self_update;

--- a/test/e2e-runner/src/linux/scenarios/self_update.rs
+++ b/test/e2e-runner/src/linux/scenarios/self_update.rs
@@ -1,0 +1,141 @@
+use crate::common::oci::{OciRegistry, push_ac_package};
+use crate::common::on_drop::CleanUp;
+use crate::common::runtime::tokio_runtime;
+use crate::common::test::{TestResult, retry_panic};
+use crate::common::{InstallationArgs, RecipeData, config};
+use crate::linux;
+use crate::linux::install::{install_latest_agent_control, tear_down_test};
+use crate::linux::service::{STATUS_RUNNING, restart_service_and_wait};
+use fake_opamp_server::{FakeServer, InstanceID};
+use std::time::Duration;
+use tracing::info;
+
+const AGENT_VERSION_ATTR: &str = "agent.version";
+const SUPERVISOR_KEY_ATTR: &str = "supervisor.key";
+const AGENT_CONTROL_SUPERVISOR_KEY: &str = "agent-control";
+
+pub fn test_self_update_from_latest(args: InstallationArgs) {
+    info!("Starting self-update scenario");
+
+    let registry = OciRegistry::start();
+    let pushed_package = push_ac_package(&args);
+
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+    info!("Fake OpAMP server started at {}", opamp_server.endpoint());
+
+    let _clean_up = CleanUp::new(tear_down_test);
+
+    install_latest_agent_control(&RecipeData {
+        args: args.clone(),
+        ..Default::default()
+    });
+
+    let self_update_config = format!(
+        r#"
+agents: {{}}
+fleet_control:
+  endpoint: {}
+  signature_validation:
+    public_key_server_url: {}
+oci:
+  registry: {}
+log:
+  file:
+    enabled: true
+  level: debug
+self_update:
+  enabled: true
+  signature_verification_enabled: true
+  package:
+    download:
+      oci:
+        repository: test
+        public_key_url: {}
+"#,
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        registry.url(),
+        pushed_package.jwks_url,
+    );
+    config::update_config(linux::DEFAULT_AC_CONFIG_PATH, &self_update_config);
+
+    restart_service_and_wait(linux::SERVICE_NAME, STATUS_RUNNING);
+    info!("AC service restarted with fleet and self-update configuration");
+
+    let instance_id = retry_panic(
+        20,
+        Duration::from_secs(2),
+        "AC connecting to OpAMP server",
+        || find_ac_instance_id(&opamp_server),
+    );
+    info!("AC connected to fake OpAMP server");
+
+    let initial_version = retry_panic(
+        30,
+        Duration::from_secs(2),
+        "reading initial agent.version attribute",
+        || -> TestResult<_> {
+            opamp_server
+                .get_identifying_attr_value(instance_id.clone(), AGENT_VERSION_ATTR)
+                .ok_or_else(|| "agent.version attribute not set yet".into())
+        },
+    );
+    info!(
+        version = initial_version,
+        "Verified initial AC version before self-update"
+    );
+
+    let new_version = pushed_package.reference.tag().unwrap();
+    assert_ne!(
+        initial_version, new_version,
+        "initial and new version must differ for self-update to be meaningful"
+    );
+
+    let update_config = format!("version: \"{new_version}\"\nagents: {{}}");
+    opamp_server.set_config_response(instance_id.clone(), update_config);
+    info!(tag = new_version, "Sent self-update remote config");
+
+    info!("Verifying remote config status is Applied");
+    retry_panic(
+        120,
+        Duration::from_secs(2),
+        "waiting for remote config Applied status",
+        || {
+            opamp_server
+                .is_config_status_applied(instance_id.clone())
+                .map_err(|e| e.into())
+        },
+    );
+
+    info!("Verifying agent.version attribute reflects the updated version");
+    retry_panic(
+        120,
+        Duration::from_secs(2),
+        "verifying updated agent.version attribute",
+        || {
+            let Some(reported_version) =
+                opamp_server.get_identifying_attr_value(instance_id.clone(), AGENT_VERSION_ATTR)
+            else {
+                return Err("agent.version attribute not set yet".into());
+            };
+            if reported_version == new_version {
+                Ok(())
+            } else {
+                Err(format!("expected version {new_version}, got {reported_version}").into())
+            }
+        },
+    );
+    info!(version = new_version, "AC version updated successfully");
+
+    info!("Self-update test completed successfully");
+}
+
+fn find_ac_instance_id(server: &FakeServer) -> TestResult<InstanceID> {
+    let agents =
+        server.find_agents_with_identifying_attr(SUPERVISOR_KEY_ATTR, AGENT_CONTROL_SUPERVISOR_KEY);
+    match agents.len() {
+        0 => Err("no agent-control connected to OpAMP server yet".into()),
+        1 => Ok(agents.into_iter().next().unwrap()),
+        n => Err(format!("expected exactly one agent-control, found {n}").into()),
+    }
+}

--- a/test/e2e-runner/src/linux/scenarios/self_update.rs
+++ b/test/e2e-runner/src/linux/scenarios/self_update.rs
@@ -6,13 +6,11 @@ use crate::common::{InstallationArgs, RecipeData, config};
 use crate::linux;
 use crate::linux::install::{install_latest_agent_control, tear_down_test};
 use crate::linux::service::{STATUS_RUNNING, restart_service_and_wait};
-use fake_opamp_server::{FakeServer, InstanceID};
+use fake_opamp_server::FakeServer;
 use std::time::Duration;
 use tracing::info;
 
 const AGENT_VERSION_ATTR: &str = "agent.version";
-const SUPERVISOR_KEY_ATTR: &str = "supervisor.key";
-const AGENT_CONTROL_SUPERVISOR_KEY: &str = "agent-control";
 
 pub fn test_self_update_from_latest(args: InstallationArgs) {
     info!("Starting self-update scenario");
@@ -66,7 +64,11 @@ self_update:
         20,
         Duration::from_secs(2),
         "AC connecting to OpAMP server",
-        || find_ac_instance_id(&opamp_server),
+        || {
+            opamp_server
+                .find_agent_control_instance()
+                .map_err(|e| e.into())
+        },
     );
     info!("AC connected to fake OpAMP server");
 
@@ -91,7 +93,12 @@ self_update:
         "initial and new version must differ for self-update to be meaningful"
     );
 
-    let update_config = format!("version: \"{new_version}\"\nagents: {{}}");
+    let update_config = format!(
+        r#"
+version: "{new_version}"
+agents: {{}}
+"#
+    );
     opamp_server.set_config_response(instance_id.clone(), update_config);
     info!(tag = new_version, "Sent self-update remote config");
 
@@ -128,14 +135,4 @@ self_update:
     info!(version = new_version, "AC version updated successfully");
 
     info!("Self-update test completed successfully");
-}
-
-fn find_ac_instance_id(server: &FakeServer) -> TestResult<InstanceID> {
-    let agents =
-        server.find_agents_with_identifying_attr(SUPERVISOR_KEY_ATTR, AGENT_CONTROL_SUPERVISOR_KEY);
-    match agents.len() {
-        0 => Err("no agent-control connected to OpAMP server yet".into()),
-        1 => Ok(agents.into_iter().next().unwrap()),
-        n => Err(format!("expected exactly one agent-control, found {n}").into()),
-    }
 }

--- a/test/e2e-runner/src/linux/service.rs
+++ b/test/e2e-runner/src/linux/service.rs
@@ -1,3 +1,5 @@
+use std::thread::sleep;
+use std::time::Duration;
 use tracing::info;
 
 use crate::linux::bash::exec_bash_command;
@@ -20,9 +22,6 @@ pub fn restart_service_and_wait(service_name: &str, expected_status: &str) {
         .unwrap_or_else(|err| panic!("could not restart the '{service_name}' service: {err}"));
 
     // Wait for service to reach expected status
-    use std::thread::sleep;
-    use std::time::Duration;
-
     for i in 0..30 {
         let current_status = get_service_status(service_name);
         if current_status == expected_status {
@@ -43,7 +42,17 @@ pub fn restart_service_and_wait(service_name: &str, expected_status: &str) {
         }
         sleep(Duration::from_secs(1));
     }
+
+    // Final check in case the service reached expected status right after the loop
     let final_status = get_service_status(service_name);
+    if final_status == expected_status {
+        info!(
+            service = service_name,
+            status = expected_status,
+            "Service reached expected status on final check"
+        );
+        return;
+    }
 
     // Show service logs when it fails
     info!("Service failed to reach expected status, showing logs");

--- a/test/e2e-runner/src/linux/service.rs
+++ b/test/e2e-runner/src/linux/service.rs
@@ -2,10 +2,73 @@ use tracing::info;
 
 use crate::linux::bash::exec_bash_command;
 
+pub const STATUS_RUNNING: &str = "active";
+
 /// Restarts a service using systemctl
 pub fn restart_service(service_name: &str) {
     info!(service = service_name, "Restarting service");
     let cmd = format!("systemctl restart {service_name}");
     let _ = exec_bash_command(&cmd)
         .unwrap_or_else(|err| panic!("could not restart the '{service_name}' service: {err}"));
+}
+
+/// Restarts a service using systemctl and waits for it to reach the expected status
+pub fn restart_service_and_wait(service_name: &str, expected_status: &str) {
+    info!(service = service_name, "Restarting service");
+    let cmd = format!("systemctl restart {service_name}");
+    let _ = exec_bash_command(&cmd)
+        .unwrap_or_else(|err| panic!("could not restart the '{service_name}' service: {err}"));
+
+    // Wait for service to reach expected status
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    for i in 0..30 {
+        let current_status = get_service_status(service_name);
+        if current_status == expected_status {
+            info!(
+                service = service_name,
+                status = expected_status,
+                "Service reached expected status"
+            );
+            return;
+        }
+        if i % 5 == 0 {
+            info!(
+                service = service_name,
+                current_status = current_status,
+                expected_status = expected_status,
+                "Waiting for service to reach expected status"
+            );
+        }
+        sleep(Duration::from_secs(1));
+    }
+    let final_status = get_service_status(service_name);
+
+    // Show service logs when it fails
+    info!("Service failed to reach expected status, showing logs");
+    let log_cmd = format!("journalctl -u {service_name} -n 50 --no-pager");
+    if let Ok(logs) = exec_bash_command(&log_cmd) {
+        info!("Service logs:\n{}", logs);
+    }
+
+    panic!(
+        "Service {service_name} did not reach status {expected_status} within 30 seconds. Final status: {final_status}"
+    );
+}
+
+/// Gets the current status of a service using systemctl
+pub fn get_service_status(service_name: &str) -> String {
+    let cmd = format!("systemctl show --property=ActiveState {service_name} | cut -d= -f2");
+    let output = exec_bash_command(&cmd)
+        .unwrap_or_else(|err| panic!("could not get status of '{service_name}' service: {err}"));
+
+    // Extract stdout from the formatted output
+    output
+        .lines()
+        .find(|line| line.starts_with("Stdout: "))
+        .and_then(|line| line.strip_prefix("Stdout: "))
+        .unwrap_or("")
+        .trim()
+        .to_string()
 }

--- a/test/e2e-runner/src/main.rs
+++ b/test/e2e-runner/src/main.rs
@@ -43,6 +43,9 @@ enum LinuxScenarios {
     /// This is useful when Agent Control is already deployed and you only need to trigger and monitor Fleet Control tests.
     /// Requires --fleet-id and --fleet-control-token arguments.
     FleetControlApi(FleetControlApiArgs),
+    /// Tests self-update functionality by installing Agent Control, pushing a new version to local OCI registry,
+    /// and verifying that AC updates itself when instructed via OpAMP.
+    SelfUpdateFromLatest(InstallationArgs),
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/test/e2e-runner/src/windows/scenarios/self_update.rs
+++ b/test/e2e-runner/src/windows/scenarios/self_update.rs
@@ -6,13 +6,11 @@ use crate::common::{InstallationArgs, RecipeData, config};
 use crate::windows::install::{SERVICE_NAME, install_latest_agent_control, tear_down_test};
 use crate::windows::service::{STATUS_RUNNING, restart_service};
 use crate::windows::{self};
-use fake_opamp_server::{FakeServer, InstanceID};
+use fake_opamp_server::FakeServer;
 use std::time::Duration;
 use tracing::info;
 
 const AGENT_VERSION_ATTR: &str = "agent.version";
-const SUPERVISOR_KEY_ATTR: &str = "supervisor.key";
-const AGENT_CONTROL_SUPERVISOR_KEY: &str = "agent-control";
 
 pub fn test_self_update_from_latest(args: InstallationArgs) {
     info!("Starting self-update scenario");
@@ -65,7 +63,11 @@ self_update:
         20,
         Duration::from_secs(2),
         "AC connecting to OpAMP server",
-        || find_ac_instance_id(&opamp_server),
+        || {
+            opamp_server
+                .find_agent_control_instance()
+                .map_err(|e| e.into())
+        },
     );
     info!("AC connected to fake OpAMP server");
 
@@ -90,7 +92,12 @@ self_update:
         "initial and new version must differ for self-update to be meaningful"
     );
 
-    let update_config = format!("version: \"{new_version}\"\nagents: {{}}");
+    let update_config = format!(
+        r#"
+version: "{new_version}"
+agents: {{}}
+"#
+    );
     opamp_server.set_config_response(instance_id.clone(), update_config);
     info!(tag = new_version, "Sent self-update remote config");
 
@@ -127,14 +134,4 @@ self_update:
     info!(version = new_version, "AC version updated successfully");
 
     info!("Self-update test completed successfully");
-}
-
-fn find_ac_instance_id(server: &FakeServer) -> TestResult<InstanceID> {
-    let agents =
-        server.find_agents_with_identifying_attr(SUPERVISOR_KEY_ATTR, AGENT_CONTROL_SUPERVISOR_KEY);
-    match agents.len() {
-        0 => Err("no agent-control connected to OpAMP server yet".into()),
-        1 => Ok(agents.into_iter().next().unwrap()),
-        n => Err(format!("expected exactly one agent-control, found {n}").into()),
-    }
 }


### PR DESCRIPTION
Adds Linux E2E self-update test

  ## Test Flow

  1. Install AC 1.13.0 using New Relic CLI recipe
  2. Push test version (0.900.xxx) to local OCI registry
  3. Configure self-update + OpAMP endpoint
  4. Verify initial version (1.13.0)
  5. Send remote config with new version
  6. Verify self-update completes successfully


<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
