### PR TITLE
chore: remove unused cross config file

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,0 @@
-[build.env]
-passthrough = [
-  "NEWRELIC_INFRA_AGENT_VERSION",
-  "NR_OTEL_COLLECTOR_VERSION",
-  "GIT_COMMIT",
-  "AGENT_CONTROL_VERSION",
-]


### PR DESCRIPTION
I think it is a leftover from previous build tooling