### PR TITLE
feat!: remove common variables types [NR-568035]

### DIFF
--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -28,7 +28,7 @@ The `variables` section allows developers to define variables that end users can
 
 ```yaml
 variables:
-  common:
+  linux:
     config_agent:
       description: "Newrelic infra configuration"
       type: yaml
@@ -39,12 +39,11 @@ variables:
       type: map[string]yaml
       required: false
       default: {}
-  linux:
     backoff_delay:
       description: "seconds until next retry if agent fails to start"
       type: string
       required: false
-      variants: [5s, 10s, 20s, 30s] 
+      variants: [5s, 10s, 20s, 30s]
       default: 20s
     enable_file_logging:
       description: "enable logging the on host executables' logs to files"
@@ -55,18 +54,15 @@ variables:
      ...
 ```
 
-Variables can be classified based on their applicable environments:
+Variables are scoped to their applicable environments:
 
-* `on_host`: Refers to variables utilized in on host environments.
+* `linux` / `windows`: Refers to variables utilized in on-host environments.
 * `k8s`: Applies to variables used within Kubernetes clusters.
-* `common`: For variables that are environment-agnostic.
-
-Although a variable name can be concurrently specified under both the `k8s` and `on_host` sections, it's necessary to note an exception. If a variable is already defined in the `common` section, it cannot be duplicated under any other section. In other words, any variables named in the `common` section must be unique and not repeated in either the `k8s` or the `on_host` sections.
 
 Nested variable names are supported. For instance:
 
 ```yaml
-common:
+linux:
   log:
     level:
       description: "Log level with only info and error"
@@ -389,7 +385,7 @@ This guideline shows how to build a custom agent type and integrate it with the 
     version: 0.0.1
     
     # variables:
-    #   common | on_host | k8s:
+    #   linux | windows | k8s:
     #     my_var_1:
     #       description: "Variable description here"
     #       type: string

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -39,8 +39,6 @@ pub struct AgentTypeDefinition {
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 pub struct AgentTypeVariables {
     #[serde(default)]
-    pub common: VariableDefinitionTree,
-    #[serde(default)]
     pub k8s: VariableDefinitionTree,
     #[serde(default)]
     pub linux: VariableDefinitionTree,
@@ -146,7 +144,7 @@ fn update_specs(
 ///
 /// ```yaml
 /// variables:
-///   common:
+///   linux:
 ///     system:
 ///       logging:
 ///         level:
