### PR TITLE
feat: email alerts

### DIFF
--- a/.github/workflows/component_k8s_canaries_infra.yml
+++ b/.github/workflows/component_k8s_canaries_infra.yml
@@ -49,7 +49,7 @@ jobs:
         uses: newrelic/fargate-runner-action@121b96de1a4d7135204fd8a510927b0463df1b6b # main
         with:
           aws_region: us-east-2
-          container_make_target: "SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }} CANARY_DIR=${{ inputs.canary_dir }} test/k8s-canaries/terraform-${{ inputs.apply && 'apply' || 'plan' }}"
+          container_make_target: "SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }} EMAILS=${{ vars.EMAILS }} CANARY_DIR=${{ inputs.canary_dir }} test/k8s-canaries/terraform-${{ inputs.apply && 'apply' || 'plan' }}"
           ecs_cluster_name: agent_control
           task_definition_name: agent_control
           cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control

--- a/.github/workflows/component_onhost_canaries_infra.yml
+++ b/.github/workflows/component_onhost_canaries_infra.yml
@@ -49,7 +49,7 @@ jobs:
         uses: newrelic/fargate-runner-action@121b96de1a4d7135204fd8a510927b0463df1b6b # main
         with:
           aws_region: us-east-2
-          container_make_target: "ENVIRONMENT=${{ inputs.environment }} SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }} AC_CANARY_WINDOWS_PASSWORD=${{ secrets.AC_CANARY_WINDOWS_PASSWORD }} test/onhost-canaries/infra-${{ inputs.operation }}"
+          container_make_target: "ENVIRONMENT=${{ inputs.environment }} EMAILS=${{ vars.EMAILS }} SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }} AC_CANARY_WINDOWS_PASSWORD=${{ secrets.AC_CANARY_WINDOWS_PASSWORD }} test/onhost-canaries/infra-${{ inputs.operation }}"
           ecs_cluster_name: agent_control
           task_definition_name: agent_control
           cloud_watch_logs_group_name: /ecs/test-prerelease-agent_control

--- a/test/k8s-canaries/Makefile
+++ b/test/k8s-canaries/Makefile
@@ -52,6 +52,7 @@ define check_tf_env_vars
 		exit 1; \
 	fi
 	$(call check_env_var,SLACK_WEBHOOK_URL)
+	$(call check_env_var,EMAILS)
 endef
 
 .PHONY: test/k8s-canaries/terraform-plan
@@ -59,14 +60,14 @@ test/k8s-canaries/terraform-plan:
 	@$(call check_tf_env_vars)
 	@terraform -chdir=$(K8S_TF_DIR)/$(CANARY_DIR) init && \
 	terraform -chdir=$(K8S_TF_DIR)/$(CANARY_DIR) plan \
-	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)"
+	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)" -var="emails=$(EMAILS)"
 
 .PHONY: test/k8s-canaries/terraform-apply
 test/k8s-canaries/terraform-apply:
 	@$(call check_tf_env_vars)
 	@terraform -chdir=$(K8S_TF_DIR)/$(CANARY_DIR) init && \
 	terraform -chdir=$(K8S_TF_DIR)/$(CANARY_DIR) apply -auto-approve \
