### PR TITLE
test: executable mode on fake-opamp-server

### DIFF
--- a/test/crates/fake-opamp-server/Cargo.toml
+++ b/test/crates/fake-opamp-server/Cargo.toml
@@ -16,4 +16,4 @@ opamp-client = { workspace = true }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/test/crates/fake-opamp-server/Cargo.toml
+++ b/test/crates/fake-opamp-server/Cargo.toml
@@ -16,4 +16,4 @@ opamp-client = { workspace = true }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }

--- a/test/crates/fake-opamp-server/README.md
+++ b/test/crates/fake-opamp-server/README.md
@@ -1,0 +1,68 @@
+# fake-opamp-server
+
+A minimal, in-memory OpAMP server used to drive Agent Control in tests and demos. It speaks just enough of the [OpAMP protocol](https://github.com/open-telemetry/opamp-spec) to accept agent reports, send back remote configurations, and serve a JWKS document for signature verification.
+
+It is **not** a production OpAMP server. The state is in-memory, the signing key is generated on startup, and the config hashing does not match Fleet Control's.
+
+## Two ways to use it
+
+### As a library (integration tests)
+
+`FakeServer::start(handle)` spawns the HTTP server on a random port, on the provided tokio runtime. Tests then use methods like `set_config_response`, `get_health_status`, and `find_agent_control_instance` to drive and assert behavior. See `agent-control/tests/` for examples.
+
+### As a standalone binary (manual testing / demos)
+
+```sh
+cargo run -p fake-opamp-server --bin fake-opamp-server                  # random free port
+cargo run -p fake-opamp-server --bin fake-opamp-server 127.0.0.1:4320   # explicit address
+```
+
+On startup the binary prints the actual bound address and the URL of every endpoint:
+
+```
+fake-opamp-server listening on 127.0.0.1:4320
+
+  OpAMP:        POST http://localhost:4320/opamp-fake-server
+  JWKS:         GET  http://localhost:4320/jwks
+  Admin state:  GET  http://localhost:4320/admin/state
+  Admin config: POST http://localhost:4320/admin/agents/{instance_uid}/config
+
+Press Ctrl+C to stop.
+```
+
+## Endpoints
+
+| Method | Path                                           | Purpose                                                                  |
+| ------ | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `POST` | `/opamp-fake-server`                           | OpAMP `AgentToServer` ↔ `ServerToAgent` exchange (Protobuf body).         |
+| `GET`  | `/jwks`                                        | JWKS document for the Ed25519 key used to sign remote-config messages.   |
+| `GET`  | `/admin/state`                                 | Human-readable JSON snapshot of the in-memory `ServerState`.             |
+| `POST` | `/admin/agents/{instance_uid}/config`          | Set the pending remote config for the given agent (overwrites previous). |
+
+The admin endpoints are always registered, regardless of whether the server is started via the library or the binary.
+
+## Driving the server with `curl`
+
+Inspect the current state:
+
+```sh
+curl -s http://localhost:4320/admin/state | jq
+```
+
+Push a remote config from a YAML file to a specific agent. `instance_uid` is the agent's UUIDv7 in canonical (uppercase, no-hyphen) form — both hyphenated and unhyphenated forms are accepted by the path parameter:
+
+```sh
+jq -n --rawfile cfg ./agent-config.yaml '{agentConfig: $cfg}' \
+  | curl -X POST http://localhost:4320/admin/agents/0190592A82877FB1A6D91ECAA57032BD/config \
+      -H 'Content-Type: application/json' \
+      --data-binary @-
+```
+
+The body is the raw `key -> yaml-body` map; multiple keys are allowed (use additional `--rawfile` arguments and extend the `jq` expression accordingly).
+
+A successful POST returns `204 No Content`. An invalid `instance_uid` returns `400` with the parse error. A subsequent `GET /admin/state` will show the new config under the agent's `pending_remote_config` field — the server stops sending it once the agent acknowledges the hash.
+
+## Caveats
+
+- Fields in `GET /admin/state` that come from OpAMP proto types (see [newrelic/newrelic-opamp-rs](https://github.com/newrelic/newrelic-opamp-rs)) are rendered using their `Debug` impl. The JSON shape is meant for human inspection, not for programmatic consumption, it may change without notice.
+- All state is lost when the process exits.

--- a/test/crates/fake-opamp-server/src/admin.rs
+++ b/test/crates/fake-opamp-server/src/admin.rs
@@ -1,6 +1,6 @@
 //! Admin-facing types and HTTP handlers for the fake OpAMP server.
 //!
-//! These are intended for human inspection and manual driving of the server in tests/demos —
+//! These are intended for human inspection and manual driving of the server in tests/demos,
 //! not for any stable wire format. Proto-typed fields are rendered via their `Debug` impl.
 
 use crate::{AgentState, JWKS_PUBLIC_KEY_ID, RemoteConfig, ServerState};

--- a/test/crates/fake-opamp-server/src/admin.rs
+++ b/test/crates/fake-opamp-server/src/admin.rs
@@ -1,11 +1,22 @@
-//! Admin-facing types and (later) HTTP handlers for the fake OpAMP server.
+//! Admin-facing types and HTTP handlers for the fake OpAMP server.
 //!
 //! These are intended for human inspection and manual driving of the server in tests/demos —
 //! not for any stable wire format. Proto-typed fields are rendered via their `Debug` impl.
 
 use crate::{AgentState, JWKS_PUBLIC_KEY_ID, RemoteConfig, ServerState};
+use actix_web::{HttpResponse, web};
+use opamp_client::operation::instance_uid::InstanceUid;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Path for the admin endpoint that returns a JSON snapshot of the server state.
+pub const ADMIN_STATE_PATH: &str = "/admin/state";
+
+/// Path template for the admin endpoint that sets the pending remote config for a given agent.
+/// `{instance_uid}` accepts the canonical UUIDv7 string (uppercase, no hyphens, as produced by
+/// `InstanceUid::Display`); both hyphenated and unhyphenated forms are valid.
+pub const ADMIN_CONFIG_PATH: &str = "/admin/agents/{instance_uid}/config";
 
 /// Human-readable, JSON-friendly snapshot of the server state.
 #[derive(Serialize)]
@@ -75,4 +86,28 @@ impl From<&RemoteConfig> for RemoteConfigView {
             config_map,
         }
     }
+}
+
+/// Returns a JSON snapshot of the current server state.
+pub(crate) async fn get_state_handler(state: web::Data<Arc<Mutex<ServerState>>>) -> HttpResponse {
+    let state = state.lock().unwrap();
+    HttpResponse::Ok().json(ServerStateView::from(&*state))
+}
+
+/// Sets the pending remote config for the agent identified by the path parameter, overwriting
+/// any previous config. The body is the raw `key -> yaml-body` map.
+pub(crate) async fn set_config_handler(
+    state: web::Data<Arc<Mutex<ServerState>>>,
+    path: web::Path<String>,
+    body: web::Json<HashMap<String, String>>,
+) -> HttpResponse {
+    let instance_uid = match InstanceUid::try_from(path.into_inner()) {
+        Ok(uid) => uid,
+        Err(e) => return HttpResponse::BadRequest().body(format!("invalid instance_uid: {e}")),
+    };
+    state
+        .lock()
+        .unwrap()
+        .set_multi_config(instance_uid, body.into_inner());
+    HttpResponse::NoContent().finish()
 }

--- a/test/crates/fake-opamp-server/src/admin.rs
+++ b/test/crates/fake-opamp-server/src/admin.rs
@@ -1,0 +1,78 @@
+//! Admin-facing types and (later) HTTP handlers for the fake OpAMP server.
+//!
+//! These are intended for human inspection and manual driving of the server in tests/demos —
+//! not for any stable wire format. Proto-typed fields are rendered via their `Debug` impl.
+
+use crate::{AgentState, JWKS_PUBLIC_KEY_ID, RemoteConfig, ServerState};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Human-readable, JSON-friendly snapshot of the server state.
+#[derive(Serialize)]
+pub struct ServerStateView {
+    pub jwks_public_key_id: String,
+    /// Connected agents keyed by `InstanceUid` in its canonical (uppercase, no-hyphen) form.
+    pub agents: HashMap<String, AgentStateView>,
+}
+
+#[derive(Serialize)]
+pub struct AgentStateView {
+    pub sequence_number: u64,
+    pub health_status: Option<String>,
+    pub attributes: String,
+    pub effective_config: String,
+    pub config_status: String,
+    pub pending_remote_config: Option<RemoteConfigView>,
+}
+
+#[derive(Serialize)]
+pub struct RemoteConfigView {
+    pub config_hash: String,
+    pub config_map: HashMap<String, String>,
+}
+
+impl From<&ServerState> for ServerStateView {
+    fn from(state: &ServerState) -> Self {
+        Self {
+            jwks_public_key_id: JWKS_PUBLIC_KEY_ID.to_string(),
+            agents: state
+                .agent_state
+                .iter()
+                .map(|(uid, agent)| (uid.to_string(), agent.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<&AgentState> for AgentStateView {
+    fn from(s: &AgentState) -> Self {
+        Self {
+            sequence_number: s.sequence_number,
+            health_status: s.health_status.as_ref().map(|h| format!("{h:?}")),
+            attributes: format!("{:?}", s.attributes),
+            effective_config: format!("{:?}", s.effective_config),
+            config_status: format!("{:?}", s.config_status),
+            pending_remote_config: s.remote_config.as_ref().map(Into::into),
+        }
+    }
+}
+
+impl From<&RemoteConfig> for RemoteConfigView {
+    fn from(rc: &RemoteConfig) -> Self {
+        let config_hash = String::from_utf8_lossy(&rc.0.config_hash).to_string();
+        let config_map =
+            rc.0.config
+                .as_ref()
+                .map(|cm| {
+                    cm.config_map
+                        .iter()
+                        .map(|(k, v)| (k.clone(), String::from_utf8_lossy(&v.body).to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+        Self {
+            config_hash,
+            config_map,
+        }
+    }
+}

--- a/test/crates/fake-opamp-server/src/admin.rs
+++ b/test/crates/fake-opamp-server/src/admin.rs
@@ -103,7 +103,7 @@ pub(crate) async fn set_config_handler(
 ) -> HttpResponse {
     let instance_uid = match InstanceUid::try_from(path.into_inner()) {
         Ok(uid) => uid,
-        Err(e) => return HttpResponse::BadRequest().body(format!("invalid instance_uid: {e}")),
+        Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
     };
     state
         .lock()

--- a/test/crates/fake-opamp-server/src/bin/fake-opamp-server.rs
+++ b/test/crates/fake-opamp-server/src/bin/fake-opamp-server.rs
@@ -1,0 +1,62 @@
+//! Standalone runner for the fake OpAMP server. Intended for manual testing and demos —
+//! not for production use.
+//!
+//! Usage:
+//!   fake-opamp-server [BIND_ADDR]
+//!
+//! BIND_ADDR defaults to `0.0.0.0:0` (a random free port chosen by the OS). The actual
+//! address is printed on startup.
+
+use fake_opamp_server::{
+    FAKE_SERVER_PATH, FakeServer, JWKS_SERVER_PATH,
+    admin::{ADMIN_CONFIG_PATH, ADMIN_STATE_PATH},
+};
+use std::net::TcpListener;
+use std::process::ExitCode;
+
+const DEFAULT_BIND_ADDR: &str = "0.0.0.0:0";
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let bind_addr = match args.as_slice() {
+        [] => DEFAULT_BIND_ADDR.to_string(),
+        [addr] => addr.clone(),
+        _ => {
+            eprintln!("usage: fake-opamp-server [BIND_ADDR]");
+            eprintln!("  BIND_ADDR defaults to {DEFAULT_BIND_ADDR} (random free port)");
+            return ExitCode::from(2);
+        }
+    };
+
+    let listener = match TcpListener::bind(&bind_addr) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind on {bind_addr}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let actual_addr = listener.local_addr().expect("local_addr after bind");
+    let port = actual_addr.port();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    // Holds the spawned HTTP task alive: dropping `_server` aborts the task.
+    let _server = FakeServer::start_with_listener(listener, runtime.handle());
+
+    println!("fake-opamp-server listening on {actual_addr}");
+    println!();
+    println!("  OpAMP:        POST http://localhost:{port}{FAKE_SERVER_PATH}");
+    println!("  JWKS:         GET  http://localhost:{port}{JWKS_SERVER_PATH}");
+    println!("  Admin state:  GET  http://localhost:{port}{ADMIN_STATE_PATH}");
+    println!("  Admin config: POST http://localhost:{port}{ADMIN_CONFIG_PATH}");
+    println!();
+    println!("Press Ctrl+C to stop.");
+
+    // Park the main thread on the runtime; Ctrl+C will terminate the process.
+    runtime.block_on(std::future::pending::<()>());
+    ExitCode::SUCCESS
+}

--- a/test/crates/fake-opamp-server/src/bin/fake-opamp-server.rs
+++ b/test/crates/fake-opamp-server/src/bin/fake-opamp-server.rs
@@ -56,7 +56,9 @@ fn main() -> ExitCode {
     println!();
     println!("Press Ctrl+C to stop.");
 
-    // Park the main thread on the runtime; Ctrl+C will terminate the process.
-    runtime.block_on(std::future::pending::<()>());
+    runtime.block_on(async {
+        let _ = tokio::signal::ctrl_c().await;
+    });
+    println!("Shutting down...");
     ExitCode::SUCCESS
 }

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -22,8 +22,8 @@ use tokio::task::JoinHandle;
 
 pub use opamp_client::operation::instance_uid::InstanceUid as InstanceID;
 
-const FAKE_SERVER_PATH: &str = "/opamp-fake-server";
-const JWKS_SERVER_PATH: &str = "/jwks";
+pub const FAKE_SERVER_PATH: &str = "/opamp-fake-server";
+pub const JWKS_SERVER_PATH: &str = "/jwks";
 const JWKS_PUBLIC_KEY_ID: &str = "fakeKeyName/0";
 const AGENT_CONFIG_PREFIX: &str = "agentConfig";
 const SIGNATURE_CUSTOM_CAPABILITY: &str = "com.newrelic.security.configSignature";
@@ -51,6 +51,14 @@ impl ServerState {
             agent_state: HashMap::new(),
             key_pair: generate_key_pair(),
         }
+    }
+
+    /// Sets the pending remote config for the given agent, overwriting any previous one.
+    fn set_multi_config(&mut self, identifier: InstanceUid, config_map: HashMap<String, String>) {
+        self.agent_state
+            .entry(identifier)
+            .or_default()
+            .remote_config = Some(RemoteConfig::new(config_map));
     }
 }
 
@@ -147,6 +155,16 @@ impl FakeServer {
     /// Starts the server on a random port, spawning the HTTP task on the provided runtime handle.
     pub fn start(handle: &tokio::runtime::Handle) -> Self {
         let listener = net::TcpListener::bind("0.0.0.0:0").unwrap();
+        Self::start_with_listener(listener, handle)
+    }
+
+    /// Starts the server on the given (already-bound) listener, spawning the HTTP task on the
+    /// provided runtime handle. Useful when the caller needs to choose the bind address (e.g. the
+    /// standalone binary).
+    pub fn start_with_listener(
+        listener: net::TcpListener,
+        handle: &tokio::runtime::Handle,
+    ) -> Self {
         let port = listener.local_addr().unwrap().port();
         let state = Arc::new(Mutex::new(ServerState::generate()));
         let join_handle = handle.spawn(Self::run_http_server(listener, state.clone()));
@@ -188,15 +206,13 @@ impl FakeServer {
         identifier: impl Into<InstanceUid>,
         response: impl AsRef<str>,
     ) {
-        let mut state = self.state.lock().unwrap();
-        state
-            .agent_state
-            .entry(identifier.into())
-            .or_default()
-            .remote_config = Some(RemoteConfig::new(HashMap::from([(
-            AGENT_CONFIG_PREFIX.to_string(),
-            response.as_ref().to_string(),
-        )])));
+        self.state.lock().unwrap().set_multi_config(
+            identifier.into(),
+            HashMap::from([(
+                AGENT_CONFIG_PREFIX.to_string(),
+                response.as_ref().to_string(),
+            )]),
+        );
     }
 
     /// Same as `set_config_response` but accepts multiple config keys.
@@ -205,12 +221,10 @@ impl FakeServer {
         identifier: impl Into<InstanceUid>,
         config_map: HashMap<String, String>,
     ) {
-        let mut state = self.state.lock().unwrap();
-        state
-            .agent_state
-            .entry(identifier.into())
-            .or_default()
-            .remote_config = Some(RemoteConfig::new(config_map));
+        self.state
+            .lock()
+            .unwrap()
+            .set_multi_config(identifier.into(), config_map);
     }
 
     pub fn get_health_status(&self, identifier: impl Into<InstanceUid>) -> Option<ComponentHealth> {

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -1,6 +1,4 @@
-mod admin;
-
-pub use admin::{AgentStateView, RemoteConfigView, ServerStateView};
+pub mod admin;
 
 use actix_web::{App, HttpResponse, HttpServer, web};
 use aws_lc_rs::digest;

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -1,3 +1,7 @@
+mod admin;
+
+pub use admin::{AgentStateView, RemoteConfigView, ServerStateView};
+
 use actix_web::{App, HttpResponse, HttpServer, web};
 use aws_lc_rs::digest;
 use aws_lc_rs::rand::SystemRandom;
@@ -24,25 +28,25 @@ pub use opamp_client::operation::instance_uid::InstanceUid as InstanceID;
 
 pub const FAKE_SERVER_PATH: &str = "/opamp-fake-server";
 pub const JWKS_SERVER_PATH: &str = "/jwks";
-const JWKS_PUBLIC_KEY_ID: &str = "fakeKeyName/0";
+pub(crate) const JWKS_PUBLIC_KEY_ID: &str = "fakeKeyName/0";
 const AGENT_CONFIG_PREFIX: &str = "agentConfig";
 const SIGNATURE_CUSTOM_CAPABILITY: &str = "com.newrelic.security.configSignature";
 const SIGNATURE_CUSTOM_MESSAGE_TYPE: &str = "newrelicRemoteConfigSignature";
 const ED25519_ALG: &str = "ED25519";
 
-struct ServerState {
-    agent_state: HashMap<InstanceUid, AgentState>,
-    key_pair: Ed25519KeyPair,
+pub(crate) struct ServerState {
+    pub(crate) agent_state: HashMap<InstanceUid, AgentState>,
+    pub(crate) key_pair: Ed25519KeyPair,
 }
 
 #[derive(Default)]
-struct AgentState {
-    sequence_number: u64,
-    health_status: Option<ComponentHealth>,
-    attributes: AgentDescription,
-    remote_config: Option<RemoteConfig>,
-    effective_config: EffectiveConfig,
-    config_status: RemoteConfigStatus,
+pub(crate) struct AgentState {
+    pub(crate) sequence_number: u64,
+    pub(crate) health_status: Option<ComponentHealth>,
+    pub(crate) attributes: AgentDescription,
+    pub(crate) remote_config: Option<RemoteConfig>,
+    pub(crate) effective_config: EffectiveConfig,
+    pub(crate) config_status: RemoteConfigStatus,
 }
 
 impl ServerState {
@@ -64,7 +68,7 @@ impl ServerState {
 
 /// Represents a remote configuration that can be sent to the agent.
 #[derive(Clone, Debug, Default)]
-pub struct RemoteConfig(AgentRemoteConfig);
+pub struct RemoteConfig(pub(crate) AgentRemoteConfig);
 
 impl RemoteConfig {
     pub fn new(config_map: HashMap<String, String>) -> Self {

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -202,6 +202,7 @@ impl FakeServer {
                         .route(web::post().to(admin::set_config_handler)),
                 )
         })
+        .disable_signals()
         .listen(listener)
         .unwrap_or_else(|err| panic!("Could not bind the HTTP server to the listener: {err}"))
         .run()

--- a/test/crates/fake-opamp-server/src/lib.rs
+++ b/test/crates/fake-opamp-server/src/lib.rs
@@ -195,6 +195,14 @@ impl FakeServer {
                 .app_data(web::Data::new(state.clone()))
                 .service(web::resource(FAKE_SERVER_PATH).to(opamp_handler))
                 .service(web::resource(JWKS_SERVER_PATH).to(jwks_handler))
+                .service(
+                    web::resource(admin::ADMIN_STATE_PATH)
+                        .route(web::get().to(admin::get_state_handler)),
+                )
+                .service(
+                    web::resource(admin::ADMIN_CONFIG_PATH)
+                        .route(web::post().to(admin::set_config_handler)),
+                )
         })
         .listen(listener)
         .unwrap_or_else(|err| panic!("Could not bind the HTTP server to the listener: {err}"))


### PR DESCRIPTION
## Summary

fake-opamp-server was previously library-only. It was usable from integration tests via `FakeServer::start(handle)`, but you couldn't run it as a process. This PR adds a thin binary wrapper plus two HTTP admin endpoints so the same server can also be used for manual testing and demos (e.g. driving a locally-running Agent Control without standing up Fleet Control).

There are no changes in the library API.

## Running Agent Control with the fake OpAMP server

<details>
<summary>Running on-host (Vagrant + Parallels setup)</summary>

Setup the VM:

`Vagrantfile`:
```rb
Vagrant.configure("2") do |config|
  config.vm.box = "bento/ubuntu-24.04"
  config.vm.box_version = "202404.26.0"
  config.vm.provision "shell", inline: <<-SHELL
    rm /etc/machine-id
    rm /var/lib/dbus/machine-id
    systemd-machine-id-setup
    su - vagrant -c "rustup default stable"
  SHELL
end
```

Connect to the VM and install Agent Control through `apt`:


```shell
curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg

echo "deb https://download.newrelic.com/preview/linux/apt/ noble main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list

apt update

apt install newrelic-agent-control=1.4.1
```

Run the `opamp-fake-server` on the host (from the agent-control source folder):

```shell
cargo run -p fake-opamp-server --bin fake-opamp-server -- 0.0.0.0:4320
# We could also compile it and execute it directly in the VM
```

Prepare agent-control configuration

```yaml
log:
  level: debug

fleet_control: # 10.211.55.2 address to access to the host from the VM
  endpoint: http://10.211.55.2:4320/opamp-fake-server
  poll_interval: 5s
  signature_validation:
    public_key_server_url: http://10.211.55.2:4320/jwks

agents: {}
```

Go back to the VM, copy the config, and restart agent-control

```shell
cp /vagrant/config.yaml /etc/newrelic-agent-control/local-data/agent-control/local_config.yaml
systemctl restart newrelic-agent-control
```

**Remote configuration**:

In the host, we can check that Agent Control is using the fake-server:

```shell
curl http://localhost:4320/admin/state |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1244  100  1244    0     0  1186k      0 --:--:-- --:--:-- --:--:-- 1214k
{
  "jwks_public_key_id": "fakeKeyName/0",
  "agents": {
    "019E4EE06E8375D187687EA958C68869": {
      "sequence_number": 40,
      "health_status": "ComponentHealth { healthy: true, start_time_unix_nano: 1779441234762565070, last_error: \"\", status: \"\", status_time_unix_nano: 1779441264768889854, component_health_map: {} }",
      "attributes": "AgentDescription { identifying_attributes: [KeyValue { key: \"agent.version\", value: Some(\"1.14.1\") }, KeyValue { key: \"service.namespace\", value: Some(\"newrelic\") }, KeyValue { key: \"service.name\", value: Some(\"com.newrelic.agent_control\") }, KeyValue { key: \"supervisor.key\", value: Some(\"agent-control\") }], non_identifying_attributes: [KeyValue { key: \"fleet.guid\", value: Some(\"\") }, KeyValue { key: \"host.name\", value: Some(\"vagrant\") }, KeyValue { key: \"host.id\", value: Some(\"c59d11df4ee748598e5283f56a11c11a\") }, KeyValue { key: \"os.type\", value: Some(\"linux\") }] }",
      "effective_config": "EffectiveConfig { config_map: Some(AgentConfigMap { config_map: {\"\": AgentConfigFile { body: \"agents: {}\n\", content_type: \"text/yaml\" }} }) }",
      "config_status": "RemoteConfigStatus { status: 1, last_remote_config_hash: \"15103179199444784960\", last_error: \"\" }",
      "pending_remote_config": null
    }
  }
}
```
And we can set remote configuration. Example:

`remote-config.yaml`

```yaml
agents: {}
version: 1.5.0
```

```shell
jq -n --rawfile cfg ./remote-config.yaml  '{agentConfig: $cfg}' | curl -v -X POST "localhost:4320/admin/agents/019E4EE06E8375D187687EA958C68869/config" -H 'Content-Type: application/json' --data-binary @-
```

</details>