### PR TITLE
chore: agent type id type enforcement on registry

### DIFF
--- a/agent-control/src/agent_control/config_validator.rs
+++ b/agent-control/src/agent_control/config_validator.rs
@@ -41,7 +41,7 @@ impl<R: AgentTypeRegistry> DynamicConfigValidator for RegistryDynamicConfigValid
             .try_for_each(|sub_agent_cfg| {
                 let _ = self
                     .agent_type_registry
-                    .get(sub_agent_cfg.agent_type.to_string().as_str())
+                    .get(&sub_agent_cfg.agent_type)
                     .map_err(|err| {
                         DynamicConfigValidatorError(format!(
                             "AgentType registry check failed: {err}"
@@ -55,6 +55,7 @@ impl<R: AgentTypeRegistry> DynamicConfigValidator for RegistryDynamicConfigValid
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::agent_type::definition::AgentTypeDefinition;
     use crate::agent_type::registry::tests::MockAgentTypeRegistry;
     use mockall::mock;
@@ -97,7 +98,10 @@ pub mod tests {
             AgentTypeDefinition::empty_with_metadata("ns/name:0.0.1".try_into().unwrap());
 
         //Expectations
-        registry.should_get("ns/name:0.0.1".to_string(), &agent_type_definition);
+        registry.should_get(
+            AgentTypeID::try_from("ns/name:0.0.1").unwrap(),
+            &agent_type_definition,
+        );
 
         let dynamic_config = serde_saphyr::from_str::<AgentControlDynamicConfig>(
             r#"
@@ -115,7 +119,7 @@ agents:
     #[test]
     fn test_non_existing_agent_type_validation() {
         let mut registry = MockAgentTypeRegistry::new();
-        registry.should_not_get("ns/another:0.0.1".to_string());
+        registry.expect_get_not_found(AgentTypeID::try_from("ns/another:0.0.1").unwrap());
 
         let dynamic_config = serde_saphyr::from_str::<AgentControlDynamicConfig>(
             r#"

--- a/agent-control/src/agent_type/agent_type_id.rs
+++ b/agent-control/src/agent_type/agent_type_id.rs
@@ -18,7 +18,7 @@ pub enum AgentTypeIDError {
 
 /// Holds agent type metadata that uniquely identifies an agent type.
 /// Data can be represented as a fully qualified name in the format `<namespace>/<name>:<version>`.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct AgentTypeID {
     name: String,
     namespace: String,

--- a/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/definition/agent_type_validation_tests.rs
@@ -14,6 +14,7 @@ use crate::agent_type::variable::constraints::VariableConstraints;
 use crate::{
     agent_control::{agent_id::AgentID, run::Environment},
     agent_type::{
+        agent_type_id::AgentTypeID,
         registry::{AgentTypeRegistry, embedded::EmbeddedRegistry},
         render::{TemplateRenderer, tests::testing_agent_attributes},
         variable::{Variable, namespace::Namespace},
@@ -656,7 +657,9 @@ fn all_agent_type_definitions_are_present() {
     let registry = EmbeddedRegistry::default();
     for case in get_agent_type_test_cases() {
         assert!(
-            registry.get(case.agent_type).is_ok(),
+            registry
+                .get(&AgentTypeID::try_from(case.agent_type).unwrap())
+                .is_ok(),
             "Agent type {} not found",
             case.agent_type
         );
@@ -744,7 +747,9 @@ fn iterate_test_cases(environment: &Environment) {
         };
 
         values.cases.iter().for_each(|(scenario, yaml)| {
-            let definition = registry.get(case.agent_type).unwrap();
+            let definition = registry
+                .get(&AgentTypeID::try_from(case.agent_type).unwrap())
+                .unwrap();
             let agent_type =
                 build_agent_type(definition, environment, &VariableConstraints::default());
             let attributes = testing_agent_attributes(&agent_id);

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -17,9 +17,9 @@ pub enum AgentTypeRegistryError {
     ValueConversion(#[from] serde_json::Error),
 }
 
-/// Returns the corresponding [AgentTypeDefinition] given an [AgentTypeID].
+/// Defines how to return an [AgentTypeDefinition] given an identifier.
 pub trait AgentTypeRegistry {
-    // Returns an Agent type given its id.
+    /// Returns an Agent type given its id.
     fn get(
         &self,
         agent_type_id: &AgentTypeID,

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -2,6 +2,7 @@ pub mod embedded;
 
 use thiserror::Error;
 
+use super::agent_type_id::AgentTypeID;
 use super::definition::AgentTypeDefinition;
 
 #[derive(Error, Debug)]
@@ -16,10 +17,13 @@ pub enum AgentTypeRegistryError {
     ValueConversion(#[from] serde_json::Error),
 }
 
-/// AgentTypeRegistry stores and loads Agent types.
+/// Returns the corresponding [AgentTypeDefinition] given an [AgentTypeID].
 pub trait AgentTypeRegistry {
-    // Returns an Agent type given a definition.
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+    // Returns an Agent type given its id.
+    fn get(
+        &self,
+        agent_type_id: &AgentTypeID,
+    ) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
 }
 
 #[cfg(test)]
@@ -33,24 +37,29 @@ pub mod tests {
         pub AgentTypeRegistry {}
 
         impl AgentTypeRegistry for AgentTypeRegistry  {
-            fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
+            fn get(&self, agent_type_id: &AgentTypeID) -> Result<AgentTypeDefinition, AgentTypeRegistryError>;
         }
     }
 
     impl MockAgentTypeRegistry {
-        pub fn should_get(&mut self, name: String, final_agent: &AgentTypeDefinition) {
+        pub fn should_get(
+            &mut self,
+            agent_type_id: AgentTypeID,
+            final_agent: &AgentTypeDefinition,
+        ) {
             let final_agent = final_agent.clone();
             self.expect_get()
-                .with(predicate::eq(name.clone()))
+                .with(predicate::eq(agent_type_id))
                 .once()
                 .returning(move |_| Ok(final_agent.clone()));
         }
 
-        pub fn should_not_get(&mut self, name: String) {
+        pub fn expect_get_not_found(&mut self, agent_type_id: AgentTypeID) {
+            let fqn = agent_type_id.to_string();
             self.expect_get()
-                .with(predicate::eq(name.clone()))
+                .with(predicate::eq(agent_type_id))
                 .once()
-                .returning(move |_| Err(AgentTypeRegistryError::NotFound(name.clone())));
+                .returning(move |_| Err(AgentTypeRegistryError::NotFound(fqn.clone())));
         }
     }
 }

--- a/agent-control/src/agent_type/registry/embedded.rs
+++ b/agent-control/src/agent_type/registry/embedded.rs
@@ -1,4 +1,5 @@
 use super::{AgentTypeRegistry, AgentTypeRegistryError};
+use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::agent_type::definition::AgentTypeDefinition;
 use std::{collections::HashMap, fs, path::PathBuf};
 use tracing::{debug, error};
@@ -24,11 +25,15 @@ impl Default for EmbeddedRegistry {
 }
 
 impl AgentTypeRegistry for EmbeddedRegistry {
-    fn get(&self, name: &str) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
+    fn get(
+        &self,
+        agent_type_id: &AgentTypeID,
+    ) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
+        let fqn = agent_type_id.to_string();
         self.0
-            .get(name)
+            .get(&fqn)
             .cloned()
-            .ok_or(AgentTypeRegistryError::NotFound(name.to_string()))
+            .ok_or(AgentTypeRegistryError::NotFound(fqn))
     }
 }
 
@@ -182,12 +187,18 @@ pub mod tests {
 
         let registry = EmbeddedRegistry::try_new(definitions.clone()).unwrap();
 
-        let agent_1 = registry.get("ns/agent-1:0.0.0").unwrap();
+        let agent_1 = registry
+            .get(&AgentTypeID::try_from("ns/agent-1:0.0.0").unwrap())
+            .unwrap();
         assert_eq!(definitions[0], agent_1);
-        let agent_2 = registry.get("ns/agent-2:0.0.0").unwrap();
+        let agent_2 = registry
+            .get(&AgentTypeID::try_from("ns/agent-2:0.0.0").unwrap())
+            .unwrap();
         assert_eq!(definitions[1], agent_2);
 
-        let err = registry.get("not-existent").unwrap_err();
+        let err = registry
+            .get(&AgentTypeID::try_from("ns/not-existent:0.0.0").unwrap())
+            .unwrap_err();
         assert_matches!(err, AgentTypeRegistryError::NotFound(_));
     }
 
@@ -287,12 +298,17 @@ deployment:
 
         let registry = EmbeddedRegistry::new(path.to_path_buf());
 
-        let variables = registry.get("ns/io.test:0.0.0").unwrap().variables.k8s.0;
+        let variables = registry
+            .get(&AgentTypeID::try_from("ns/io.test:0.0.0").unwrap())
+            .unwrap()
+            .variables
+            .k8s
+            .0;
         assert!(!variables.contains_key("version"));
         assert!(variables.contains_key("different"));
         assert!(
             registry
-                .get("newrelic/com.newrelic.infrastructure:0.1.0")
+                .get(&AgentTypeID::try_from("newrelic/com.newrelic.infrastructure:0.1.0").unwrap())
                 .unwrap()
                 .variables
                 .k8s

--- a/agent-control/src/agent_type/registry/embedded.rs
+++ b/agent-control/src/agent_type/registry/embedded.rs
@@ -16,7 +16,7 @@ include!(concat!(
 /// Its default implementation, loads the AgentTypeDefinitions from yaml files which are embedded into the binary
 /// at compilation time. Check out the agent-control build script for details.
 #[derive(Debug)]
-pub struct EmbeddedRegistry(HashMap<String, AgentTypeDefinition>);
+pub struct EmbeddedRegistry(HashMap<AgentTypeID, AgentTypeDefinition>);
 
 impl Default for EmbeddedRegistry {
     fn default() -> Self {
@@ -29,11 +29,10 @@ impl AgentTypeRegistry for EmbeddedRegistry {
         &self,
         agent_type_id: &AgentTypeID,
     ) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
-        let fqn = agent_type_id.to_string();
         self.0
-            .get(&fqn)
+            .get(agent_type_id)
             .cloned()
-            .ok_or(AgentTypeRegistryError::NotFound(fqn))
+            .ok_or_else(|| AgentTypeRegistryError::NotFound(agent_type_id.to_string()))
     }
 }
 
@@ -48,9 +47,9 @@ impl EmbeddedRegistry {
         Self::dynamic_agent_type(dynamic_agent_type_path)
             .iter()
             .for_each(|agent_type| {
-                let metadata = agent_type.agent_type_id.to_string();
-                debug!("Storing dynamic agent type: {}", metadata);
-                registry.0.insert(metadata, agent_type.clone());
+                let id = agent_type.agent_type_id.clone();
+                debug!("Storing dynamic agent type: {}", id);
+                registry.0.insert(id, agent_type.clone());
             });
         registry
     }
@@ -66,11 +65,11 @@ impl EmbeddedRegistry {
     }
 
     fn insert(&mut self, definition: AgentTypeDefinition) -> Result<(), AgentTypeRegistryError> {
-        let metadata = definition.agent_type_id.to_string();
-        if self.0.contains_key(&metadata) {
-            return Err(AgentTypeRegistryError::AlreadyExists(metadata));
+        let id = definition.agent_type_id.clone();
+        if self.0.contains_key(&id) {
+            return Err(AgentTypeRegistryError::AlreadyExists(id.to_string()));
         }
-        self.0.insert(metadata, definition);
+        self.0.insert(id, definition);
         Ok(())
     }
 
@@ -161,9 +160,9 @@ pub mod tests {
             "expected one AgentTypeDefinition for each file"
         );
 
-        // The expected key for each definition should be the metadata string
+        // The key for each definition should be its agent type id
         for (key, definition) in registry.0.iter() {
-            assert_eq!(key.to_string(), definition.agent_type_id.to_string())
+            assert_eq!(key, &definition.agent_type_id)
         }
 
         let registry_nonexistent_dynamic =

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -158,9 +158,7 @@ where
         environment: &Environment,
     ) -> Result<EffectiveAgent, EffectiveAgentsAssemblerError> {
         // Load the agent type definition
-        let agent_type_definition = self
-            .registry
-            .get(&agent_identity.agent_type_id.to_string())?;
+        let agent_type_definition = self.registry.get(&agent_identity.agent_type_id)?;
         // Build the corresponding agent type
         let agent_type = build_agent_type(
             agent_type_definition,
@@ -293,7 +291,10 @@ pub(crate) mod tests {
         let values = YAMLConfig::default();
 
         //Expectations
-        registry.should_get("ns/name:0.0.1".to_string(), &agent_type_definition);
+        registry.should_get(
+            AgentTypeID::try_from("ns/name:0.0.1").unwrap(),
+            &agent_type_definition,
+        );
 
         let assembler = LocalEffectiveAgentsAssembler::new_for_testing(registry);
 
@@ -316,7 +317,7 @@ pub(crate) mod tests {
         ));
 
         //Expectations
-        registry.should_not_get("namespace/name:0.0.1".to_string());
+        registry.expect_get_not_found(AgentTypeID::try_from("namespace/name:0.0.1").unwrap());
         let assembler = LocalEffectiveAgentsAssembler::new_for_testing(registry);
 
         let result = assembler.assemble_agent(


### PR DESCRIPTION
The `AgentTypeRegistry` trait keyed lookups on a `&str` (the stringified fully-qualified name, e.g. `"ns/name:0.0.1"`). Every caller had to call .to_string() on an AgentTypeID it already held, only for the registry to use that string as a HashMap key. This is a stringly-typed seam in an otherwise typed path: nothing prevented passing an arbitrary, malformed string, and the round-trip through String was pure boilerplate.

This PR pushes the `AgentTypeID` type all the way through the registry, so the type system enforces that lookups are done with a valid, parsed identifier rather than a free-form string.