### PR TITLE
feat: add resolute ubuntu 26.4 to debian

### DIFF
--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -27,11 +27,11 @@ jobs:
     name: Test package installation
     runs-on: ubuntu-latest
     steps:
-      - uses: newrelic/pkg-installation-testing-action@91a825b6303412dbd33bf71acaf7bc67f2c9efc7 # v1
+      - uses: newrelic/pkg-installation-testing-action@cc9c7caf234c8af6085a1ebb6d0199a2b981a571 # v1
         with:
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: ${{ inputs.PACKAGE_NAME }}
           package_version: ${{ inputs.TAG }}
           version_command: "version"
-          platforms: "al2023,centos8,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2023,centos8,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,ubuntu2004,ubuntu2204,ubuntu2404,ubuntu2604"

--- a/build/upload-schema-linux-deb.yml
+++ b/build/upload-schema-linux-deb.yml
@@ -8,6 +8,7 @@
       src_repo: "{access_point_host}/preview/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal


### PR DESCRIPTION
Add new os to packges for debian ubuntu 26.4 resolute

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
