### PR TITLE
chore: rollback JP docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,7 +127,6 @@ These are the endpoints the AC process itself directly communicates with at runt
 |---|---|---|---|
 | `opamp.service.newrelic.com` | 443 | HTTPS | Fleet Control communication — US region |
 | `opamp.service.eu.newrelic.com` | 443 | HTTPS | Fleet Control communication — EU region |
-| `opamp.service.jp.newrelic.com` | 443 | HTTPS | Fleet Control communication — JP region |
 
 #### Authentication — always required
 
@@ -147,7 +146,6 @@ AC fetches public keys (JWKS) from these endpoints to verify the signatures of N
 |---|---|---|---|
 | `publickeys.newrelic.com` | 443 | HTTPS | Public key fetch for signature verification — US region |
 | `publickeys.eu.newrelic.com` | 443 | HTTPS | Public key fetch for signature verification — EU region |
-| `publickeys.jp.newrelic.com` | 443 | HTTPS | Public key fetch for signature verification — JP region |
 
 #### Self-instrumentation — optional
 
@@ -157,7 +155,6 @@ If AC's built-in OpenTelemetry self-instrumentation is enabled (see [`CONFIG.md`
 |---|---|---|---|
 | `otlp.nr-data.net` | 4317 | HTTPS/gRPC | AC self-telemetry (OTLP) — US region |
 | `otlp.eu01.nr-data.net` | 4317 | HTTPS/gRPC | AC self-telemetry (OTLP) — EU region |
-| `otlp.jp.nr-data.net` | 4317 | HTTPS/gRPC | AC self-telemetry (OTLP) — JP region |
 
 #### Cloud metadata
 


### PR DESCRIPTION
This was adding too soon, rolling it back for now in order to avoid misunderstandings.