@@ -247,7 +245,6 @@ pub mod tests {
             Self {
                 agent_type_id: metadata,
                 variables: AgentTypeVariables {
-                    common: VariableDefinitionTree::default(),
                     k8s: VariableDefinitionTree::default(),
                     linux: VariableDefinitionTree::default(),
                     windows: VariableDefinitionTree::default(),
@@ -272,7 +269,7 @@ pub mod tests {
         pub fn build_for_testing(yaml_definition: &str, environment: &Environment) -> Self {
             let definition =
                 serde_saphyr::from_str::<AgentTypeDefinition>(yaml_definition).unwrap();
-            build_agent_type(definition, environment, &VariableConstraints::default()).unwrap()
+            build_agent_type(definition, environment, &VariableConstraints::default())
         }
 
         /// Retrieve the `variables` field of the agent type at the specified key, if any.
@@ -300,7 +297,14 @@ name: nrdot
 namespace: newrelic
 version: 0.0.1
 variables:
-  common:
+  linux:
+    description:
+      name:
+        description: "Name of the agent"
+        type: string
+        required: false
+        default: nrdot
+  windows:
     description:
       name:
         description: "Name of the agent"
@@ -418,7 +422,17 @@ name: newrelic-infra
 namespace: newrelic
 version: 1.39.1
 variables:
-  common:
+  linux:
+    config3:
+      description: "Newrelic infra configuration yaml"
+      type: map[string]yaml
+      required: true
+    status_server_port:
+      description: "Newrelic infra health status port"
+      type: number
+      required: false
+      default: 8003
+  windows:
     config3:
       description: "Newrelic infra configuration yaml"
       type: map[string]yaml
@@ -508,7 +522,16 @@ name: variant-values
 namespace: newrelic
 version: 0.0.1
 variables:
-  common:
+  linux:
+    restart_policy:
+      type:
+        description: "restart policy type"
+        type: string
+        required: false
+        variants:
+          values: [fixed, linear]
+        default: exponential
+  windows:
     restart_policy:
       type:
         description: "restart policy type"

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -751,7 +751,7 @@ fn iterate_test_cases(environment: &Environment) {
         values.cases.iter().for_each(|(scenario, yaml)| {
             let definition = registry.get(case.agent_type).unwrap();
             let agent_type =
-                build_agent_type(definition, environment, &VariableConstraints::default()).unwrap();
+                build_agent_type(definition, environment, &VariableConstraints::default());
             let attributes = testing_agent_attributes(&agent_id);
             let variables = serde_saphyr::from_str::<YAMLConfig>(yaml).unwrap();
 

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -25,8 +25,6 @@ pub enum AgentTypeError {
     InvalidVariant(String),
     #[error("rendering template: {0}")]
     RenderingTemplate(String),
-    #[error("conflicting variable definition: {0}")]
-    ConflictingVariableDefinition(String),
     #[error("error parsing oci reference: {0}")]
     OCIReferenceParsingError(String),
 }

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -611,7 +611,17 @@ namespace: newrelic
 name: first
 version: 0.1.0
 variables:
-  common:
+  linux:
+    config_path:
+      description: "config file string"
+      type: string
+      required: true
+    config_argument:
+      description: "config argument"
+      type: string
+      required: false
+      default: bar
+  windows:
     config_path:
       description: "config file string"
       type: string
@@ -626,32 +636,32 @@ deployment:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - --config_path
-          - ${nr-var:config_path} 
+          - ${nr-var:config_path}
           - --foo
           - ${nr-var:config_argument}
       - id: second
         path: /opt/second
-        args: 
+        args:
         - --config_path
-        - ${nr-var:config_path} 
+        - ${nr-var:config_path}
         - --foo
         - ${nr-var:config_argument}
   windows:
     executables:
       - id: first
         path: /opt/first
-        args: 
+        args:
           - --config_path
-          - ${nr-var:config_path} 
+          - ${nr-var:config_path}
           - --foo
           - ${nr-var:config_argument}
       - id: second
         path: /opt/second
-        args: 
+        args:
         - --config_path
-        - ${nr-var:config_path} 
+        - ${nr-var:config_path}
         - --foo
         - ${nr-var:config_argument}
 "#;
@@ -669,7 +679,28 @@ name: nrdot
 namespace: newrelic
 version: 0.1.0
 variables:
-  common:
+  linux:
+    backoff:
+      delay:
+        description: "Backoff delay"
+        type: string
+        required: false
+        default: 1s
+      retries:
+        description: "Backoff retries"
+        type: number
+        required: false
+        default: 3
+      interval:
+        description: "Backoff interval"
+        type: string
+        required: false
+        default: 30s
+      type:
+        description: "Backoff strategy type"
+        type: string
+        required: true
+  windows:
     backoff:
       delay:
         description: "Backoff delay"

--- a/agent-control/src/agent_type/variable/tree.rs
+++ b/agent-control/src/agent_type/variable/tree.rs
@@ -4,7 +4,7 @@
 //!
 //! ```yaml
 //! variables:
-//!   common:
+//!   linux:
 //!     foo:
 //!       bar:
 //!         variable_name:
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::agent_type::{error::AgentTypeError, templates::TEMPLATE_KEY_SEPARATOR};
+use crate::agent_type::templates::TEMPLATE_KEY_SEPARATOR;
 
 /// This struct assures that variables have at least a name (one level of nested names).
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -51,44 +51,6 @@ impl<T: Clone> VarTree<T> {
             .collect()
     }
 
-    /// Merges the current [VarTree] with another, returning an error if any key overlaps.
-    pub fn merge(self, variables: Self) -> Result<Self, AgentTypeError> {
-        Ok(Self(
-            Self::merge_inner(&self.0, &variables.0)
-                .map_err(AgentTypeError::ConflictingVariableDefinition)?,
-        ))
-    }
-
-    /// Merges recursively two inner hashmaps if there is no conflicting key.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an String error containing the full path of the first conflicting key if any
-    /// [VariableDefinitionTree::End] overlaps.
-    fn merge_inner(
-        a: &HashMap<String, Tree<T>>,
-        b: &HashMap<String, Tree<T>>,
-    ) -> Result<HashMap<String, Tree<T>>, String> {
-        let mut merged = a.clone();
-        for (key, value) in b {
-            match (merged.get(key), value) {
-                // Include the value when its key doesn't overlap.
-                (None, _) => {
-                    merged.insert(key.into(), value.clone());
-                }
-                // Merge overlapping mappings.
-                (Some(Tree::Mapping(inner_a)), Tree::Mapping(inner_b)) => {
-                    let merged_inner = Self::merge_inner(inner_a, inner_b)
-                        .map_err(|err| format!("{key}.{err}"))?;
-                    merged.insert(key.clone(), Tree::Mapping(merged_inner));
-                }
-                // Any other option implies an overlapping end (conflicting key).
-                (Some(_), _) => return Err(key.into()),
-            }
-        }
-        Ok(merged)
-    }
-
     /// Helper for [Self::flatten] implementation.
     fn inner_flatten(key: String, spec: Tree<T>) -> HashMap<String, T> {
         let mut result = HashMap::new();
@@ -102,104 +64,5 @@ impl<T: Clone> VarTree<T> {
             }),
         }
         result
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-    use rstest::rstest;
-
-    use super::*;
-
-    #[test]
-    fn test_merge_trees() {
-        let a = r#"
-config:
-  general: "general"
-common: "common"
-        "#;
-
-        let b = r#"
-config:
-  specific: "specific"
-env:
-  key: "value"
-        "#;
-
-        let expected = r#"
-config:
-  general: "general"
-  specific: "specific"
-common: "common"
-env:
-  key: "value"
-        "#;
-
-        let a: VarTree<String> = serde_saphyr::from_str(a).unwrap();
-        let b: VarTree<String> = serde_saphyr::from_str(b).unwrap();
-        let expected: VarTree<String> = serde_saphyr::from_str(expected).unwrap();
-
-        assert_eq!(expected, a.merge(b).unwrap());
-    }
-
-    #[rstest]
-    #[case::conflicting_leaves(
-        r#"
-config:
-  general: a
-        "#,
-        r#"
-config:
-  general: b
-        "#,
-        "config.general"
-    )]
-    #[case::conflicting_branch_leave(
-        r#"
-var:
-  nested: nested
-        "#,
-        r#"
-var: var
-        "#,
-        "var"
-    )]
-    #[case::conflicting_leave_branch(
-        r#"
-var: var
-        "#,
-        r#"
-var:
-  nested: nested
-        "#,
-        "var"
-    )]
-    #[case::conflicting_branch_and_leave_nested(
-        r#"
-var:
-  several:
-    nested:
-      levels: value
-        "#,
-        r#"
-var:
-  several:
-    nested: nested
-        "#,
-        "var.several.nested"
-    )]
-
-    fn test_merge_variable_tree_errors(
-        #[case] a: &str,
-        #[case] b: &str,
-        #[case] conflicting_key: &str,
-    ) {
-        let a: VarTree<String> = serde_saphyr::from_str(a).unwrap();
-        let b: VarTree<String> = serde_saphyr::from_str(b).unwrap();
-        let result = a.merge(b);
-        assert_matches!(result, Err(AgentTypeError::ConflictingVariableDefinition(k)) => {
-            assert_eq!(k, conflicting_key);
-        })
     }
 }

