### PR TITLE
feat: add new filesystem format with ephemeral and persistent folders

### DIFF
--- a/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.infrastructure-0.1.0.yaml
@@ -175,13 +175,15 @@ deployment:
         - --version
       regex: \d+\.\d+\.\d+
     filesystem:
-      config:
-        newrelic-infra.yaml: |
-          ${nr-var:config_agent}
-      integrations.d: ${nr-var:config_integrations}
-      logging.d: ${nr-var:config_logging}
-      # this is needed in order to create the logging integration directory expected by fluentBit
-      newrelic-infra/newrelic-integrations/logging: { }
+      persistent:
+        config:
+          newrelic-infra.yaml: |
+            ${nr-var:config_agent}
+        logging.d: ${nr-var:config_logging}
+        # this is needed in order to create the logging integration directory expected by fluentBit
+        newrelic-infra/newrelic-integrations/logging: { }
+      ephemeral:
+        integrations.d: ${nr-var:config_integrations}
     executables:
       - id: newrelic-infra
         path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
@@ -244,11 +246,13 @@ deployment:
         - --version
       regex: \d+\.\d+\.\d+
     filesystem:
-      config:
-        newrelic-infra.yaml: |
-          ${nr-var:config_agent}
-      integrations.d: ${nr-var:config_integrations}
-      logging.d: ${nr-var:config_logging}
+      persistent:
+        config:
+          newrelic-infra.yaml: |
+            ${nr-var:config_agent}
+        logging.d: ${nr-var:config_logging}
+      ephemeral:
+        integrations.d: ${nr-var:config_integrations}
     executables:
       - id: newrelic-infra
         path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra

--- a/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -146,9 +146,10 @@ deployment:
         - -v
       regex: \d+\.\d+\.\d+
     filesystem:
-      otel-config:
-        config.yaml: |
-          ${nr-var:config}
+      persistent:
+        otel-config:
+          config.yaml: |
+            ${nr-var:config}
     executables:
       - # Important to note the binary name is nrdot-collector matching the new nrdot binary
         id: nrdot-collector
@@ -185,9 +186,10 @@ deployment:
         - -v
       regex: \d+\.\d+\.\d+
     filesystem:
-      otel-config:
-        config.yaml: |
-          ${nr-var:config}
+      persistent:
+        otel-config:
+          config.yaml: |
+            ${nr-var:config}
     executables:
       - # Important to note the binary name is nrdot-collector matching the new nrdot binary
         id: nrdot-collector

--- a/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/io.opentelemetry.collector-0.1.0.yaml
@@ -85,9 +85,10 @@ deployment:
         - -v
       regex: \d+\.\d+\.\d+
     filesystem:
-      otel-config:
-        config.yaml: |
-          ${nr-var:config}
+      persistent:
+        otel-config:
+          config.yaml: |
+            ${nr-var:config}
     executables:
       - # Important to note the binary name is nrdot-collector matching the new nrdot binary
         id: nrdot-collector

--- a/agent-control/src/agent_control/resource_cleaner.rs
+++ b/agent-control/src/agent_control/resource_cleaner.rs
@@ -1,5 +1,6 @@
 pub mod k8s_garbage_collector;
 pub(super) mod no_op;
+pub mod on_host;
 
 use thiserror::Error;
 

