### PR TITLE
fix: onhost canaries staging alerts slack channel

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -183,7 +183,7 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
       AC_CANARY_WINDOWS_PASSWORD: ${{ secrets.AC_CANARY_WINDOWS_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.AC_FLEET_COMMON_SLACK_WEBHOOK }}
+      SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
 
   onhost_canaries:
     uses: ./.github/workflows/component_onhost_canaries.yml

--- a/.github/workflows/on_demand_onhost_canaries.yml
+++ b/.github/workflows/on_demand_onhost_canaries.yml
@@ -36,7 +36,7 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
       AC_CANARY_WINDOWS_PASSWORD: ${{ secrets.AC_CANARY_WINDOWS_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.AC_FLEET_COMMON_SLACK_WEBHOOK }}
+      SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
 
   onhost_canaries:
     name: Install/Upgrade Agent Control

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -212,7 +212,7 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_VPC_SUBNET: ${{ secrets.AWS_VPC_SUBNET }}
       AC_CANARY_WINDOWS_PASSWORD: ${{ secrets.AC_CANARY_WINDOWS_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.AC_FLEET_COMMON_SLACK_WEBHOOK }}
+      SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
 
   onhost_canaries:
     uses: ./.github/workflows/component_onhost_canaries.yml


### PR DESCRIPTION
Onhost canaries staging was using the wrong slack channel url. This PR fixes it.
Launched https://github.com/newrelic/newrelic-agent-control/actions/runs/26231951907 and it worked.