### PR TITLE
ci: dhat-enabled workflow

### DIFF
--- a/.github/workflows/on_demand_dhat_heap_build.yml
+++ b/.github/workflows/on_demand_dhat_heap_build.yml
@@ -1,0 +1,97 @@
+name: ⏯️ Build DHAT profiling binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to associate with the build'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+    name: Build dhat-heap Linux binaries (${{ matrix.arch }})
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/install-rust-toolchain
+        with:
+          targets: >-
+            aarch64-unknown-linux-musl,
+            x86_64-unknown-linux-musl
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.15.2
+
+      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        with:
+          tool: cargo-zigbuild@0.20.1
+
+      - name: Build dhat-heap binaries
+        env:
+          BUILD_MODE: release-debug
+          CARGO_FEATURES: dhat-heap
+          PKG: newrelic_agent_control
+          AGENT_CONTROL_VERSION: ${{ inputs.tag_name }}
+        run: |
+          ARCH=${{ matrix.arch }} BIN=newrelic-agent-control ./build/scripts/build_binary.sh
+          ARCH=${{ matrix.arch }} BIN=newrelic-agent-control-cli ./build/scripts/build_binary.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          retention-days: 7
+          name: dhat-heap-linux-${{ matrix.arch }}-${{ inputs.tag_name }}
+          path: ./bin/*
+
+  build-windows:
+    runs-on: ubuntu-latest
+    name: Build dhat-heap Windows binaries
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/install-rust-toolchain
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Install Windows cross-compilation dependencies
+        run: |
+          sudo apt-get install -y llvm
+
+      - name: Install cargo-xwin and go-winres
+        run: |
+          cargo install --locked cargo-xwin --force
+          go install github.com/tc-hib/go-winres@latest
+
+      - name: Build dhat-heap Windows binaries
+        env:
+          AGENT_CONTROL_VERSION: ${{ inputs.tag_name }}
+        run: |
+          cargo xwin build --target x86_64-pc-windows-msvc --profile release-debug --package newrelic_agent_control --bin newrelic-agent-control --features dhat-heap
+          cargo xwin build --target x86_64-pc-windows-msvc --profile release-debug --package newrelic_agent_control --bin newrelic-agent-control-cli --features dhat-heap
+
+      - name: Copy binaries
+        run: |
+          mkdir -p bin
+          cp target/x86_64-pc-windows-msvc/release-debug/newrelic-agent-control.exe bin/newrelic-agent-control-windows-amd64.exe
+          cp target/x86_64-pc-windows-msvc/release-debug/newrelic-agent-control-cli.exe bin/newrelic-agent-control-cli-windows-amd64.exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          retention-days: 7
+          name: dhat-heap-windows-amd64-${{ inputs.tag_name }}
+          path: ./bin/*

--- a/.github/workflows/on_demand_dhat_heap_build.yml
+++ b/.github/workflows/on_demand_dhat_heap_build.yml
@@ -81,7 +81,7 @@ jobs:
           AGENT_CONTROL_VERSION: ${{ inputs.tag_name }}
         run: |
           cargo xwin build --target x86_64-pc-windows-msvc --profile release-debug --package newrelic_agent_control --bin newrelic-agent-control --features dhat-heap
-          cargo xwin build --target x86_64-pc-windows-msvc --profile release-debug --package newrelic_agent_control --bin newrelic-agent-control-cli --features dhat-heap
+          cargo xwin build --target x86_64-pc-windows-msvc --profile release-debug --package newrelic_agent_control --bin newrelic-agent-control-cli
 
       - name: Copy binaries
         run: |

--- a/.github/workflows/on_demand_dhat_heap_image.yml
+++ b/.github/workflows/on_demand_dhat_heap_image.yml
@@ -1,0 +1,102 @@
+name: ⏯️🚀 Build dhat-heap images to ghcr.io
+
+# This workflow builds Agent Control container images with the dhat-heap feature enabled
+# and pushes them to the GitHub Container Registry.
+#
+# The resulting images can be used to replace the standard Agent Control image in a
+# Kubernetes installation for heap profiling purposes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: 'Image tag suffix (e.g., 1.15.0-dhat)'
+        type: string
+        required: true
+      ac-version:
+        description: 'Agent Control version to embed in the binary'
+        type: string
+        required: false
+        default: 'dev-build'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    name: Build/Push dhat-heap images
+    env:
+      DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/install-rust-toolchain
+        with:
+          targets: >-
+            aarch64-unknown-linux-musl,
+            x86_64-unknown-linux-musl
+
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          identifier: 'release'
+          restore-strategy: 'nearest'
+          save-cache: false
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.15.2
+
+      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        with:
+          tool: cargo-zigbuild@0.20.1
+
+      - name: Build Agent Control for K8s with dhat-heap
+        env:
+          AGENT_CONTROL_VERSION: ${{ inputs.ac-version }}
+          BUILD_MODE: release-debug
+          CARGO_FEATURES: dhat-heap
+        run: |
+          make build-agent-control-k8s ARCH=arm64 PKG=newrelic_agent_control
+          make build-agent-control-k8s ARCH=amd64 PKG=newrelic_agent_control
+          
+          # We do not do it in parallel because most of the dependencies are shared
+          make build-agent-control-k8s-cli ARCH=arm64 PKG=newrelic_agent_control
+          make build-agent-control-k8s-cli ARCH=amd64 PKG=newrelic_agent_control
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push dhat-heap images
+        run: |
+          docker buildx build \
+            --push \
+            --platform=$DOCKER_PLATFORMS \
+            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev:dhat-heap-${{ inputs.image-tag }} \
+            --file Dockerfiles/Dockerfile_agent_control \
+            --attest type=provenance,mode=max \
+            --attest type=sbom \
+            .
+          docker buildx build \
+            --push \
+            --platform=$DOCKER_PLATFORMS \
+            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-cli-dev:dhat-heap-${{ inputs.image-tag }} \
+            --file Dockerfiles/Dockerfile_agent_control_cli \
+            --attest type=provenance,mode=max \
+            --attest type=sbom \
+            .

--- a/.github/workflows/on_demand_dhat_heap_image.yml
+++ b/.github/workflows/on_demand_dhat_heap_image.yml
@@ -1,4 +1,4 @@
-name: ⏯️🚀 Build dhat-heap images to ghcr.io
+name: ⏯️🚀 Build dhat-heap AC image to ghcr.io
 
 # This workflow builds Agent Control container images with the dhat-heap feature enabled
 # and pushes them to the GitHub Container Registry.
@@ -10,14 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       image-tag:
-        description: 'Image tag suffix (e.g., 1.15.0-dhat)'
+        description: 'Image tag (will be appended to "dhat-heap-")'
         type: string
         required: true
-      ac-version:
-        description: 'Agent Control version to embed in the binary'
-        type: string
-        required: false
-        default: 'dev-build'
 
 permissions:
   contents: read
@@ -61,16 +56,12 @@ jobs:
 
       - name: Build Agent Control for K8s with dhat-heap
         env:
-          AGENT_CONTROL_VERSION: ${{ inputs.ac-version }}
+          AGENT_CONTROL_VERSION: dhat-dev-build
           BUILD_MODE: release-debug
           CARGO_FEATURES: dhat-heap
         run: |
           make build-agent-control-k8s ARCH=arm64 PKG=newrelic_agent_control
           make build-agent-control-k8s ARCH=amd64 PKG=newrelic_agent_control
-          
-          # We do not do it in parallel because most of the dependencies are shared
-          make build-agent-control-k8s-cli ARCH=arm64 PKG=newrelic_agent_control
-          make build-agent-control-k8s-cli ARCH=amd64 PKG=newrelic_agent_control
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -89,14 +80,6 @@ jobs:
             --platform=$DOCKER_PLATFORMS \
             -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev:dhat-heap-${{ inputs.image-tag }} \
             --file Dockerfiles/Dockerfile_agent_control \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-cli-dev:dhat-heap-${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control_cli \
             --attest type=provenance,mode=max \
             --attest type=sbom \
             .

--- a/agent-control/src/bin/main_k8s.rs
+++ b/agent-control/src/bin/main_k8s.rs
@@ -16,9 +16,18 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() -> ExitCode {
     #[cfg(feature = "dhat-heap")]
-    let _profiler = dhat::Profiler::new_heap();
+    let _profiler = if let Ok(path) = std::env::var("DHAT_HEAP_OUTPUT_PATH") {
+        dhat::Profiler::builder().file_name(path).build()
+    } else {
+        dhat::Profiler::new_heap()
+    };
+
     #[cfg(feature = "dhat-ad-hoc")]
-    let _profiler = dhat::Profiler::new_ad_hoc();
+    let _profiler = if let Ok(path) = std::env::var("DHAT_AD_HOC_OUTPUT_PATH") {
+        dhat::Profiler::builder().ad_hoc().file_name(path).build()
+    } else {
+        dhat::Profiler::new_ad_hoc()
+    };
 
     #[cfg(target_family = "unix")]
     return Command::execute(AGENT_CONTROL_MODE_K8S, _main);

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -16,9 +16,18 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() -> ExitCode {
     #[cfg(feature = "dhat-heap")]
-    let _profiler = dhat::Profiler::new_heap();
+    let _profiler = if let Ok(path) = std::env::var("DHAT_HEAP_OUTPUT_PATH") {
+        dhat::Profiler::builder().file_name(path).build()
+    } else {
+        dhat::Profiler::new_heap()
+    };
+
     #[cfg(feature = "dhat-ad-hoc")]
-    let _profiler = dhat::Profiler::new_ad_hoc();
+    let _profiler = if let Ok(path) = std::env::var("DHAT_AD_HOC_OUTPUT_PATH") {
+        dhat::Profiler::builder().ad_hoc().file_name(path).build()
+    } else {
+        dhat::Profiler::new_ad_hoc()
+    };
 
     #[cfg(target_family = "unix")]
     {

--- a/build/scripts/build_binary.sh
+++ b/build/scripts/build_binary.sh
@@ -22,9 +22,19 @@ if [ "$BUILD_MODE" = "debug" ];then
 fi
 # compile release version if not specified
 : "${BUILD_MODE:=release}"
-: "${BUILD_OUT_DIR:=release}"
 
-echo "arch: ${ARCH}, target: ${TARGET_TUPLE}"
+# Determine the output directory based on the build mode if not explicitly set.
+if [ -z "$BUILD_OUT_DIR" ]; then
+  if [ "$BUILD_MODE" = "dev" ]; then
+    BUILD_OUT_DIR="debug"
+  elif [ "$BUILD_MODE" = "release" ]; then
+    BUILD_OUT_DIR="release"
+  else
+    BUILD_OUT_DIR="$BUILD_MODE"
+  fi
+fi
+
+echo "arch: ${ARCH}, target: ${TARGET_TUPLE}, profile: ${BUILD_MODE}, out_dir: ${BUILD_OUT_DIR}"
 
 # Binary metadata
 GIT_COMMIT=$( git rev-parse HEAD )
@@ -33,7 +43,12 @@ export AGENT_CONTROL_VERSION=${AGENT_CONTROL_VERSION}
 
 export RUSTFLAGS="-C target-feature=+crt-static"
 
-cargo zigbuild --target "${TARGET_TUPLE}" --profile "${BUILD_MODE}" --package "${PKG}" --bin "${BIN}"
+CARGO_ARGS=(zigbuild --target "${TARGET_TUPLE}" --profile "${BUILD_MODE}" --package "${PKG}" --bin "${BIN}")
+if [ -n "$CARGO_FEATURES" ]; then
+  CARGO_ARGS+=(--features "${CARGO_FEATURES}")
+fi
+
+cargo "${CARGO_ARGS[@]}"
 
 mkdir -p "bin"
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -359,15 +359,11 @@ build and push multi-arch (`linux/amd64`, `linux/arm64`) images to the GitHub Co
 
 #### 1. Build the profiling images
 
-Navigate to **Actions → ⏯️🚀 Build dhat-heap images to ghcr.io → Run workflow** and provide:
+Navigate to **Actions → ⏯️🚀 Build dhat-heap images to ghcr.io → Run workflow** and run it:
 
-- `image-tag`: a suffix for the image tag, e.g. `1.15.0-dhat`
-- `ac-version`: the Agent Control version to embed in the binary (defaults to `dev-build`)
-
-The workflow produces two images:
+The workflow produces a new image:
 
 - `ghcr.io/<org>/newrelic-agent-control-dev:dhat-heap-<image-tag>`
-- `ghcr.io/<org>/newrelic-agent-control-cli-dev:dhat-heap-<image-tag>`
 
 #### 2. Create a shared volume to store the report
 
@@ -381,24 +377,23 @@ clusters (adapt the storage class for production environments).
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: dhat-heap-pv
+  name: agent-control-profiles-pv
 spec:
   capacity:
     storage: 1Gi
   accessModes:
-    - ReadWriteMany
-  persistentVolumeReclaimPolicy: Retain
+    - ReadWriteOnce
   hostPath:
-    path: /var/dhat-heap
+    path: /data/agent-control-profiles
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: dhat-heap-pvc
-  namespace: newrelic
+  name: agent-control-profiles-pvc
+  namespace: newrelic-agent-control
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -419,20 +414,20 @@ Create a helper pod running a basic utility image so you can `kubectl exec` into
 apiVersion: v1
 kind: Pod
 metadata:
-  name: dhat-debug
-  namespace: newrelic
+  name: profile-accessor
+  namespace: newrelic-agent-control
 spec:
   containers:
-    - name: debug
-      image: busybox:latest
-      command: ["sh", "-c", "sleep infinity"]
-      volumeMounts:
-        - name: dhat-vol
-          mountPath: /shared-vol
+  - name: accessor
+    image: alpine:latest
+    command: ["sleep", "infinity"]
+    volumeMounts:
+    - name: profiles
+      mountPath: /var/profiles
   volumes:
-    - name: dhat-vol
-      persistentVolumeClaim:
-        claimName: dhat-heap-pvc
+  - name: profiles
+    persistentVolumeClaim:
+      claimName: agent-control-profiles-pvc
 ```
 
 ```sh
@@ -445,34 +440,32 @@ Update your `agent-control-deployment` Helm values to use the dhat-heap image an
 
 ```yaml
 # dhat-helm-values.yaml
-image:
-  repository: ghcr.io/<org>/newrelic-agent-control-dev
-  tag: dhat-heap-1.15.0-dhat
-  pullPolicy: Always
-
-toolkitImage:
-  repository: ghcr.io/<org>/newrelic-agent-control-cli-dev
-  tag: dhat-heap-1.15.0-dhat
-  pullPolicy: Always
-
-extraEnv:
-  - name: DHAT_HEAP_OUTPUT_PATH
-    value: /shared-vol/dhat-heap.json
-
-extraVolumes:
-  - name: dhat-vol
-    persistentVolumeClaim:
-      claimName: dhat-heap-pvc
-
-extraVolumeMounts:
-  - name: dhat-vol
-    mountPath: /shared-vol
-
-resources:
-  requests:
-    memory: "15Mi"
-  limits:
-    memory: "1Gi"
+# ... other values
+agentControlDeployment:
+  chartValues:
+    resources:
+      requests:
+        memory: "100Mi"
+      limits:
+        memory: "1Gi"
+    image:
+      registry: ghrc.io
+      repository: newrelic/newrelic-agent-control-dev
+      tag: dhat-heap-dev-1
+      pullPolicy: Always
+    extraEnv:
+      - name: DHAT_HEAP_OUTPUT_PATH
+        value: "/var/profiles/dhat-heap.json"
+    extraVolumes:
+      - name: profiles
+        persistentVolumeClaim:
+          claimName: agent-control-profiles-pvc
+    extraVolumeMounts:
+      - name: profiles
+        mountPath: /var/profiles
+    config:
+      # ... remaining AC config
+# ... other values
 ```
 
 > **Note on memory limits:** DHAT serialises the entire heap profile into memory before writing it to disk. The memory
@@ -493,8 +486,8 @@ Once Agent Control has been stopped or restarted (which triggers the DHAT profil
 retrieve the report from the debug pod:
 
 ```sh
-kubectl exec -n newrelic dhat-debug -- ls -la /shared-vol/
-kubectl cp newrelic/dhat-debug:/shared-vol/dhat-heap.json ./dhat-heap.json
+kubectl exec -n newrelic-agent-control profile-accessor -- ls -la /var/profiles
+kubectl cp newrelic-agent-control/profile-accessor:/var/profiles/dhat-heap.json ./dhat-heap.json
 ```
 
 Open `dhat-heap.json` in the [DHAT Viewer](https://nnethercote.github.io/dh_view/dh_view.html) to inspect the results.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -351,6 +351,163 @@ for details on how to instrument your code.
 cargo build -p newrelic_agent_control --profile release-debug --features dhat-ad-hoc
 ```
 
+### Heap Profiling in Kubernetes
+
+You can run heap profiling inside a Kubernetes cluster by using pre-built container images that have the `dhat-heap`
+feature compiled in. A dedicated GitHub Actions workflow (`⏯️🚀 Build dhat-heap images to ghcr.io`) is available to
+build and push multi-arch (`linux/amd64`, `linux/arm64`) images to the GitHub Container Registry.
+
+#### 1. Build the profiling images
+
+Navigate to **Actions → ⏯️🚀 Build dhat-heap images to ghcr.io → Run workflow** and provide:
+
+- `image-tag`: a suffix for the image tag, e.g. `1.15.0-dhat`
+- `ac-version`: the Agent Control version to embed in the binary (defaults to `dev-build`)
+
+The workflow produces two images:
+
+- `ghcr.io/<org>/newrelic-agent-control-dev:dhat-heap-<image-tag>`
+- `ghcr.io/<org>/newrelic-agent-control-cli-dev:dhat-heap-<image-tag>`
+
+#### 2. Create a shared volume to store the report
+
+Because the container filesystem is ephemeral, the DHAT report must be written to a persistent volume so it can be
+retrieved after the pod exits. Below is an example using a `hostPath` PersistentVolume suitable for single-node
+clusters (adapt the storage class for production environments).
+
+```yaml
+# dhat-pv.yaml
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: dhat-heap-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /var/dhat-heap
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhat-heap-pvc
+  namespace: newrelic
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+Apply it:
+
+```sh
+kubectl apply -f dhat-pv.yaml
+```
+
+#### 3. Deploy a debug pod to retrieve the report
+
+Create a helper pod running a basic utility image so you can `kubectl exec` into it and access the shared volume.
+
+```yaml
+# dhat-debug-pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dhat-debug
+  namespace: newrelic
+spec:
+  containers:
+    - name: debug
+      image: busybox:latest
+      command: ["sh", "-c", "sleep infinity"]
+      volumeMounts:
+        - name: dhat-vol
+          mountPath: /shared-vol
+  volumes:
+    - name: dhat-vol
+      persistentVolumeClaim:
+        claimName: dhat-heap-pvc
+```
+
+```sh
+kubectl apply -f dhat-debug-pod.yaml
+```
+
+#### 4. Configure the Agent Control Helm deployment
+
+Update your `agent-control-deployment` Helm values to use the dhat-heap image and mount the shared volume.
+
+```yaml
+# dhat-helm-values.yaml
+image:
+  repository: ghcr.io/<org>/newrelic-agent-control-dev
+  tag: dhat-heap-1.15.0-dhat
+  pullPolicy: Always
+
+toolkitImage:
+  repository: ghcr.io/<org>/newrelic-agent-control-cli-dev
+  tag: dhat-heap-1.15.0-dhat
+  pullPolicy: Always
+
+extraEnv:
+  - name: DHAT_HEAP_OUTPUT_PATH
+    value: /shared-vol/dhat-heap.json
+
+extraVolumes:
+  - name: dhat-vol
+    persistentVolumeClaim:
+      claimName: dhat-heap-pvc
+
+extraVolumeMounts:
+  - name: dhat-vol
+    mountPath: /shared-vol
+
+resources:
+  requests:
+    memory: "15Mi"
+  limits:
+    memory: "1Gi"
+```
+
+> **Note on memory limits:** DHAT serialises the entire heap profile into memory before writing it to disk. The memory
+> limit must be high enough to accommodate this spike. `1Gi` is a reasonable starting point; you may need to increase it
+> for long-running processes or workloads with heavy allocation.
+
+Upgrade your release:
+
+```sh
+helm upgrade --install agent-control newrelic/agent-control-deployment \
+  --namespace newrelic \
+  --values dhat-helm-values.yaml
+```
+
+#### 5. Retrieve the results
+
+Once Agent Control has been stopped or restarted (which triggers the DHAT profiler to write the file on `Drop`),
+retrieve the report from the debug pod:
+
+```sh
+kubectl exec -n newrelic dhat-debug -- ls -la /shared-vol/
+kubectl cp newrelic/dhat-debug:/shared-vol/dhat-heap.json ./dhat-heap.json
+```
+
+Open `dhat-heap.json` in the [DHAT Viewer](https://nnethercote.github.io/dh_view/dh_view.html) to inspect the results.
+
+#### 6. Clean up
+
+Remove the debug pod and the PersistentVolume when you are done:
+
+```sh
+kubectl delete -f dhat-debug-pod.yaml
+kubectl delete -f dhat-pv.yaml
+```
+
 ## Codeql
 
 Codeql is executed automatically in GitHub pipelines, in order to check the results locally you need to install the tool


### PR DESCRIPTION
## Summary

Adds on-demand workflows and supporting changes to produce DHAT-enabled Agent Control artifacts for heap profiling, without disturbing the regular release pipeline.

## What changes

### CI — two `workflow_dispatch` workflows
- **`on_demand_dhat_heap_build.yml`** — builds `dhat-heap` binaries for Linux (`amd64`, `arm64`) and Windows (`amd64`) using the `release-debug` profile, and uploads them as artifacts tagged with the user-supplied `tag_name`. The CLI is intentionally built without the `dhat-heap` feature (the profiler is only meaningful for the long-running agent process).
- **`on_demand_dhat_heap_image.yml`** — builds and pushes a multi-arch (`linux/amd64`, `linux/arm64`) Agent Control K8s image to `ghcr.io/<org>/newrelic-agent-control-dev:dhat-heap-<image-tag>`, intended as a drop-in replacement for the standard image in a cluster.

Both are manually triggered to avoid running this on every push — DHAT-instrumented builds are only useful for targeted profiling sessions.

### Configurable DHAT output path (`agent-control/src/bin/main_k8s.rs`, `main_onhost.rs`)
The DHAT profiler now honours `DHAT_HEAP_OUTPUT_PATH` / `DHAT_AD_HOC_OUTPUT_PATH` env vars when set, falling back to the previous default behaviour otherwise. This is required for containerised runs: the profile is written on `Drop`, so without redirecting it to a mounted volume the report is lost when the pod terminates.

### `build/scripts/build_binary.sh`
- Forwards `CARGO_FEATURES` to `cargo zigbuild` so the workflows can opt into `dhat-heap` without a separate script.
- Derives `BUILD_OUT_DIR` from `BUILD_MODE` (e.g. `release-debug` → `release-debug`) instead of hard-coding `release`, so non-standard profiles land their binaries where the rest of the pipeline expects them.
- Logs the resolved profile and output dir for easier debugging.

### Docs (`docs/DEVELOPMENT.md`)
End-to-end guide for running heap profiling in Kubernetes: building the image, provisioning a `PersistentVolume` for the report, wiring up `DHAT_HEAP_OUTPUT_PATH` and volume mounts in the `agent-control-deployment` Helm values, retrieving `dhat-heap.json` via a debug pod, and a note on the memory-limit spike caused by DHAT serialising the heap on shutdown.