### PR TITLE
feat: add new filesystem format with ephemeral and persistent folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Remember that the keywords that you can use are the following:
 - Agent type definitions now use a flat per-platform schema (one YAML file per `(platform, operating_system)` pair). 
   Agent type FQNs and configuration values are unchanged, so this is **not a breaking change** for end users.
   Internal authors of custom agent type definitions need to migrate their YAMLs — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
+- Introduced ephemeral/persistent lifecycle semantics for sub-agent filesystem directories.
+  Ephemeral directories are cleared on agent stop/restart/config updates.
+  extra tracking. Persistent directories survive config changes and are only deleted on agent removal — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
 
 ## v1.16.1 - 2026-06-04
 

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -69,11 +69,13 @@ deployment:
       - --version
     regex: \d+\.\d+\.\d+
   filesystem:
-    config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+    persistent:
+      config:
+        newrelic-infra.yaml: |
+          ${nr-var:config_agent}
+      logging.d: ${nr-var:config_logging}
+    ephemeral:
+      integrations.d: ${nr-var:config_integrations}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -62,9 +62,10 @@ deployment:
       - -v
     regex: \d+\.\d+\.\d+
   filesystem:
-    otel-config:
-      config.yaml: |
-        ${nr-var:config}
+    persistent:
+      otel-config:
+        config.yaml: |
+          ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
@@ -42,9 +42,10 @@ deployment:
       - -v
     regex: \d+\.\d+\.\d+
   filesystem:
-    otel-config:
-      config.yaml: |
-        ${nr-var:config}
+    persistent:
+      otel-config:
+        config.yaml: |
+          ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -65,13 +65,15 @@ deployment:
       - --version
     regex: \d+\.\d+\.\d+
   filesystem:
-    config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
-    # this is needed in order to create the logging integration directory expected by fluentBit
-    newrelic-infra/newrelic-integrations/logging: { }
+    persistent:
+      config:
+        newrelic-infra.yaml: |
+          ${nr-var:config_agent}
+      logging.d: ${nr-var:config_logging}
+      # this is needed in order to create the logging integration directory expected by fluentBit
+      newrelic-infra/newrelic-integrations/logging: { }
+    ephemeral:
+      integrations.d: ${nr-var:config_integrations}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -68,9 +68,10 @@ deployment:
       - -v
     regex: \d+\.\d+\.\d+
   filesystem:
-    otel-config:
-      config.yaml: |
-        ${nr-var:config}
+    persistent:
+      otel-config:
+        config.yaml: |
+          ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -1,17 +1,19 @@
+use std::path::PathBuf;
 use std::sync::Arc;
-
 use thiserror::Error;
 use tracing::{debug, instrument};
 
 use crate::agent_control::agent_id::AgentID;
+use crate::agent_control::defaults::AGENT_FILESYSTEM_FOLDER_NAME;
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::opamp::instance_id::storer::{InstanceIDStorer, StorerError};
 use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
 
 use super::{ResourceCleaner, ResourceCleanerError};
 
-/// On-host implementation of [`ResourceCleaner`] that wipes a sub-agent's fleet data by
-/// delegating to the same storers that wrote it.
+/// On-host implementation of [`ResourceCleaner`] that cleans up all agent resources:
+/// - Fleet data (instance IDs, remote config) via storers
+/// - Filesystem directories (ephemeral and persistent files)
 pub struct OnHostCleaner<S, C>
 where
     S: InstanceIDStorer,
@@ -19,6 +21,7 @@ where
 {
     instance_id_storer: Arc<S>,
     config_repo: Arc<C>,
+    remote_dir: PathBuf,
 }
 
 impl<S, C> OnHostCleaner<S, C>
@@ -26,10 +29,11 @@ where
     S: InstanceIDStorer,
     C: ConfigRepository,
 {
-    pub fn new(instance_id_storer: Arc<S>, config_repo: Arc<C>) -> Self {
+    pub fn new(instance_id_storer: Arc<S>, config_repo: Arc<C>, remote_dir: PathBuf) -> Self {
         Self {
             instance_id_storer,
             config_repo,
+            remote_dir,
         }
     }
 }
@@ -59,6 +63,23 @@ where
             .delete(agent_id)
             .map_err(OnHostCleanerError::InstanceId)?;
 
+        if let AgentID::SubAgent(id) = agent_id {
+            let agent_fs_dir = self
+                .remote_dir
+                .join(AGENT_FILESYSTEM_FOLDER_NAME)
+                .join(id.as_str());
+
+            if agent_fs_dir.exists() {
+                debug!(%agent_id, "Removing agent filesystem directory");
+                std::fs::remove_dir_all(&agent_fs_dir).map_err(|e| {
+                    ResourceCleanerError(format!(
+                        "removing agent filesystem dir {}: {e}",
+                        agent_fs_dir.display()
+                    ))
+                })?;
+            }
+        }
+
         Ok(())
     }
 }
