### PR TITLE
feat: add DaemonSet health-check on pipeline-control-gateway Agent Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+
+- Add DaemonSet health-check in pipeline-control-gateway-config Agent Type
+
 ## v1.15.1 - 2026-05-26
 
 ### 🐞 Bug fixes

--- a/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/pipeline-control-gateway-config-0.1.0.yaml
@@ -19,16 +19,28 @@ variables:
       type: string
       required: false
       default: "pipeline-control-gateway"
+    daemonset_name:
+      description: "Name of the pipeline control daemonset for health-checks (used when PCG is deployed as a DaemonSet via daemonset.enabled=true)"
+      type: string
+      required: false
+      default: "pipeline-control-gateway-daemonset"
 
 deployment:
   k8s:
     health:
       interval: 30s
       initial_delay: 15s
+      # Both checks coexist: PCG's chart renders either a Deployment or a DaemonSet (mutually
+      # exclusive via daemonset.enabled). The unused workload simply isn't found by name and the
+      # corresponding check is treated as healthy, so the agent reports healthy in both modes.
       checks:
         - namespace: ${nr-ac:namespace_agents}
           name: ${nr-var:deployment_name}
           kind: Deployment
+          target_namespace: ${nr-ac:namespace_agents}
+        - namespace: ${nr-ac:namespace_agents}
+          name: ${nr-var:daemonset_name}
+          kind: DaemonSet
           target_namespace: ${nr-ac:namespace_agents}
     objects:
       config:


### PR DESCRIPTION
This PR adds an additional check in pipeline-control-gateway health-checker for scenarios where PCG is deployed as a DaemonSet.