-	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)"
+	-var="api_key=$(NEW_RELIC_API_KEY)" -var="account_id=$(NEW_RELIC_ACCOUNT_ID)" -var="slack_webhook_url=$(SLACK_WEBHOOK_URL)" -var="emails=$(EMAILS)"
 
 .PHONY: test/k8s-canaries/update-kubeconfig-from-aws
 test/k8s-canaries/update-kubeconfig-from-aws:

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -10,12 +10,14 @@ module "eks_cluster" {
 variable "account_id" {}
 variable "api_key" {}
 variable "slack_webhook_url" {}
+variable "emails" {}
 module "alerts" {
   source = "../../../terraform/modules/nr_alerts"
 
   api_key           = var.api_key
   account_id        = var.account_id
   slack_webhook_url = var.slack_webhook_url
+  emails            = var.emails
   policies_prefix   = "Agent Control canaries metric monitoring"
 
   region      = "US"

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -11,13 +11,14 @@ module "eks_cluster" {
 variable "account_id" {}
 variable "api_key" {}
 variable "slack_webhook_url" {}
-
+variable "emails" {}
 module "alerts" {
   source = "../../../terraform/modules/nr_alerts"
 
   api_key           = var.api_key
   account_id        = var.account_id
   slack_webhook_url = var.slack_webhook_url
+  emails            = var.emails
   policies_prefix   = "Agent Control canaries metric monitoring"
 
   region      = "Staging"

--- a/test/onhost-canaries/Makefile
+++ b/test/onhost-canaries/Makefile
@@ -56,6 +56,7 @@ define check_env_vars_infra
 	$(call check_env_vars_base)
 	$(call check_env_var,AC_CANARY_WINDOWS_PASSWORD)
 	$(call check_env_var,SLACK_WEBHOOK_URL)
+	$(call check_env_var,EMAILS)
 endef
 
 define check_env_vars_install
@@ -84,6 +85,7 @@ test/onhost-canaries/infra-plan:
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_slack_webhook_url="${SLACK_WEBHOOK_URL}" \
+	TF_VAR_emails="${EMAILS}" \
 	terraform -chdir=$(ONHOST_TF_DIR) plan -var-file "environments/$(ENVIRONMENT)/inputs.tfvars"
 
 .PHONY: test/onhost-canaries/infra-apply
@@ -94,6 +96,7 @@ test/onhost-canaries/infra-apply:
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_slack_webhook_url="${SLACK_WEBHOOK_URL}" \
+	TF_VAR_emails="${EMAILS}" \
 	terraform -chdir=$(ONHOST_TF_DIR) apply -auto-approve -var-file "environments/$(ENVIRONMENT)/inputs.tfvars"
 
 .PHONY: test/onhost-canaries/infra-destroy
@@ -104,6 +107,7 @@ test/onhost-canaries/infra-destroy:
 	TF_VAR_account_id=${NEW_RELIC_ACCOUNT_ID} \
 	TF_VAR_api_key=${NEW_RELIC_API_KEY} \
 	TF_VAR_slack_webhook_url="${SLACK_WEBHOOK_URL}" \
+	TF_VAR_emails="${EMAILS}" \
 	terraform -chdir=$(ONHOST_TF_DIR) destroy -auto-approve -var-file "environments/$(ENVIRONMENT)/inputs.tfvars"
 
 .PHONY: test/onhost-canaries/ansible-install

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -43,6 +43,11 @@ variable "slack_webhook_url" {
   type        = string
 }
 
+variable "emails" {
+  description = "Comma-separated list of emails to receive alert notifications"
+  type        = string
+}
+
 locals {
   ec2_instances = {
     "amd64:ubuntu22.04" = {
@@ -365,11 +370,21 @@ resource "newrelic_notification_destination" "slack_webhook" {
   }
 }
 
+resource "newrelic_notification_destination" "email" {
+  name = "Email"
+  type = "EMAIL"
+
+  property {
+    key   = "email"
+    value = var.emails
+  }
+}
+
 # Create notification channel for each instance
-resource "newrelic_notification_channel" "channel" {
+resource "newrelic_notification_channel" "slack_channel" {
   for_each = local.instance_alerts
 
-  name           = each.key
+  name           = "${each.key}-slack"
   type           = "WEBHOOK"
   destination_id = newrelic_notification_destination.slack_webhook.id
   product        = "IINT"
@@ -377,6 +392,20 @@ resource "newrelic_notification_channel" "channel" {
   property {
     key   = "payload"
     value = "{\"text\": \":warning: ${each.key} Alert @hero\"}"
+  }
+}
+
+resource "newrelic_notification_channel" "email_channel" {
+  for_each = local.instance_alerts
+
+  name           = "${each.key}-email"
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.email.id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "Alert: ${each.key}"
   }
 }
 
@@ -398,7 +427,11 @@ resource "newrelic_workflow" "workflow" {
   }
 
   destination {
-    channel_id = newrelic_notification_channel.channel[each.key].id
+    channel_id = newrelic_notification_channel.slack_channel[each.key].id
+  }
+
+  destination {
+    channel_id = newrelic_notification_channel.email_channel[each.key].id
   }
 }
 

--- a/test/terraform/modules/nr_alerts/main.tf
+++ b/test/terraform/modules/nr_alerts/main.tf
@@ -27,15 +27,19 @@ resource "newrelic_workflow" "workflow" {
   }
 
   destination {
-    channel_id = newrelic_notification_channel.channel.id
+    channel_id = newrelic_notification_channel.slack_channel.id
+  }
+
+  destination {
+    channel_id = newrelic_notification_channel.email_channel.id
   }
 }
 
 
-resource "newrelic_notification_channel" "channel" {
+resource "newrelic_notification_channel" "slack_channel" {
   name           = var.instance_id
   type           = "WEBHOOK"
-  destination_id = newrelic_notification_destination.destination.id
+  destination_id = newrelic_notification_destination.slack_webhook.id
   product        = "IINT"
 
   property {
@@ -44,13 +48,35 @@ resource "newrelic_notification_channel" "channel" {
   }
 }
 
-resource "newrelic_notification_destination" "destination" {
+resource "newrelic_notification_channel" "email_channel" {
+  name           = var.instance_id
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.email.id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "Alert: ${var.instance_id}"
+  }
+}
+
+resource "newrelic_notification_destination" "slack_webhook" {
   name = "SlackWebhook"
   type = "WEBHOOK"
 
   property {
     key   = "url"
     value = var.slack_webhook_url
+  }
+}
+
+resource "newrelic_notification_destination" "email" {
+  name = "Email"
+  type = "EMAIL"
+
+  property {
+    key   = "recipients"
+    value = var.emails
   }
 }
 

--- a/test/terraform/modules/nr_alerts/variables.tf
+++ b/test/terraform/modules/nr_alerts/variables.tf
@@ -30,6 +30,10 @@ variable "slack_webhook_url" {
   description = "Slack webhook where New Relic will send alerts"
 }
 
+variable "emails" {
+  description = "Comma-separated list of emails to receive alert notifications"
+}
+
 # conditions should follow next structure:
 #[
 # {


### PR DESCRIPTION
Add email alerts as a secondary channel for newrelic alerts.

### Context

Slack alerts where broken and as a consequence, we didn't notice a memory leak. This PR adds emails as a secondary channel in case slack channel get's broken.

I haven't tested it out on a separated infra set up. 

### Technical details

* Added a repository variable for the emails. I don't think it's a problem since this is not a secret. If not, we can move it to a secret.

<img width="787" height="162" alt="Captura de pantalla 2026-05-12 a las 17 39 20" src="https://github.com/user-attachments/assets/c8c6deac-4784-426e-b1ba-39e7fc608ee0" />