### PR TITLE
feat!: remove self instrumentation trace export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ### bugfix
 - On-host: clean the OpAMP instance id and remote config of an agent when it is removed, matching the k8s behavior (previously these files were left orphaned under `fleet-data/`).
+- self-instrumentation: dropped the internal traces exporter support for self-instrumentation.
 
 ## v1.15.0 - 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "glob",
  "oci-client",
  "oci-test-utils",
- "reqwest 0.13.3",
+ "reqwest",
  "semver",
  "serde",
  "serde-saphyr",
@@ -3001,7 +3001,7 @@ dependencies = [
  "predicates",
  "rcgen",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "resource-detection",
  "rstest",
  "rustls-pki-types",
@@ -3086,7 +3086,7 @@ dependencies = [
  "http 1.4.1",
  "jsonwebtoken",
  "rcgen",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3179,7 +3179,7 @@ dependencies = [
  "oci-spec",
  "olpc-cjson",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3274,9 +3274,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3288,35 +3288,34 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
  "tracing-core",
- "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.1",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.1",
  "opentelemetry",
@@ -3324,41 +3323,39 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
 ]
@@ -3939,46 +3936,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.1",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"
@@ -5241,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -60,21 +60,19 @@ tracing-appender = "0.2.5"
 cfg-if = "1.0.4"
 # HOST_ID and HOST_NAME attributes are experimental fields and after 0.26.0 are not included by default.
 # Check <https://github.com/open-telemetry/opentelemetry-rust/pull/2098> for details.
-opentelemetry-semantic-conventions = { version = "0.31.0", features = [
+opentelemetry-semantic-conventions = { version = "0.32.0", features = [
   "semconv_experimental",
 ] }
 http-serde = "2.1.1"
 config = { version = "0.15.23", features = ["yaml"] }
 aws-lc-rs = { workspace = true }
 bytes = "1.11.1"
-opentelemetry = { version = "0.31.0" }
-opentelemetry_sdk = { version = "0.31.0" }
-tracing-opentelemetry = "0.32.1"
-opentelemetry-otlp = { version = "0.31.1", features = ["reqwest-rustls"] }
-opentelemetry-http = { version = "0.31.0" }
-opentelemetry-appender-tracing = { version = "0.31.1", features = [
-  "experimental_use_tracing_span_context",
-] }
+opentelemetry = { version = "0.32.0" }
+opentelemetry_sdk = { version = "0.32.0" }
+tracing-opentelemetry = "0.33.0"
+opentelemetry-otlp = { version = "0.32.0", features = ["reqwest-rustls"] }
+opentelemetry-http = { version = "0.32.0" }
+opentelemetry-appender-tracing = { version = "0.32.0" }
 async-trait = "0.1.89"
 flate2 = "1.1.9"
 tar = "0.4.46"

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -67,8 +67,8 @@ http-serde = "2.1.1"
 config = { version = "0.15.23", features = ["yaml"] }
 aws-lc-rs = { workspace = true }
 bytes = "1.11.1"
-opentelemetry = { version = "0.31.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
+opentelemetry = { version = "0.31.0" }
+opentelemetry_sdk = { version = "0.31.0" }
 tracing-opentelemetry = "0.32.1"
 opentelemetry-otlp = { version = "0.31.1", features = ["reqwest-rustls"] }
 opentelemetry-http = { version = "0.31.0" }

--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -119,7 +119,7 @@ pub struct BootstrapContext {
 pub struct Context {
     /// Context used to build and start [crate::agent_control::AgentControl]
     pub ac_runner_context: RunnerContext,
-    /// This must be kept alive for the duration of the program to ensure logs and traces are flushed.
+    /// This must be kept alive for the duration of the program to ensure logs are flushed.
     pub tracer: Vec<TracingGuardBox>,
     /// A handler used to signal the application to stop when running as a Windows Service
     #[cfg(target_family = "windows")]

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -12,9 +12,9 @@ const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Default interval for exporting metrics.
 const DEFAULT_METRICS_EXPORT_INTERVAL: Duration = Duration::from_secs(60);
 /// Default maximum batch size [logs::BatchLogProcessor] for details.
-const DEFAULT_BATCH_MAX_SIZE: usize = 512;
+const DEFAULT_LOG_BATCH_MAX_SIZE: usize = 512;
 /// Default scheduled delay [logs::BatchLogProcessor] for details.
-const DEFAULT_BATCH_SCHEDULED_DELAY: Duration = Duration::from_secs(30);
+const DEFAULT_LOG_BATCH_SCHEDULED_DELAY: Duration = Duration::from_secs(30);
 /// Default insecure_level filter.
 const DEFAULT_FILTER: &str = "newrelic_agent_control=debug,opamp_client=debug,off";
 
@@ -139,8 +139,8 @@ pub(crate) struct BatchConfig {
 impl Default for BatchConfig {
     fn default() -> Self {
         Self {
-            scheduled_delay: DEFAULT_BATCH_SCHEDULED_DELAY,
-            max_size: DEFAULT_BATCH_MAX_SIZE,
+            scheduled_delay: DEFAULT_LOG_BATCH_SCHEDULED_DELAY,
+            max_size: DEFAULT_LOG_BATCH_MAX_SIZE,
         }
     }
 }
@@ -222,10 +222,10 @@ logs:
         let config = OtelConfig::default_with_endpoint("https://some.endpoint:4318");
         let default_batch_config = BatchConfig::default();
 
-        assert_eq!(default_batch_config.max_size, DEFAULT_BATCH_MAX_SIZE);
+        assert_eq!(default_batch_config.max_size, DEFAULT_LOG_BATCH_MAX_SIZE);
         assert_eq!(
             default_batch_config.scheduled_delay,
-            DEFAULT_BATCH_SCHEDULED_DELAY
+            DEFAULT_LOG_BATCH_SCHEDULED_DELAY
         );
 
         assert!(!config.metrics.enabled);

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -1,6 +1,5 @@
 use duration_str::deserialize_duration;
 use opentelemetry_sdk::logs;
-use opentelemetry_sdk::trace;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 use url::Url;
@@ -12,15 +11,13 @@ use crate::http::config::ProxyConfig;
 const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Default interval for exporting metrics.
 const DEFAULT_METRICS_EXPORT_INTERVAL: Duration = Duration::from_secs(60);
-/// Default maximum batch size [trace::BatchSpanProcessor] for details.
+/// Default maximum batch size [logs::BatchLogProcessor] for details.
 const DEFAULT_BATCH_MAX_SIZE: usize = 512;
-/// Default scheduled delay [trace::BatchSpanProcessor] for details.
+/// Default scheduled delay [logs::BatchLogProcessor] for details.
 const DEFAULT_BATCH_SCHEDULED_DELAY: Duration = Duration::from_secs(30);
 /// Default insecure_level filter.
 const DEFAULT_FILTER: &str = "newrelic_agent_control=debug,opamp_client=debug,off";
 
-/// Traces suffix for the OpenTelemetry endpoint
-const TRACES_SUFFIX: &str = "/v1/traces";
 /// Metrics suffix for the OpenTelemetry endpoint
 const METRICS_SUFFIX: &str = "/v1/metrics";
 /// Logs suffix for the OpenTelemetry endpoint
@@ -32,18 +29,15 @@ pub struct OtelConfig {
     /// Metrics configuration
     #[serde(default)]
     pub(crate) metrics: MetricsConfig,
-    /// Traces configuration
-    #[serde(default)]
-    pub(crate) traces: TracesConfig,
     /// Logs configuration
     #[serde(default)]
     pub(crate) logs: LogsConfig,
-    /// Filter metrics, tracer, and logs. By default [DEFAULT_FILTER] is used. This is marked as
+    /// Filter metrics and logs. By default [DEFAULT_FILTER] is used. This is marked as
     /// insecure because sensitive data could be sent if some crates are not filtered like the http client.
     #[serde(default = "default_insecure_level")]
     pub(crate) insecure_level: String,
     /// OpenTelemetry HTTP base endpoint to report instrumentation, to send each instrumentation
-    /// type, the corresponding suffix will be added [TRACES_SUFFIX], [METRICS_SUFFIX], [LOGS_SUFFIX].
+    /// type, the corresponding suffix will be added [METRICS_SUFFIX], [LOGS_SUFFIX].
     pub(crate) endpoint: Url,
     /// Headers to include in every request to the OpenTelemetry endpoint
     #[serde(default)]
@@ -55,7 +49,7 @@ pub struct OtelConfig {
     /// serde serialization and deserialization.
     #[serde(skip)]
     pub(crate) proxy: ProxyConfig,
-    /// Custom attributes to be added to all traces/metrics.
+    /// Custom attributes to be added to all metrics.
     #[serde(default)]
     pub(crate) custom_attributes: HashMap<String, String>,
 }
@@ -76,11 +70,6 @@ impl OtelConfig {
             custom_attributes,
             ..self
         }
-    }
-
-    /// Returns the otel endpoint to report traces to.
-    pub(crate) fn traces_endpoint(&self) -> String {
-        self.target_endpoint(TRACES_SUFFIX)
     }
 
     /// Returns the otel endpoint to report metrics to.
@@ -118,24 +107,13 @@ pub(crate) struct MetricsConfig {
     pub(crate) interval: MetricsExportInterval,
 }
 
-/// Defines the configuration settings to report traces to OpenTelemetry
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
-pub(crate) struct TracesConfig {
-    /// Indicates if traces are enabled or not
-    #[serde(default)]
-    pub(crate) enabled: bool,
-    /// Traces are reported in batches, this field defines the batch configuration.
-    #[serde(default)]
-    pub(crate) batch_config: BatchConfig,
-}
-
 /// Defines the configuration settings to report logs to OpenTelemetry
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
 pub(crate) struct LogsConfig {
     /// Indicates if logs are enabled or not
     #[serde(default)]
     pub(crate) enabled: bool,
-    /// Traces are reported in batches, this field defines the batch configuration.
+    /// Logs are reported in batches, this field defines the batch configuration.
     #[serde(default)]
     pub(crate) batch_config: BatchConfig,
 }
@@ -150,7 +128,7 @@ pub struct ClientTimeout(#[serde(deserialize_with = "deserialize_duration")] Dur
 #[wrapper_default_value(DEFAULT_METRICS_EXPORT_INTERVAL)]
 pub struct MetricsExportInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
-/// Holds the batch configuration to send traces/logs telemetry data through OpenTelemetry.
+/// Holds the batch configuration to send logs telemetry data through OpenTelemetry.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub(crate) struct BatchConfig {
     #[serde(deserialize_with = "deserialize_duration")]
@@ -167,14 +145,6 @@ impl Default for BatchConfig {
     }
 }
 
-impl From<&BatchConfig> for trace::BatchConfig {
-    fn from(value: &BatchConfig) -> Self {
-        trace::BatchConfigBuilder::default()
-            .with_max_export_batch_size(value.max_size)
-            .with_scheduled_delay(value.scheduled_delay)
-            .build()
-    }
-}
 impl From<&BatchConfig> for logs::BatchConfig {
     fn from(value: &BatchConfig) -> Self {
         logs::BatchConfigBuilder::default()
@@ -193,8 +163,6 @@ insecure_level: "newrelic_agent_control=info,off"
 endpoint: https://otlp.nr-data.net:4318
 metrics:
   enabled: true
-traces:
-  enabled: true
 logs:
   enabled: true
 "#;
@@ -210,11 +178,6 @@ custom_attributes:
 metrics:
   enabled: true
   interval: 120s
-traces:
-  enabled: true
-  batch_config:
-    scheduled_delay: 30s
-    max_size: 512
 logs:
   enabled: true
   batch_config:
@@ -231,7 +194,6 @@ logs:
         fn default_with_endpoint(endpoint: &str) -> Self {
             Self {
                 metrics: Default::default(),
-                traces: Default::default(),
                 logs: Default::default(),
                 insecure_level: default_insecure_level(),
                 endpoint: endpoint.parse().unwrap(),
@@ -245,10 +207,6 @@ logs:
     #[test]
     fn test_endpoints() {
         let config = OtelConfig::default_with_endpoint("https://some.endpoint:4318");
-        assert_eq!(
-            config.traces_endpoint(),
-            "https://some.endpoint:4318/v1/traces".to_string()
-        );
         assert_eq!(
             config.metrics_endpoint(),
             "https://some.endpoint:4318/v1/metrics".to_string()
@@ -269,9 +227,6 @@ logs:
             default_batch_config.scheduled_delay,
             DEFAULT_BATCH_SCHEDULED_DELAY
         );
-
-        assert_eq!(config.traces.batch_config, default_batch_config);
-        assert!(!config.traces.enabled);
 
         assert!(!config.metrics.enabled);
         assert_eq!(

--- a/agent-control/src/instrumentation/tracing.rs
+++ b/agent-control/src/instrumentation/tracing.rs
@@ -114,11 +114,6 @@ pub fn try_init_tracing(config: TracingConfig) -> Result<Vec<TracingGuardBox>, T
         let (otel_layers, otel_guard) = OtelLayers::try_build(otel_config)?;
         layers.push(otel_layers);
         guards.push(Box::new(otel_guard));
-
-        // Allows including the log information on spans that contain them when send to otlp.
-        opentelemetry::global::set_text_map_propagator(
-            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
-        );
     }
     try_init_tracing_subscriber(layers)?;
     debug!("tracing_subscriber initialized successfully");

--- a/agent-control/src/instrumentation/tracing_layers/otel.rs
+++ b/agent-control/src/instrumentation/tracing_layers/otel.rs
@@ -3,19 +3,17 @@ use crate::http::config::HttpConfig;
 use crate::instrumentation::config::otel::OtelConfig;
 use crate::instrumentation::tracing::{LayerBox, TracingGuard};
 use opentelemetry::KeyValue;
-use opentelemetry::trace::TracerProvider;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_http::HttpClient as OtelHttpClient;
 use opentelemetry_otlp::{ExporterBuildError, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
 use thiserror::Error;
 use tracing_opentelemetry::MetricsLayer;
 use tracing_subscriber::{EnvFilter, Layer};
 
-const TRACER_NAME: &str = "agent-control-self-instrumentation";
+const SERVICE_NAME: &str = "agent-control-self-instrumentation";
 
 /// Enumerates the possible error building OpenTelemetry providers.
 #[derive(Debug, Error)]
@@ -34,11 +32,10 @@ pub enum OtelBuildError {
 /// The underlying OpenTelemetry providers will be automatically shutdown when all their references are dropped.
 /// Therefore, in order to keep the reference for as long as needed, a guard is returned with the layers.
 /// For more information about automatic shutting down the OpenTelemetry providers, check the providers documentation.
-/// Eg: [SdkTracerProvider].
+/// Eg: [SdkLoggerProvider].
 #[derive(Default)]
 pub struct OtelLayers {
     logs_layer_builder: Option<(SdkLoggerProvider, EnvFilter)>,
-    traces_layer_builder: Option<(SdkTracerProvider, EnvFilter)>,
     // Metrics are reported regardless of the configured level, there are no filtering options supported for now.
     metrics_layer_builder: Option<SdkMeterProvider>,
 }
@@ -66,7 +63,7 @@ impl OtelLayers {
     where
         C: OtelHttpClient + Send + Sync + Clone + 'static,
     {
-        if !(config.traces.enabled || config.metrics.enabled || config.logs.enabled) {
+        if !(config.metrics.enabled || config.logs.enabled) {
             return Ok(Self::default());
         }
 
@@ -78,19 +75,9 @@ impl OtelLayers {
             .collect();
 
         let resource = Resource::builder()
-            .with_service_name(TRACER_NAME)
+            .with_service_name(SERVICE_NAME)
             .with_attributes(attributes)
             .build();
-
-        // Build each layer if configured
-        let traces_layer_builder = if config.traces.enabled {
-            Some((
-                Self::traces_provider(client.clone(), config, resource.clone())?,
-                Self::filter(&config.insecure_level)?,
-            ))
-        } else {
-            None
-        };
 
         let metrics_layer_builder = if config.metrics.enabled {
             Some(Self::metrics_provider(
@@ -114,7 +101,6 @@ impl OtelLayers {
         Ok(Self {
             logs_layer_builder,
             metrics_layer_builder,
-            traces_layer_builder,
         })
     }
 
@@ -125,31 +111,6 @@ impl OtelLayers {
                 err: err.to_string(),
             }
         })
-    }
-
-    fn traces_provider<C>(
-        client: C,
-        config: &OtelConfig,
-        resource: Resource,
-    ) -> Result<SdkTracerProvider, OtelBuildError>
-    where
-        C: OtelHttpClient + Send + Sync + 'static,
-    {
-        let exporter = opentelemetry_otlp::SpanExporter::builder()
-            .with_http()
-            .with_http_client(client)
-            .with_endpoint(config.traces_endpoint().to_string())
-            .with_headers(config.headers.clone())
-            .build()?;
-
-        let batch_processor = BatchSpanProcessor::builder(exporter)
-            .with_batch_config((&config.traces.batch_config).into())
-            .build();
-
-        Ok(SdkTracerProvider::builder()
-            .with_span_processor(batch_processor)
-            .with_resource(resource)
-            .build())
     }
 
     fn metrics_provider<C>(
@@ -206,13 +167,6 @@ impl OtelLayers {
         let mut layers = Vec::<LayerBox>::new();
         let mut guard = OtelGuard::default();
 
-        if let Some((traces_provider, traces_filter)) = self.traces_layer_builder {
-            guard._traces_provider = Some(traces_provider.clone());
-            let layer =
-                tracing_opentelemetry::layer().with_tracer(traces_provider.tracer(TRACER_NAME));
-            layers.push(Box::new(layer.with_filter(traces_filter)));
-        }
-
         if let Some(metrics_provider) = self.metrics_layer_builder {
             guard._metrics_provider = Some(metrics_provider.clone());
             let layer = MetricsLayer::new(metrics_provider.clone());
@@ -235,7 +189,6 @@ impl OtelLayers {
 pub struct OtelGuard {
     _logs_provider: Option<SdkLoggerProvider>,
     _metrics_provider: Option<SdkMeterProvider>,
-    _traces_provider: Option<SdkTracerProvider>,
 }
 
 impl TracingGuard for OtelGuard {}

--- a/agent-control/tests/on_host/scenarios.rs
+++ b/agent-control/tests/on_host/scenarios.rs
@@ -15,3 +15,4 @@ mod oci_auth;
 mod opamp;
 mod remote_agent_removal;
 mod restarting_processes;
+mod self_instrumentation_otel;

--- a/agent-control/tests/on_host/scenarios/self_instrumentation_otel.rs
+++ b/agent-control/tests/on_host/scenarios/self_instrumentation_otel.rs
@@ -1,0 +1,86 @@
+use crate::on_host::cli::cmd_with_config_file;
+use crate::on_host::tools::config::create_file;
+use httpmock::Method::POST;
+use httpmock::MockServer;
+use newrelic_agent_control::agent_control::defaults::{
+    AGENT_CONTROL_ID, FOLDER_NAME_LOCAL_DATA, STORE_KEY_LOCAL_DATA_CONFIG,
+};
+use newrelic_agent_control::on_host::file_store::build_config_name;
+use tempfile::TempDir;
+
+const API_KEY_HEADER: &str = "api-key";
+const API_KEY_VALUE: &str = "test-api-key";
+
+#[test]
+#[ignore = "requires root"]
+fn self_instrumentation_otel_exports_logs_and_metrics_as_root() {
+    let server = MockServer::start();
+
+    let logs_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/logs")
+            .header(API_KEY_HEADER, API_KEY_VALUE);
+        then.status(200);
+    });
+    let metrics_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/metrics")
+            .header(API_KEY_HEADER, API_KEY_VALUE);
+        then.status(200);
+    });
+
+    let dir = TempDir::new().unwrap();
+    let endpoint = server.base_url();
+
+    let config = format!(
+        r#"
+host_id: integration-test
+agents: {{}}
+server:
+  enabled: false
+uptime_report:
+  interval: 200ms
+self_instrumentation:
+  opentelemetry:
+    endpoint: {endpoint}
+    headers:
+      {API_KEY_HEADER}: {API_KEY_VALUE}
+    metrics:
+      enabled: true
+      interval: 200ms
+    logs:
+      enabled: true
+      batch_config:
+        scheduled_delay: 500ms
+        max_size: 1
+"#
+    );
+    create_file(
+        config,
+        dir.path()
+            .join(FOLDER_NAME_LOCAL_DATA)
+            .join(AGENT_CONTROL_ID)
+            .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG).as_str()),
+    );
+
+    // The binary runs until a timeout kills it.
+    let mut cmd = cmd_with_config_file(dir.path());
+    let output = cmd.output().expect("running newrelic-agent-control binary");
+
+    let ac_stdout = String::from_utf8_lossy(&output.stdout);
+    let ac_stderr = String::from_utf8_lossy(&output.stderr);
+
+    eprintln!("--- agent-control stdout ---\n{ac_stdout}");
+    eprintln!("--- agent-control stderr ---\n{ac_stderr}");
+
+    let logs_hits = logs_mock.calls();
+    let metrics_hits = metrics_mock.calls();
+    assert!(
+        logs_hits >= 1,
+        "expected at least one POST /v1/logs, got {logs_hits}"
+    );
+    assert!(
+        metrics_hits >= 1,
+        "expected at least one POST /v1/metrics, got {metrics_hits}"
+    );
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -131,7 +131,7 @@ health_check:
 
 ### self_instrumentation
 
-Agent Control can be configured to instrument itself and report traces, logs and metrics through OpenTelemetry. If proxy is configured globally it will also apply to self-instrumentation.
+Agent Control can be configured to instrument itself and report logs and metrics through OpenTelemetry. If proxy is configured globally it will also apply to self-instrumentation.
 
 ```yaml
 self_instrumentation:
@@ -140,15 +140,10 @@ self_instrumentation:
     endpoint: https://otlp.nr-data.net:4318 # HTTPS endpoint to report instrumentation to.
     headers: {} # Headers that will be included in any request to the endpoint
     client_timeout: 10s # Timeout for performing requests, defaults to 30s.
-    custom_attributes: {} # Attributes to be decorated in all metrics, traces and logs
+    custom_attributes: {} # Attributes to be decorated in all metrics and logs
     metrics:
       enabled: true # Defaults to false.
       interval: 120s # Interval to report metrics, it defaults to 60s.
-    traces:
-      enabled: true # Defaults to false.
-      batch_config:
-        scheduled_delay: 30s # Set the scheduled delay for batch export of traces. Defaults to 30s.
-        max_size: 512 # Se the maximum number of traces to process in a single batch. Defaults to 512.
     logs:
       enabled: true # Defaults to false.
       batch_config:

--- a/test/k8s-canaries/helm/agent-control.yml
+++ b/test/k8s-canaries/helm/agent-control.yml
@@ -9,11 +9,6 @@ agentControlDeployment:
         secretKeyName: "private_key"
       log:
         level: debug
-      override:
-        self_instrumentation:
-          opentelemetry:
-            traces:
-              enabled: true
       agents:
         infra:
           agent_type: newrelic/com.newrelic.infrastructure:0.1.0

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -102,17 +102,5 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
-    {
-      name      = "Opamp traces per minute"
-      metric    = "*"
-      sample    = "Span"
-      threshold = 1
-      duration  = 3600
-      operator  = "below_or_equals"
-      wheres = {
-        name = "opamp"
-      }
-      template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
-    },
   ]
 }

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -103,18 +103,6 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
-    {
-      name      = "Opamp traces per minute"
-      metric    = "*"
-      sample    = "Span"
-      threshold = 1
-      duration  = 3600
-      operator  = "below_or_equals"
-      wheres = {
-        name = "opamp"
-      }
-      template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
-    },
   ]
 }
 

--- a/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
+++ b/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
@@ -73,8 +73,6 @@
               endpoint: "{{ otlp_endpoint }}"
               headers:
                 api-key: "{{ nr_license_key }}"
-              traces:
-                enabled: true
               logs:
                 enabled: true
           agents:


### PR DESCRIPTION
This PR removes self-instrumentation traces export feature. 

We had issues when wrongly introducing long-lived spans that accumulated events and never closed, leaking memory. We don't consider these spans useful for this codebase. 

Logs and metrics export are unchanged. All #[instrument] / info_span! instrumentation stays — it still decorates log records via the file/stderr formatter.

Changes:
  - Drop the trace exports
  - Bump the OTel crate family
  - Introduce some integration tests for the remaining sefl-instrumentation feature.