### PR TITLE
feat: add agent-type registry remote config [NR-568046]

### DIFF
--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -89,7 +89,7 @@ pub struct AgentControlConfig {
     /// Configuration for the agent type registry remote source.
     /// Reuses the global `oci` registry/auth; see [AgentTypeRegistryConfig].
     #[serde(default)]
-    pub agent_types: AgentTypeRegistryConfig,
+    pub agent_types: AgentTypeConfig,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
@@ -210,7 +210,7 @@ pub struct SignatureVerificationEnabled(bool);
 /// Configuration for the agent type registry's remote source(s).
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 #[serde(default)]
-pub struct AgentTypeRegistryConfig {
+pub struct AgentTypeConfig {
     /// The default (New Relic) remote source for agent types.
     pub default_remote: DefaultAgentTypeRemote,
 }
@@ -1383,7 +1383,7 @@ oci:
 
     #[test]
     fn test_agent_types_default_when_block_or_subfields_omitted() {
-        let expected = AgentTypeRegistryConfig::default();
+        let expected = AgentTypeConfig::default();
         for config_input in [
             "agents: {}",                                     // agent_types omitted entirely
             "agents: {}\nagent_types: {}",                    // empty agent_types block

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -2,8 +2,8 @@ use super::agent_id::AgentID;
 use super::http_server::config::ServerConfig;
 use super::uptime_report::UptimeReportConfig;
 use crate::agent_control::defaults::{
-    AC_OCI_PACKAGE_DEFAULT_REGISTRY, AC_OCI_PACKAGE_DEFAULT_REPOSITORY,
-    AC_OCI_PACKAGE_PUBLIC_KEY_URL,
+    AC_OCI_AGENT_TYPES_DEFAULT_REPOSITORY, AC_OCI_AGENT_TYPES_PUBLIC_KEY_URL,
+    AC_OCI_DEFAULT_REGISTRY, AC_OCI_PACKAGE_DEFAULT_REPOSITORY, AC_OCI_PACKAGE_PUBLIC_KEY_URL,
 };
 use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
 use crate::agent_type::runtime_config::on_host::package::rendered::{Repository, Version};
@@ -85,6 +85,11 @@ pub struct AgentControlConfig {
     /// Oci configuration (used for AC and agents packages)
     #[serde(default)]
     pub oci: OciConfig,
+
+    /// Configuration for the agent type registry remote source.
+    /// Reuses the global `oci` registry/auth; see [AgentTypeRegistryConfig].
+    #[serde(default)]
+    pub agent_types: AgentTypeRegistryConfig,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
@@ -125,7 +130,7 @@ pub struct Registry(String);
 
 impl Default for Registry {
     fn default() -> Self {
-        Registry(AC_OCI_PACKAGE_DEFAULT_REGISTRY.to_string())
+        Registry(AC_OCI_DEFAULT_REGISTRY.to_string())
     }
 }
 
@@ -201,6 +206,42 @@ const DEFAULT_SIGNATURE_VERIFICATION_ENABLED: bool = true;
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_SIGNATURE_VERIFICATION_ENABLED)]
 pub struct SignatureVerificationEnabled(bool);
+
+/// Configuration for the agent type registry's remote source(s).
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
+#[serde(default)]
+pub struct AgentTypeRegistryConfig {
+    /// The default (New Relic) remote source for agent types.
+    pub default_remote: DefaultAgentTypeRemote,
+}
+
+/// The default remote agent type source.
+///
+/// It reuses the global `oci.registry`/`oci.auth` (see [OciConfig]); it does not carry its own
+/// registry or auth. It only specifies the repository to pull agent types from, whether to
+/// verify their signature, and the signing key.
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(default)]
+pub struct DefaultAgentTypeRemote {
+    /// Repository (within the global OCI registry) holding the agent type definitions
+    pub repository: Repository,
+    /// Indicates whether agent type signature verification is enabled or not
+    pub signature_verification_enabled: SignatureVerificationEnabled,
+    /// Public key url (jwks) used to verify agent type signatures
+    pub public_key_url: Url,
+}
+
+impl Default for DefaultAgentTypeRemote {
+    fn default() -> Self {
+        DefaultAgentTypeRemote {
+            repository: Repository::from_str(AC_OCI_AGENT_TYPES_DEFAULT_REPOSITORY)
+                .expect("valid default agent types repository"),
+            signature_verification_enabled: SignatureVerificationEnabled::default(),
+            public_key_url: Url::parse(AC_OCI_AGENT_TYPES_PUBLIC_KEY_URL)
+                .expect("valid default agent types public key url"),
+        }
+    }
+}
 
 impl TryFrom<YAMLConfig> for AgentControlConfig {
     type Error = AgentControlConfigError;
@@ -1324,6 +1365,99 @@ oci:
 "#;
         let config = serde_saphyr::from_str::<AgentControlConfig>(config_input).unwrap();
         assert_eq!("custom-registry.io".to_string(), config.oci.registry.0);
+    }
+
+    #[test]
+    fn test_agent_type_registry_default_values() {
+        let default_remote = DefaultAgentTypeRemote::default();
+        assert_eq!(
+            AC_OCI_AGENT_TYPES_DEFAULT_REPOSITORY,
+            default_remote.repository.to_string()
+        );
+        assert!(default_remote.signature_verification_enabled.0);
+        assert_eq!(
+            AC_OCI_AGENT_TYPES_PUBLIC_KEY_URL,
+            default_remote.public_key_url.as_str()
+        );
+    }
+
+    #[test]
+    fn test_agent_types_default_when_block_or_subfields_omitted() {
+        let expected = AgentTypeRegistryConfig::default();
+        for config_input in [
+            "agents: {}",                                     // agent_types omitted entirely
+            "agents: {}\nagent_types: {}",                    // empty agent_types block
+            "agents: {}\nagent_types:\n  default_remote: {}", // empty default_remote block
+        ] {
+            let config = serde_saphyr::from_str::<AgentControlConfig>(config_input).unwrap();
+            assert_eq!(expected, config.agent_types);
+        }
+    }
+
+    #[test]
+    fn test_agent_types_partial_override_keeps_defaults() {
+        let config_input = r#"
+agents: {}
+agent_types:
+  default_remote:
+    repository: myorg/my-agent-types
+"#;
+        let config = serde_saphyr::from_str::<AgentControlConfig>(config_input).unwrap();
+        let default_remote = config.agent_types.default_remote;
+        // Overridden field.
+        assert_eq!(
+            "myorg/my-agent-types",
+            default_remote.repository.to_string()
+        );
+        // Untouched fields stay at default.
+        assert!(default_remote.signature_verification_enabled.0);
+        assert_eq!(
+            AC_OCI_AGENT_TYPES_PUBLIC_KEY_URL,
+            default_remote.public_key_url.as_str()
+        );
+    }
+
+    #[test]
+    fn test_agent_types_full_override() {
+        let config_input = r#"
+agents: {}
+agent_types:
+  default_remote:
+    repository: myorg/my-agent-types
+    signature_verification_enabled: false
+    public_key_url: https://example.com/jwks.json
+"#;
+        let config = serde_saphyr::from_str::<AgentControlConfig>(config_input).unwrap();
+        let default_remote = config.agent_types.default_remote;
+        assert_eq!(
+            "myorg/my-agent-types",
+            default_remote.repository.to_string()
+        );
+        assert!(!default_remote.signature_verification_enabled.0);
+        assert_eq!(
+            "https://example.com/jwks.json",
+            default_remote.public_key_url.as_str()
+        );
+    }
+
+    #[test]
+    fn test_agent_types_tolerates_unknown_future_fields() {
+        // A `custom_remotes` sibling is not implemented yet; an older binary must still parse a
+        // config that includes it (forward compatibility), populating the known `default_remote`.
+        let config_input = r#"
+agents: {}
+agent_types:
+  default_remote:
+    repository: myorg/my-agent-types
+  custom_remotes:
+    - namespaces: [fake_company]
+      repository: agent-control-agent-types
+"#;
+        let config = serde_saphyr::from_str::<AgentControlConfig>(config_input).unwrap();
+        assert_eq!(
+            "myorg/my-agent-types",
+            config.agent_types.default_remote.repository.to_string()
+        );
     }
 
     ////////////////////////////////////////////////////////////////////////////////////

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -26,11 +26,17 @@ pub const OPAMP_AGENT_VERSION_ATTRIBUTE_KEY: &str = "agent.version";
 
 pub const ENVIRONMENT_VARIABLES_FILE_NAME: &str = "environment_variables.yaml";
 
-// TODO verify this whenever the package is published.
-pub const AC_OCI_PACKAGE_DEFAULT_REGISTRY: &str = "docker.io";
+// Default OCI registry host. Shared by all OCI pulls (agent packages, self-update, and the
+// agent type registry); customers override it via `oci.registry` to point at a mirror.
+pub const AC_OCI_DEFAULT_REGISTRY: &str = "docker.io";
+
 pub const AC_OCI_PACKAGE_DEFAULT_REPOSITORY: &str = "newrelic/agent-control-artifacts";
 pub const AC_OCI_PACKAGE_PUBLIC_KEY_URL: &str =
     "https://publickeys.newrelic.com/g/agent-control-oci/global/agent-control-artifacts/jwks.json";
+
+pub const AC_OCI_AGENT_TYPES_DEFAULT_REPOSITORY: &str = "newrelic/agent-control-agent-types";
+pub const AC_OCI_AGENT_TYPES_PUBLIC_KEY_URL: &str =
+    "https://publickeys.newrelic.com/g/agent-control-oci/global/agent-type/jwks.json";
 
 // Auth
 pub const AUTH_PRIVATE_KEY_FILE_NAME: &str = "auth_key";


### PR DESCRIPTION
## Summary

Introduces the `agent_types` block in the Agent Control local configuration, defining where agent type definitions are pulled from and how they are verified. This is the **configuration definition** step for remote agent types: it parses and exposes the config, reusing the existing global OCI mirror. It does **not** implement any remote-pull logic (that lands in a follow-up).

## Config shape

```yaml
agent_types:
  default_remote:
    repository: newrelic/agent-control-agent-types
    signature_verification_enabled: true
    public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/agent-type/jwks.json
```

The `default_remote` block **reuses the global `oci` mirror** (`oci.registry` + `oci.auth`) rather than re-declaring a registry/auth. A customer already mirroring packages needs no extra config for agent types.
- It only adds the agent-type-specific bits: the repository, the signature toggle, and the signing key. 
- The signature fields follow the existing package convention (`signature_verification_enabled` + `public_key_url`).

All fields default, so omitting the block (or any sub-field) yields the New Relic defaults.

## Notes for reviewers
- Renamed the `AC_OCI_PACKAGE_DEFAULT_REGISTRY` constant to `AC_OCI_DEFAULT_REGISTRY`, since it backs the shared default registry host used by packages, self-update, and now agent types.
- Keep in mind the **follow-ups** in the next section.

## Follow-ups (out of scope)

### `custom_remotes` can be added without a breaking change

The shape is intentionally nested under `default_remote` so a future `custom_remotes` list (for customer/custom-namespace agent types) can be added as a **purely additive** `#[serde(default)]` sibling. No existing field is renamed, retyped, or made required, and the struct does not use `deny_unknown_fields`, so:
- existing configs keep parsing unchanged, and
- a newer config that already includes `custom_remotes` is silently tolerated by an older binary (forward-compatible in both directions).

A future config **could** look like:

```yaml
agent_types:
  default_remote:
    repository: newrelic/agent-control-agent-types
    signature_verification_enabled: true
    public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/agent-type/jwks.json
  # NEW (additive, non-breaking): per-namespace custom sources
  custom_remotes:
    - namespaces: [fake_company]
      repository: agent-control-agent-types
      signature_verification_enabled: true
      public_key_url: https://my-company.example/keys/jwks.json
```

A test (`test_agent_types_tolerates_unknown_future_fields`) already locks in this guarantee by parsing a config that includes an unknown `custom_remotes` key.

### Per-registry override left out of scope (deliberately)

The `default_remote` block does **not** expose a `registry` field to override the OCI host per agent-type source. This was a conscious decision rather than an omission:

- **Consistency with packages:** there is currently no per-package registry override either — the registry host is global (`oci.registry`). Adding a per-source override only for agent types would diverge from how packages behave today.
- **Not a breaking change to add later:** introducing a per-registry override would itself be additive (a new optional field), so nothing here forecloses it.

> [!NOTE]
> If/when we want per-source registry overrides, we should design it **uniformly across all OCI usages** (packages *and* agent types) rather than bolting it onto agent types alone.

### This is only the config definition

- The implementation of the OCI registry will be addressed separately.
- Docs exposing the new configuration will be addes when the implementation is ready.
