### PR TITLE
feat: build oci artifact

### DIFF
--- a/.github/workflows/post-release-agent-metadata.yml
+++ b/.github/workflows/post-release-agent-metadata.yml
@@ -30,41 +30,19 @@ jobs:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
         run: |
           echo "Downloading agent-control release artifacts for version ${VERSION}"
+          
           gh release download "${VERSION}" \
             --repo newrelic/newrelic-agent-control \
-            --pattern "newrelic-agent-control_${VERSION}_linux_amd64.tar.gz" \
-            --pattern "newrelic-agent-control_${VERSION}_linux_arm64.tar.gz" \
-            --pattern "newrelic-agent-control_${VERSION}_windows_amd64.zip"
-          echo "Downloaded artifacts:"
-          ls -lh newrelic-agent-control_${VERSION}_*
+            --pattern "newrelic-agent-control_${VERSION}_linux_amd64_oci.tar.gz" \
+            --pattern "newrelic-agent-control_${VERSION}_linux_arm64_oci.tar.gz" \
+            --pattern "newrelic-agent-control_${VERSION}_windows_amd64_oci.zip"
 
-      - name: Repackage archives
-        env:
-          VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-        run: |
-          echo "Repackaging archives to keep only the binary"
           mkdir -p /tmp/artifacts
-
-          echo "Processing linux_amd64..."
-          mkdir -p /tmp/extract_amd64
-          tar -xzf "newrelic-agent-control_${VERSION}_linux_amd64.tar.gz" -C /tmp/extract_amd64
-          tar -czf "/tmp/artifacts/linux_amd64.tar.gz" -C /tmp/extract_amd64 newrelic-agent-control
-          rm -rf /tmp/extract_amd64
-
-          echo "Processing linux_arm64..."
-          mkdir -p /tmp/extract_arm64
-          tar -xzf "newrelic-agent-control_${VERSION}_linux_arm64.tar.gz" -C /tmp/extract_arm64
-          tar -czf "/tmp/artifacts/linux_arm64.tar.gz" -C /tmp/extract_arm64 newrelic-agent-control
-          rm -rf /tmp/extract_arm64
-
-          echo "Processing windows_amd64..."
-          mkdir -p /tmp/extract_win
-          unzip -q "newrelic-agent-control_${VERSION}_windows_amd64.zip" -d /tmp/extract_win
-          cd /tmp/extract_win && zip -q "/tmp/artifacts/windows_amd64.zip" newrelic-agent-control.exe
-          cd -
-          rm -rf /tmp/extract_win
-
-          echo "Repackaged artifacts:"
+          mv "newrelic-agent-control_${VERSION}_linux_amd64_oci.tar.gz" "/tmp/artifacts/linux_amd64.tar.gz"
+          mv "newrelic-agent-control_${VERSION}_linux_arm64_oci.tar.gz" "/tmp/artifacts/linux_arm64.tar.gz"
+          mv "newrelic-agent-control_${VERSION}_windows_amd64_oci.zip" "/tmp/artifacts/windows_amd64.zip"
+          
+          echo "Downloaded artifacts:"
           ls -lh /tmp/artifacts/
 
       - name: Upload agent metadata to New Relic

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,6 +101,17 @@ archives:
     ids:
       - newrelic-agent-control-linux
       - newrelic-agent-control-cli-linux
+    files:
+      - THIRD_PARTY_NOTICES.md
+      - LICENSE.md
+  - id: linux-oci
+    formats: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_oci"
+    ids:
+      - newrelic-agent-control-linux
+    files:
+      - THIRD_PARTY_NOTICES.md
+      - LICENSE.md
   - id: windows
     formats: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -112,6 +123,16 @@ archives:
         dst: install.ps1
       - src: build/package/windows/uninstall.ps1
         dst: uninstall.ps1
+      - THIRD_PARTY_NOTICES.md
+      - LICENSE.md
+  - id: windows-oci
+    formats: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_oci"
+    ids:
+      - newrelic-agent-control-windows
+    files:
+      - THIRD_PARTY_NOTICES.md
+      - LICENSE.md
 
 nfpms: # deb and rpm are only built for linux targets
   - package_name: newrelic-agent-control


### PR DESCRIPTION
- Generates self-update oci artifacts on building process instead of doing it in metadata workflow.
- By default goreleaser was bundling some files into the archives like the README.md because of [this](https://goreleaser.com/customization/package/archives/). I'm adding licenses files overriding the default hidden behaviour. 
