### PR TITLE
chore: move agent-type registry to its own module [NR-568043]

### DIFF
--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::config::AgentControlDynamicConfig;
-use crate::agent_type::agent_type_registry::AgentRegistry;
+use crate::agent_type::registry::AgentTypeRegistry;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -18,11 +18,11 @@ pub trait DynamicConfigValidator {
 }
 
 /// Validator that checks the agent type exists in the agent type registry.
-pub struct RegistryDynamicConfigValidator<R: AgentRegistry> {
+pub struct RegistryDynamicConfigValidator<R: AgentTypeRegistry> {
     agent_type_registry: Arc<R>,
 }
 
-impl<R: AgentRegistry> RegistryDynamicConfigValidator<R> {
+impl<R: AgentTypeRegistry> RegistryDynamicConfigValidator<R> {
     pub fn new(agent_type_registry: Arc<R>) -> Self {
         Self {
             agent_type_registry,
@@ -30,7 +30,7 @@ impl<R: AgentRegistry> RegistryDynamicConfigValidator<R> {
     }
 }
 
-impl<R: AgentRegistry> DynamicConfigValidator for RegistryDynamicConfigValidator<R> {
+impl<R: AgentTypeRegistry> DynamicConfigValidator for RegistryDynamicConfigValidator<R> {
     fn validate(
         &self,
         dynamic_config: &AgentControlDynamicConfig,
@@ -55,8 +55,8 @@ impl<R: AgentRegistry> DynamicConfigValidator for RegistryDynamicConfigValidator
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::agent_type::agent_type_registry::tests::MockAgentRegistry;
     use crate::agent_type::definition::AgentTypeDefinition;
+    use crate::agent_type::registry::tests::MockAgentTypeRegistry;
     use mockall::mock;
 
     mock! {
@@ -91,7 +91,7 @@ pub mod tests {
 
     #[test]
     fn test_existing_agent_type_validation() {
-        let mut registry = MockAgentRegistry::new();
+        let mut registry = MockAgentTypeRegistry::new();
 
         let agent_type_definition =
             AgentTypeDefinition::empty_with_metadata("ns/name:0.0.1".try_into().unwrap());
@@ -114,7 +114,7 @@ agents:
     }
     #[test]
     fn test_non_existing_agent_type_validation() {
-        let mut registry = MockAgentRegistry::new();
+        let mut registry = MockAgentTypeRegistry::new();
         registry.should_not_get("ns/another:0.0.1".to_string());
 
         let dynamic_config = serde_saphyr::from_str::<AgentControlDynamicConfig>(

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -5,7 +5,7 @@ use super::defaults::{
 use crate::agent_control::config::AgentControlConfig;
 use crate::agent_control::config_repository::store::AgentControlConfigStore;
 use crate::agent_control::http_server::runner::Runner;
-use crate::agent_type::embedded_registry::EmbeddedRegistry;
+use crate::agent_type::registry::embedded::EmbeddedRegistry;
 use crate::command::RunnerContext;
 use crate::data_store::DataStore;
 use crate::event::broadcaster::unbounded::UnboundedBroadcast;

--- a/agent-control/src/agent_type.rs
+++ b/agent-control/src/agent_type.rs
@@ -1,10 +1,9 @@
 pub mod agent_attributes;
 pub mod agent_type_id;
-pub mod agent_type_registry;
 pub mod definition;
-pub mod embedded_registry;
 pub mod error;
 pub mod guid_config;
+pub mod registry;
 pub mod render;
 pub mod runtime_config;
 pub mod templates;

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -14,8 +14,7 @@ use crate::agent_type::variable::constraints::VariableConstraints;
 use crate::{
     agent_control::{agent_id::AgentID, run::Environment},
     agent_type::{
-        agent_type_registry::AgentRegistry,
-        embedded_registry::EmbeddedRegistry,
+        registry::{AgentTypeRegistry, embedded::EmbeddedRegistry},
         render::{TemplateRenderer, tests::testing_agent_attributes},
         variable::{Variable, namespace::Namespace},
     },

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -18,8 +18,7 @@ pub enum AgentTypeRegistryError {
 
 /// AgentTypeRegistry stores and loads Agent types.
 pub trait AgentTypeRegistry {
-    // get returns an Agent type given a definition.
-    // TODO: evaluate if returning an owned value is needed, CoW?
+    // Returns an Agent type given a definition.
     fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
 }
 

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -1,9 +1,11 @@
+pub mod embedded;
+
 use thiserror::Error;
 
 use super::definition::AgentTypeDefinition;
 
 #[derive(Error, Debug)]
-pub enum AgentRepositoryError {
+pub enum AgentTypeRegistryError {
     #[error("agent type {0} not found")]
     NotFound(String),
     #[error("agent {0} already exists")]
@@ -14,11 +16,11 @@ pub enum AgentRepositoryError {
     ValueConversion(#[from] serde_json::Error),
 }
 
-/// AgentRegistry stores and loads Agent types.
-pub trait AgentRegistry {
+/// AgentTypeRegistry stores and loads Agent types.
+pub trait AgentTypeRegistry {
     // get returns an Agent type given a definition.
     // TODO: evaluate if returning an owned value is needed, CoW?
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentRepositoryError>;
+    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
 }
 
 #[cfg(test)]
@@ -29,14 +31,14 @@ pub mod tests {
 
     // Mock
     mock! {
-        pub AgentRegistry {}
+        pub AgentTypeRegistry {}
 
-        impl AgentRegistry for AgentRegistry  {
-            fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentRepositoryError>;
+        impl AgentTypeRegistry for AgentTypeRegistry  {
+            fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
         }
     }
 
-    impl MockAgentRegistry {
+    impl MockAgentTypeRegistry {
         pub fn should_get(&mut self, name: String, final_agent: &AgentTypeDefinition) {
             let final_agent = final_agent.clone();
             self.expect_get()
@@ -49,7 +51,7 @@ pub mod tests {
             self.expect_get()
                 .with(predicate::eq(name.clone()))
                 .once()
-                .returning(move |_| Err(AgentRepositoryError::NotFound(name.clone())));
+                .returning(move |_| Err(AgentTypeRegistryError::NotFound(name.clone())));
         }
     }
 }

--- a/agent-control/src/agent_type/registry/embedded.rs
+++ b/agent-control/src/agent_type/registry/embedded.rs
@@ -1,7 +1,5 @@
-use super::{
-    agent_type_registry::{AgentRegistry, AgentRepositoryError},
-    definition::AgentTypeDefinition,
-};
+use super::{AgentTypeRegistry, AgentTypeRegistryError};
+use crate::agent_type::definition::AgentTypeDefinition;
 use std::{collections::HashMap, fs, path::PathBuf};
 use tracing::{debug, error};
 
@@ -12,7 +10,7 @@ include!(concat!(
     env!("GENERATED_REGISTRY_FILE"), // Set in the agent-control build script
 ));
 
-/// Defines an [AgentRegistry] by keeping AgentTypeDefinitions in memory.
+/// Defines an [AgentTypeRegistry] by keeping AgentTypeDefinitions in memory.
 ///
 /// Its default implementation, loads the AgentTypeDefinitions from yaml files which are embedded into the binary
 /// at compilation time. Check out the agent-control build script for details.
@@ -25,12 +23,12 @@ impl Default for EmbeddedRegistry {
     }
 }
 
-impl AgentRegistry for EmbeddedRegistry {
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentRepositoryError> {
+impl AgentTypeRegistry for EmbeddedRegistry {
+    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
         self.0
             .get(name)
             .cloned()
-            .ok_or(AgentRepositoryError::NotFound(name.to_string()))
+            .ok_or(AgentTypeRegistryError::NotFound(name.to_string()))
     }
 }
 
@@ -54,7 +52,7 @@ impl EmbeddedRegistry {
 
     fn try_new<T: IntoIterator<Item = AgentTypeDefinition>>(
         definitions_iter: T,
-    ) -> Result<Self, AgentRepositoryError> {
+    ) -> Result<Self, AgentTypeRegistryError> {
         let mut registry = Self(HashMap::new());
         definitions_iter
             .into_iter()
@@ -62,10 +60,10 @@ impl EmbeddedRegistry {
         Ok(registry)
     }
 
-    fn insert(&mut self, definition: AgentTypeDefinition) -> Result<(), AgentRepositoryError> {
+    fn insert(&mut self, definition: AgentTypeDefinition) -> Result<(), AgentTypeRegistryError> {
         let metadata = definition.agent_type_id.to_string();
         if self.0.contains_key(&metadata) {
-            return Err(AgentRepositoryError::AlreadyExists(metadata));
+            return Err(AgentTypeRegistryError::AlreadyExists(metadata));
         }
         self.0.insert(metadata, definition);
         Ok(())
@@ -190,7 +188,7 @@ pub mod tests {
         assert_eq!(definitions[1], agent_2);
 
         let err = registry.get("not-existent").unwrap_err();
-        assert_matches!(err, AgentRepositoryError::NotFound(_));
+        assert_matches!(err, AgentTypeRegistryError::NotFound(_));
     }
 
     #[test]
@@ -205,7 +203,7 @@ pub mod tests {
         assert!(registry.insert(definition).is_ok());
 
         let err = registry.insert(duplicate).unwrap_err();
-        assert_matches!(err, AgentRepositoryError::AlreadyExists(name) => {
+        assert_matches!(err, AgentTypeRegistryError::AlreadyExists(name) => {
             assert_eq!("ns/agent:0.0.0", name);
         })
     }

--- a/agent-control/src/config_migrate/migration/converter.rs
+++ b/agent-control/src/config_migrate/migration/converter.rs
@@ -1,4 +1,4 @@
-use crate::agent_type::agent_type_registry::AgentRepositoryError;
+use crate::agent_type::registry::AgentTypeRegistryError;
 use crate::config_migrate::migration::config::{FileInfo, MappingType};
 use crate::config_migrate::migration::{
     agent_value_spec::AgentValueError,
@@ -17,7 +17,7 @@ use tracing::debug;
 #[derive(Error, Debug)]
 pub enum ConversionError {
     #[error("{0}")]
-    Repository(#[from] AgentRepositoryError),
+    Registry(#[from] AgentTypeRegistryError),
     #[error("{0}")]
     FileSystem(io::Error),
     #[error("{0}")]

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -810,7 +810,7 @@ pub mod tests {
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
     use crate::agent_type::definition::AgentTypeDefinition;
-    use crate::agent_type::embedded_registry::EmbeddedRegistry;
+    use crate::agent_type::registry::embedded::EmbeddedRegistry;
     use crate::agent_type::render::TemplateRenderer;
     use crate::agent_type::variable::constraints::VariableConstraints;
     use crate::checkers::health::health_checker::{Healthy, Unhealthy};

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -1,8 +1,8 @@
 use crate::agent_control::run::Environment;
 use crate::agent_type::agent_attributes::AgentAttributes;
-use crate::agent_type::agent_type_registry::{AgentRegistry, AgentRepositoryError};
 use crate::agent_type::definition::{AgentType, AgentTypeDefinition};
 use crate::agent_type::error::AgentTypeError;
+use crate::agent_type::registry::{AgentTypeRegistry, AgentTypeRegistryError};
 use crate::agent_type::render::TemplateRenderer;
 use crate::agent_type::runtime_config::k8s::K8s;
 use crate::agent_type::runtime_config::on_host::rendered::OnHost;
@@ -25,7 +25,7 @@ pub enum EffectiveAgentsAssemblerError {
     #[error("error assembling agents: {0}")]
     EffectiveAgentsAssemblerError(String),
     #[error("error assembling agents: {0}")]
-    RepositoryError(#[from] AgentRepositoryError),
+    Registry(#[from] AgentTypeRegistryError),
     #[error("error assembling agents: {0}")]
     SerializationError(#[from] serde_saphyr::Error),
     #[error("error assembling agents: {0}")]
@@ -117,7 +117,7 @@ pub trait EffectiveAgentsAssembler {
 }
 
 /// Implements [EffectiveAgentsAssembler] and is responsible for:
-/// - Getting [AgentType] from [AgentRegistry]
+/// - Getting [AgentType] from [AgentTypeRegistry]
 /// - Getting Local or Remote configs from [ConfigRepository]
 /// - Rendering the [Runtime] configuration of an Agent
 ///
@@ -125,7 +125,7 @@ pub trait EffectiveAgentsAssembler {
 /// or removing configs when the Runtime is [Renderer].
 pub struct LocalEffectiveAgentsAssembler<R>
 where
-    R: AgentRegistry,
+    R: AgentTypeRegistry,
 {
     registry: Arc<R>,
     renderer: TemplateRenderer,
@@ -136,7 +136,7 @@ where
 
 impl<R> LocalEffectiveAgentsAssembler<R>
 where
-    R: AgentRegistry,
+    R: AgentTypeRegistry,
 {
     pub fn new(
         registry: Arc<R>,
@@ -157,7 +157,7 @@ where
 
 impl<R> EffectiveAgentsAssembler for LocalEffectiveAgentsAssembler<R>
 where
-    R: AgentRegistry,
+    R: AgentTypeRegistry,
 {
     fn assemble_agent(
         &self,
@@ -262,8 +262,8 @@ pub(crate) mod tests {
     use super::*;
     use crate::agent_control::{agent_id::AgentID, run::on_host::AGENT_CONTROL_MODE_ON_HOST};
     use crate::agent_type::agent_type_id::AgentTypeID;
-    use crate::agent_type::agent_type_registry::tests::MockAgentRegistry;
     use crate::agent_type::definition::AgentTypeDefinition;
+    use crate::agent_type::registry::tests::MockAgentTypeRegistry;
     use crate::values::yaml_config::YAMLConfig;
     use assert_matches::assert_matches;
     use mockall::mock;
@@ -284,7 +284,7 @@ pub(crate) mod tests {
 
     impl<R> LocalEffectiveAgentsAssembler<R>
     where
-        R: AgentRegistry,
+        R: AgentTypeRegistry,
     {
         pub fn new_for_testing(registry: R) -> Self {
             Self {
@@ -300,7 +300,7 @@ pub(crate) mod tests {
     #[test]
     fn test_assemble_agents() {
         // Mocks
-        let mut registry = MockAgentRegistry::new();
+        let mut registry = MockAgentTypeRegistry::new();
 
         // Objects
         let agent_identity = AgentIdentity::from((
@@ -326,7 +326,7 @@ pub(crate) mod tests {
     #[test]
     fn test_assemble_agents_error_on_registry() {
         //Mocks
-        let mut registry = MockAgentRegistry::new();
+        let mut registry = MockAgentTypeRegistry::new();
 
         // Objects
         let agent_identity = AgentIdentity::from((


### PR DESCRIPTION
This PR refactors the code handling the Agent Type registry by moving it to its own `registry` module under `agent_type`. It also renames some structs to make them consistent:
- `AgentRegistry` --> `AgentTypeRegistry`
- `AgentRepositoryError` --> `AgentTypeRepositoryError`

The purpose of this refactor is making room for new registry implementations without growing the current flat `agent_type` module further.