--- a/agent-control/src/agent_control/resource_cleaner/no_op.rs
+++ b/agent-control/src/agent_control/resource_cleaner/no_op.rs
@@ -3,6 +3,7 @@ use crate::{agent_control::agent_id::AgentID, agent_type::agent_type_id::AgentTy
 use super::{ResourceCleaner, ResourceCleanerError};
 
 /// Basic implementation of a no-op ResourceCleaner.
+#[allow(dead_code)]
 pub struct NoOpResourceCleaner;
 
 impl ResourceCleaner for NoOpResourceCleaner {

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+use tracing::debug;
+
+use crate::{
+    agent_control::{agent_id::AgentID, defaults::AGENT_FILESYSTEM_FOLDER_NAME},
+    agent_type::agent_type_id::AgentTypeID,
+};
+
+use super::{ResourceCleaner, ResourceCleanerError};
+
+/// On-host resource cleaner that removes an agent's filesystem directory upon removal.
+///
+/// When an agent is removed from the config, its entire filesystem directory
+/// (`{remote_dir}/filesystem/{agent_id}/`) is deleted. This includes both ephemeral
+/// and persistent files.
+///
+/// Note: Persistent files are only preserved during agent restarts and config updates
+/// (handled by startup cleanup in FileSystem::write), not during complete agent removal.
+pub struct OnHostFilesystemCleaner {
+    remote_dir: PathBuf,
+}
+
+impl OnHostFilesystemCleaner {
+    pub fn new(remote_dir: PathBuf) -> Self {
+        Self { remote_dir }
+    }
+}
+
+impl ResourceCleaner for OnHostFilesystemCleaner {
+    fn clean(
+        &self,
+        agent_id: &AgentID,
+        _agent_type: &AgentTypeID,
+    ) -> Result<(), ResourceCleanerError> {
+        let AgentID::SubAgent(id) = agent_id else {
+            return Ok(());
+        };
+
+        let agent_fs_dir = self
+            .remote_dir
+            .join(AGENT_FILESYSTEM_FOLDER_NAME)
+            .join(id.as_str());
+
+        if !agent_fs_dir.exists() {
+            debug!(%agent_id, "Agent filesystem dir does not exist, skipping cleanup");
+            return Ok(());
+        }
+
+        debug!(%agent_id, "Removing agent filesystem directory on agent removal");
+        std::fs::remove_dir_all(&agent_fs_dir).map_err(|e| {
+            ResourceCleanerError(format!(
+                "removing agent filesystem dir {}: {e}",
+                agent_fs_dir.display()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_control::agent_id::AgentID;
+    use crate::agent_type::agent_type_id::AgentTypeID;
+    use tempfile::TempDir;
+
+    fn agent_id(id: &str) -> AgentID {
+        AgentID::try_from(id.to_string()).unwrap()
+    }
+
+    fn agent_type() -> AgentTypeID {
+        AgentTypeID::try_from("ns/test:0.0.1").unwrap()
+    }
+
+    #[test]
+    fn no_agent_fs_dir_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = OnHostFilesystemCleaner::new(tmp.path().to_path_buf());
+        let id = agent_id("missing-agent");
+        assert!(cleaner.clean(&id, &agent_type()).is_ok());
+    }
+
+    #[test]
+    fn removes_entire_filesystem_directory() {
+        let tmp = TempDir::new().unwrap();
+        let remote_dir = tmp.path();
+
+        let id = agent_id("my-agent");
+        let AgentID::SubAgent(ref raw_id) = id else {
+            panic!()
+        };
+        let agent_fs = remote_dir
+            .join(AGENT_FILESYSTEM_FOLDER_NAME)
+            .join(raw_id.as_str());
+
+        // Create various files and directories
+        std::fs::create_dir_all(agent_fs.join("config")).unwrap();
+        std::fs::write(agent_fs.join("config/agent.yaml"), "key: val").unwrap();
+        std::fs::create_dir_all(agent_fs.join("data/store")).unwrap();
+        std::fs::write(agent_fs.join("data/store/db.json"), "{}").unwrap();
+        std::fs::write(agent_fs.join("some_file.txt"), "content").unwrap();
+
+        let cleaner = OnHostFilesystemCleaner::new(remote_dir.to_path_buf());
+        cleaner.clean(&id, &agent_type()).unwrap();
+
+        // The entire agent filesystem directory should be removed
+        assert!(
+            !agent_fs.exists(),
+            "entire agent filesystem directory should be removed on agent removal"
+        );
+    }
+}

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -8,7 +8,7 @@ use crate::agent_control::defaults::{
     OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
 };
 use crate::agent_control::http_server::runner::Runner;
-use crate::agent_control::resource_cleaner::no_op::NoOpResourceCleaner;
+use crate::agent_control::resource_cleaner::on_host::OnHostFilesystemCleaner;
 use crate::agent_control::run::{
     AgentControlRunner, Environment, GracefulShutdownReason, RunError, RunningMode,
     setup_config_repository_and_store,
@@ -259,7 +259,7 @@ impl AgentControlRunner {
             agent_control_internal_consumer,
             SupportedRemoteConfigValidator::Signature(signature_validator),
             dynamic_config_validator,
-            NoOpResourceCleaner,
+            OnHostFilesystemCleaner::new(remote_dir.clone()),
             self_updater,
             |t| Some(NoOpHealthChecker::new(t)),
             agent_control_config,

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -27,28 +27,40 @@ use serde::Deserialize;
 pub mod rendered;
 
 /// Represents the file system configuration for the deployment of a host agent. Consisting of
-/// a set of directories (map keys) which in turn contain a set of files (nested map keys) with
-/// their respective content (map values).
+/// two sections — `ephemeral` and `persistent` — each mapping directory paths (keys) to their
+/// file entries (values).
+///
+/// Directories under `ephemeral` are deleted when the agent is removed from the config.
+/// Directories under `persistent` are preserved across agent removal.
 ///
 /// It would be equivalent to a YAML mapping of this format:
 /// ```yaml
 /// filesystem:
-///   "path/to/my-dir":
-///      # YAML content, expected to be a mapping string -> yaml
-///      filepath1: "file1 content"
-///      filepath2: | # multi-line string content
-///        key: value
-///   # fully templated content, expected to render to a valid YAML mapping string -> string
-///   "another/path/to/my-dir": ${nr-var:some_var_that_renders_to_a_yaml_mapping}
+///   ephemeral:
+///     "path/to/my-dir":
+///        # YAML content, expected to be a mapping string -> yaml
+///        filepath1: "file1 content"
+///        filepath2: | # multi-line string content
+///          key: value
+///   persistent:
+///     # fully templated content, expected to render to a valid YAML mapping string -> string
+///     "another/path/to/my-dir": ${nr-var:some_var_that_renders_to_a_yaml_mapping}
 /// ```
 ///
 /// The files can be hardcoded, with the contents possibly containing templates, or the whole set of
 /// files can be templated so a directory contains an arbitrary number of files (a place to use a
 /// `map[string]yaml` variable type). **The paths cannot be templated.**
 ///
-/// See [`AgentDirectoryEntry`] and [`DirEntriesType`] for more details.
+/// See [`DirEntriesType`] for more details.
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
-pub struct FileSystem(HashMap<SafePath, DirEntriesType>);
+pub struct FileSystem {
+    /// Directories that are deleted when the agent is removed from the config.
+    #[serde(default)]
+    pub(crate) ephemeral: HashMap<SafePath, DirEntriesType>,
+    /// Directories that are preserved when the agent is removed from the config.
+    #[serde(default)]
+    pub(crate) persistent: HashMap<SafePath, DirEntriesType>,
+}
 
 /// A path to a file or directory that has been validated to be "safe",
 /// i.e. relative and not escaping its base directory (e.g. with parent dir specifiers like `..`).
@@ -91,7 +103,7 @@ impl From<SafePath> for PathBuf {
 ///      a placeholder for later rendering.
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
-enum DirEntriesType {
+pub(crate) enum DirEntriesType {
     /// A directory with a fixed set of entries (i.e. files). Each entry's content can be templated.
     /// E.g.
     /// ```yaml
@@ -133,21 +145,26 @@ impl Templateable for FileSystem {
             )
             .and_then(Variable::get_final_value)
         {
-            let filesystem = self
-                .0
-                .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        // The only place where we construct a `SafePath` directly, prepending the
-                        // sub-agent's filesystem directory to the user-provided relative path.
-                        // FIXME: when we fix the templating and make the agent type definitions
-                        // type-safe, we will make sure to always build correct "final paths" here.
-                        SafePath(PathBuf::from(filesystem_dir.clone()).join(k)),
-                        v.template_with(variables)?,
-                    ))
-                })
-                .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-            Ok(rendered::FileSystem(filesystem))
+            let filesystem_dir_path = PathBuf::from(filesystem_dir.clone());
+
+            // The only place where we construct a `SafePath` directly, prepending the
+            // sub-agent's filesystem directory to the user-provided relative path.
+            // FIXME: when we fix the templating and make the agent type definitions
+            // type-safe, we will make sure to always build correct "final paths" here.
+            let template_map =
+                |map: HashMap<SafePath, DirEntriesType>| -> Result<HashMap<SafePath, _>, AgentTypeError> {
+                    map.into_iter()
+                        .map(|(k, v)| {
+                            Ok((SafePath(filesystem_dir_path.join(k)), v.template_with(variables)?))
+                        })
+                        .collect()
+                };
+
+            Ok(rendered::FileSystem {
+                ephemeral: template_map(self.ephemeral)?,
+                persistent: template_map(self.persistent)?,
+                filesystem_dir: filesystem_dir_path,
+            })
         } else {
             Err(AgentTypeError::MissingValue(
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
@@ -157,9 +174,10 @@ impl Templateable for FileSystem {
 }
 
 impl FileSystem {
-    /// Returns the list of directory paths (keys) defined in this filesystem configuration.
+    /// Returns the list of directory paths (keys) defined in this filesystem configuration,
+    /// covering both ephemeral and persistent sections.
     pub fn dir_paths(&self) -> impl Iterator<Item = &SafePath> {
-        self.0.keys()
+        self.ephemeral.keys().chain(self.persistent.keys())
     }
 }
 
@@ -309,26 +327,33 @@ mod tests {
             Variable::new_final_string_variable("/base/dir"),
         )]);
 
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::from_template("some content".to_string()),
-            )])),
-        )]));
+        let filesystem_entry = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("my/path").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    TemplateableValue::from_template("some content".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
 
         let rendered = filesystem_entry.template_with(&variables);
         assert!(rendered.is_ok());
         let rendered = rendered.unwrap();
-        assert!(rendered.0.len() == 1);
+        assert!(rendered.ephemeral.len() == 1);
 
-        let expected_filesystem = rendered::FileSystem(HashMap::from([(
-            SafePath(PathBuf::from("/base/dir/my/path")),
-            DirEntriesMap(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                "some content".to_string(),
-            )])),
-        )]));
+        let expected_filesystem = rendered::FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(PathBuf::from("/base/dir/my/path")),
+                DirEntriesMap(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    "some content".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: PathBuf::from("/base/dir"),
+        };
 
         assert_eq!(rendered, expected_filesystem);
     }