@@ -85,17 +106,18 @@ mod tests {
     use crate::opamp::instance_id::storer::tests::MockInstanceIDStorer;
     use crate::values::config_repository::tests::MockConfigRepository;
     use mockall::predicate;
+    use tempfile::TempDir;
 
     fn agent_id(s: &str) -> AgentID {
         AgentID::try_from(s).unwrap()
     }
 
-    fn any_type_id() -> AgentTypeID {
+    fn agent_type() -> AgentTypeID {
         AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap()
     }
 
     #[test]
-    fn clean_deletes_instance_id_and_remote_config() {
+    fn clean_deletes_instance_id_remote_config_and_filesystem() {
         let id = agent_id("foo-agent");
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer
@@ -111,9 +133,31 @@ mod tests {
             .with(predicate::eq(id.clone()))
             .returning(|_| Ok(()));
 
-        let cleaner = OnHostCleaner::new(Arc::new(instance_id_storer), Arc::new(config_repo));
+        // Setup filesystem
+        let tmp = TempDir::new().unwrap();
+        let remote_dir = tmp.path();
 
-        assert!(cleaner.clean(&id, &any_type_id()).is_ok());
+        let AgentID::SubAgent(ref raw_id) = id else {
+            panic!()
+        };
+        let agent_fs = remote_dir
+            .join(AGENT_FILESYSTEM_FOLDER_NAME)
+            .join(raw_id.as_str());
+
+        std::fs::create_dir_all(agent_fs.join("config")).unwrap();
+        std::fs::write(agent_fs.join("config/agent.yaml"), "key: val").unwrap();
+
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            remote_dir.to_path_buf(),
+        );
+
+        assert!(cleaner.clean(&id, &agent_type()).is_ok());
+        assert!(
+            !agent_fs.exists(),
+            "agent filesystem directory should be removed"
+        );
     }
 
     #[test]
@@ -124,10 +168,44 @@ mod tests {
         let mut config_repo = MockConfigRepository::new();
         config_repo.expect_delete_remote().never();
 
-        let cleaner = OnHostCleaner::new(Arc::new(instance_id_storer), Arc::new(config_repo));
+        let tmp = TempDir::new().unwrap();
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            tmp.path().to_path_buf(),
+        );
 
-        let result = cleaner.clean(&AgentID::AgentControl, &any_type_id());
+        let result = cleaner.clean(&AgentID::AgentControl, &agent_type());
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn clean_succeeds_when_no_filesystem_dir() {
+        let id = agent_id("foo-agent");
+
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer
+            .expect_delete()
+            .once()
+            .with(predicate::eq(id.clone()))
+            .returning(|_| Ok(()));
+
+        let mut config_repo = MockConfigRepository::new();
+        config_repo
+            .expect_delete_remote()
+            .once()
+            .with(predicate::eq(id.clone()))
+            .returning(|_| Ok(()));
+
+        let tmp = TempDir::new().unwrap();
+
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            tmp.path().to_path_buf(),
+        );
+
+        assert!(cleaner.clean(&id, &agent_type()).is_ok());
     }
 }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -111,8 +111,11 @@ impl AgentControlRunner {
         let instance_id_getter =
             InstanceIDWithIdentifiersGetter::new(instance_id_storer.clone(), identifiers.clone());
 
-        let resource_cleaner =
-            OnHostCleaner::new(instance_id_storer, yaml_config_repository.clone());
+        let resource_cleaner = OnHostCleaner::new(
+            instance_id_storer,
+            yaml_config_repository.clone(),
+            remote_dir.clone(),
+        );
 
         let proxy = self.bootstrap_config.proxy;
         let opamp_client_builder = maybe_opamp.map(|config| {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -28,28 +28,40 @@ use serde::de::Error;
 pub mod rendered;
 
 /// Represents the file system configuration for the deployment of a host agent. Consisting of
-/// a set of directories (map keys) which in turn contain a set of files (nested map keys) with
-/// their respective content (map values).
+/// two sections — `ephemeral` and `persistent` — each mapping directory paths (keys) to their
+/// file entries (values).
+///
+/// Directories under `ephemeral` are deleted when the agent is stopped, removed or restarted.
+/// Directories under `persistent` are only deleted if the agent is removed.
 ///
 /// It would be equivalent to a YAML mapping of this format:
 /// ```yaml
 /// filesystem:
-///   "path/to/my-dir":
-///      # YAML content, expected to be a mapping string -> yaml
-///      filepath1: "file1 content"
-///      filepath2: | # multi-line string content
-///        key: value
-///   # fully templated content, expected to render to a valid YAML mapping string -> string
-///   "another/path/to/my-dir": ${nr-var:some_var_that_renders_to_a_yaml_mapping}
+///   ephemeral:
+///     "path/to/my-dir":
+///        # YAML content, expected to be a mapping string -> yaml
+///        filepath1: "file1 content"
+///        filepath2: | # multi-line string content
+///          key: value
+///   persistent:
+///     # fully templated content, expected to render to a valid YAML mapping string -> string
+///     "another/path/to/my-dir": ${nr-var:some_var_that_renders_to_a_yaml_mapping}
 /// ```
 ///
 /// The files can be hardcoded, with the contents possibly containing templates, or the whole set of
 /// files can be templated so a directory contains an arbitrary number of files (a place to use a
 /// `map[string]yaml` variable type). **The paths cannot be templated.**
 ///
-/// See [`AgentDirectoryEntry`] and [`DirEntriesType`] for more details.
+/// See [`DirEntriesType`] for more details.
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
-pub struct FileSystem(HashMap<SafePath, DirEntriesType>);
+pub struct FileSystem {
+    /// Directories that are deleted when the agent is stopped, removed or restarted.
+    #[serde(default)]
+    pub(crate) ephemeral: HashMap<SafePath, DirEntriesType>,
+    /// Directories that are only deleted if the agent is removed.
+    #[serde(default)]
+    pub(crate) persistent: HashMap<SafePath, DirEntriesType>,
+}
 
 /// A path to a file or directory that has been validated to be "safe",
 /// i.e. relative and not escaping its base directory (e.g. with parent dir specifiers like `..`).
@@ -92,7 +104,7 @@ impl From<SafePath> for PathBuf {
 ///      a placeholder for later rendering.
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
-enum DirEntriesType {
+pub(crate) enum DirEntriesType {
     /// A directory with a fixed set of entries (i.e. files). Each entry's content can be templated.
     /// E.g.
     /// ```yaml
@@ -134,21 +146,26 @@ impl Templateable for FileSystem {
             )
             .and_then(Variable::get_final_value)
         {
-            let filesystem = self
-                .0
-                .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        // The only place where we construct a `SafePath` directly, prepending the
-                        // sub-agent's filesystem directory to the user-provided relative path.
-                        // FIXME: when we fix the templating and make the agent type definitions
-                        // type-safe, we will make sure to always build correct "final paths" here.
-                        SafePath(PathBuf::from(filesystem_dir.clone()).join(k)),
-                        v.template_with(variables)?,
-                    ))
-                })
-                .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-            Ok(rendered::FileSystem(filesystem))
+            let filesystem_dir_path = PathBuf::from(filesystem_dir.clone());
+
+            // The only place where we construct a `SafePath` directly, prepending the
+            // sub-agent's filesystem directory to the user-provided relative path.
+            // FIXME: when we fix the templating and make the agent type definitions
+            // type-safe, we will make sure to always build correct "final paths" here.
+            let template_map =
+                |map: HashMap<SafePath, DirEntriesType>| -> Result<HashMap<SafePath, _>, AgentTypeError> {
+                    map.into_iter()
+                        .map(|(k, v)| {
+                            Ok((SafePath(filesystem_dir_path.join(k)), v.template_with(variables)?))
+                        })
+                        .collect()
+                };
+
+            Ok(rendered::FileSystem {
+                ephemeral: template_map(self.ephemeral)?,
+                persistent: template_map(self.persistent)?,
+                filesystem_dir: filesystem_dir_path,
+            })
         } else {
             Err(AgentTypeError::MissingValue(
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
@@ -158,9 +175,10 @@ impl Templateable for FileSystem {
 }
 
 impl FileSystem {
-    /// Returns the list of directory paths (keys) defined in this filesystem configuration.
+    /// Returns the list of directory paths (keys) defined in this filesystem configuration,
+    /// covering both ephemeral and persistent sections.
     pub fn dir_paths(&self) -> impl Iterator<Item = &SafePath> {
-        self.0.keys()
+        self.ephemeral.keys().chain(self.persistent.keys())
     }
 }
 
@@ -310,26 +328,33 @@ mod tests {
             Variable::new_final_string_variable("/base/dir"),
         )]);
 
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::from_template("some content".to_string()),
-            )])),
-        )]));
+        let filesystem_entry = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("my/path").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    TemplateableValue::from_template("some content".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
 
         let rendered = filesystem_entry.template_with(&variables);
         assert!(rendered.is_ok());
         let rendered = rendered.unwrap();
-        assert!(rendered.0.len() == 1);
+        assert!(rendered.ephemeral.len() == 1);
 
-        let expected_filesystem = rendered::FileSystem(HashMap::from([(
-            SafePath(PathBuf::from("/base/dir/my/path")),
-            DirEntriesMap(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                "some content".to_string(),
-            )])),
-        )]));
+        let expected_filesystem = rendered::FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(PathBuf::from("/base/dir/my/path")),
+                DirEntriesMap(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    "some content".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: PathBuf::from("/base/dir"),
+        };
 
         assert_eq!(rendered, expected_filesystem);
     }