--- a/agent-control/src/config_migrate/migration/converter.rs
+++ b/agent-control/src/config_migrate/migration/converter.rs
@@ -4,7 +4,6 @@ use crate::config_migrate::migration::{
     agent_value_spec::AgentValueError,
     config::{DirInfo, MigrationAgentConfig},
 };
-use crate::sub_agent::effective_agents_assembler::AgentTypeDefinitionError;
 use fs::file::LocalFile;
 use fs::file::reader::FileReader;
 use regex::Regex;
@@ -22,8 +21,6 @@ pub enum ConversionError {
     FileSystem(io::Error),
     #[error("{0}")]
     AgentValue(#[from] AgentValueError),
-    #[error("{0}")]
-    AgentTypeDefinition(#[from] AgentTypeDefinitionError),
     #[error("cannot find required file map: {0}")]
     RequiredFileMappingNotFound(String),
     #[error("cannot find required dir map: {0}")]

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -951,7 +951,13 @@ name: default
 namespace: default
 version: 0.0.1
 variables:
-  common:
+  linux:
+    var:
+      description: "fake"
+      type: string
+      required: false
+      default: ""
+  windows:
     var:
       description: "fake"
       type: string
@@ -978,13 +984,22 @@ name: default
 namespace: default
 version: 0.0.1
 variables:
-  common:
+  linux:
+    var:
+      description: "fake"
+      type: string
+      required: true
+  windows:
     var:
       description: "fake"
       type: string
       required: true
 deployment:
   linux:
+    executables:
+      - id: exec
+        path: ${nr-var:var}
+  windows:
     executables:
       - id: exec
         path: ${nr-var:var}

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -32,16 +32,8 @@ pub enum EffectiveAgentsAssemblerError {
     ValueConversionError(#[from] serde_json::Error),
     #[error("error assembling agents: {0}")]
     AgentTypeError(#[from] AgentTypeError),
-    #[error("error assembling agents: {0}")]
-    AgentTypeDefinitionError(#[from] AgentTypeDefinitionError),
     #[error("error loading secrets: {0}")]
     SecretVariablesError(#[from] SecretVariablesError),
-}
-
-#[derive(Error, Debug)]
-pub enum AgentTypeDefinitionError {
-    #[error("invalid agent-type for '{0}' environment: {1}")]
-    EnvironmentError(AgentTypeError, Environment),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -174,7 +166,7 @@ where
             agent_type_definition,
             environment,
             &self.variable_constraints,
-        )?;
+        );
 
         // Build the agent attributes
         let attributes =
@@ -202,7 +194,7 @@ pub fn build_agent_type(
     definition: AgentTypeDefinition,
     environment: &Environment,
     variable_constraints: &VariableConstraints,
-) -> Result<AgentType, AgentTypeDefinitionError> {
+) -> AgentType {
     // Select vars and runtime config according to the environment
     let (specific_vars, runtime_config) = match environment {
         Environment::K8s => (
@@ -236,20 +228,10 @@ pub fn build_agent_type(
             },
         ),
     };
-    // Merge common and specific variables
-    let merged_variables = definition
-        .variables
-        .common
-        .merge(specific_vars)
-        .map_err(|err| AgentTypeDefinitionError::EnvironmentError(err, *environment))?;
 
-    let agent_type_vars = merged_variables.with_config(variable_constraints);
+    let agent_type_vars = specific_vars.with_config(variable_constraints);
 
-    Ok(AgentType::new(
-        definition.agent_type_id,
-        agent_type_vars,
-        runtime_config,
-    ))
+    AgentType::new(definition.agent_type_id, agent_type_vars, runtime_config)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -265,7 +247,6 @@ pub(crate) mod tests {
     use crate::agent_type::agent_type_registry::tests::MockAgentRegistry;
     use crate::agent_type::definition::AgentTypeDefinition;
     use crate::values::yaml_config::YAMLConfig;
-    use assert_matches::assert_matches;
     use mockall::mock;
 
     mock! {
@@ -360,10 +341,8 @@ pub(crate) mod tests {
             definition.clone(),
             &Environment::K8s,
             &VariableConstraints::default(),
-        )
-        .unwrap();
+        );
         let k8s_vars = k8s_agent_type.variables.flatten();
-        assert!(k8s_vars.contains_key("config.really_common"));
         let var = k8s_vars.get("config.var").unwrap();
         assert_eq!("K8s var".to_string(), var.description);
         assert!(
@@ -379,10 +358,8 @@ pub(crate) mod tests {
             definition,
             &AGENT_CONTROL_MODE_ON_HOST,
             &VariableConstraints::default(),
-        )
-        .unwrap();
+        );
         let on_host_vars = on_host_agent_type.variables.flatten();
-        assert!(on_host_vars.contains_key("config.really_common"));
         let var = on_host_vars.get("config.var").unwrap();
         #[cfg(target_family = "unix")]
         assert_eq!("Linux var".to_string(), var.description);
@@ -394,38 +371,11 @@ pub(crate) mod tests {
         );
     }
 
-    #[test]
-    fn test_build_agent_type_error() {
-        let definition =
-            serde_saphyr::from_str::<AgentTypeDefinition>(CONFLICTING_AGENT_TYPE_DEFINITION)
-                .unwrap();
-
-        let expected_err = build_agent_type(
-            definition,
-            &Environment::K8s,
-            &VariableConstraints::default(),
-        )
-        .err()
-        .unwrap();
-        assert_matches!(expected_err, AgentTypeDefinitionError::EnvironmentError(err, env) => {
-            assert_matches!(err, AgentTypeError::ConflictingVariableDefinition(key) => {
-                assert_eq!("config.var".to_string(), key);
-            });
-            assert_matches!(env, Environment::K8s);
-        });
-    }
-
     const AGENT_TYPE_DEFINITION: &str = r#"
 name: common
 namespace: newrelic
 version: 0.0.1
 variables:
-  common:
-    config:
-      really_common:
-        description: "Common var"
-        type: string
-        required: true
   k8s:
     config:
       var:
@@ -449,15 +399,13 @@ deployment:
       executables:
         - id: my-exec
           path: /some/path
-          args: 
-            - ${nr-var:config.really_common} 
+          args:
             - ${config.var}
     windows:
       executables:
         - id: my-exec
           path: /some/path
-          args: 
-            - ${nr-var:config.really_common} 
+          args:
             - ${config.var}
     k8s:
       objects:
@@ -468,29 +416,6 @@ deployment:
             name: ${nr-sub:agent_id}
             namespace: ${nr-ac:namespace}
           spec:
-            some_key: ${nr-var:config.really_common}
             other: ${nr-avar:config.var}
-"#;
-
-    const CONFLICTING_AGENT_TYPE_DEFINITION: &str = r#"
-name: common
-namespace: newrelic
-version: 0.0.1
-variables:
-  common:
-    config:
-      var:
-        description: "Common variable"
-        type: string
-        required: true
-  k8s:
-    config:
-      var:
-        description: "K8s variable"
-        type: string
-        required: true
-deployment:
-    k8s:
-      objects: {}
 "#;
 }

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -259,7 +259,18 @@ name: nrdot
 namespace: newrelic
 version: 0.1.0
 variables:
-  common:
+  linux:
+    whatever:
+      test:
+        path:
+          description: "Path to the agent"
+          type: string
+          required: true
+        args:
+          description: "Args passed to the agent"
+          type: string
+          required: true
+  windows:
     whatever:
       test:
         path:

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -24,7 +24,16 @@ namespace: test
 name: file-logging-agent
 version: 0.0.0
 variables:
-  common:
+  linux:
+    message:
+      description: "Message to echo to stdout"
+      type: "string"
+      required: true
+    enable_file_logging:
+      description: "Whether to enable file logging"
+      type: "string"
+      required: true
+  windows:
     message:
       description: "Message to echo to stdout"
       type: "string"

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -142,7 +142,20 @@ namespace: test
 name: test
 version: 0.0.0
 variables:
-  common:
+  linux:
+    yaml_file_contents:
+      description: "Contents of the YAML file"
+      type: yaml
+      required: true
+    some_string:
+      description: "Contents of an arbitrary string file"
+      type: string
+      required: true
+    some_mapstringyaml:
+      description: "A directory structure"
+      type: map[string]yaml
+      required: true
+  windows:
     yaml_file_contents:
       description: "Contents of the YAML file"
       type: yaml
@@ -308,7 +321,20 @@ namespace: test
 name: infra-agent
 version: 0.0.0
 variables:
-  common:
+  linux:
+    config_agent:
+      description: "Agent configuration"
+      type: yaml
+      required: true
+    config_integrations:
+      description: "Integrations configuration"
+      type: yaml
+      required: true
+    config_logging:
+      description: "Logging configuration"
+      type: yaml
+      required: true
+  windows:
     config_agent:
       description: "Agent configuration"
       type: yaml

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -60,7 +60,7 @@ impl Display for CustomAgentType {
             serde_saphyr::from_str(&content).unwrap();
         let mut variables = serde_json::Map::<String, serde_json::Value>::new();
         if let Some(v) = self.variables.as_ref() {
-            variables.insert("common".into(), v.clone());
+            variables.insert(AGENT_CONTROL_MODE_ON_HOST.to_string(), v.clone());
         }
         let mut deployment_content = serde_json::Map::<String, serde_json::Value>::new();
         if let Some(executables) = self.executables.as_ref() {

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -27,7 +27,7 @@ version: 0.1.0
 
 ### Agent Type Variables
 
-This section, defined under the top-level field `variables`, enables the dynamic configuration of the workload created by AC by exposing arbitrary variables. The variables are grouped into three main sections: `common`, `linux` and `k8s`. Inside these, the variables can be arbitrarily grouped into common fields forming a tree, where the final leaf will determine the actual variable, its type and its allowed contents.
+This section, defined under the top-level field `variables`, enables the dynamic configuration of the workload created by AC by exposing arbitrary variables. The variables are grouped into per-environment sections: `linux`, `windows` and `k8s`. Inside these, the variables can be arbitrarily grouped into common fields forming a tree, where the final leaf will determine the actual variable, its type and its allowed contents.
 
 Defining variables is entirely optional, but if no variables are defined then no dynamic configuration will be possible for this sub-agent, AC will be only capable of adding or removing it as a workload using its deployment instructions and at most the environment variables available to AC at the time it's running (see the [deployment](#agent-type-deployment) section below).
 
@@ -70,7 +70,7 @@ variables:
       required: true
 ```
 
-See that we don't have a `common` section, for `linux` we define a single variable called `config_agent`, while inside `k8s` we have a field `chart_values` that defines three variables inside (`newrelic-infrastructure`, `nri-metadata-injection` and `global`) while a remaining variable `chart_version` is outside, as another top-level field for the `k8s` section.
+For `linux` we define a single variable called `config_agent`, while inside `k8s` we have a field `chart_values` that defines three variables inside (`newrelic-infrastructure`, `nri-metadata-injection` and `global`) while a remaining variable `chart_version` is outside, as another top-level field for the `k8s` section.
 
 When referencing these variables elsewhere, as you will see in the [deployment](#agent-type-deployment) and [applying configuration](#applying-configurations) sections, you would access these nested fields using a dot (`.`), as usual for accessing fields in programming languages. For our example, we would use `chart_values.newrelic-infrastructure` `chart_values.nri-metadata-injection` `chart_values.global` and `chart_version` respectively.
 


### PR DESCRIPTION
Removes the `common` section of agent type variables 

I was planning to add a single changelog entry alongside the PR that flattens the environment to reduce the noise 