@@ -339,13 +364,16 @@ mod tests {
         // templating must fail.
         let variables = Variables::default();
 
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::new("some content".to_string()),
-            )])),
-        )]));
+        let filesystem_entry = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("my/path").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    TemplateableValue::new("some content".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
 
         let rendered = filesystem_entry.template_with(&variables);
         assert!(rendered.is_err());
@@ -380,11 +408,12 @@ mod tests {
     }
 
     const EXAMPLE_FILESYSTEM: &str = r#"
-"path/to/my-dir":
+ephemeral:
+  "path/to/my-dir":
     filepath1: "file1 content"
     filepath2: |
-        key: ${nr-var:some_var}
-"another/path/to/my-dir":
+      key: ${nr-var:some_var}
+  "another/path/to/my-dir":
     ${nr-var:some_var_that_renders_to_a_yaml_mapping}
 "#;
 
@@ -392,11 +421,11 @@ mod tests {
     fn parse_valid_directories() {
         let parsed: Result<FileSystem, _> = serde_yaml::from_str(EXAMPLE_FILESYSTEM);
         assert!(
-            parsed.as_ref().is_ok_and(|p| p.0.len() == 2),
+            parsed.as_ref().is_ok_and(|p| p.ephemeral.len() == 2),
             "Parsed directories: {parsed:?}"
         );
 
-        let parsed = parsed.unwrap().0;
+        let parsed = parsed.unwrap().ephemeral;
         let my_dir = parsed
             .get(&SafePath(PathBuf::from("path/to/my-dir")))
             .unwrap();
@@ -412,26 +441,27 @@ mod tests {
     }
 
     const FILESYSTEM_EXAMPLE: &str = r#"
-"some/files":
+ephemeral:
+  "some/files":
     "path/to/my-file": "something ${nr-var:some_file_var}"
     "another/path/to/my-file": |
-        some
-        multi-line
-        content
-"path/to/my-dir":
+      some
+      multi-line
+      content
+  "path/to/my-dir":
     filepath1: "file1 content"
     filepath2: |
-        key: ${nr-var:some_dir_var}
-"another/path/to/my-dir":
+      key: ${nr-var:some_dir_var}
+  "another/path/to/my-dir":
     ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-"empty/dir": {}
+  "empty/dir": {}
 "#;
 
     #[test]
     fn parse_and_template_filesystem() {
         let parsed = serde_yaml::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
         assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
+            parsed.as_ref().is_ok_and(|fs| fs.ephemeral.len() == 4),
             "Parsed filesystem: {parsed:?}"
         );
 
@@ -475,7 +505,7 @@ mod tests {
     fn rendered_files() {
         let parsed = serde_yaml::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
         assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
+            parsed.as_ref().is_ok_and(|fs| fs.ephemeral.len() == 4),
             "Parsed filesystem: {parsed:?}"
         );
         let tmp_dir = TempDir::new().unwrap();
@@ -563,5 +593,146 @@ mod tests {
                 r_path.display()
             );
         }
+    }
+
+    /// When a config update removes a file from an ephemeral directory (e.g. an integration
+    /// removed from `config_integrations`), the stale file must be deleted on the next write.
+    #[test]
+    fn ephemeral_dir_stale_files_are_deleted_on_next_write() {
+        let tmp_dir = TempDir::new().unwrap();
+        let base_variables = |dir: &str| {
+            Variables::from_iter(vec![(
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(dir),
+            )])
+        };
+
+        // First write: integrations.d contains apache, nginx, mysql
+        let first_config = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("integrations.d").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([
+                    (
+                        PathBuf::from("apache.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("apache config".to_string()),
+                    ),
+                    (
+                        PathBuf::from("nginx.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("nginx config".to_string()),
+                    ),
+                    (
+                        PathBuf::from("mysql.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("mysql config".to_string()),
+                    ),
+                ])),
+            )]),
+            persistent: HashMap::default(),
+        };
+
+        let dir = tmp_dir.path().to_string_lossy().to_string();
+        first_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(tmp_dir.path().join("integrations.d/apache.yaml").exists());
+        assert!(tmp_dir.path().join("integrations.d/nginx.yaml").exists());
+        assert!(tmp_dir.path().join("integrations.d/mysql.yaml").exists());
+
+        // Second write: nginx and mysql removed from config_integrations
+        let second_config = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("integrations.d").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("apache.yaml").try_into().unwrap(),
+                    TemplateableValue::from_template("apache config".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
+
+        second_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(
+            tmp_dir.path().join("integrations.d/apache.yaml").exists(),
+            "apache.yaml should still be present"
+        );
+        assert!(
+            !tmp_dir.path().join("integrations.d/nginx.yaml").exists(),
+            "nginx.yaml should have been deleted"
+        );
+        assert!(
+            !tmp_dir.path().join("integrations.d/mysql.yaml").exists(),
+            "mysql.yaml should have been deleted"
+        );
+    }
+
+    /// Files in persistent directories must never be deleted by a config update,
+    /// even if they are absent from the new configuration.
+    #[test]
+    fn persistent_dir_files_survive_config_update() {
+        let tmp_dir = TempDir::new().unwrap();
+        let base_variables = |dir: &str| {
+            Variables::from_iter(vec![(
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(dir),
+            )])
+        };
+
+        let dir = tmp_dir.path().to_string_lossy().to_string();
+
+        // First write: persistent dir gets a file written by the config
+        let first_config = FileSystem {
+            ephemeral: HashMap::default(),
+            persistent: HashMap::from([(
+                PathBuf::from("logging").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("fluent.yaml").try_into().unwrap(),
+                    TemplateableValue::from_template("fluent config".to_string()),
+                )])),
+            )]),
+        };
+
+        first_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // Simulate a file written by the sub-agent itself into the persistent dir
+        std::fs::write(
+            tmp_dir.path().join("logging/agent-created.yaml"),
+            "runtime data",
+        )
+        .unwrap();
+
+        // Second write: persistent dir entry is now empty in the config
+        let second_config = FileSystem {
+            ephemeral: HashMap::default(),
+            persistent: HashMap::from([(
+                PathBuf::from("logging").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::default()),
+            )]),
+        };
+
+        second_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(
+            tmp_dir.path().join("logging/fluent.yaml").exists(),
+            "fluent.yaml written by the config must survive a config update in a persistent dir"
+        );
+        assert!(
+            tmp_dir.path().join("logging/agent-created.yaml").exists(),
+            "file written by the sub-agent must survive a config update in a persistent dir"
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -1,12 +1,18 @@
 use crate::agent_type::runtime_config::on_host::filesystem::{DirEntriesMap, SafePath};
 use ::fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::trace;
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct FileSystem(pub(super) HashMap<SafePath, DirEntriesMap>);
+pub struct FileSystem {
+    pub(super) ephemeral: HashMap<SafePath, DirEntriesMap>,
+    pub(super) persistent: HashMap<SafePath, DirEntriesMap>,
+    /// Absolute path to the agent's dedicated filesystem directory
+    /// (e.g. `{remote_dir}/filesystem/{agent_id}`).
+    pub(super) filesystem_dir: PathBuf,
+}
 
 impl FileSystem {
     pub fn write(
@@ -14,20 +20,106 @@ impl FileSystem {
         file_writer: &impl FileWriter,
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
-        self.0.iter().try_for_each(|(dir_path, dir_entries)| {
-            // Create the base directory so that we support empty directories
-            dir_manager.create(dir_path.as_ref()).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
-            })?;
-            dir_entries
-                .0
-                .iter()
-                .try_for_each(|(sub_path, file_content)| {
-                    let file_path = dir_path.as_ref().join(sub_path);
-                    create_file(file_writer, dir_manager, &file_path, file_content)
-                })
-        })
+        // Clean up ephemeral entries from previous runs before writing new ones.
+        // This ensures stale files are removed even if agent-control was down when the config changed.
+        self.cleanup_ephemeral_on_startup(dir_manager)?;
+
+        write_ephemeral_dirs(&self.ephemeral, file_writer, dir_manager)?;
+        write_persistent_dirs(&self.persistent, file_writer, dir_manager)?;
+
+        Ok(())
     }
+
+    /// Cleans up ephemeral filesystem entries from a previous run before writing new ones.
+    ///
+    /// Compares what's on disk against the current agent type's filesystem configuration
+    /// (`self.ephemeral` and `self.persistent`) and deletes any directories that don't match.
+    /// This ensures:
+    /// - Old ephemeral directories that are no longer in the config are removed
+    /// - Persistent directories that are still in the config are preserved
+    ///
+    /// This is a no-op if the filesystem directory doesn't exist yet (first run).
+    fn cleanup_ephemeral_on_startup(
+        &self,
+        dir_manager: &impl DirectoryManager,
+    ) -> Result<(), FileSystemEntriesError> {
+        if self.filesystem_dir.as_os_str().is_empty() || !self.filesystem_dir.exists() {
+            return Ok(());
+        }
+
+        // Build a set of all directories that should exist based on the current config
+        let should_exist: std::collections::HashSet<PathBuf> = self
+            .ephemeral
+            .keys()
+            .chain(self.persistent.keys())
+            .map(|safe_path| safe_path.as_ref().to_path_buf())
+            .collect();
+
+        // If no directories are configured, we can delete the entire filesystem dir
+        if should_exist.is_empty() {
+            trace!(
+                "No filesystem directories configured, removing entire filesystem dir: {}",
+                self.filesystem_dir.display()
+            );
+            dir_manager.delete(&self.filesystem_dir).map_err(|e| {
+                FileSystemEntriesError(format!(
+                    "removing filesystem dir on startup {}: {e}",
+                    self.filesystem_dir.display()
+                ))
+            })?;
+            return Ok(());
+        }
+
+        // Delete directories that exist on disk but are not in the current config
+        delete_stale_directories(&self.filesystem_dir, &should_exist, dir_manager)
+    }
+}
+
+/// Clears each directory before writing its contents.
+/// This ensures files no longer present in the config are removed from disk.
+fn write_ephemeral_dirs(
+    dirs: &HashMap<SafePath, DirEntriesMap>,
+    file_writer: &impl FileWriter,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    dirs.iter().try_for_each(|(dir_path, dir_entries)| {
+        // Delete existing contents so stale files (e.g. removed integrations) are cleaned up.
+        // `delete` is a no-op when the directory does not yet exist.
+        dir_manager.delete(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("clearing ephemeral directory {dir_path:?}: {err}"))
+        })?;
+        dir_manager.create(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
+        })?;
+        dir_entries
+            .0
+            .iter()
+            .try_for_each(|(sub_path, file_content)| {
+                let file_path = dir_path.as_ref().join(sub_path);
+                create_file(file_writer, dir_manager, &file_path, file_content)
+            })
+    })
+}
+
+/// Writes directory contents additively — existing files are overwritten but never deleted.
+/// Used for persistent directories whose contents must survive config updates.
+fn write_persistent_dirs(
+    dirs: &HashMap<SafePath, DirEntriesMap>,
+    file_writer: &impl FileWriter,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    dirs.iter().try_for_each(|(dir_path, dir_entries)| {
+        dir_manager.create(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
+        })?;
+        dir_entries
+            .0
+            .iter()
+            .try_for_each(|(sub_path, file_content)| {
+                let file_path = dir_path.as_ref().join(sub_path);
+                create_file(file_writer, dir_manager, &file_path, file_content)
+            })
+    })
 }
 
 fn create_file(
@@ -49,6 +141,341 @@ fn create_file(
         .map_err(|err| FileSystemEntriesError(format!("creating file {file_path:?}: {err}")))
 }
 
+/// Deletes directories in `filesystem_dir` that are not in the `should_exist` set.
+/// This is used during startup cleanup to remove stale directories based on the current
+/// agent type configuration.
+fn delete_stale_directories(
+    filesystem_dir: &Path,
+    should_exist: &std::collections::HashSet<PathBuf>,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    let entries = std::fs::read_dir(filesystem_dir).map_err(|e| {
+        FileSystemEntriesError(format!(
+            "reading filesystem dir {}: {e}",
+            filesystem_dir.display()
+        ))
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            FileSystemEntriesError(format!(
+                "reading dir entry in {}: {e}",
+                filesystem_dir.display()
+            ))
+        })?;
+        let entry_path = entry.path();
+
+        // Keep this directory if it's in the current config (ephemeral or persistent)
+        if should_exist.contains(&entry_path) {
+            trace!("Keeping configured directory: {}", entry_path.display());
+            continue;
+        }
+
+        // Keep this directory if it's a parent of any configured directory
+        // e.g., keep "data" if "data/store" is configured
+        let is_parent_of_configured = should_exist
+            .iter()
+            .any(|path| path.starts_with(&entry_path));
+
+        if is_parent_of_configured {
+            trace!(
+                "Keeping parent directory of configured path: {}",
+                entry_path.display()
+            );
+            continue;
+        }
+
+        // This directory is stale - not in the current config
+        trace!(
+            "Removing stale directory on startup: {}",
+            entry_path.display()
+        );
+        dir_manager.delete(&entry_path).map_err(|e| {
+            FileSystemEntriesError(format!(
+                "removing stale directory {}: {e}",
+                entry_path.display()
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 #[error("file system entries error: {0}")]
 pub struct FileSystemEntriesError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::runtime_config::on_host::filesystem::SafePath;
+    use fs::directory_manager::DirectoryManagerFs;
+    use fs::file::LocalFile;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Test that ephemeral directories are cleaned up on startup before writing new files.
+    /// This simulates the scenario where agent-control was shut down, files were left on disk,
+    /// and then agent-control starts up again. The old ephemeral files should be removed,
+    /// but persistent files should be kept.
+    #[test]
+    fn cleanup_ephemeral_on_startup() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        // Step 1: Create initial filesystem with both ephemeral and persistent dirs
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("config")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("agent.yaml")),
+                    "initial config".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::from([(
+                SafePath(filesystem_dir.join("data")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("state.json")),
+                    "initial state".to_string(),
+                )])),
+            )]),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        // Write the initial filesystem
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        // Verify initial state: both ephemeral and persistent files exist
+        assert!(
+            filesystem_dir.join("config/agent.yaml").exists(),
+            "Initial ephemeral file should exist"
+        );
+        assert!(
+            filesystem_dir.join("data/state.json").exists(),
+            "Initial persistent file should exist"
+        );
+
+        // Step 2: Simulate a filesystem with different ephemeral content but same persistent dirs.
+        // When this is written, the old ephemeral files should be cleaned up.
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("integrations")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("integration.yaml")),
+                    "new integration".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::from([(
+                SafePath(filesystem_dir.join("data")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("state.json")),
+                    "updated state".to_string(),
+                )])),
+            )]),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        // Write the new filesystem
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        // Verify: old ephemeral dir (config/) should be removed
+        assert!(
+            !filesystem_dir.join("config").exists(),
+            "Old ephemeral dir 'config' should be removed on startup cleanup"
+        );
+        assert!(
+            !filesystem_dir.join("config/agent.yaml").exists(),
+            "Old ephemeral file should be removed"
+        );
+
+        // Verify: new ephemeral dir should exist
+        assert!(
+            filesystem_dir
+                .join("integrations/integration.yaml")
+                .exists(),
+            "New ephemeral file should exist"
+        );
+
+        // Verify: persistent dir and its contents should survive
+        assert!(
+            filesystem_dir.join("data/state.json").exists(),
+            "Persistent file should survive startup cleanup"
+        );
+
+        // Verify: the content of persistent file should be updated
+        let persistent_content =
+            std::fs::read_to_string(filesystem_dir.join("data/state.json")).unwrap();
+        assert_eq!(
+            persistent_content, "updated state",
+            "Persistent file content should be updated"
+        );
+    }
+
+    /// Test that cleanup removes directories not in the current agent type configuration.
+    #[test]
+    fn cleanup_removes_stale_dirs_not_in_config() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        // Create an old directory on disk (simulating a previous run or manual creation)
+        std::fs::create_dir_all(filesystem_dir.join("old_dir")).unwrap();
+        std::fs::write(filesystem_dir.join("old_dir/old_file.txt"), "old content").unwrap();
+
+        // Create a new filesystem with different directories
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("new_dir")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("new_file.txt")),
+                    "new content".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        // Write the new filesystem - should clean up old_dir since it's not in the config
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        // Old directory should be removed (not in current agent type config)
+        assert!(
+            !filesystem_dir.join("old_dir").exists(),
+            "Stale directory should be removed when not in current config"
+        );
+
+        // New files should exist
+        assert!(
+            filesystem_dir.join("new_dir/new_file.txt").exists(),
+            "New files should be created"
+        );
+    }
+
+    /// Test that parent directories of configured nested paths are preserved during cleanup.
+    /// For example, if "data/store" is configured, the "data" parent directory should be kept
+    /// during startup cleanup (it won't be deleted even though it's not directly in the config).
+    #[test]
+    fn cleanup_preserves_parent_directories() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        // Step 1: Create initial filesystem with a top-level directory
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("cache")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("temp.json")),
+                    "cache data".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        assert!(
+            filesystem_dir.join("cache/temp.json").exists(),
+            "Initial cache file should exist"
+        );
+
+        // Step 2: Change config to use a nested path "data/store" instead of "cache"
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("data/store")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("items.json")),
+                    "store data".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        // The old "cache" directory should be removed (not in new config)
+        assert!(
+            !filesystem_dir.join("cache").exists(),
+            "Old cache directory should be removed during cleanup"
+        );
+
+        // The new nested path should exist, with its parent directory preserved
+        assert!(
+            filesystem_dir.join("data").exists(),
+            "Parent directory 'data' should exist"
+        );
+        assert!(
+            filesystem_dir.join("data/store/items.json").exists(),
+            "Nested path should be created"
+        );
+    }
+
+    /// Test cleanup when all dirs are ephemeral (no persistent dirs).
+    /// The entire filesystem dir should be removed and recreated.
+    #[test]
+    fn cleanup_removes_all_when_no_persistent_dirs() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        // Step 1: Create initial filesystem with only ephemeral dirs
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("config")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("agent.yaml")),
+                    "config".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        assert!(filesystem_dir.join("config/agent.yaml").exists());
+
+        // Step 2: Write a new filesystem with different ephemeral content
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("integrations")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("integration.yaml")),
+                    "integration".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        // Old ephemeral dir should be gone
+        assert!(
+            !filesystem_dir.join("config").exists(),
+            "Old ephemeral dir should be removed"
+        );
+
+        // New ephemeral dir should exist
+        assert!(
+            filesystem_dir
+                .join("integrations/integration.yaml")
+                .exists(),
+            "New ephemeral dir should exist"
+        );
+    }
+}

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -42,12 +42,14 @@ variables: {{}}
 deployment:
   linux:
     filesystem:
-      {dir_entry}:
-        {file_path}: "{expected_file_contents}"
+      ephemeral:
+        {dir_entry}:
+          {file_path}: "{expected_file_contents}"
   windows:
     filesystem:
-      {dir_entry}:
-        {file_path}: "{expected_file_contents}"
+      ephemeral:
+        {dir_entry}:
+          {file_path}: "{expected_file_contents}"
 "#,
         ),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -158,26 +160,28 @@ variables:
 deployment:
   windows:
     filesystem:
-      randomdir:
-        "{yaml_file_path}": |-
-          ${{nr-var:yaml_file_contents}}
-        "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
-      {dir_path}:
-        file1.txt: "File 1 contents"
-        file2.txt: |
-          File 2 contents with a variable: ${{nr-var:some_string}}
-      "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
+      ephemeral:
+        randomdir:
+          "{yaml_file_path}": |-
+            ${{nr-var:yaml_file_contents}}
+          "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
+        {dir_path}:
+          file1.txt: "File 1 contents"
+          file2.txt: |
+            File 2 contents with a variable: ${{nr-var:some_string}}
+        "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
   linux:
     filesystem:
-      randomdir:
-        "{yaml_file_path}": |-
-          ${{nr-var:yaml_file_contents}}
-        "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
-      {dir_path}:
-        file1.txt: "File 1 contents"
-        file2.txt: |
-          File 2 contents with a variable: ${{nr-var:some_string}}
-      "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
+      ephemeral:
+        randomdir:
+          "{yaml_file_path}": |-
+            ${{nr-var:yaml_file_contents}}
+          "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
+        {dir_path}:
+          file1.txt: "File 1 contents"
+          file2.txt: |
+            File 2 contents with a variable: ${{nr-var:some_string}}
+        "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
 "#,
         ),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -285,9 +289,17 @@ some_mapstringyaml:
     });
 }
 