@@ -340,13 +365,16 @@ mod tests {
         // templating must fail.
         let variables = Variables::default();
 
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::new("some content".to_string()),
-            )])),
-        )]));
+        let filesystem_entry = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("my/path").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("my/file/path").try_into().unwrap(),
+                    TemplateableValue::new("some content".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
 
         let rendered = filesystem_entry.template_with(&variables);
         assert!(rendered.is_err());
@@ -381,11 +409,12 @@ mod tests {
     }
 
     const EXAMPLE_FILESYSTEM: &str = r#"
-"path/to/my-dir":
+ephemeral:
+  "path/to/my-dir":
     filepath1: "file1 content"
     filepath2: |
-        key: ${nr-var:some_var}
-"another/path/to/my-dir":
+      key: ${nr-var:some_var}
+  "another/path/to/my-dir":
     ${nr-var:some_var_that_renders_to_a_yaml_mapping}
 "#;
 
@@ -393,11 +422,11 @@ mod tests {
     fn parse_valid_directories() {
         let parsed: Result<FileSystem, _> = serde_saphyr::from_str(EXAMPLE_FILESYSTEM);
         assert!(
-            parsed.as_ref().is_ok_and(|p| p.0.len() == 2),
+            parsed.as_ref().is_ok_and(|p| p.ephemeral.len() == 2),
             "Parsed directories: {parsed:?}"
         );
 
-        let parsed = parsed.unwrap().0;
+        let parsed = parsed.unwrap().ephemeral;
         let my_dir = parsed
             .get(&SafePath(PathBuf::from("path/to/my-dir")))
             .unwrap();
@@ -413,26 +442,27 @@ mod tests {
     }
 
     const FILESYSTEM_EXAMPLE: &str = r#"
-"some/files":
+ephemeral:
+  "some/files":
     "path/to/my-file": "something ${nr-var:some_file_var}"
     "another/path/to/my-file": |
-        some
-        multi-line
-        content
-"path/to/my-dir":
+      some
+      multi-line
+      content
+  "path/to/my-dir":
     filepath1: "file1 content"
     filepath2: |
-        key: ${nr-var:some_dir_var}
-"another/path/to/my-dir":
+      key: ${nr-var:some_dir_var}
+  "another/path/to/my-dir":
     ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-"empty/dir": {}
+  "empty/dir": {}
 "#;
 
     #[test]
     fn parse_and_template_filesystem() {
         let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
         assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
+            parsed.as_ref().is_ok_and(|fs| fs.ephemeral.len() == 4),
             "Parsed filesystem: {parsed:?}"
         );
 
@@ -476,7 +506,7 @@ mod tests {
     fn rendered_files() {
         let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
         assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
+            parsed.as_ref().is_ok_and(|fs| fs.ephemeral.len() == 4),
             "Parsed filesystem: {parsed:?}"
         );
         let tmp_dir = TempDir::new().unwrap();
@@ -564,5 +594,144 @@ mod tests {
                 r_path.display()
             );
         }
+    }
+
+    /// When a config update removes a file from an ephemeral directory (e.g. an integration
+    /// removed from `config_integrations`), the stale file must be deleted on the next write.
+    #[test]
+    fn ephemeral_dir_stale_files_are_deleted_on_next_write() {
+        let tmp_dir = TempDir::new().unwrap();
+        let base_variables = |dir: &str| {
+            Variables::from_iter(vec![(
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(dir),
+            )])
+        };
+
+        let first_config = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("integrations.d").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([
+                    (
+                        PathBuf::from("apache.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("apache config".to_string()),
+                    ),
+                    (
+                        PathBuf::from("nginx.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("nginx config".to_string()),
+                    ),
+                    (
+                        PathBuf::from("mysql.yaml").try_into().unwrap(),
+                        TemplateableValue::from_template("mysql config".to_string()),
+                    ),
+                ])),
+            )]),
+            persistent: HashMap::default(),
+        };
+
+        let dir = tmp_dir.path().to_string_lossy().to_string();
+        first_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(tmp_dir.path().join("integrations.d/apache.yaml").exists());
+        assert!(tmp_dir.path().join("integrations.d/nginx.yaml").exists());
+        assert!(tmp_dir.path().join("integrations.d/mysql.yaml").exists());
+
+        let second_config = FileSystem {
+            ephemeral: HashMap::from([(
+                PathBuf::from("integrations.d").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("apache.yaml").try_into().unwrap(),
+                    TemplateableValue::from_template("apache config".to_string()),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+        };
+
+        second_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(
+            tmp_dir.path().join("integrations.d/apache.yaml").exists(),
+            "apache.yaml should still be present"
+        );
+        assert!(
+            !tmp_dir.path().join("integrations.d/nginx.yaml").exists(),
+            "nginx.yaml should have been deleted"
+        );
+        assert!(
+            !tmp_dir.path().join("integrations.d/mysql.yaml").exists(),
+            "mysql.yaml should have been deleted"
+        );
+    }
+
+    /// Files in persistent directories must never be deleted by a config update,
+    /// even if they are absent from the new configuration.
+    #[test]
+    fn persistent_dir_files_survive_config_update() {
+        let tmp_dir = TempDir::new().unwrap();
+        let base_variables = |dir: &str| {
+            Variables::from_iter(vec![(
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(dir),
+            )])
+        };
+
+        let dir = tmp_dir.path().to_string_lossy().to_string();
+
+        // First write: persistent dir gets a file written by the config
+        let first_config = FileSystem {
+            ephemeral: HashMap::default(),
+            persistent: HashMap::from([(
+                PathBuf::from("logging").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
+                    PathBuf::from("fluent.yaml").try_into().unwrap(),
+                    TemplateableValue::from_template("fluent config".to_string()),
+                )])),
+            )]),
+        };
+
+        first_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // Simulate a file written by the sub-agent itself into the persistent dir
+        std::fs::write(
+            tmp_dir.path().join("logging/agent-created.yaml"),
+            "runtime data",
+        )
+        .unwrap();
+
+        // Second write: persistent dir entry is now empty in the config
+        let second_config = FileSystem {
+            ephemeral: HashMap::default(),
+            persistent: HashMap::from([(
+                PathBuf::from("logging").try_into().unwrap(),
+                DirEntriesType::FixedWithTemplatedContent(HashMap::default()),
+            )]),
+        };
+
+        second_config
+            .template_with(&base_variables(&dir))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(
+            tmp_dir.path().join("logging/fluent.yaml").exists(),
+            "fluent.yaml written by the config must survive a config update in a persistent dir"
+        );
+        assert!(
+            tmp_dir.path().join("logging/agent-created.yaml").exists(),
+            "file written by the sub-agent must survive a config update in a persistent dir"
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -1,12 +1,18 @@
 use crate::agent_type::runtime_config::on_host::filesystem::{DirEntriesMap, SafePath};
 use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::trace;
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct FileSystem(pub(super) HashMap<SafePath, DirEntriesMap>);
+pub struct FileSystem {
+    pub(super) ephemeral: HashMap<SafePath, DirEntriesMap>,
+    pub(super) persistent: HashMap<SafePath, DirEntriesMap>,
+    /// Absolute path to the agent's dedicated filesystem directory
+    /// (e.g. `{remote_dir}/filesystem/{agent_id}`).
+    pub(super) filesystem_dir: PathBuf,
+}
 
 impl FileSystem {
     pub fn write(
@@ -14,20 +20,102 @@ impl FileSystem {
         file_writer: &impl FileWriter,
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
-        self.0.iter().try_for_each(|(dir_path, dir_entries)| {
-            // Create the base directory so that we support empty directories
-            dir_manager.create(dir_path.as_ref()).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
-            })?;
-            dir_entries
-                .0
-                .iter()
-                .try_for_each(|(sub_path, file_content)| {
-                    let file_path = dir_path.as_ref().join(sub_path);
-                    create_file(file_writer, dir_manager, &file_path, file_content)
-                })
-        })
+        // Clean up ephemeral entries from previous runs before writing new ones.
+        // This ensures stale files are removed even if agent-control was down when the config changed.
+        self.cleanup_ephemeral_on_startup(dir_manager)?;
+
+        write_ephemeral_dirs(&self.ephemeral, file_writer, dir_manager)?;
+        write_persistent_dirs(&self.persistent, file_writer, dir_manager)?;
+
+        Ok(())
     }
+
+    /// Cleans up ephemeral filesystem entries from a previous run before writing new ones.
+    ///
+    /// Compares what's on disk against the current agent type's filesystem configuration
+    /// (`self.ephemeral` and `self.persistent`) and deletes any directories that don't match.
+    /// This ensures:
+    /// - Old ephemeral directories that are no longer in the config are removed
+    /// - Persistent directories that are still in the config are preserved
+    ///
+    /// This is a no-op if the filesystem directory doesn't exist yet (first run).
+    fn cleanup_ephemeral_on_startup(
+        &self,
+        dir_manager: &impl DirectoryManager,
+    ) -> Result<(), FileSystemEntriesError> {
+        if self.filesystem_dir.as_os_str().is_empty() || !self.filesystem_dir.exists() {
+            return Ok(());
+        }
+
+        // Build a set of all directories that should exist based on the current config
+        let should_exist: std::collections::HashSet<PathBuf> = self
+            .ephemeral
+            .keys()
+            .chain(self.persistent.keys())
+            .map(|safe_path| safe_path.as_ref().to_path_buf())
+            .collect();
+
+        if should_exist.is_empty() {
+            trace!(
+                "No filesystem directories configured, removing entire filesystem dir: {}",
+                self.filesystem_dir.display()
+            );
+            dir_manager.delete(&self.filesystem_dir).map_err(|e| {
+                FileSystemEntriesError(format!(
+                    "removing filesystem dir on startup {}: {e}",
+                    self.filesystem_dir.display()
+                ))
+            })?;
+            return Ok(());
+        }
+
+        delete_stale_directories(&self.filesystem_dir, &should_exist, dir_manager)
+    }
+}
+
+/// Clears each directory before writing its contents.
+/// This ensures files no longer present in the config are removed from disk.
+fn write_ephemeral_dirs(
+    dirs: &HashMap<SafePath, DirEntriesMap>,
+    file_writer: &impl FileWriter,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    dirs.iter().try_for_each(|(dir_path, dir_entries)| {
+        dir_manager.delete(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("clearing ephemeral directory {dir_path:?}: {err}"))
+        })?;
+        dir_manager.create(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
+        })?;
+        dir_entries
+            .0
+            .iter()
+            .try_for_each(|(sub_path, file_content)| {
+                let file_path = dir_path.as_ref().join(sub_path);
+                create_file(file_writer, dir_manager, &file_path, file_content)
+            })
+    })
+}
+
+/// Writes directory contents additively — existing files are overwritten but never deleted.
+/// Used for persistent directories whose contents must survive config updates.
+fn write_persistent_dirs(
+    dirs: &HashMap<SafePath, DirEntriesMap>,
+    file_writer: &impl FileWriter,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    dirs.iter().try_for_each(|(dir_path, dir_entries)| {
+        dir_manager.create(dir_path.as_ref()).map_err(|err| {
+            FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
+        })?;
+        dir_entries
+            .0
+            .iter()
+            .try_for_each(|(sub_path, file_content)| {
+                let file_path = dir_path.as_ref().join(sub_path);
+                create_file(file_writer, dir_manager, &file_path, file_content)
+            })
+    })
 }
 
 fn create_file(
@@ -49,6 +137,311 @@ fn create_file(
         .map_err(|err| FileSystemEntriesError(format!("creating file {file_path:?}: {err}")))
 }
 
+/// Deletes directories in `filesystem_dir` that are not in the `should_exist` set.
+/// This is used during startup cleanup to remove stale directories based on the current
+/// agent type configuration.
+fn delete_stale_directories(
+    filesystem_dir: &Path,
+    should_exist: &std::collections::HashSet<PathBuf>,
+    dir_manager: &impl DirectoryManager,
+) -> Result<(), FileSystemEntriesError> {
+    let entries = std::fs::read_dir(filesystem_dir).map_err(|e| {
+        FileSystemEntriesError(format!(
+            "reading filesystem dir {}: {e}",
+            filesystem_dir.display()
+        ))
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            FileSystemEntriesError(format!(
+                "reading dir entry in {}: {e}",
+                filesystem_dir.display()
+            ))
+        })?;
+        let entry_path = entry.path();
+
+        if should_exist.contains(&entry_path) {
+            trace!("Keeping configured directory: {}", entry_path.display());
+            continue;
+        }
+
+        let is_parent_of_configured = should_exist
+            .iter()
+            .any(|path| path.starts_with(&entry_path));
+
+        if is_parent_of_configured {
+            trace!(
+                "Keeping parent directory of configured path: {}",
+                entry_path.display()
+            );
+            continue;
+        }
+
+        trace!(
+            "Removing stale directory on startup: {}",
+            entry_path.display()
+        );
+        dir_manager.delete(&entry_path).map_err(|e| {
+            FileSystemEntriesError(format!(
+                "removing stale directory {}: {e}",
+                entry_path.display()
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 #[error("file system entries error: {0}")]
 pub struct FileSystemEntriesError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::runtime_config::on_host::filesystem::SafePath;
+    use fs::directory_manager::DirectoryManagerFs;
+    use fs::file::LocalFile;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Test that ephemeral directories are cleaned up on startup before writing new files.
+    /// This simulates the scenario where agent-control was shut down, files were left on disk,
+    /// and then agent-control starts up again. The old ephemeral files should be removed,
+    /// but persistent files should be kept.
+    #[test]
+    fn cleanup_ephemeral_on_startup() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("config")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("agent.yaml")),
+                    "initial config".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::from([(
+                SafePath(filesystem_dir.join("data")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("state.json")),
+                    "initial state".to_string(),
+                )])),
+            )]),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        assert!(
+            filesystem_dir.join("config/agent.yaml").exists(),
+            "Initial ephemeral file should exist"
+        );
+        assert!(
+            filesystem_dir.join("data/state.json").exists(),
+            "Initial persistent file should exist"
+        );
+
+        // Simulate a filesystem with different ephemeral content but same persistent dirs.
+        // When this is written, the old ephemeral files should be cleaned up.
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("integrations")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("integration.yaml")),
+                    "new integration".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::from([(
+                SafePath(filesystem_dir.join("data")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("state.json")),
+                    "updated state".to_string(),
+                )])),
+            )]),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        assert!(
+            !filesystem_dir.join("config").exists(),
+            "Old ephemeral dir 'config' should be removed on startup cleanup"
+        );
+        assert!(
+            !filesystem_dir.join("config/agent.yaml").exists(),
+            "Old ephemeral file should be removed"
+        );
+
+        assert!(
+            filesystem_dir
+                .join("integrations/integration.yaml")
+                .exists(),
+            "New ephemeral file should exist"
+        );
+        assert!(
+            filesystem_dir.join("data/state.json").exists(),
+            "Persistent file should survive startup cleanup"
+        );
+
+        let persistent_content =
+            std::fs::read_to_string(filesystem_dir.join("data/state.json")).unwrap();
+        assert_eq!(
+            persistent_content, "updated state",
+            "Persistent file content should be updated"
+        );
+    }
+
+    /// Test that cleanup removes directories not in the current agent type configuration.
+    #[test]
+    fn cleanup_removes_stale_dirs_not_in_config() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        // Create an old directory on disk (simulating a previous run or manual creation)
+        std::fs::create_dir_all(filesystem_dir.join("old_dir")).unwrap();
+        std::fs::write(filesystem_dir.join("old_dir/old_file.txt"), "old content").unwrap();
+
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("new_dir")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("new_file.txt")),
+                    "new content".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+        assert!(
+            !filesystem_dir.join("old_dir").exists(),
+            "Stale directory should be removed when not in current config"
+        );
+
+        assert!(
+            filesystem_dir.join("new_dir/new_file.txt").exists(),
+            "New files should be created"
+        );
+    }
+
+    /// Test that parent directories of configured nested paths are preserved during cleanup.
+    /// For example, if "data/store" is configured, the "data" parent directory should be kept
+    /// during startup cleanup (it won't be deleted even though it's not directly in the config).
+    #[test]
+    fn cleanup_preserves_parent_directories() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("cache")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("temp.json")),
+                    "cache data".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        assert!(
+            filesystem_dir.join("cache/temp.json").exists(),
+            "Initial cache file should exist"
+        );
+
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("data/store")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("items.json")),
+                    "store data".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        assert!(
+            !filesystem_dir.join("cache").exists(),
+            "Old cache directory should be removed during cleanup"
+        );
+        assert!(
+            filesystem_dir.join("data").exists(),
+            "Parent directory 'data' should exist"
+        );
+        assert!(
+            filesystem_dir.join("data/store/items.json").exists(),
+            "Nested path should be created"
+        );
+    }
+
+    /// Test cleanup when all dirs are ephemeral (no persistent dirs).
+    /// The entire filesystem dir should be removed and recreated.
+    #[test]
+    fn cleanup_removes_all_when_no_persistent_dirs() {
+        let tmp_dir = TempDir::new().unwrap();
+        let filesystem_dir = tmp_dir.path().to_path_buf();
+
+        let initial_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("config")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("agent.yaml")),
+                    "config".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        initial_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write initial filesystem");
+
+        assert!(filesystem_dir.join("config/agent.yaml").exists());
+
+        let new_fs = FileSystem {
+            ephemeral: HashMap::from([(
+                SafePath(filesystem_dir.join("integrations")),
+                DirEntriesMap(HashMap::from([(
+                    SafePath(PathBuf::from("integration.yaml")),
+                    "integration".to_string(),
+                )])),
+            )]),
+            persistent: HashMap::default(),
+            filesystem_dir: filesystem_dir.clone(),
+        };
+
+        new_fs
+            .write(&LocalFile, &DirectoryManagerFs)
+            .expect("Failed to write new filesystem");
+
+        assert!(
+            !filesystem_dir.join("config").exists(),
+            "Old ephemeral dir should be removed"
+        );
+        assert!(
+            filesystem_dir
+                .join("integrations/integration.yaml")
+                .exists(),
+            "New ephemeral dir should exist"
+        );
+    }
+}

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -43,8 +43,9 @@ operating_system: {AGENT_CONTROL_MODE_ON_HOST}
 variables: {{}}
 deployment:
   filesystem:
-    {dir_entry}:
-      {file_path}: "{expected_file_contents}"
+    ephemeral:
+      {dir_entry}:
+        {file_path}: "{expected_file_contents}"
 "#,
         ),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -155,15 +156,16 @@ variables:
     required: true
 deployment:
   filesystem:
-    randomdir:
-      "{yaml_file_path}": |-
-        ${{nr-var:yaml_file_contents}}
-      "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
-    {dir_path}:
-      file1.txt: "File 1 contents"
-      file2.txt: |
-        File 2 contents with a variable: ${{nr-var:some_string}}
-    "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
+    ephemeral:
+      randomdir:
+        "{yaml_file_path}": |-
+          ${{nr-var:yaml_file_contents}}
+        "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
+      {dir_path}:
+        file1.txt: "File 1 contents"
+        file2.txt: |
+          File 2 contents with a variable: ${{nr-var:some_string}}
+      "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
 "#,
         ),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -271,9 +273,17 @@ some_mapstringyaml:
     });
 }
 
-/// Filesystem entries should persist across agent control restarts.
-/// This test verifies that directories like newrelic-infra/newrelic-integrations/logging
-/// are not deleted when agent control restarts, ensuring persistent storage across restarts.
+/// Filesystem entries should persist across agent control restarts, and ephemeral directories
+/// should replace their contents when the config changes (stale files are removed).
+///
+/// This test verifies three behaviours:
+///   1. **Restart with same config** — neither ephemeral nor persistent files are deleted.
+///      The resource cleaner only runs when an agent is removed from config, so a plain restart
+///      must leave all files intact (the sub-agent may still be running and needs them).
+///   2. **Ephemeral dirs on config change** — when an integration is removed from the config the
+///      corresponding file is deleted from disk (ephemeral replace-on-write semantics).
+///   3. **Persistent dirs always survive** — files created by the sub-agent in a persistent dir
+///      (e.g. `newrelic-infra/newrelic-integrations/logging`) are never deleted by agent control.
 #[test]
 fn filesystem_persists_across_restarts() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
