### PR TITLE
chore: automate license generation

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,8 +9,18 @@ permissions:
   contents: read
 
 jobs:
+  third-party-notices-check:
+    name: Check third party licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+        with:
+          template-file: THIRD_PARTY_NOTICES.md.tmpl
+
   build-packages:
     name: Build packages
+    needs: [ third-party-notices-check ]
     uses: ./.github/workflows/component_packages.yml
     permissions:
       contents: write
@@ -26,6 +36,7 @@ jobs:
 
   build-image:
     name: Build and Push container image
+    needs: [ third-party-notices-check ]
     uses: ./.github/workflows/component_image.yml
     with:
       image-tag: ${{ github.event.release.tag_name }}-rc
@@ -142,6 +153,7 @@ jobs:
       REPO_ENDPOINT: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
 
   onhost-e2e:
+    needs: [ third-party-notices-check ]
     uses: ./.github/workflows/component_onhost_e2e.yaml
     with:
       caller_workflow: prerelease
@@ -153,6 +165,7 @@ jobs:
       E2E_LICENSE_KEY: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
 
   k8s-e2e-tests:
+    needs: [ third-party-notices-check ]
     uses: ./.github/workflows/component_k8s_e2e.yml
     with:
       # TODO

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -79,21 +79,6 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
 
-  third-party-notices-check:
-    name: ⚖️ Check third party licenses
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/install-rust-toolchain
-
-      - name: Fetch dependencies
-        run: cargo fetch
-
-      - uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
-        with:
-          template-file: THIRD_PARTY_NOTICES.md.tmpl
-
   unused-dependencies-check:
     name: cargo shear (unused dependencies)
     runs-on: ${{ matrix.os }}
@@ -370,7 +355,6 @@ jobs:
       - cargo-clippy
       - cargo-fmt
       - cargo-doc
-      - third-party-notices-check
       - unused-dependencies-check
       - codespell
       - security

--- a/.github/workflows/shared_create_prerelease_pr.yml
+++ b/.github/workflows/shared_create_prerelease_pr.yml
@@ -81,6 +81,25 @@ jobs:
           # Refresh Cargo.lock (assumed at repo root) so it reflects the bumped version.
           cargo update --workspace --manifest-path "$CARGO_TOML_PATH"
 
+      - name: Regenerate THIRD_PARTY_NOTICES.md
+        id: regen-notices
+        # The action fails the step whenever it regenerates the file with new content; the
+        # follow-up step distinguishes that expected case from a real error.
+        continue-on-error: true
+        uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+        with:
+          template-file: THIRD_PARTY_NOTICES.md.tmpl
+
+      - name: Fail if regeneration errored without producing changes
+        if: steps.regen-notices.outcome == 'failure'
+        run: |
+          if git diff --quiet -- THIRD_PARTY_NOTICES.md; then
+            echo "::error::THIRD_PARTY_NOTICES.md regeneration failed and the file did not change."
+            echo "::error::Likely a transient error (network, action upstream); please investigate."
+            exit 1
+          fi
+          echo "Action reported failure because THIRD_PARTY_NOTICES.md needed updating; the regenerated file is on disk and will be committed."
+
       # Commits are created via the GraphQL `createCommitOnBranch` mutation so GitHub signs them automatically.
       - name: Create release branch and commit files (signed via API)
         env:
@@ -104,6 +123,7 @@ jobs:
             --rawfile changelog CHANGELOG.md \
             --rawfile cargo "$CARGO_TOML_PATH" \
             --rawfile lock Cargo.lock \
+            --rawfile notices THIRD_PARTY_NOTICES.md \
             --arg repo "$REPO" \
             --arg branch "$BRANCH" \
             --arg msg "chore(release): prepare $VERSION" \
@@ -120,7 +140,8 @@ jobs:
                     additions: [
                       {path: "CHANGELOG.md", contents: ($changelog | @base64)},
                       {path: $cargo_path, contents: ($cargo | @base64)},
-                      {path: "Cargo.lock", contents: ($lock | @base64)}
+                      {path: "Cargo.lock", contents: ($lock | @base64)},
+                      {path: "THIRD_PARTY_NOTICES.md", contents: ($notices | @base64)}
                     ]
                   }
                 }


### PR DESCRIPTION
This PR automates the license file update as part of the pre-release PR creation. On the other hand it also remove the check on each PR to unblock renovate branch automerge. 

Once this is merge i'll do follow ups pr to the repos leveraging the shared wf