-/// Filesystem entries should persist across agent control restarts.
-/// This test verifies that directories like newrelic-infra/newrelic-integrations/logging
-/// are not deleted when agent control restarts, ensuring persistent storage across restarts.
+/// Filesystem entries should persist across agent control restarts, and ephemeral directories
+/// should replace their contents when the config changes (stale files are removed).
+///
+/// This test verifies three behaviours:
+///   1. **Restart with same config** — neither ephemeral nor persistent files are deleted.
+///      The resource cleaner only runs when an agent is removed from config, so a plain restart
+///      must leave all files intact (the sub-agent may still be running and needs them).
+///   2. **Ephemeral dirs on config change** — when an integration is removed from the config the
+///      corresponding file is deleted from disk (ephemeral replace-on-write semantics).
+///   3. **Persistent dirs always survive** — files created by the sub-agent in a persistent dir
+///      (e.g. `newrelic-infra/newrelic-integrations/logging`) are never deleted by agent control.
 #[test]
 fn filesystem_persists_across_restarts() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
@@ -298,10 +310,15 @@ fn filesystem_persists_across_restarts() {
 
     let agent_id = "test-agent";
     let config_content = "license_key: test_key\nlog_level: info\n";
-    let integrations_content = "integration: test\n";
+    // Expected content when a map[string]yaml value of `{type: apache}` / `{type: nginx}` is
+    // serialised to a YAML file.
+    let apache_content = "type: apache\n";
+    let nginx_content = "type: nginx\n";
     let logging_content = "fluent_bit: true\n";
 
-    // Create agent type definition with filesystem structure similar to newrelic-infra
+    // Create agent type definition with filesystem structure similar to newrelic-infra.
+    // `config_integrations` uses `map[string]yaml` so that each key becomes a file name and
+    // the directory is fully replaced on every write (ephemeral replace-on-write semantics).
     create_file(
         r#"
 namespace: test
@@ -314,8 +331,8 @@ variables:
       type: yaml
       required: true
     config_integrations:
-      description: "Integrations configuration"
-      type: yaml
+      description: "Integrations configuration (map of filename -> yaml content)"
+      type: map[string]yaml
       required: true
     config_logging:
       description: "Logging configuration"
@@ -324,30 +341,30 @@ variables:
 deployment:
   linux:
     filesystem:
-      config:
-        newrelic-infra.yaml: |-
-          ${nr-var:config_agent}
-      integrations.d:
-        integration.yaml: |-
-          ${nr-var:config_integrations}
-      logging.d:
-        logging.yaml: |-
-          ${nr-var:config_logging}
-      # This directory needs to persist across restarts for the infra agent
-      newrelic-infra/newrelic-integrations/logging: {}
+      ephemeral:
+        config:
+          newrelic-infra.yaml: |-
+            ${nr-var:config_agent}
+        integrations.d: ${nr-var:config_integrations}
+        logging.d:
+          logging.yaml: |-
+            ${nr-var:config_logging}
+      # This directory needs to survive agent removal
+      persistent:
+        newrelic-infra/newrelic-integrations/logging: {}
   windows:
     filesystem:
-      config:
-        newrelic-infra.yaml: |-
-          ${nr-var:config_agent}
-      integrations.d:
-        integration.yaml: |-
-          ${nr-var:config_integrations}
-      logging.d:
-        logging.yaml: |-
-          ${nr-var:config_logging}
-      # This directory needs to persist across restarts for the infra agent
-      newrelic-infra/newrelic-integrations/logging: {}
+      ephemeral:
+        config:
+          newrelic-infra.yaml: |-
+            ${nr-var:config_agent}
+        integrations.d: ${nr-var:config_integrations}
+        logging.d:
+          logging.yaml: |-
+            ${nr-var:config_logging}
+      # This directory needs to survive agent removal
+      persistent:
+        newrelic-infra/newrelic-integrations/logging: {}
 "#
         .to_string(),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -367,6 +384,7 @@ deployment:
         local_dir.to_path_buf(),
     );
 
+    // Initial config: two integrations (apache + nginx)
     create_local_config(
         agent_id.to_string(),
         r#"
@@ -374,7 +392,10 @@ config_agent:
   license_key: test_key
   log_level: info
 config_integrations:
-  integration: test
+  apache.yaml:
+    type: apache
+  nginx.yaml:
+    type: nginx
 config_logging:
   fluent_bit: true
 "#
@@ -389,6 +410,12 @@ config_logging:
     };
 
     // Define expected file paths (used throughout the test)
+    let integrations_dir = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("integrations.d");
+
     let config_file_path = base_paths
         .remote_dir
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
@@ -396,12 +423,8 @@ config_logging:
         .join("config")
         .join("newrelic-infra.yaml");
 
-    let integrations_file_path = base_paths
-        .remote_dir
-        .join(AGENT_FILESYSTEM_FOLDER_NAME)
-        .join(agent_id)
-        .join("integrations.d")
-        .join("integration.yaml");
+    let apache_file_path = integrations_dir.join("apache.yaml");
+    let nginx_file_path = integrations_dir.join("nginx.yaml");
 
     let logging_file_path = base_paths
         .remote_dir
@@ -420,18 +443,17 @@ config_logging:
 
     let test_file_path = persistent_dir_path.join("test.yaml");
 
-    // First agent control run - creates the filesystem structure
+    // First agent control run — creates the filesystem structure with two integrations
     {
         let _agent_control =
             start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
 
-        // Wait for files to be created
         retry(30, Duration::from_secs(1), || {
             read_file_and_expect_content(&config_file_path, config_content)?;
-            read_file_and_expect_content(&integrations_file_path, integrations_content)?;
+            read_file_and_expect_content(&apache_file_path, apache_content)?;
+            read_file_and_expect_content(&nginx_file_path, nginx_content)?;
             read_file_and_expect_content(&logging_file_path, logging_content)?;
 
-            // Verify the persistent directory exists
             if !persistent_dir_path.exists() {
                 return Err(format!(
                     "Persistent directory does not exist: {}",
@@ -445,14 +467,18 @@ config_logging:
         // Agent control is dropped here, simulating a shutdown
     }
 
-    // Verify files still exist on disk after shutdown, before restart
+    // Verify all files still exist on disk after shutdown.
+    // The resource cleaner only runs when an agent is *removed from config*; a plain restart of
+    // agent control with the same config must not delete any files (ephemeral or persistent),
+    // because the sub-agent may still be running and needs its config files.
     read_file_and_expect_content(&config_file_path, config_content)
         .expect("Config file content should match after shutdown");
-    read_file_and_expect_content(&integrations_file_path, integrations_content)
-        .expect("Integrations file content should match after shutdown");
+    read_file_and_expect_content(&apache_file_path, apache_content)
+        .expect("Apache integration file should exist after shutdown");
+    read_file_and_expect_content(&nginx_file_path, nginx_content)
+        .expect("Nginx integration file should exist after shutdown");
     read_file_and_expect_content(&logging_file_path, logging_content)
         .expect("Logging file content should match after shutdown");
-
     assert!(
         persistent_dir_path.exists(),
         "Persistent directory should still exist after shutdown: {}",
@@ -462,17 +488,44 @@ config_logging:
     // Simulate a file created by the infra agent in the persistent directory
     create_file("test\n".to_string(), test_file_path.clone());
 
-    // Second agent control run - simulates restart
+    // Update the config to remove nginx — only apache remains
+    create_local_config(
+        agent_id.to_string(),
+        r#"
+config_agent:
+  license_key: test_key
+  log_level: info
+config_integrations:
+  apache.yaml:
+    type: apache
+config_logging:
+  fluent_bit: true
+"#
+        .to_string(),
+        local_dir.to_path_buf(),
+    );
+
+    // Second agent control run — restarts with the updated config
     {
         let _agent_control =
             start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
 
-        // Verify all files and directories still exist after restart
+        // Wait until the new config has been applied (apache.yaml is present with fresh content)
         retry(30, Duration::from_secs(1), || {
             read_file_and_expect_content(&config_file_path, config_content)?;
-            read_file_and_expect_content(&integrations_file_path, integrations_content)?;
+            read_file_and_expect_content(&apache_file_path, apache_content)?;
             read_file_and_expect_content(&logging_file_path, logging_content)?;
 
+            // Ephemeral replace-on-write: nginx was removed from config, so the file must be gone
+            if nginx_file_path.exists() {
+                return Err(format!(
+                    "Stale nginx integration file should have been deleted: {}",
+                    nginx_file_path.display()
+                )
+                .into());
+            }
+
+            // Persistent dir: test.yaml created by the sub-agent must survive the restart
             if !persistent_dir_path.exists() {
                 return Err(format!(
                     "Persistent directory was deleted after restart: {}",
@@ -480,8 +533,6 @@ config_logging:
                 )
                 .into());
             }
-
-            // Verify the test file created in the persistent directory still exists
             read_file_and_expect_content(&test_file_path, "test\n")?;
 
             Ok(())

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -581,8 +581,9 @@ fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
 
     let filesystem_config = format!(
         r#"
-{dir_entry}:
-  {file_path}: "{content_template}"
+persistent:
+  {dir_entry}:
+    {file_path}: "{content_template}"
 "#
     );
 

--- a/fs/src/win_permissions.rs
+++ b/fs/src/win_permissions.rs
@@ -2,6 +2,10 @@ use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
 use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, GetLastError};
+
+// Standard Windows access right (winnt.h 0x00010000). Not exported from the windows_sys
+// Win32_Foundation feature set, so defined locally as a raw value.
+const DELETE: u32 = 0x0001_0000;
 use windows_sys::Win32::Security::Authorization::{
     EXPLICIT_ACCESS_W, SE_FILE_OBJECT, SET_ACCESS, SetEntriesInAclW, SetNamedSecurityInfoW,
     TRUSTEE_IS_SID, TRUSTEE_W,
@@ -40,7 +44,7 @@ fn get_administrator_sid() -> Result<Vec<u8>, PermissionError> {
 }
 
 /// set_file_permissions_for_administrator removes any other ACL from a file only granting
-/// read and write to Administrators.
+/// read, write, and delete to Administrators.
 pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), PermissionError> {
     // Conversion to UTF-16 format (native string representation in Windows OS)
     let path_wstr: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
@@ -55,9 +59,12 @@ pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), Permiss
         ..Default::default()
     };
 
-    // Define the access entry to allow read and write for the trustee
+    // Define the access entry to allow read, write, and delete for the trustee.
+    // DELETE is required so that Agent Control can remove config files when an agent is
+    // removed from the configuration (see OnHostFilesystemCleaner) and when ephemeral
+    // directories are replaced on each config write.
     let access_entry = EXPLICIT_ACCESS_W {
-        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE,
+        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE | DELETE,
         grfAccessMode: SET_ACCESS,
         grfInheritance: NO_INHERITANCE,
         Trustee: trustee,
@@ -101,6 +108,7 @@ pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), Permiss
 
 #[cfg(test)]
 pub mod tests {
+    use super::DELETE;
     use windows_sys::Win32::{
         Foundation::ERROR_SUCCESS,
         Security::{
@@ -112,12 +120,12 @@ pub mod tests {
 
     use super::*;
 
-    /// Asserts directory permissions are set to only allow Administrators read and write access on Windows.
+    /// Asserts directory permissions are set to only allow Administrators read, write, and delete access on Windows.
     ///
     /// This is a helper function that checks the following:
     /// 1. The DACL of the file contains exactly one ACE.
     /// 2. The ACE is for the Administrators SID.
-    /// 3. The ACE grants FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions.
+    /// 3. The ACE grants FILE_GENERIC_READ, FILE_GENERIC_WRITE, and DELETE permissions.
     pub fn assert_windows_permissions(path: &Path) {
         let mut admin_sid_size = SECURITY_MAX_SID_SIZE;
         let mut admin_sid: Vec<u8> = vec![0; admin_sid_size as usize];
@@ -178,11 +186,11 @@ pub mod tests {
             let sids_equal = EqualSid(sid_in_ace, admin_sid.as_mut_ptr() as *mut _);
             assert_ne!(sids_equal, 0, "ACE SID should match Administrators SID");
 
-            // FILE_GENERIC_READ and FILE_GENERIC_WRITE are what GENERIC_READ/WRITE map to
-            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE;
+            // GENERIC_READ/WRITE map to FILE_GENERIC_READ/WRITE; DELETE is a standard right.
+            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE;
             assert_eq!(
                 ace.Mask, expected_mask,
-                "ACE should have FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions"
+                "ACE should have FILE_GENERIC_READ, FILE_GENERIC_WRITE, and DELETE permissions"
             );
         }
     }


### PR DESCRIPTION
Introduces ephemeral/persistent lifecycle semantics for sub-agent filesystem directories.                                                                                                                                        
                                                                                                                                                                                                                                 
- Replaces the flat FileSystem map with two explicit sections — ephemeral and persistent — allowing agent type authors to declare the intended lifecycle of each directory in the agent type definition.                         
- Ephemeral directories are cleared and repopulated on every config update, so files removed from dynamic variables (e.g. config_integrations in com.newrelic.infrastructure) are automatically deleted from disk without any  extra tracking.                                                                                                                                                                                                                   - Persistent directories are written additively and survive agent removal, intended for directories owned by the sub-agent process itself (e.g. newrelic-infra/newrelic-integrations/logging).                                 
- A JSON manifest (.supervisor-manifest.json) is written alongside the filesystem on every write() call, recording persistent paths so OnHostFilesystemCleaner can safely clean up ephemeral content when an agent is removed from the config.
- Backward compatible: the absence of a manifest is treated as a signal that the filesystem predates this feature, preserving the previous no-op cleanup behaviour for existing deployments.


<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
