### PR TITLE
feat: extend agent-type-registry trait [NR-568043]

### DIFF
--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -39,14 +39,12 @@ impl<R: AgentTypeRegistry> DynamicConfigValidator for RegistryDynamicConfigValid
             .agents
             .values()
             .try_for_each(|sub_agent_cfg| {
-                let _ = self
-                    .agent_type_registry
-                    .get(sub_agent_cfg.agent_type.to_string().as_str())
-                    .map_err(|err| {
-                        DynamicConfigValidatorError(format!(
-                            "AgentType registry check failed: {err}"
-                        ))
-                    })?;
+                let agent_type = sub_agent_cfg.agent_type.to_string();
+                if !self.agent_type_registry.contains(&agent_type) {
+                    return Err(DynamicConfigValidatorError(format!(
+                        "AgentType registry check failed: agent type {agent_type} not found"
+                    )));
+                }
                 Ok(())
             })
     }
@@ -55,7 +53,6 @@ impl<R: AgentTypeRegistry> DynamicConfigValidator for RegistryDynamicConfigValid
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::agent_type::definition::AgentTypeDefinition;
     use crate::agent_type::registry::tests::MockAgentTypeRegistry;
     use mockall::mock;
 
@@ -93,11 +90,8 @@ pub mod tests {
     fn test_existing_agent_type_validation() {
         let mut registry = MockAgentTypeRegistry::new();
 
-        let agent_type_definition =
-            AgentTypeDefinition::empty_with_metadata("ns/name:0.0.1".try_into().unwrap());
-
         //Expectations
-        registry.should_get("ns/name:0.0.1".to_string(), &agent_type_definition);
+        registry.should_contain("ns/name:0.0.1".to_string());
 
         let dynamic_config = serde_saphyr::from_str::<AgentControlDynamicConfig>(
             r#"
@@ -115,7 +109,7 @@ agents:
     #[test]
     fn test_non_existing_agent_type_validation() {
         let mut registry = MockAgentTypeRegistry::new();
-        registry.should_not_get("ns/another:0.0.1".to_string());
+        registry.should_not_contain("ns/another:0.0.1".to_string());
 
         let dynamic_config = serde_saphyr::from_str::<AgentControlDynamicConfig>(
             r#"

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -660,7 +660,7 @@ fn all_agent_type_definitions_are_present() {
     let registry = EmbeddedRegistry::default();
     for case in get_agent_type_test_cases() {
         assert!(
-            registry.get(case.agent_type).is_ok(),
+            registry.contains(case.agent_type),
             "Agent type {} not found",
             case.agent_type
         );

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -18,8 +18,11 @@ pub enum AgentTypeRegistryError {
 
 /// AgentTypeRegistry stores and loads Agent types.
 pub trait AgentTypeRegistry {
-    // Returns an Agent type given a definition.
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+    /// Returns an Agent type given a definition.
+    fn get(&self, agent_type_id: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+
+    /// Returns true if the registry has an Agent type for the given id.
+    fn contains(&self, agent_type_id: &str) -> bool;
 }
 
 #[cfg(test)]
@@ -33,24 +36,39 @@ pub mod tests {
         pub AgentTypeRegistry {}
 
         impl AgentTypeRegistry for AgentTypeRegistry  {
-            fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+            fn get(&self, agent_type_id: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+            fn contains(&self, agent_type_id: &str) -> bool;
         }
     }
 
     impl MockAgentTypeRegistry {
-        pub fn should_get(&mut self, name: String, final_agent: &AgentTypeDefinition) {
+        pub fn should_get(&mut self, agent_type_id: String, final_agent: &AgentTypeDefinition) {
             let final_agent = final_agent.clone();
             self.expect_get()
-                .with(predicate::eq(name.clone()))
+                .with(predicate::eq(agent_type_id))
                 .once()
                 .returning(move |_| Ok(final_agent.clone()));
         }
 
-        pub fn should_not_get(&mut self, name: String) {
+        pub fn should_not_get(&mut self, agent_type_id: String) {
             self.expect_get()
-                .with(predicate::eq(name.clone()))
+                .with(predicate::eq(agent_type_id.clone()))
                 .once()
-                .returning(move |_| Err(AgentTypeRegistryError::NotFound(name.clone())));
+                .returning(move |_| Err(AgentTypeRegistryError::NotFound(agent_type_id.clone())));
+        }
+
+        pub fn should_contain(&mut self, agent_type_id: String) {
+            self.expect_contains()
+                .with(predicate::eq(agent_type_id))
+                .once()
+                .returning(|_| true);
+        }
+
+        pub fn should_not_contain(&mut self, agent_type_id: String) {
+            self.expect_contains()
+                .with(predicate::eq(agent_type_id))
+                .once()
+                .returning(|_| false);
         }
     }
 }

--- a/agent-control/src/agent_type/registry/embedded.rs
+++ b/agent-control/src/agent_type/registry/embedded.rs
@@ -24,11 +24,15 @@ impl Default for EmbeddedRegistry {
 }
 
 impl AgentTypeRegistry for EmbeddedRegistry {
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
+    fn get(&self, agent_type_id: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
         self.0
-            .get(name)
+            .get(agent_type_id)
             .cloned()
-            .ok_or(AgentTypeRegistryError::NotFound(name.to_string()))
+            .ok_or(AgentTypeRegistryError::NotFound(agent_type_id.to_string()))
+    }
+
+    fn contains(&self, agent_type_id: &str) -> bool {
+        self.0.contains_key(agent_type_id)
     }
 }
 
@@ -189,6 +193,18 @@ pub mod tests {
 
         let err = registry.get("not-existent").unwrap_err();
         assert_matches!(err, AgentTypeRegistryError::NotFound(_));
+    }
+
+    #[test]
+    fn test_contains() {
+        let definitions = vec![AgentTypeDefinition::empty_with_metadata(
+            AgentTypeID::try_from("ns/agent-1:0.0.0").unwrap(),
+        )];
+
+        let registry = EmbeddedRegistry::try_new(definitions).unwrap();
+
+        assert!(registry.contains("ns/agent-1:0.0.0"));
+        assert!(!registry.contains("ns/non-existent:0.0.0"));
     }
 
     #[test]


### PR DESCRIPTION
The `RegistryDynamicConfigValidator` only needs to verify that a given agent type id exists in the registry, but it was forced to call `AgentTypeRegistry::get`, which returns (and clones) the full AgentTypeDefinition only for the result to be discarded. 

This PR adds an explicit `contains` method to the trait so callers that just need an existence check don't pay the cost of cloning the definition unnecessarily.