### PR TITLE
chore(start_settings): improve handling of customCapabilities

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -7,7 +7,8 @@ use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, CD_EXTERNAL_ENABLED_ATTRIBUTE_KEY,
     CD_REMOTE_UPDATE_ENABLED_ATTRIBUTE_KEY, CLUSTER_NAME_ATTRIBUTE_KEY, FLEET_ID_ATTRIBUTE_KEY,
     HOST_NAME_ATTRIBUTE_KEY, OPAMP_AC_CHART_VERSION_ATTRIBUTE_KEY,
-    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CD_CHART_VERSION_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_CD_CHART_VERSION_ATTRIBUTE_KEY, default_capabilities,
+    default_custom_capabilities,
 };
 use crate::agent_control::health_checker::k8s::agent_control_health_checker_builder;
 use crate::agent_control::http_server::runner::Runner;
@@ -34,7 +35,7 @@ use crate::opamp::http::builder::OpAMPHttpClientBuilder;
 use crate::opamp::instance_id::getter::{InstanceIDGetter, InstanceIDWithIdentifiersGetter};
 use crate::opamp::instance_id::k8s::identifiers::{Identifiers, get_identifiers};
 use crate::opamp::instance_id::storer::Storer;
-use crate::opamp::operations::{agent_description, start_settings};
+use crate::opamp::operations::agent_description;
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::secret_retriever::k8s::retrieve::K8sSecretRetriever;
@@ -321,14 +322,19 @@ pub fn build_ac_opamp_start_settings(
         .get(&agent_identity.id)
         .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
 
-    let mut settings = start_settings(instance_id, agent_description);
-    if !k8s_config.cd_enabled
-        && let Some(ref mut caps) = settings.custom_capabilities
-    {
-        caps.capabilities
+    let mut custom_capabilities = default_custom_capabilities();
+    if !k8s_config.cd_enabled {
+        custom_capabilities
+            .capabilities
             .push(K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY.to_string());
     }
-    Ok(settings)
+
+    Ok(StartSettings {
+        instance_uid: instance_id.into(),
+        capabilities: default_capabilities(),
+        custom_capabilities: Some(custom_capabilities),
+        agent_description,
+    })
 }
 
 pub fn agent_control_opamp_non_identifying_attributes(

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -5,7 +5,7 @@ use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, EXECUTION_MODE_ATTRIBUTE_KEY, FLEET_ID_ATTRIBUTE_KEY,
     HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
-    OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
+    OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE, default_capabilities, default_custom_capabilities,
 };
 use crate::agent_control::http_server::runner::Runner;
 use crate::agent_control::resource_cleaner::no_op::NoOpResourceCleaner;
@@ -33,7 +33,7 @@ use crate::opamp::http::client::HttpOpAMPClient;
 use crate::opamp::instance_id::getter::{InstanceIDGetter, InstanceIDWithIdentifiersGetter};
 use crate::opamp::instance_id::on_host::identifiers::{Identifiers, IdentifiersProvider};
 use crate::opamp::instance_id::storer::Storer;
-use crate::opamp::operations::{agent_description, start_settings};
+use crate::opamp::operations::agent_description;
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::opamp::remote_config::validators::regexes::RegexValidator;
 use crate::package::oci::downloader::OCIArtifactDownloader;
@@ -318,7 +318,12 @@ pub fn build_ac_opamp_start_settings(
         .get(&agent_identity.id)
         .map_err(|err| RunError(format!("error getting instance id: {err}")))?;
 
-    Ok(start_settings(instance_id, agent_description))
+    Ok(StartSettings {
+        instance_uid: instance_id.into(),
+        capabilities: default_capabilities(),
+        custom_capabilities: Some(default_custom_capabilities()),
+        agent_description,
+    })
 }
 
 /// Builds the [AgentDescription] for Agent Control on-host.

--- a/agent-control/src/opamp/operations.rs
+++ b/agent-control/src/opamp/operations.rs
@@ -1,4 +1,3 @@
-use super::instance_id::InstanceID;
 use super::{client_builder::OpAMPClientBuilderError, instance_id::getter::InstanceIDGetter};
 use crate::agent_control::defaults::{
     OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SUPERVISOR_KEY,
@@ -27,14 +26,16 @@ pub fn sub_agent_start_settings<IG: InstanceIDGetter>(
         DescriptionValueType::Bytes(parent_instance_id.into()),
     );
 
-    Ok(start_settings(
-        instance_id_getter.get(&agent_identity.id)?,
-        agent_description(
+    Ok(StartSettings {
+        instance_uid: instance_id_getter.get(&agent_identity.id)?.into(),
+        capabilities: default_capabilities(),
+        custom_capabilities: Some(default_custom_capabilities()),
+        agent_description: agent_description(
             agent_identity,
             additional_identifying_attributes,
             non_identifying_attributes,
         ),
-    ))
+    })
 }
 
 /// Builds [AgentDescription] from the provided [AgentIdentity] and additional attributes
@@ -63,19 +64,6 @@ pub fn agent_description(
     AgentDescription {
         identifying_attributes,
         non_identifying_attributes,
-    }
-}
-
-/// Builds the OpAMP StartSettings corresponding to the provided arguments for any sub agent and agent control.
-pub fn start_settings(
-    instance_id: InstanceID,
-    agent_description: AgentDescription,
-) -> StartSettings {
-    StartSettings {
-        instance_uid: instance_id.into(),
-        capabilities: default_capabilities(),
-        custom_capabilities: Some(default_custom_capabilities()),
-        agent_description,
     }
 }
 

--- a/agent-control/src/sub_agent/k8s/builder.rs
+++ b/agent-control/src/sub_agent/k8s/builder.rs
@@ -170,7 +170,9 @@ pub mod tests {
     use super::*;
     use crate::agent_control::agent_id::AgentID;
 
-    use crate::agent_control::defaults::PARENT_AGENT_ID_ATTRIBUTE_KEY;
+    use crate::agent_control::defaults::{
+        PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities, default_custom_capabilities,
+    };
     use crate::agent_control::run::k8s::AGENT_CONTROL_MODE_K8S;
     use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::agent_type::runtime_config::k8s::{K8s, K8sObject};
@@ -180,7 +182,7 @@ pub mod tests {
     use crate::opamp::http::builder::HttpClientBuilderError;
     use crate::opamp::instance_id::InstanceID;
     use crate::opamp::instance_id::getter::tests::MockInstanceIDGetter;
-    use crate::opamp::operations::{agent_description, start_settings};
+    use crate::opamp::operations::agent_description;
     use crate::sub_agent::effective_agents_assembler::tests::MockEffectiveAgentAssembler;
     use crate::sub_agent::remote_config_parser::tests::MockRemoteConfigParser;
     use crate::sub_agent::supervisor::tests::MockSupervisorStarter;
@@ -191,6 +193,7 @@ pub mod tests {
     };
     use assert_matches::assert_matches;
     use mockall::predicate;
+    use opamp_client::operation::settings::StartSettings;
     use std::collections::HashMap;
 
     const TEST_CLUSTER_NAME: &str = "cluster_name";
@@ -361,26 +364,31 @@ pub mod tests {
         let started_client = MockStartedOpAMPClient::new();
 
         let mut opamp_builder = MockOpAMPClientBuilder::new();
-        let start_settings = start_settings(
-            instance_id.clone(),
-            agent_description(
-                &agent_identity,
-                HashMap::from([(
-                    OPAMP_SERVICE_VERSION.to_string(),
-                    agent_identity.agent_type_id.version().to_string().into(),
-                )]),
-                HashMap::from([
-                    (
-                        CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
-                        DescriptionValueType::String(TEST_CLUSTER_NAME.to_string()),
-                    ),
-                    (
-                        PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
-                        DescriptionValueType::Bytes(instance_id.clone().into()),
-                    ),
-                ]),
-            ),
+
+        let agent_description = agent_description(
+            &agent_identity,
+            HashMap::from([(
+                OPAMP_SERVICE_VERSION.to_string(),
+                agent_identity.agent_type_id.version().to_string().into(),
+            )]),
+            HashMap::from([
+                (
+                    CLUSTER_NAME_ATTRIBUTE_KEY.to_string(),
+                    DescriptionValueType::String(TEST_CLUSTER_NAME.to_string()),
+                ),
+                (
+                    PARENT_AGENT_ID_ATTRIBUTE_KEY.to_string(),
+                    DescriptionValueType::Bytes(instance_id.clone().into()),
+                ),
+            ]),
         );
+
+        let start_settings = StartSettings {
+            instance_uid: instance_id.clone().into(),
+            capabilities: default_capabilities(),
+            custom_capabilities: Some(default_custom_capabilities()),
+            agent_description,
+        };
 
         if opamp_builder_fails {
             opamp_builder


### PR DESCRIPTION
I am removing "start_settings" since it was a bit redundant and was just setting defaults and we avoid doing `let Some(ref mut caps) = settings.custom_capabilities`