### PR TITLE
build: allow unused variables for non-debug-assertion code

### DIFF
--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -218,7 +218,9 @@ impl Command {
         }
     }
 
-    fn build_bootstrap_context(args: &Args) -> Result<BootstrapContext, Box<dyn Error>> {
+    fn build_bootstrap_context(
+        #[cfg_attr(not(debug_assertions), allow(unused_variables))] args: &Args,
+    ) -> Result<BootstrapContext, Box<dyn Error>> {
         let base_paths = BasePaths::default();
 
         #[cfg(debug_assertions)]


### PR DESCRIPTION
<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->

Release builds emit a warning about the `args` variable being unused.