@@ -284,10 +294,13 @@ fn filesystem_persists_across_restarts() {
 
     let agent_id = "test-agent";
     let config_content = "license_key: test_key\nlog_level: info\n";
-    let integrations_content = "integration: test\n";
+    let apache_content = "type: apache\n";
+    let nginx_content = "type: nginx\n";
     let logging_content = "fluent_bit: true\n";
 
-    // Create agent type definition with filesystem structure similar to newrelic-infra
+    // Create agent type definition with filesystem structure similar to newrelic-infra.
+    // `config_integrations` uses `map[string]yaml` so that each key becomes a file name and
+    // the directory is fully replaced on every write (ephemeral replace-on-write semantics).
     create_file(
         format!(
             r#"
@@ -311,17 +324,17 @@ variables:
     required: true
 deployment:
   filesystem:
-    config:
-      newrelic-infra.yaml: |-
-        ${{nr-var:config_agent}}
-    integrations.d:
-      integration.yaml: |-
+    ephemeral:
+      config:
+        newrelic-infra.yaml: |-
+          ${{nr-var:config_agent}}
+      integrations.d: |-
         ${{nr-var:config_integrations}}
-    logging.d:
-      logging.yaml: |-
-        ${{nr-var:config_logging}}
-    # This directory needs to persist across restarts for the infra agent
-    newrelic-infra/newrelic-integrations/logging: {{}}
+      logging.d:
+        logging.yaml: |-
+          ${{nr-var:config_logging}}
+    persistent:
+      newrelic-infra/newrelic-integrations/logging: {{}}
 "#,
         ),
         local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -341,6 +354,7 @@ deployment:
         local_dir.to_path_buf(),
     );
 
+    // Initial config: two integrations (apache + nginx)
     create_local_config(
         agent_id.to_string(),
         r#"
@@ -348,7 +362,10 @@ config_agent:
   license_key: test_key
   log_level: info
 config_integrations:
-  integration: test
+  apache.yaml:
+    type: apache
+  nginx.yaml:
+    type: nginx
 config_logging:
   fluent_bit: true
 "#
@@ -362,7 +379,12 @@ config_logging:
         log_dir: local_dir.to_path_buf(),
     };
 
-    // Define expected file paths (used throughout the test)
+    let integrations_dir = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("integrations.d");
+
     let config_file_path = base_paths
         .remote_dir
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
@@ -370,12 +392,8 @@ config_logging:
         .join("config")
         .join("newrelic-infra.yaml");
 
-    let integrations_file_path = base_paths
-        .remote_dir
-        .join(AGENT_FILESYSTEM_FOLDER_NAME)
-        .join(agent_id)
-        .join("integrations.d")
-        .join("integration.yaml");
+    let apache_file_path = integrations_dir.join("apache.yaml");
+    let nginx_file_path = integrations_dir.join("nginx.yaml");
 
     let logging_file_path = base_paths
         .remote_dir
@@ -394,18 +412,17 @@ config_logging:
 
     let test_file_path = persistent_dir_path.join("test.yaml");
 
-    // First agent control run - creates the filesystem structure
+    // First agent control run — creates the filesystem structure with two integrations
     {
         let _agent_control =
             start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
 
-        // Wait for files to be created
         retry(30, Duration::from_secs(1), || {
             read_file_and_expect_content(&config_file_path, config_content)?;
-            read_file_and_expect_content(&integrations_file_path, integrations_content)?;
+            read_file_and_expect_content(&apache_file_path, apache_content)?;
+            read_file_and_expect_content(&nginx_file_path, nginx_content)?;
             read_file_and_expect_content(&logging_file_path, logging_content)?;
 
-            // Verify the persistent directory exists
             if !persistent_dir_path.exists() {
                 return Err(format!(
                     "Persistent directory does not exist: {}",
@@ -419,14 +436,15 @@ config_logging:
         // Agent control is dropped here, simulating a shutdown
     }
 
-    // Verify files still exist on disk after shutdown, before restart
+    // Verify all files still exist on disk after shutdown.
     read_file_and_expect_content(&config_file_path, config_content)
         .expect("Config file content should match after shutdown");
-    read_file_and_expect_content(&integrations_file_path, integrations_content)
-        .expect("Integrations file content should match after shutdown");
+    read_file_and_expect_content(&apache_file_path, apache_content)
+        .expect("Apache integration file should exist after shutdown");
+    read_file_and_expect_content(&nginx_file_path, nginx_content)
+        .expect("Nginx integration file should exist after shutdown");
     read_file_and_expect_content(&logging_file_path, logging_content)
         .expect("Logging file content should match after shutdown");
-
     assert!(
         persistent_dir_path.exists(),
         "Persistent directory should still exist after shutdown: {}",
@@ -436,17 +454,42 @@ config_logging:
     // Simulate a file created by the infra agent in the persistent directory
     create_file("test\n".to_string(), test_file_path.clone());
 
-    // Second agent control run - simulates restart
+    // Update the config to remove nginx — only apache remains
+    create_local_config(
+        agent_id.to_string(),
+        r#"
+config_agent:
+  license_key: test_key
+  log_level: info
+config_integrations:
+  apache.yaml:
+    type: apache
+config_logging:
+  fluent_bit: true
+"#
+        .to_string(),
+        local_dir.to_path_buf(),
+    );
+
     {
         let _agent_control =
             start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
 
-        // Verify all files and directories still exist after restart
         retry(30, Duration::from_secs(1), || {
             read_file_and_expect_content(&config_file_path, config_content)?;
-            read_file_and_expect_content(&integrations_file_path, integrations_content)?;
+            read_file_and_expect_content(&apache_file_path, apache_content)?;
             read_file_and_expect_content(&logging_file_path, logging_content)?;
 
+            // Ephemeral replace-on-write: nginx was removed from config, so the file must be gone
+            if nginx_file_path.exists() {
+                return Err(format!(
+                    "Stale nginx integration file should have been deleted: {}",
+                    nginx_file_path.display()
+                )
+                .into());
+            }
+
+            // Persistent dir: test.yaml created by the sub-agent must survive the restart
             if !persistent_dir_path.exists() {
                 return Err(format!(
                     "Persistent directory was deleted after restart: {}",
@@ -454,8 +497,6 @@ config_logging:
                 )
                 .into());
             }
-
-            // Verify the test file created in the persistent directory still exists
             read_file_and_expect_content(&test_file_path, "test\n")?;
 
             Ok(())

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -13,7 +13,8 @@ use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
-    AGENT_CONTROL_ID, FOLDER_NAME_FLEET_DATA, STORE_KEY_OPAMP_DATA_CONFIG,
+    AGENT_CONTROL_ID, AGENT_FILESYSTEM_FOLDER_NAME, FOLDER_NAME_FLEET_DATA,
+    STORE_KEY_OPAMP_DATA_CONFIG,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -542,5 +543,182 @@ status_time_unix_nano: 1725444001
             return Err("not the expected content for first config".into());
         }
         check_latest_health_status_was_healthy(&opamp_server, &sub_agent_instance_id)
+    });
+}
+
+/// Given a agent-control whose local configuration has no agents and then a valid remote configuration with an agent
+/// is set through OpAMP. Then the agent is removed via a new remote configuration. Finally, the agent is added again
+/// with the same ID.
+/// - The agent control reports healthy
+/// - The subagent reports healthy at the end
+#[test]
+fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
+    // Given a agent-control without agents and opamp configured.
+
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    let agents = "{}";
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        agents.to_string(),
+        local_dir.path().to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+
+    let dir_entry = "test-dir";
+    let file_path = "test-file.txt";
+    let content_template = "${nr-var:file_contents}";
+    let first_templated_content = "filesystem-ops-test";
+    let second_templated_content = "updated-filesystem-ops-test";
+
+    let filesystem_config = format!(
+        r#"
+ephemeral: {{}}
+persistent:
+  {dir_entry}:
+    {file_path}: "{content_template}"
+"#
+    );
+
+    let defined_variables = r#"
+file_contents:
+  description: "Contents of the file"
+  type: "string"
+  required: false
+  default: "filesystem-ops-test"
+"#;
+
+    // Add custom agent_type to registry with filesystem operations
+    let sleep_agent_type = CustomAgentType::default()
+        .with_filesystem(Some(&filesystem_config))
+        .with_variables(defined_variables)
+        .build(local_dir.path().to_path_buf());
+
+    let _agent_control =
+        start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+    let agent_control_instance_id = get_instance_id(&AgentID::AgentControl, base_paths.clone());
+
+    let agent_id = "nr-sleep-agent";
+    let agents_config_with_agent = format!(
+        r#"
+agents:
+  {agent_id}:
+    agent_type: "{sleep_agent_type}"
+"#
+    );
+
+    let agents_config_empty = "agents: {}";
+
+    // 1. Add agent
+    opamp_server.set_config_response(
+        agent_control_instance_id.clone(),
+        agents_config_with_agent.as_str(),
+    );
+
+    // Wait for AC to apply configuration and report healthy
+    retry(60, Duration::from_secs(1), || {
+        check_latest_health_status_was_healthy(&opamp_server, &agent_control_instance_id)
+    });
+
+    let subagent_instance_id = get_instance_id(
+        &AgentID::try_from("nr-sleep-agent").unwrap(),
+        base_paths.clone(),
+    );
+
+    // Provide config for the subagent so it starts healthy
+    opamp_server.set_config_response(
+        subagent_instance_id.clone(),
+        format!("file_contents: {}", first_templated_content),
+    );
+
+    // Wait for subagent to be healthy
+    retry(60, Duration::from_secs(1), || {
+        check_latest_health_status_was_healthy(&opamp_server, &subagent_instance_id)
+    });
+
+    // Check that the file was created
+    let agent_filesystem_path = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join(dir_entry)
+        .join(file_path);
+
+    retry(60, Duration::from_secs(1), || {
+        if !agent_filesystem_path.exists() {
+            return Err(format!("File not found at {:?}", agent_filesystem_path).into());
+        }
+        let content = std::fs::read_to_string(&agent_filesystem_path)?;
+        if content != first_templated_content {
+            return Err(format!(
+                "Content mismatch: expected {}, got {}",
+                first_templated_content, content
+            )
+            .into());
+        }
+        Ok(())
+    });
+
+    // 2. Remove agent
+    opamp_server.set_config_response(agent_control_instance_id.clone(), agents_config_empty);
+
+    // Verify agent control updates its effective config to empty
+    // This confirms the removal was processed
+    retry(60, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &agent_control_instance_id,
+            "agents: {}\n".to_string(),
+        )
+    });
+
+    // 3. Add agent again
+    opamp_server.set_config_response(
+        agent_control_instance_id.clone(),
+        agents_config_with_agent.as_str(),
+    );
+
+    // Get the new instance ID after re-adding the agent
+    let new_subagent_instance_id = get_instance_id(
+        &AgentID::try_from("nr-sleep-agent").unwrap(),
+        base_paths.clone(),
+    );
+
+    // 4. Add a remote config for the agent with updated values so it refreshes the filesystem
+    opamp_server.set_config_response(
+        new_subagent_instance_id.clone(),
+        format!("file_contents: {}", second_templated_content),
+    );
+
+    // 5. Validate it is running properly
+    // The subagent should start again. We check if it reports healthy.
+    retry(60, Duration::from_secs(1), || {
+        check_latest_health_status_was_healthy(&opamp_server, &new_subagent_instance_id)
+    });
+
+    // Check that the file still exists (or was recreated) and has correct content
+    retry(60, Duration::from_secs(1), || {
+        if !agent_filesystem_path.exists() {
+            return Err(format!("File not found at {:?}", agent_filesystem_path).into());
+        }
+        let content = std::fs::read_to_string(&agent_filesystem_path)?;
+        if content != second_templated_content {
+            return Err(format!(
+                "Content mismatch: expected {}, got {}",
+                second_templated_content, content
+            )
+            .into());
+        }
+        Ok(())
     });
 }

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -52,8 +52,10 @@ fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
     let sleep_agent_type = CustomAgentType::default()
         .with_filesystem(Some(&format!(
             r#"
-{dir_entry}:
-  {file_path}: "{content_template}"
+ephemeral:
+  {dir_entry}:
+    {file_path}: "{content_template}"
+persistent: {{}}
 "#
         )))
         .with_variables(

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -206,11 +206,13 @@ deployment:
           repository: ${nr-var:oci.repository}
           version: ${nr-var:version}
   filesystem:
-    config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+    ephemeral:
+      config:
+        newrelic-infra.yaml: |
+          ${nr-var:config_agent}
+      integrations.d: ${nr-var:config_integrations}
+    persistent:
+      logging.d: ${nr-var:config_logging}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
@@ -248,11 +250,13 @@ deployment:
           repository: ${nr-var:oci.repository}
           version: ${nr-var:version}
   filesystem:
-    config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+    ephemeral:
+      config:
+        newrelic-infra.yaml: |
+          ${nr-var:config_agent}
+      integrations.d: ${nr-var:config_integrations}
+    persistent:
+      logging.d: ${nr-var:config_logging}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
@@ -339,9 +343,18 @@ As of now, the `executables` field is array and is actually **optional**. This w
 
 ##### `filesystem`
 
-Represents the file system configuration for the deployment of a host agent.
-Consisting of a set of directories (map keys) which in turn contain a set of files (nested map keys)
-with their respective content (map values).
+Represents the file system configuration for the deployment of a host agent with lifecycle semantics.
+The filesystem is divided into two sections — `ephemeral` and `persistent` — each consisting of a set
+of directories (map keys) which in turn contain a set of files (nested map keys) with their respective
+content (map values).
+
+**Lifecycle semantics:**
+- **`ephemeral`**: Directories that are deleted when the agent is stopped, removed, or restarted. These
+  directories are cleared and repopulated on every config update, so files removed from dynamic variables
+  (e.g., `config_integrations`) are automatically deleted from disk without extra tracking.
+- **`persistent`**: Directories that are only deleted when the agent is removed. These directories are
+  written additively and survive agent stops, restarts, and config updates, intended for directories owned
+  by the sub-agent process itself (e.g., logging directories).
 
 The contents defined here will be written to the sub-agent's dedicated directory for filesystem
 files, which can be referenced in other fields via the variable `${nr-sub:filesystem_agent_dir}`.

--- a/fs/src/win_permissions.rs
+++ b/fs/src/win_permissions.rs
@@ -2,6 +2,10 @@ use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
 use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, GetLastError};
+
+// Standard Windows access right (winnt.h 0x00010000). Not exported from the windows_sys
+// Win32_Foundation feature set, so defined locally as a raw value.
+const DELETE: u32 = 0x0001_0000;
 use windows_sys::Win32::Security::Authorization::{
     EXPLICIT_ACCESS_W, SE_FILE_OBJECT, SET_ACCESS, SetEntriesInAclW, SetNamedSecurityInfoW,
     TRUSTEE_IS_SID, TRUSTEE_W,
@@ -40,7 +44,7 @@ fn get_administrator_sid() -> Result<Vec<u8>, PermissionError> {
 }
 
 /// set_file_permissions_for_administrator removes any other ACL from a file only granting
-/// read and write to Administrators.
+/// read, write, and delete to Administrators.
 pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), PermissionError> {
     // Conversion to UTF-16 format (native string representation in Windows OS)
     let path_wstr: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
@@ -55,9 +59,12 @@ pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), Permiss
         ..Default::default()
     };
 
-    // Define the access entry to allow read and write for the trustee
+    // Define the access entry to allow read, write, and delete for the trustee.
+    // DELETE is required so that Agent Control can remove config files when an agent is
+    // removed from the configuration (see OnHostFilesystemCleaner) and when ephemeral
+    // directories are replaced on each config write.
     let access_entry = EXPLICIT_ACCESS_W {
-        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE,
+        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE | DELETE,
         grfAccessMode: SET_ACCESS,
         grfInheritance: NO_INHERITANCE,
         Trustee: trustee,
@@ -101,6 +108,7 @@ pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), Permiss
 
 #[cfg(test)]
 pub mod tests {
+    use super::DELETE;
     use windows_sys::Win32::{
         Foundation::ERROR_SUCCESS,
         Security::{
@@ -112,12 +120,12 @@ pub mod tests {
 
     use super::*;
 
-    /// Asserts directory permissions are set to only allow Administrators read and write access on Windows.
+    /// Asserts directory permissions are set to only allow Administrators read, write, and delete access on Windows.
     ///
     /// This is a helper function that checks the following:
     /// 1. The DACL of the file contains exactly one ACE.
     /// 2. The ACE is for the Administrators SID.
-    /// 3. The ACE grants FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions.
+    /// 3. The ACE grants FILE_GENERIC_READ, FILE_GENERIC_WRITE, and DELETE permissions.
     pub fn assert_windows_permissions(path: &Path) {
         let mut admin_sid_size = SECURITY_MAX_SID_SIZE;
         let mut admin_sid: Vec<u8> = vec![0; admin_sid_size as usize];
@@ -178,11 +186,11 @@ pub mod tests {
             let sids_equal = EqualSid(sid_in_ace, admin_sid.as_mut_ptr() as *mut _);
             assert_ne!(sids_equal, 0, "ACE SID should match Administrators SID");
 
-            // FILE_GENERIC_READ and FILE_GENERIC_WRITE are what GENERIC_READ/WRITE map to
-            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE;
+            // GENERIC_READ/WRITE map to FILE_GENERIC_READ/WRITE; DELETE is a standard right.
+            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE;
             assert_eq!(
                 ace.Mask, expected_mask,
-                "ACE should have FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions"
+                "ACE should have FILE_GENERIC_READ, FILE_GENERIC_WRITE, and DELETE permissions"
             );
         }
     }


### PR DESCRIPTION
Introduces ephemeral/persistent lifecycle semantics for sub-agent filesystem directories.
                                                                                                                                                                                                                                   
Replaces the flat FileSystem map with two explicit sections — ephemeral and persistent — allowing agent type authors to declare the intended lifecycle of each directory in the agent type definition.                         

- Ephemeral directories are deleted when the agent is stopped, removed, or restarted. They are cleared and repopulated on every config update, so files removed from dynamic variables (e.g. config_integrations in com.newrelic.infrastructure) are  automatically deleted from disk without any extra tracking.
- Persistent directories are only deleted when the agent is removed. They are written additively and survive agent stops,  restarts, and config updates, intended for directories owned by the sub-agent process itself (e.g. newrelic-infra/newrelic-integrations/logging).

On every write() call, a startup cleanup phase compares what's on disk against the current agent type configuration and removes stale directories that are no longer in the config. Persistent directories that are still in the config are preserved, while ephemeral directories are always cleared and recreated.


<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
