### PR TITLE
feat: alert for consistent memory growth over time

### DIFF
--- a/test/k8s-canaries/terraform/production/alert_nrql_templates/generic_metric_threshold.tftpl
+++ b/test/k8s-canaries/terraform/production/alert_nrql_templates/generic_metric_threshold.tftpl
@@ -7,3 +7,6 @@ WHERE (
   AND ${k}='${v}'
   %{ endfor }
 )
+%{ if since != "" }
+SINCE ${since} seconds ago
+%{ endif }

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -13,12 +13,12 @@ variable "slack_webhook_url" {}
 module "alerts" {
   source = "../../../terraform/modules/nr_alerts"
 
-  api_key         = var.api_key
-  account_id      = var.account_id
+  api_key           = var.api_key
+  account_id        = var.account_id
   slack_webhook_url = var.slack_webhook_url
-  policies_prefix = "Agent Control canaries metric monitoring"
+  policies_prefix   = "Agent Control canaries metric monitoring"
 
-  region       = "US"
+  region      = "US"
   instance_id = "Agent_Control_Canaries_Production-Cluster"
 
   conditions = [
@@ -69,6 +69,18 @@ module "alerts" {
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
     },
     {
+      name   = "Memory growth (bytes/hour)"
+      metric = "derivative(memoryResidentSizeBytes, 1 hour)"
+      sample = "ProcessSample"
+      # 3 hours in seconds
+      since = 10800
+      # 210KB/hour = ~5MB over 24 hours
+      threshold     = 210000
+      duration      = 3600
+      operator      = "above"
+      template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+    },
+    {
       name          = "Agent Control container"
       metric        = "*"
       sample        = "K8sContainerSample"
@@ -78,13 +90,13 @@ module "alerts" {
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
     {
-      name          = "Opamp traces per minute"
-      metric        = "*"
-      sample        = "Span"
-      threshold     = 1
-      duration      = 3600
-      operator      = "below_or_equals"
-      wheres        = {
+      name      = "Opamp traces per minute"
+      metric    = "*"
+      sample    = "Span"
+      threshold = 1
+      duration  = 3600
+      operator  = "below_or_equals"
+      wheres = {
         name = "opamp"
       }
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"

--- a/test/k8s-canaries/terraform/staging/alert_nrql_templates/generic_metric_threshold.tftpl
+++ b/test/k8s-canaries/terraform/staging/alert_nrql_templates/generic_metric_threshold.tftpl
@@ -7,3 +7,6 @@ WHERE (
   AND ${k}='${v}'
   %{ endfor }
 )
+%{ if since != "" }
+SINCE ${since} seconds ago
+%{ endif }

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -15,13 +15,13 @@ variable "slack_webhook_url" {}
 module "alerts" {
   source = "../../../terraform/modules/nr_alerts"
 
-  api_key         = var.api_key
-  account_id      = var.account_id
+  api_key           = var.api_key
+  account_id        = var.account_id
   slack_webhook_url = var.slack_webhook_url
-  policies_prefix = "Agent Control canaries metric monitoring"
+  policies_prefix   = "Agent Control canaries metric monitoring"
 
-  region       = "Staging"
-  instance_id  = "Agent_Control_Canaries_Staging-Cluster"
+  region      = "Staging"
+  instance_id = "Agent_Control_Canaries_Staging-Cluster"
 
   conditions = [
     {
@@ -71,6 +71,18 @@ module "alerts" {
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
     },
     {
+      name   = "Memory growth (bytes/hour)"
+      metric = "derivative(memoryResidentSizeBytes, 1 hour)"
+      sample = "ProcessSample"
+      # 3 hours in seconds
+      since = 10800
+      # 210KB/hour = ~5MB over 24 hours
+      threshold     = 210000
+      duration      = 3600
+      operator      = "above"
+      template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+    },
+    {
       name          = "Agent Control container"
       metric        = "*"
       sample        = "K8sContainerSample"
@@ -80,13 +92,13 @@ module "alerts" {
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
     {
-      name          = "Opamp traces per minute"
-      metric        = "*"
-      sample        = "Span"
-      threshold     = 1
-      duration      = 3600
-      operator      = "below_or_equals"
-      wheres        = {
+      name      = "Opamp traces per minute"
+      metric    = "*"
+      sample    = "Span"
+      threshold = 1
+      duration  = 3600
+      operator  = "below_or_equals"
+      wheres = {
         name = "opamp"
       }
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"

--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_threshold.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_threshold.tftpl
@@ -7,3 +7,6 @@ WHERE (
   AND ${k}='${v}'
   %{ endfor }
 )
+%{ if since != "" }
+SINCE ${since} seconds ago
+%{ endif }

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -120,26 +120,56 @@ locals {
   // Platform-specific memory conditions.
   // Linux uses virtual size; Windows uses working set (physical memory committed to the process).
   memory_alert_condition_by_platform = {
-    linux = {
-      name          = "Memory usage (bytes)"
-      metric        = "max(memoryResidentSizeBytes) OR 0"
-      sample        = "ProcessSample"
-      threshold     = 42000000
-      duration      = 600
-      operator      = "above"
-      template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
-    }
-    windows = {
-      name          = "Memory usage (bytes)"
-      # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
-      # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
-      metric        = "max(memoryVirtualSizeBytes) OR 0"
-      sample        = "ProcessSample"
-      threshold     = 35000000
-      duration      = 600
-      operator      = "above"
-      template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
-    }
+    linux = [
+      {
+        name          = "Memory usage (bytes)"
+        metric        = "max(memoryResidentSizeBytes) OR 0"
+        sample        = "ProcessSample"
+        threshold     = 42000000
+        duration      = 600
+        operator      = "above"
+        template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+      },
+      {
+        name   = "Memory growth (bytes/hour)"
+        metric = "derivative(memoryResidentSizeBytes, 1 hour)"
+        sample = "ProcessSample"
+        # 3 hours in seconds
+        since = 10800
+        # 210KB/hour = ~5MB over 24 hours
+        threshold     = 210000
+        duration      = 3600
+        operator      = "above"
+        template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+      }
+    ],
+    windows = [
+      {
+        name = "Memory usage (bytes)"
+        # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
+        # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
+        metric        = "max(memoryVirtualSizeBytes) OR 0"
+        sample        = "ProcessSample"
+        threshold     = 35000000
+        duration      = 600
+        operator      = "above"
+        template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+      },
+      {
+        name = "Memory growth (bytes/hour)"
+        # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
+        # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
+        metric = "derivative(memoryVirtualSizeBytes, 1 hour)"
+        sample = "ProcessSample"
+        # 3 hours in seconds
+        since = 10800
+        # 210KB/hour = ~5MB over 24 hours
+        threshold     = 210000
+        duration      = 3600
+        operator      = "above"
+        template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+      }
+    ]
   }
 
   // To setup the alerts, we need to know the hostnames of the instances.
@@ -156,7 +186,7 @@ locals {
       platform = v.platform
       conditions = concat(
         local.common_alert_conditions,
-        [local.memory_alert_condition_by_platform[v.platform]]
+        local.memory_alert_condition_by_platform[v.platform]
       )
     }
   }
@@ -165,10 +195,10 @@ locals {
   alert_conditions_flat = flatten([
     for instance_id, instance_data in local.instance_alerts : [
       for idx, condition in instance_data.conditions : {
-        instance_id  = instance_id
-        condition    = condition
-        policy_id    = newrelic_alert_policy.alert_policy[instance_id].id
-        unique_key   = "${instance_id}-${idx}"
+        instance_id = instance_id
+        condition   = condition
+        policy_id   = newrelic_alert_policy.alert_policy[instance_id].id
+        unique_key  = "${instance_id}-${idx}"
       }
     ]
   ])
@@ -366,7 +396,8 @@ resource "newrelic_nrql_alert_condition" "condition" {
         {
           "instance_id" : each.value.instance_id,
           "function" : null,
-          "wheres" : {}
+          "wheres" : {},
+          "since" : ""
         },
         each.value.condition
       )

--- a/test/terraform/modules/nr_alerts/main.tf
+++ b/test/terraform/modules/nr_alerts/main.tf
@@ -74,7 +74,8 @@ resource "newrelic_nrql_alert_condition" "condition_nrql_canary" {
         {
           "instance_id" : "${local.policies_with_instance_id[count.index].instance_id}",
           "function" : null,
-          "wheres" : {}
+          "wheres" : {},
+          "since" : ""
         },
         local.policies_with_instance_id[count.index].condition
       )


### PR DESCRIPTION
Adds new alert to detect slow memory leaks.

### Context

We detected a memory leak in k8s canaries. It was already present on onhost. However, the memory leak was so slow that the threshold wasn't reached before the new nightly version was deployed to the canaries machines.

This new alert is designed to detect memory leaks in a 24 hours time frame.

### Technical details

We use the [derivative](https://docs.newrelic.com/docs/nrql/nrql-syntax-clauses-functions/#derivative) to compute the rate of change within a 3 hour windows. The bigger the window, the better that we avoid triggering the alert because of an spike. We use a 1 hour duration for the alert. The advantage of that combination is that we could get the first alert at 09:00am CEST time, at the beginning of the day. The disadvantage is that it might get spammy with 1 alert per hour.

I think this is a good compromise, but we could increase the window or the duration or both.