### PR TITLE
test: check capabilities and custom capabilities in integration tests [NR-566846]

### DIFF
--- a/agent-control/src/agent_control/run/k8s.rs
+++ b/agent-control/src/agent_control/run/k8s.rs
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn test_start_settings_cd_remote_update_false_adds_k8s_config_only_capability() {
+    fn test_start_settings_cd_enabled_false_adds_k8s_config_only_capability() {
         let k8s_config = K8sConfig {
             cd_enabled: false,
             ..Default::default()

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -53,19 +53,17 @@ pub fn check_identifying_attributes_contains_expected(
     )
     .map_err(|e| format!("Identifying attributes missing required elements: {e}"))
 }
-
-#[allow(dead_code)] // helper used on unix only
+#[cfg(unix)]
 /// Checks that the latest `CustomCapabilities` match the `expected`
 pub fn check_custom_capabilities_match(
     opamp_server: &FakeServer,
     instance_id: &InstanceID,
-    expected: Vec<String>,
+    expected: HashSet<String>,
 ) -> Result<(), String> {
     let current = opamp_server
         .get_custom_capabilities(instance_id.clone())
         .ok_or_else(|| "Custom capabilities not reported yet".to_string())?;
     let current: HashSet<String> = HashSet::from_iter(current.capabilities.clone());
-    let expected: HashSet<String> = HashSet::from_iter(expected);
     if current != expected {
         return Err(format!(
             "custom capabilities don't match expected.  Expected: {:?}. Found: {:?}",
@@ -75,7 +73,7 @@ pub fn check_custom_capabilities_match(
     Ok(())
 }
 
-#[allow(dead_code)] // helper used on unix only
+#[cfg(unix)]
 /// Checks that the latest `Capabilities` match the `expected`
 pub fn check_capabilities_match_expected(
     opamp_server: &FakeServer,

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use std::collections::HashSet;
 
 use fake_opamp_server::FakeServer;
@@ -53,6 +54,7 @@ pub fn check_identifying_attributes_contains_expected(
     )
     .map_err(|e| format!("Identifying attributes missing required elements: {e}"))
 }
+
 #[cfg(unix)]
 /// Checks that the latest `CustomCapabilities` match the `expected`
 pub fn check_custom_capabilities_match(

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -52,6 +52,67 @@ pub fn check_identifying_attributes_contains_expected(
     .map_err(|e| format!("Identifying attributes missing required elements: {e}"))
 }
 
+#[allow(dead_code)] // helper used on unix only
+/// Asserts that the latest `CustomCapabilities` reported by `instance_id` to `opamp_server` contains every
+/// entry in `expected`.
+pub fn check_custom_capabilities_contains(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected: Vec<String>,
+) -> Result<(), String> {
+    let current = opamp_server
+        .get_custom_capabilities(instance_id.clone())
+        .ok_or_else(|| "Custom capabilities not reported yet".to_string())?;
+
+    if expected.iter().any(|c| !current.capabilities.contains(c)) {
+        return Err(format!(
+            "some capabilities are missing. Should contain: {:?} Found: {:?}",
+            expected, current.capabilities
+        ));
+    }
+    Ok(())
+}
+
+#[allow(dead_code)] // helper used on unix only
+/// Asserts that the latest `CustomCapabilities` reported by `instance_id` to `opamp_server`
+/// contains none of the entries in `forbidden`.
+pub fn check_custom_capabilities_does_not_contain(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    forbidden: Vec<String>,
+) -> Result<(), String> {
+    let current = opamp_server
+        .get_custom_capabilities(instance_id.clone())
+        .ok_or_else(|| "Custom capabilities not reported yet".to_string())?;
+
+    if forbidden.iter().any(|c| current.capabilities.contains(c)) {
+        return Err(format!(
+            "custom capabilities contains unexpected elements. Should not contain: {:?}. Found: {:?}",
+            forbidden, current.capabilities
+        ));
+    }
+    Ok(())
+}
+
+#[allow(dead_code)] // helper used on unix only
+/// Checks that the latest `Capabilities` match the `expected`
+pub fn check_capabilities_match_expected(
+    opamp_server: &FakeServer,
+    instance_id: &InstanceID,
+    expected: u64,
+) -> Result<(), String> {
+    let current = opamp_server
+        .get_capabilities(instance_id.clone())
+        .ok_or_else(|| "Capabilities not reported yet".to_string())?;
+
+    if current != expected {
+        return Err(format!(
+            "capabilities don't match. Expected: {expected:#b}, Found: {current:#b}"
+        ));
+    }
+    Ok(())
+}
+
 fn check_opamp_attributes(
     mut expected_vec: Vec<KeyValue>,
     mut current_vec: Vec<KeyValue>,

--- a/agent-control/tests/common/attributes.rs
+++ b/agent-control/tests/common/attributes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::opamp::instance_id::InstanceID;
 
@@ -53,9 +55,8 @@ pub fn check_identifying_attributes_contains_expected(
 }
 
 #[allow(dead_code)] // helper used on unix only
-/// Asserts that the latest `CustomCapabilities` reported by `instance_id` to `opamp_server` contains every
-/// entry in `expected`.
-pub fn check_custom_capabilities_contains(
+/// Checks that the latest `CustomCapabilities` match the `expected`
+pub fn check_custom_capabilities_match(
     opamp_server: &FakeServer,
     instance_id: &InstanceID,
     expected: Vec<String>,
@@ -63,32 +64,12 @@ pub fn check_custom_capabilities_contains(
     let current = opamp_server
         .get_custom_capabilities(instance_id.clone())
         .ok_or_else(|| "Custom capabilities not reported yet".to_string())?;
-
-    if expected.iter().any(|c| !current.capabilities.contains(c)) {
+    let current: HashSet<String> = HashSet::from_iter(current.capabilities.clone());
+    let expected: HashSet<String> = HashSet::from_iter(expected);
+    if current != expected {
         return Err(format!(
-            "some capabilities are missing. Should contain: {:?} Found: {:?}",
-            expected, current.capabilities
-        ));
-    }
-    Ok(())
-}
-
-#[allow(dead_code)] // helper used on unix only
-/// Asserts that the latest `CustomCapabilities` reported by `instance_id` to `opamp_server`
-/// contains none of the entries in `forbidden`.
-pub fn check_custom_capabilities_does_not_contain(
-    opamp_server: &FakeServer,
-    instance_id: &InstanceID,
-    forbidden: Vec<String>,
-) -> Result<(), String> {
-    let current = opamp_server
-        .get_custom_capabilities(instance_id.clone())
-        .ok_or_else(|| "Custom capabilities not reported yet".to_string())?;
-
-    if forbidden.iter().any(|c| current.capabilities.contains(c)) {
-        return Err(format!(
-            "custom capabilities contains unexpected elements. Should not contain: {:?}. Found: {:?}",
-            forbidden, current.capabilities
+            "custom capabilities don't match expected.  Expected: {:?}. Found: {:?}",
+            expected, current
         ));
     }
     Ok(())

--- a/agent-control/tests/k8s/data/k8s_custom_capabilities_cd_disabled/local-data-agent-control.template
+++ b/agent-control/tests/k8s/data/k8s_custom_capabilities_cd_disabled/local-data-agent-control.template
@@ -1,0 +1,14 @@
+fleet_control:
+  endpoint: <opamp-endpoint>
+  poll_interval: 5s
+  signature_validation:
+    public_key_server_url: <jwks-endpoint>
+k8s:
+  namespace: <ns>
+  namespace_agents: <agents-ns>
+  cluster_name: <cluster-name>
+  cd_enabled: false
+  auth_secret:
+    secret_name: agent-control-auth
+    secret_key_name: private_key
+agents: {}

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -1,14 +1,15 @@
 #![cfg(target_family = "unix")]
 use crate::common::attributes::{
-    check_latest_identifying_attributes_match_expected,
+    check_capabilities_match_expected, check_custom_capabilities_contains,
+    check_custom_capabilities_does_not_contain, check_latest_identifying_attributes_match_expected,
     check_latest_non_identifying_attributes_match_expected, convert_to_vec_key_value,
 };
 use crate::common::retry::retry;
 use crate::common::runtime::{block_on, tokio_runtime};
-use crate::k8s::tools::agent_control::CUSTOM_AGENT_TYPE_PATH;
-use crate::k8s::tools::{
-    agent_control::start_agent_control_with_testdata_config, instance_id, k8s_env::K8sEnv,
+use crate::k8s::tools::agent_control::{
+    CUSTOM_AGENT_TYPE_PATH, start_agent_control_with_testdata_config,
 };
+use crate::k8s::tools::{instance_id, k8s_env::K8sEnv};
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
@@ -16,8 +17,10 @@ use newrelic_agent_control::agent_control::defaults::{
     CD_REMOTE_UPDATE_ENABLED_ATTRIBUTE_KEY, CLUSTER_NAME_ATTRIBUTE_KEY, FLEET_ID_ATTRIBUTE_KEY,
     HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_SERVICE_NAME,
     OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, OPAMP_SUBAGENT_CHART_VERSION_ATTRIBUTE_KEY,
-    OPAMP_SUPERVISOR_KEY, PARENT_AGENT_ID_ATTRIBUTE_KEY,
+    OPAMP_SUPERVISOR_KEY, PARENT_AGENT_ID_ATTRIBUTE_KEY, default_capabilities,
 };
+use newrelic_agent_control::agent_control::run::k8s::K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY;
+use newrelic_agent_control::opamp::remote_config::signature::SIGNATURE_CUSTOM_CAPABILITY;
 use nix::unistd::gethostname;
 use opamp_client::opamp::proto::any_value::Value;
 use opamp_client::opamp::proto::any_value::Value::BytesValue;
@@ -105,7 +108,9 @@ agents:
         ),
     ]));
 
-    // Check attributes of Agent Control
+    // Check attributes and capabilities of Agent Control. With cd_release_name set and
+    // cd_enabled defaulting to true, the K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY must NOT
+    // be reported.
     retry(60, Duration::from_secs(5), || {
         check_latest_identifying_attributes_match_expected(
             &server,
@@ -116,6 +121,17 @@ agents:
             &server,
             &instance_id,
             ac_expected_non_identifying_attributes.clone(),
+        )?;
+        check_capabilities_match_expected(&server, &instance_id, default_capabilities().into())?;
+        check_custom_capabilities_contains(
+            &server,
+            &instance_id,
+            vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
+        )?;
+        check_custom_capabilities_does_not_contain(
+            &server,
+            &instance_id,
+            vec![K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY.to_string()], // only when cd_enabled=false
         )?;
         Ok(())
     });
@@ -154,7 +170,8 @@ agents:
         ),
     ]));
 
-    // Check attributes of sub agent
+    // Check attributes and capabilities of sub agent. Sub-agents always advertise the default
+    // OpAMP capabilities and the signature custom capability.
     retry(90, Duration::from_secs(5), || {
         let instance_id_sub_agent = instance_id::get_instance_id(
             k8s.client.clone(),
@@ -170,6 +187,59 @@ agents:
             &server,
             &instance_id_sub_agent,
             sub_agent_expected_non_identifying_attributes.clone(),
+        )?;
+        check_capabilities_match_expected(
+            &server,
+            &instance_id_sub_agent,
+            default_capabilities().into(),
+        )?;
+        check_custom_capabilities_contains(
+            &server,
+            &instance_id_sub_agent,
+            vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
+        )?;
+        Ok(())
+    })
+}
+
+/// When `cd_enabled` is set to `false` in the k8s config, Agent Control must report the
+/// `com.newrelic.k8s_config_only_agents` custom capability through OpAMP. This signals to
+/// Fleet Control that this AC is not paired with an agent-control-cd deployment.
+#[test]
+#[ignore = "needs a k8s cluster"]
+fn k8s_test_custom_capabilities_when_cd_disabled() {
+    let test_name = "k8s_custom_capabilities_cd_disabled";
+
+    let server = FakeServer::start(tokio_runtime().handle());
+
+    let mut k8s = block_on(K8sEnv::new());
+    let namespace = block_on(k8s.test_namespace());
+    let tmp_dir = tempdir().expect("failed to create local temp dir");
+
+    let _ac = start_agent_control_with_testdata_config(
+        test_name,
+        CUSTOM_AGENT_TYPE_PATH,
+        k8s.client.clone(),
+        &namespace,
+        &namespace,
+        Some(&server.endpoint()),
+        Some(&server.jwks_endpoint()),
+        Vec::new(),
+        tmp_dir.path(),
+    );
+
+    let instance_id =
+        instance_id::get_instance_id(k8s.client.clone(), &namespace, &AgentID::AgentControl);
+
+    retry(60, Duration::from_secs(5), || {
+        check_capabilities_match_expected(&server, &instance_id, default_capabilities().into())?;
+        check_custom_capabilities_contains(
+            &server,
+            &instance_id,
+            vec![
+                SIGNATURE_CUSTOM_CAPABILITY.to_string(),
+                K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY.to_string(),
+            ],
         )?;
         Ok(())
     })

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -1,7 +1,7 @@
 #![cfg(target_family = "unix")]
 use crate::common::attributes::{
-    check_capabilities_match_expected, check_custom_capabilities_contains,
-    check_custom_capabilities_does_not_contain, check_latest_identifying_attributes_match_expected,
+    check_capabilities_match_expected, check_custom_capabilities_match,
+    check_latest_identifying_attributes_match_expected,
     check_latest_non_identifying_attributes_match_expected, convert_to_vec_key_value,
 };
 use crate::common::retry::retry;
@@ -123,15 +123,10 @@ agents:
             ac_expected_non_identifying_attributes.clone(),
         )?;
         check_capabilities_match_expected(&server, &instance_id, default_capabilities().into())?;
-        check_custom_capabilities_contains(
+        check_custom_capabilities_match(
             &server,
             &instance_id,
             vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
-        )?;
-        check_custom_capabilities_does_not_contain(
-            &server,
-            &instance_id,
-            vec![K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY.to_string()], // only when cd_enabled=false
         )?;
         Ok(())
     });
@@ -193,7 +188,7 @@ agents:
             &instance_id_sub_agent,
             default_capabilities().into(),
         )?;
-        check_custom_capabilities_contains(
+        check_custom_capabilities_match(
             &server,
             &instance_id_sub_agent,
             vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
@@ -233,7 +228,7 @@ fn k8s_test_custom_capabilities_when_cd_disabled() {
 
     retry(60, Duration::from_secs(5), || {
         check_capabilities_match_expected(&server, &instance_id, default_capabilities().into())?;
-        check_custom_capabilities_contains(
+        check_custom_capabilities_match(
             &server,
             &instance_id,
             vec![

--- a/agent-control/tests/k8s/scenarios/attributes.rs
+++ b/agent-control/tests/k8s/scenarios/attributes.rs
@@ -24,6 +24,7 @@ use newrelic_agent_control::opamp::remote_config::signature::SIGNATURE_CUSTOM_CA
 use nix::unistd::gethostname;
 use opamp_client::opamp::proto::any_value::Value;
 use opamp_client::opamp::proto::any_value::Value::BytesValue;
+use std::collections::HashSet;
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -126,7 +127,7 @@ agents:
         check_custom_capabilities_match(
             &server,
             &instance_id,
-            vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
+            HashSet::from([SIGNATURE_CUSTOM_CAPABILITY.to_string()]),
         )?;
         Ok(())
     });
@@ -191,7 +192,7 @@ agents:
         check_custom_capabilities_match(
             &server,
             &instance_id_sub_agent,
-            vec![SIGNATURE_CUSTOM_CAPABILITY.to_string()],
+            HashSet::from([SIGNATURE_CUSTOM_CAPABILITY.to_string()]),
         )?;
         Ok(())
     })
@@ -231,10 +232,10 @@ fn k8s_test_custom_capabilities_when_cd_disabled() {
         check_custom_capabilities_match(
             &server,
             &instance_id,
-            vec![
+            HashSet::from([
                 SIGNATURE_CUSTOM_CAPABILITY.to_string(),
                 K8S_CONFIG_ONLY_AGENTS_CUSTOM_CAPABILITY.to_string(),
-            ],
+            ]),
         )?;
         Ok(())
     })

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -9,8 +9,8 @@ use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD};
 use opamp_client::opamp::proto::any_value::Value;
 use opamp_client::opamp::proto::{
     AgentConfigFile, AgentConfigMap, AgentDescription, AgentRemoteConfig, AgentToServer,
-    ComponentHealth, CustomMessage, EffectiveConfig, RemoteConfigStatus, RemoteConfigStatuses,
-    ServerToAgent, ServerToAgentFlags,
+    ComponentHealth, CustomCapabilities, CustomMessage, EffectiveConfig, RemoteConfigStatus,
+    RemoteConfigStatuses, ServerToAgent, ServerToAgentFlags,
 };
 use opamp_client::operation::instance_uid::InstanceUid;
 use prost::Message;
@@ -38,10 +38,12 @@ pub(crate) struct ServerState {
 }
 
 #[derive(Default)]
-pub(crate) struct AgentState {
+struct AgentState {
     pub(crate) sequence_number: u64,
     pub(crate) health_status: Option<ComponentHealth>,
     pub(crate) attributes: AgentDescription,
+    pub(crate) capabilities: u64, // Proto requires this field to be set in every message
+    pub(crate) custom_capabilities: Option<CustomCapabilities>,
     pub(crate) remote_config: Option<RemoteConfig>,
     pub(crate) effective_config: EffectiveConfig,
     pub(crate) config_status: RemoteConfigStatus,
@@ -254,6 +256,29 @@ impl FakeServer {
             .map(|s| s.attributes.clone())
     }
 
+    /// Returns the latest `CustomCapabilities` reported by the given agent, or `None` if the agent
+    /// is unknown or has not reported them yet.
+    pub fn get_custom_capabilities(
+        &self,
+        identifier: impl Into<InstanceUid>,
+    ) -> Option<CustomCapabilities> {
+        let state = self.state.lock().unwrap();
+        state
+            .agent_state
+            .get(&identifier.into())
+            .and_then(|s| s.custom_capabilities.clone())
+    }
+
+    /// Returns the latest standard OpAMP `capabilities` bitfield reported by the given agent,
+    /// or `None` if the agent has not connected yet.
+    pub fn get_capabilities(&self, identifier: impl Into<InstanceUid>) -> Option<u64> {
+        let state = self.state.lock().unwrap();
+        state
+            .agent_state
+            .get(&identifier.into())
+            .map(|s| s.capabilities)
+    }
+
     pub fn get_effective_config(
         &self,
         identifier: impl Into<InstanceUid>,
@@ -358,6 +383,14 @@ async fn opamp_handler(state: web::Data<Arc<Mutex<ServerState>>>, req: web::Byte
     if let Some(attributes) = message.agent_description {
         agent_state.attributes = attributes;
     }
+
+    if let Some(custom_capabilities) = message.custom_capabilities {
+        agent_state.custom_capabilities = Some(custom_capabilities);
+    }
+
+    // `AgentToServer.capabilities` is required on every message per the OpAMP spec, so always
+    // record the latest value.
+    agent_state.capabilities = message.capabilities;
 
     if let Some(effective_cfg) = message.effective_config {
         agent_state.effective_config = effective_cfg;


### PR DESCRIPTION
This PR extends the integration tests to check that `capabilities` and  `custom_capabilities` are reported as expected in OpAMP messages.