### PR TITLE
feat: add Agent type definition `protocol_version` (NR-568042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Remember that the keywords that you can use are the following:
 - Agent type definitions now use a flat per-platform schema (one YAML file per `(platform, operating_system)` pair). 
   Agent type FQNs and configuration values are unchanged, so this is **not a breaking change** for end users.
   Internal authors of custom agent type definitions need to migrate their YAMLs — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
+- Agent type definitions now declare a top-level `protocol_version` (a quoted `MAJOR.MINOR` string) that versions the
+  agent-type schema language itself. It is validated against the version Agent Control supports at registry ingestion,
+  so definitions targeting an incompatible schema are rejected early. Internal authors of custom agent type definitions
+  must add this field — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
 
 ## v1.16.1 - 2026-06-04
 

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 publish.workspace = true
 license-file.workspace = true
 
+[package.metadata]
+# Max agent-type schema protocol version this Agent Control understands (MAJOR.MINOR).
+agent_type_protocol_version = "0.1"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -10,7 +10,7 @@ license-file.workspace = true
 
 [package.metadata]
 # Max agent-type schema protocol version this Agent Control understands (MAJOR.MINOR).
-agent_type_protocol_version = "0.1"
+agent_type_protocol_version = "1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/agent-control/agent-type-registry/README.md
+++ b/agent-control/agent-type-registry/README.md
@@ -3,9 +3,13 @@
 Any `*.yaml` file defined in this folder or any subfolder will be embedded into the agent control binary
 at compilation time. These files define the agent-type registry.
 
-Each YAML file describes a single agent type definition. The metadata declares a `platform`
-(`host` or `kubernetes`) and, when `platform: host`, also an `operating_system` (`linux` or
-`windows`). An agent that targets multiple host operating systems and/or kubernetes is split
+Each YAML file declares a top-level `protocol_version` (a quoted `MAJOR.MINOR` string identifying the
+agent-type schema language, e.g. `"0.1"`), which is parsed separately and validated against the version
+this Agent Control supports at ingestion time; see the
+[agent type integration guide](../../docs/INTEGRATING_AGENTS.md#agent-type-metadata) for the
+compatibility rules. The metadata then declares a `platform` (`host` or `kubernetes`) and, when
+`platform: host`, also an `operating_system` (`linux` or `windows`). An agent that targets multiple
+host operating systems and/or kubernetes is split
 into one file per `(platform, operating_system)` pair, all sharing the same `namespace`,
 `name` and `version`. At startup, Agent Control loads only the definitions whose `platform`
 (and `operating_system`, when `platform: host`) match the binary it's running in: the on-host

--- a/agent-control/agent-type-registry/README.md
+++ b/agent-control/agent-type-registry/README.md
@@ -4,7 +4,7 @@ Any `*.yaml` file defined in this folder or any subfolder will be embedded into 
 at compilation time. These files define the agent-type registry.
 
 Each YAML file declares a top-level `protocol_version` (a quoted `MAJOR.MINOR` string identifying the
-agent-type schema language, e.g. `"0.1"`), which is parsed separately and validated against the version
+agent-type schema language, e.g. `"1.0"`), which is parsed separately and validated against the version
 this Agent Control supports at ingestion time; see the
 [agent type integration guide](../../docs/INTEGRATING_AGENTS.md#agent-type-metadata) for the
 compatibility rules. The metadata then declares a `platform` (`host` or `kubernetes`) and, when

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
@@ -3,6 +3,7 @@ name: com.newrelic.ebpf
 version: 0.1.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables:
   config_agent:
     DEPLOYMENT_NAME:

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
@@ -3,7 +3,7 @@ name: com.newrelic.ebpf
 version: 0.1.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config_agent:
     DEPLOYMENT_NAME:

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -3,6 +3,7 @@ name: com.newrelic.infrastructure
 version: 0.1.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables:
   config_agent:
     description: "Newrelic infra configuration"

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -3,7 +3,7 @@ name: com.newrelic.infrastructure
 version: 0.1.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config_agent:
     description: "Newrelic infra configuration"

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -3,6 +3,7 @@ name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -3,7 +3,7 @@ name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
@@ -3,7 +3,7 @@ name: io.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
@@ -3,6 +3,7 @@ name: io.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -3,6 +3,7 @@ name: com.newrelic.infrastructure
 version: 0.1.0
 platform: host
 operating_system: windows
+protocol_version: "0.1"
 variables:
   config_agent:
     description: "Newrelic infra configuration"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -3,7 +3,7 @@ name: com.newrelic.infrastructure
 version: 0.1.0
 platform: host
 operating_system: windows
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config_agent:
     description: "Newrelic infra configuration"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -3,7 +3,7 @@ name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: windows
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -3,6 +3,7 @@ name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: host
 operating_system: windows
+protocol_version: "0.1"
 variables:
   config:
     description: "Newrelic otel collector configuration"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_dotnet-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_dotnet
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_dotnet-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_dotnet-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_dotnet
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_java-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_java
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_java-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_java-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_java
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_node-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_node
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_node-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_node-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_node
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_python-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_python
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_python-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_python-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_python
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_ruby-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_ruby
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_ruby-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.apm_ruby-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.apm_ruby
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   podLabelSelector:
     description: "Pod label selector"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.ebpf-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.ebpf
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     nr-ebpf-agent:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.ebpf-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.ebpf
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     nr-ebpf-agent:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   # HelmChart based sub agents should always have `chart_values`.
   chart_values:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   # HelmChart based sub agents should always have `chart_values`.
   chart_values:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.k8s_agent_operator
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     k8s-agents-operator:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.k8s_agent_operator-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.k8s_agent_operator-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.k8s_agent_operator
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     k8s-agents-operator:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     nr-k8s-otel-collector:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.opentelemetry.collector
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     nr-k8s-otel-collector:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.prometheus
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     newrelic-prometheus-agent:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.prometheus
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     newrelic-prometheus-agent:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-io.fluentbit-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: io.fluentbit
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     newrelic-logging:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-io.fluentbit-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-io.fluentbit-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: io.fluentbit
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     newrelic-logging:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-io.opentelemetry.collector-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: io.opentelemetry.collector
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     nr-k8s-otel-collector:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-io.opentelemetry.collector-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: io.opentelemetry.collector
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     nr-k8s-otel-collector:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     gateway:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     gateway:

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-0.1.0.yaml
@@ -5,7 +5,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway_config
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config:
     description: "OTel Collector configuration for the Pipeline Control Gateway"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-0.1.0.yaml
@@ -5,6 +5,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway_config
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   config:
     description: "OTel Collector configuration for the Pipeline Control Gateway"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-mode-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-mode-0.1.0.yaml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway_config_mode
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config:
     description: "OTel Collector configuration for the Pipeline Control Gateway"

--- a/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-mode-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-pipeline-control-gateway-config-mode-0.1.0.yaml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.pipeline_control_gateway_config_mode
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   config:
     description: "OTel Collector configuration for the Pipeline Control Gateway"

--- a/agent-control/build.rs
+++ b/agent-control/build.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 const REGISTRY_PATH: &str = "agent-type-registry/";
 const GENERATED_REGISTRY_FILE: &str = "generated_agent_type_registry.rs";
+const GENERATED_PROTOCOL_VERSION_FILE: &str = "generated_protocol_version.rs";
 
 // List of crates whose logs are enabled at the configured level.
 const LOGGING_ENABLED_CRATES: &[&str] = &[
@@ -33,9 +34,11 @@ const LOGGING_DISABLED_CRATES: &[&str] = &[
 
 fn main() {
     generate_agent_type_registry();
+    generate_protocol_version_const();
     check_logging_crates();
     // setup the env variable for the generated registry path
     println!("cargo:rustc-env=GENERATED_REGISTRY_FILE={GENERATED_REGISTRY_FILE}");
+    println!("cargo:rustc-env=GENERATED_PROTOCOL_VERSION_FILE={GENERATED_PROTOCOL_VERSION_FILE}");
     // re-run only if the registry has changed
     println!("cargo:rerun-if-changed={REGISTRY_PATH}");
     set_git_commit();
@@ -133,6 +136,50 @@ fn check_logging_crates() {
 
     let crates_value = LOGGING_ENABLED_CRATES.join(",");
     println!("cargo:rustc-env=LOGGING_ENABLED_CRATES={crates_value}");
+}
+
+/// Reads `package.metadata.agent_type_protocol_version` from this crate's `Cargo.toml`,
+/// validates that it is a `MAJOR.MINOR` numeric string, and emits a generated `.rs` file
+/// defining `SUPPORTED_PROTOCOL_VERSION`, and included by `agent_type::protocol_version`.
+fn generate_protocol_version_const() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let manifest_path = Path::new(&manifest_dir).join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", manifest_path.display());
+
+    let manifest: toml::Table = fs::read_to_string(&manifest_path)
+        .expect("Could not read agent-control Cargo.toml")
+        .parse()
+        .expect("Could not parse agent-control Cargo.toml");
+
+    let raw = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("agent_type_protocol_version"))
+        .and_then(|v| v.as_str())
+        .expect(
+            "package.metadata.agent_type_protocol_version is missing or not a string in agent-control/Cargo.toml",
+        );
+
+    let (major, minor) = parse_major_minor(raw).unwrap_or_else(|| {
+        panic!(
+            "package.metadata.agent_type_protocol_version = \"{raw}\" is not a valid MAJOR.MINOR \
+            numeric string"
+        )
+    });
+
+    let contents = format!(
+        "/// Maximum protocol version this Agent Control supports.
+pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion {{ major: {major}, minor: {minor} }};\n"
+    );
+
+    let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
+    let dest = Path::new(&out_dir).join(GENERATED_PROTOCOL_VERSION_FILE);
+    fs::write(dest, contents).expect("Could not write generated protocol_version file");
+}
+
+fn parse_major_minor(s: &str) -> Option<(u64, u64)> {
+    let (major, minor) = s.split_once('.')?;
+    Some((major.parse().ok()?, minor.parse().ok()?))
 }
 
 fn generate_agent_type_registry() {

--- a/agent-control/src/agent_type.rs
+++ b/agent-control/src/agent_type.rs
@@ -4,6 +4,7 @@ pub mod definition;
 pub mod error;
 pub mod guid_config;
 pub mod oci;
+pub mod protocol_version;
 pub mod registry;
 pub mod render;
 pub mod runtime_config;

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -4,6 +4,22 @@ Agent Type Definition is a YAML file that defines an agent's configuration and b
 
 By defining these three sections, developers can create a customizable and flexible agent type that can be used in various environments.
 
+On top of those sections, every file declares a top-level [`protocol_version`](#protocol-version) that versions the schema language the file is written against.
+
+## Protocol version
+
+`protocol_version` is a top-level field — separate from the three sections below — that declares the version of the agent-type **schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata*. It is decoupled from both the agent type `version` (the definition's semver) and the Agent Control release version.
+
+It is a quoted `MAJOR.MINOR` string (e.g. `"0.1"`). The value **must be quoted**, otherwise YAML parses `0.1` as a float and the field is rejected.
+
+It is parsed and validated on its own, at the registry ingestion boundary, *before* the rest of the document is interpreted — so it can gate files whose metadata or other sections use a shape this Agent Control would not otherwise understand. Each Agent Control release understands a single maximum protocol version, and the compatibility rules are:
+
+* Different `major` (either direction): rejected — a major bump is a breaking schema change.
+* Same `major`, higher `minor`: rejected — the file is newer than this Agent Control understands.
+* Same `major`, equal or lower `minor`: accepted — minor bumps are additive and backward-compatible.
+
+For example, an Agent Control supporting `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new), and rejects `0.9` and `2.0` (wrong major).
+
 ## Metadata
 
 The metadata section contains information about the agent type: its `name`, `version`, `namespace`, and the target platform.
@@ -382,6 +398,8 @@ This guideline shows how to build a custom agent type and integrate it with the 
     name: com.influxdata.telegraf
     # version: semver scheme
     version: 0.0.1
+    # protocol_version: quoted MAJOR.MINOR of the agent-type schema language
+    protocol_version: "0.1"
     # platform: host or kubernetes
     platform: host
     # operating_system: required when platform is host. linux or windows

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -10,7 +10,7 @@ On top of those sections, every file declares a top-level [`protocol_version`](#
 
 `protocol_version` is a top-level field — separate from the three sections below — that declares the version of the agent-type **schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata*. It is decoupled from both the agent type `version` (the definition's semver) and the Agent Control release version.
 
-It is a quoted `MAJOR.MINOR` string (e.g. `"0.1"`). The value **must be quoted**, otherwise YAML parses `0.1` as a float and the field is rejected.
+It is a quoted `MAJOR.MINOR` string (e.g. `"1.0"`). The value **must be quoted**, otherwise YAML parses `0.1` as a float and the field is rejected.
 
 It is parsed and validated on its own, at the registry ingestion boundary, *before* the rest of the document is interpreted — so it can gate files whose metadata or other sections use a shape this Agent Control would not otherwise understand. Each Agent Control release understands a single maximum protocol version, and the compatibility rules are:
 
@@ -399,7 +399,7 @@ This guideline shows how to build a custom agent type and integrate it with the 
     # version: semver scheme
     version: 0.0.1
     # protocol_version: quoted MAJOR.MINOR of the agent-type schema language
-    protocol_version: "0.1"
+    protocol_version: "1.0"
     # platform: host or kubernetes
     platform: host
     # operating_system: required when platform is host. linux or windows

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -43,8 +43,8 @@ pub struct AgentTypeDefinition {
     pub runtime_config: Runtime,
 }
 
-/// Wraps [AgentTypeDefinition] to force deserialization using [parse_agent_type_definition] which
-/// verifies the `protocol_version`.
+/// Wraps [AgentTypeDefinition] to force deserialization through [AgentTypeDefinition::from_slice],
+/// which verifies the `protocol_version`.
 struct RawAgentTypeDefinition(AgentTypeDefinition);
 
 impl<'de> Deserialize<'de> for RawAgentTypeDefinition {
@@ -84,17 +84,6 @@ impl<'de> Deserialize<'de> for RawAgentTypeDefinition {
     }
 }
 
-/// Parses raw yaml content into an [AgentTypeDefinition], validating the file's `protocol_version`
-/// before the document is converted into the definition.
-pub fn parse_agent_type_definition(
-    content: &[u8],
-) -> Result<AgentTypeDefinition, AgentTypeDefinitionParseError> {
-    let document: serde_json::Value = serde_saphyr::from_slice(content)?;
-    protocol_version::check(&document)?;
-    let definition = serde_json::from_value::<RawAgentTypeDefinition>(document)?.0;
-    Ok(definition)
-}
-
 #[derive(Error, Debug)]
 pub enum AgentTypeDefinitionParseError {
     #[error("incompatible protocol version: {0}")]
@@ -106,6 +95,15 @@ pub enum AgentTypeDefinitionParseError {
 }
 
 impl AgentTypeDefinition {
+    /// Parses raw yaml content into an [AgentTypeDefinition], validating the file's
+    /// `protocol_version` before the document is converted into the definition.
+    pub fn from_slice(content: &[u8]) -> Result<Self, AgentTypeDefinitionParseError> {
+        let document: serde_json::Value = serde_saphyr::from_slice(content)?;
+        protocol_version::check(&document)?;
+        let definition = serde_json::from_value::<RawAgentTypeDefinition>(document)?.0;
+        Ok(definition)
+    }
+
     pub fn agent_type_id(&self) -> &AgentTypeID {
         &self.metadata.id
     }
@@ -549,7 +547,7 @@ deployment:
             "protocol_version: \"{SUPPORTED_PROTOCOL_VERSION}\""
         ));
 
-        let definition = parse_agent_type_definition(yaml.as_bytes()).unwrap();
+        let definition = AgentTypeDefinition::from_slice(yaml.as_bytes()).unwrap();
 
         assert_eq!(definition.agent_type_id().namespace(), "ns");
         assert_eq!(definition.agent_type_id().name(), "test");
@@ -571,7 +569,7 @@ deployment: {{}}
 "#
         );
 
-        let definition = parse_agent_type_definition(yaml.as_bytes()).unwrap();
+        let definition = AgentTypeDefinition::from_slice(yaml.as_bytes()).unwrap();
 
         assert_eq!(definition.metadata.environment, Environment::Linux);
         assert_matches!(definition.runtime_config.deployment, Deployment::Host(_));
@@ -582,7 +580,7 @@ deployment: {{}}
         let yaml = k8s_definition_yaml("");
 
         assert_matches!(
-            parse_agent_type_definition(yaml.as_bytes()),
+            AgentTypeDefinition::from_slice(yaml.as_bytes()),
             Err(AgentTypeDefinitionParseError::ProtocolVersion(
                 ProtocolVersionError::Missing
             ))
@@ -595,7 +593,7 @@ deployment: {{}}
         let yaml = k8s_definition_yaml("protocol_version: \"99.0\"");
 
         assert_matches!(
-            parse_agent_type_definition(yaml.as_bytes()),
+            AgentTypeDefinition::from_slice(yaml.as_bytes()),
             Err(AgentTypeDefinitionParseError::ProtocolVersion(
                 ProtocolVersionError::IncompatibleMajor { .. }
             ))
@@ -608,7 +606,7 @@ deployment: {{}}
         let yaml = k8s_definition_yaml(&format!("protocol_version: {SUPPORTED_PROTOCOL_VERSION}"));
 
         assert_matches!(
-            parse_agent_type_definition(yaml.as_bytes()),
+            AgentTypeDefinition::from_slice(yaml.as_bytes()),
             Err(AgentTypeDefinitionParseError::ProtocolVersion(
                 ProtocolVersionError::InvalidFormat(_)
             ))
@@ -617,7 +615,7 @@ deployment: {{}}
 
     #[test]
     fn parse_rejects_malformed_yaml() {
-        let err = parse_agent_type_definition(b"name: [unclosed").unwrap_err();
+        let err = AgentTypeDefinition::from_slice(b"name: [unclosed").unwrap_err();
 
         assert_matches!(err, AgentTypeDefinitionParseError::Yaml(_));
     }
@@ -638,7 +636,7 @@ platform: host
         );
 
         assert_matches!(
-            parse_agent_type_definition(yaml.as_bytes()),
+            AgentTypeDefinition::from_slice(yaml.as_bytes()),
             Err(AgentTypeDefinitionParseError::Definition(_))
         );
     }

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -7,6 +7,7 @@
 use super::{
     agent_type_id::AgentTypeID,
     error::AgentTypeError,
+    protocol_version::{self, ProtocolVersionError},
     runtime_config::{Deployment, Runtime},
     variable::{Variable, VariableDefinition, tree::Tree},
 };
@@ -42,13 +43,17 @@ pub struct AgentTypeDefinition {
     pub runtime_config: Runtime,
 }
 
-impl<'de> Deserialize<'de> for AgentTypeDefinition {
+/// Wraps [AgentTypeDefinition] to force deserialization using [parse_agent_type_definition] which
+/// verifies the `protocol_version`.
+struct RawAgentTypeDefinition(AgentTypeDefinition);
+
+impl<'de> Deserialize<'de> for RawAgentTypeDefinition {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
-        struct Raw {
+        struct Fields {
             #[serde(flatten)]
             metadata: AgentTypeMetadata,
             #[serde(default)]
@@ -56,26 +61,48 @@ impl<'de> Deserialize<'de> for AgentTypeDefinition {
             deployment: serde_json::Value,
         }
 
-        let raw = Raw::deserialize(deserializer)?;
+        let fields = Fields::deserialize(deserializer)?;
 
-        let deployment = match raw.metadata.environment {
+        let deployment = match fields.metadata.environment {
             Environment::Linux | Environment::Windows => {
                 let on_host: OnHost =
-                    serde_json::from_value(raw.deployment).map_err(D::Error::custom)?;
+                    serde_json::from_value(fields.deployment).map_err(D::Error::custom)?;
                 Deployment::Host(on_host)
             }
             Environment::K8s => {
-                let k8s: K8s = serde_json::from_value(raw.deployment).map_err(D::Error::custom)?;
+                let k8s: K8s =
+                    serde_json::from_value(fields.deployment).map_err(D::Error::custom)?;
                 Deployment::K8s(k8s)
             }
         };
 
-        Ok(AgentTypeDefinition {
-            metadata: raw.metadata,
-            variables: raw.variables,
+        Ok(RawAgentTypeDefinition(AgentTypeDefinition {
+            metadata: fields.metadata,
+            variables: fields.variables,
             runtime_config: Runtime { deployment },
-        })
+        }))
     }
+}
+
+/// Parses raw yaml content into an [AgentTypeDefinition], validating the file's `protocol_version`
+/// before the document is converted into the definition.
+pub fn parse_agent_type_definition(
+    content: &[u8],
+) -> Result<AgentTypeDefinition, AgentTypeDefinitionParseError> {
+    let document: serde_json::Value = serde_saphyr::from_slice(content)?;
+    protocol_version::check(&document)?;
+    let definition = serde_json::from_value::<RawAgentTypeDefinition>(document)?.0;
+    Ok(definition)
+}
+
+#[derive(Error, Debug)]
+pub enum AgentTypeDefinitionParseError {
+    #[error("incompatible protocol version: {0}")]
+    ProtocolVersion(#[from] ProtocolVersionError),
+    #[error("invalid agent type yaml: {0}")]
+    Yaml(#[from] serde_saphyr::Error),
+    #[error("invalid agent type definition: {0}")]
+    Definition(#[from] serde_json::Error),
 }
 
 impl AgentTypeDefinition {
@@ -333,12 +360,26 @@ pub fn get_sub_agent_variable(variables: &Variables, variable_name: &str) -> Opt
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::agent_type::protocol_version::SUPPORTED_PROTOCOL_VERSION;
     use crate::agent_type::trivial_value::TrivialValue;
     use crate::agent_type::variable::constraints::VariableConstraints;
+    use assert_matches::assert_matches;
     use rstest::rstest;
     use serde_json::Number;
     use serde_saphyr::Error;
     use std::collections::HashMap as Map;
+
+    /// `AgentTypeDefinition` deliberately has no production `Deserialize` impl: production code must go
+    /// through the registry boundary so the `protocol_version` is always checked first. This test-only
+    /// impl lets unit tests build definitions directly from inline yaml without that check.
+    impl<'de> Deserialize<'de> for AgentTypeDefinition {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            RawAgentTypeDefinition::deserialize(deserializer).map(|raw| raw.0)
+        }
+    }
 
     impl AgentTypeDefinition {
         /// This helper returns an [AgentTypeDefinition] including only the provided id.
@@ -482,6 +523,123 @@ variables: {}
         assert!(
             err.to_string().contains("missing field `deployment`"),
             "unexpected error: {err}"
+        );
+    }
+
+    /// A minimal valid k8s definition where the line carrying `protocol_version` can be customized
+    /// (or omitted by passing an empty string).
+    fn k8s_definition_yaml(protocol_version_line: &str) -> String {
+        format!(
+            r#"
+namespace: ns
+name: test
+version: 0.0.0
+{protocol_version_line}
+platform: kubernetes
+variables: {{}}
+deployment:
+  objects: {{}}
+"#
+        )
+    }
+
+    #[test]
+    fn parse_accepts_k8s_definition_with_supported_protocol_version() {
+        let yaml = k8s_definition_yaml(&format!(
+            "protocol_version: \"{SUPPORTED_PROTOCOL_VERSION}\""
+        ));
+
+        let definition = parse_agent_type_definition(yaml.as_bytes()).unwrap();
+
+        assert_eq!(definition.agent_type_id().namespace(), "ns");
+        assert_eq!(definition.agent_type_id().name(), "test");
+        assert_eq!(definition.metadata.environment, Environment::K8s);
+    }
+
+    #[test]
+    fn parse_accepts_host_definition_dispatching_to_host_deployment() {
+        let yaml = format!(
+            r#"
+namespace: newrelic
+name: nrdot
+version: 0.0.1
+protocol_version: "{SUPPORTED_PROTOCOL_VERSION}"
+platform: host
+operating_system: linux
+variables: {{}}
+deployment: {{}}
+"#
+        );
+
+        let definition = parse_agent_type_definition(yaml.as_bytes()).unwrap();
+
+        assert_eq!(definition.metadata.environment, Environment::Linux);
+        assert_matches!(definition.runtime_config.deployment, Deployment::Host(_));
+    }
+
+    #[test]
+    fn parse_rejects_missing_protocol_version() {
+        let yaml = k8s_definition_yaml("");
+
+        assert_matches!(
+            parse_agent_type_definition(yaml.as_bytes()),
+            Err(AgentTypeDefinitionParseError::ProtocolVersion(
+                ProtocolVersionError::Missing
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_incompatible_protocol_version() {
+        // Assumes the supported version is on major 0; a major-1 file is a breaking change.
+        let yaml = k8s_definition_yaml("protocol_version: \"99.0\"");
+
+        assert_matches!(
+            parse_agent_type_definition(yaml.as_bytes()),
+            Err(AgentTypeDefinitionParseError::ProtocolVersion(
+                ProtocolVersionError::IncompatibleMajor { .. }
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unquoted_protocol_version() {
+        // An unquoted `0.1` is a yaml float, not the required quoted MAJOR.MINOR string.
+        let yaml = k8s_definition_yaml(&format!("protocol_version: {SUPPORTED_PROTOCOL_VERSION}"));
+
+        assert_matches!(
+            parse_agent_type_definition(yaml.as_bytes()),
+            Err(AgentTypeDefinitionParseError::ProtocolVersion(
+                ProtocolVersionError::InvalidFormat(_)
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_yaml() {
+        let err = parse_agent_type_definition(b"name: [unclosed").unwrap_err();
+
+        assert_matches!(err, AgentTypeDefinitionParseError::Yaml(_));
+    }
+
+    #[test]
+    fn parse_rejects_valid_yaml_with_invalid_definition() {
+        // Valid yaml and a compatible protocol version, but the `deployment` block is missing, so
+        // the failure must come from building the definition, not the protocol check.
+        let supported = protocol_version::SUPPORTED_PROTOCOL_VERSION;
+        let yaml = format!(
+            r#"
+namespace: ns
+name: test
+version: 0.0.0
+protocol_version: "{supported}"
+platform: host
+"#
+        );
+
+        assert_matches!(
+            parse_agent_type_definition(yaml.as_bytes()),
+            Err(AgentTypeDefinitionParseError::Definition(_))
         );
     }
 

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -28,17 +28,17 @@ pub enum ProtocolVersionError {
     #[error("invalid protocol_version \"{0}\": expected a quoted MAJOR.MINOR string")]
     InvalidFormat(String),
     #[error(
-        "unsupported protocol_version {file}: incompatible major version (this agent control supports {supported})"
+        "unsupported protocol_version {target}: incompatible major version (this agent control supports {supported})"
     )]
     IncompatibleMajor {
-        file: ProtocolVersion,
+        target: ProtocolVersion,
         supported: ProtocolVersion,
     },
     #[error(
-        "unsupported protocol_version {file}: newer than supported (this agent control supports up to {supported})"
+        "unsupported protocol_version {target}: newer than supported (this agent control supports up to {supported})"
     )]
     TooNew {
-        file: ProtocolVersion,
+        target: ProtocolVersion,
         supported: ProtocolVersion,
     },
 }
@@ -76,20 +76,20 @@ impl ProtocolVersion {
     /// A different major is a breaking change in either direction; a higher minor under the same major
     /// is too new for this Agent Control. Equal or lower minors under the same major are additive and
     /// backward-compatible.
-    pub fn is_compatible_with_supported(&self) -> Result<(), ProtocolVersionError> {
+    pub fn is_supported(&self) -> Result<(), ProtocolVersionError> {
         check_compatibility(*self, SUPPORTED_PROTOCOL_VERSION)
     }
 }
 
 fn check_compatibility(
-    file: ProtocolVersion,
+    target: ProtocolVersion,
     supported: ProtocolVersion,
 ) -> Result<(), ProtocolVersionError> {
-    if file.major != supported.major {
-        return Err(ProtocolVersionError::IncompatibleMajor { file, supported });
+    if target.major != supported.major {
+        return Err(ProtocolVersionError::IncompatibleMajor { target, supported });
     }
-    if file.minor > supported.minor {
-        return Err(ProtocolVersionError::TooNew { file, supported });
+    if target.minor > supported.minor {
+        return Err(ProtocolVersionError::TooNew { target, supported });
     }
     Ok(())
 }
@@ -104,7 +104,7 @@ pub fn check(document: &serde_json::Value) -> Result<(), ProtocolVersionError> {
         Some(other) => return Err(ProtocolVersionError::InvalidFormat(other.to_string())),
     };
 
-    version.is_compatible_with_supported()
+    version.is_supported()
 }
 
 #[cfg(test)]
@@ -138,16 +138,16 @@ mod tests {
     #[case(pv(1, 5), pv(1, 6), Ok(()))]
     #[case(pv(1, 6), pv(1, 6), Ok(()))]
     #[case(pv(1, 0), pv(1, 6), Ok(()))]
-    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::TooNew { file: pv(1, 7), supported: pv(1, 6) }))]
+    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::TooNew { target: pv(1, 7), supported: pv(1, 6) }))]
     // Any major mismatch is rejected in either direction.
-    #[case(pv(0, 9), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { file: pv(0, 9), supported: pv(1, 6) }))]
-    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { file: pv(2, 0), supported: pv(1, 6) }))]
+    #[case(pv(0, 9), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { target: pv(0, 9), supported: pv(1, 6) }))]
+    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { target: pv(2, 0), supported: pv(1, 6) }))]
     fn compatibility_matrix(
-        #[case] file: ProtocolVersion,
+        #[case] target: ProtocolVersion,
         #[case] supported: ProtocolVersion,
         #[case] expected: Result<(), ProtocolVersionError>,
     ) {
-        assert_eq!(check_compatibility(file, supported), expected);
+        assert_eq!(check_compatibility(target, supported), expected);
     }
 
     #[test]
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(
             check(&yaml_value("protocol_version: \"1.0\"")),
             Err(ProtocolVersionError::IncompatibleMajor {
-                file: pv(1, 0),
+                target: pv(1, 0),
                 supported: SUPPORTED_PROTOCOL_VERSION,
             })
         );

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn check_accepts_supported_version() {
         assert_eq!(
-            check(&yaml_value("protocol_version: \"0.1\"\nname: whatever")),
+            check(&yaml_value("protocol_version: \"1.0\"\nname: whatever")),
             Ok(())
         );
     }
@@ -184,9 +184,9 @@ mod tests {
     #[test]
     fn check_rejects_incompatible_version() {
         assert_eq!(
-            check(&yaml_value("protocol_version: \"1.0\"")),
+            check(&yaml_value("protocol_version: \"99.0\"")),
             Err(ProtocolVersionError::IncompatibleMajor {
-                target: pv(1, 0),
+                target: pv(99, 0),
                 supported: SUPPORTED_PROTOCOL_VERSION,
             })
         );

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -18,8 +18,14 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 use thiserror::Error;
 
-/// Maximum protocol version this Agent Control understands.
-pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion { major: 0, minor: 1 };
+// Generated from `package.metadata.agent_type_protocol_version` in agent-control/Cargo.toml by
+// build.rs; defines `SUPPORTED_PROTOCOL_VERSION` (the maximum protocol version this Agent Control
+// understands).
+include!(concat!(
+    env!("OUT_DIR"),
+    "/",
+    env!("GENERATED_PROTOCOL_VERSION_FILE")
+));
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ProtocolVersionError {

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -1,0 +1,196 @@
+//! Versioning for the agent-type *schema language* itself, decoupled from both the agent type
+//! `version` (semver) and the Agent Control release version.
+//!
+//! Agent Control declares a single [SUPPORTED_PROTOCOL_VERSION] (the maximum it understands). Every
+//! agent type file must declare a `protocol_version` (a quoted `MAJOR.MINOR` string), which is
+//! validated against the supported version at the registry ingestion boundary before the rest of
+//! the file is parsed.
+//!
+//! Compatibility rules for a file's version against the supported version:
+//! - different `major` (either direction) → rejected: a major bump is a breaking schema change.
+//! - same `major`, higher `minor` → rejected: the file is newer than this Agent Control understands.
+//! - same `major`, equal or lower `minor` → accepted: minor bumps are additive and backward-compatible.
+//!
+//! For example, an Agent Control supporting `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new),
+//! and rejects `0.9` and `2.0` (wrong major).
+
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use thiserror::Error;
+
+/// Maximum protocol version this Agent Control understands.
+pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion { major: 0, minor: 1 };
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ProtocolVersionError {
+    #[error("missing required field protocol_version")]
+    Missing,
+    #[error("invalid protocol_version \"{0}\": expected a quoted MAJOR.MINOR string")]
+    InvalidFormat(String),
+    #[error(
+        "unsupported protocol_version {file}: incompatible major version (this agent control supports {supported})"
+    )]
+    IncompatibleMajor {
+        file: ProtocolVersion,
+        supported: ProtocolVersion,
+    },
+    #[error(
+        "unsupported protocol_version {file}: newer than supported (this agent control supports up to {supported})"
+    )]
+    TooNew {
+        file: ProtocolVersion,
+        supported: ProtocolVersion,
+    },
+}
+
+/// A two-part `MAJOR.MINOR` schema-language version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProtocolVersion {
+    major: u64,
+    minor: u64,
+}
+
+impl Display for ProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl FromStr for ProtocolVersion {
+    type Err = ProtocolVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let invalid = || ProtocolVersionError::InvalidFormat(s.to_string());
+        let [major, minor] = s.split('.').collect::<Vec<_>>()[..] else {
+            return Err(invalid());
+        };
+        Ok(ProtocolVersion {
+            major: major.parse().map_err(|_| invalid())?,
+            minor: minor.parse().map_err(|_| invalid())?,
+        })
+    }
+}
+
+impl ProtocolVersion {
+    /// Checks this version against [SUPPORTED_PROTOCOL_VERSION].
+    /// A different major is a breaking change in either direction; a higher minor under the same major
+    /// is too new for this Agent Control. Equal or lower minors under the same major are additive and
+    /// backward-compatible.
+    pub fn is_compatible_with_supported(&self) -> Result<(), ProtocolVersionError> {
+        check_compatibility(*self, SUPPORTED_PROTOCOL_VERSION)
+    }
+}
+
+fn check_compatibility(
+    file: ProtocolVersion,
+    supported: ProtocolVersion,
+) -> Result<(), ProtocolVersionError> {
+    if file.major != supported.major {
+        return Err(ProtocolVersionError::IncompatibleMajor { file, supported });
+    }
+    if file.minor > supported.minor {
+        return Err(ProtocolVersionError::TooNew { file, supported });
+    }
+    Ok(())
+}
+
+/// Validates the `protocol_version` field of an already-parsed agent-type document. It reads only
+/// that field and ignores the rest, so it can run before the document is converted into a
+/// definition.
+pub fn check(document: &serde_json::Value) -> Result<(), ProtocolVersionError> {
+    let version = match document.get("protocol_version") {
+        None => return Err(ProtocolVersionError::Missing),
+        Some(serde_json::Value::String(raw)) => ProtocolVersion::from_str(raw)?,
+        Some(other) => return Err(ProtocolVersionError::InvalidFormat(other.to_string())),
+    };
+
+    version.is_compatible_with_supported()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("0.1", ProtocolVersion { major: 0, minor: 1 })]
+    #[case("1.0", ProtocolVersion { major: 1, minor: 0 })]
+    #[case("12.34", ProtocolVersion { major: 12, minor: 34 })]
+    fn parses_valid_versions(#[case] input: &str, #[case] expected: ProtocolVersion) {
+        assert_eq!(ProtocolVersion::from_str(input).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case::three_parts("1.2.0")]
+    #[case::one_part("1")]
+    #[case::non_numeric("x.y")]
+    #[case::empty("")]
+    #[case::trailing_dot("1.")]
+    fn rejects_invalid_format(#[case] input: &str) {
+        assert_eq!(
+            ProtocolVersion::from_str(input),
+            Err(ProtocolVersionError::InvalidFormat(input.to_string()))
+        );
+    }
+
+    #[rstest]
+    // Same major, lower/equal minor is accepted; higher minor is too new.
+    #[case(pv(1, 5), pv(1, 6), Ok(()))]
+    #[case(pv(1, 6), pv(1, 6), Ok(()))]
+    #[case(pv(1, 0), pv(1, 6), Ok(()))]
+    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::TooNew { file: pv(1, 7), supported: pv(1, 6) }))]
+    // Any major mismatch is rejected in either direction.
+    #[case(pv(0, 9), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { file: pv(0, 9), supported: pv(1, 6) }))]
+    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { file: pv(2, 0), supported: pv(1, 6) }))]
+    fn compatibility_matrix(
+        #[case] file: ProtocolVersion,
+        #[case] supported: ProtocolVersion,
+        #[case] expected: Result<(), ProtocolVersionError>,
+    ) {
+        assert_eq!(check_compatibility(file, supported), expected);
+    }
+
+    #[test]
+    fn check_accepts_supported_version() {
+        assert_eq!(
+            check(&yaml_value("protocol_version: \"0.1\"\nname: whatever")),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn check_reports_missing_field() {
+        assert_eq!(
+            check(&yaml_value("name: whatever")),
+            Err(ProtocolVersionError::Missing)
+        );
+    }
+
+    #[test]
+    fn check_rejects_unquoted_float() {
+        // An unquoted `0.1` is a yaml float, not the required quoted MAJOR.MINOR string.
+        assert_eq!(
+            check(&yaml_value("protocol_version: 0.1")),
+            Err(ProtocolVersionError::InvalidFormat("0.1".to_string()))
+        );
+    }
+
+    #[test]
+    fn check_rejects_incompatible_version() {
+        assert_eq!(
+            check(&yaml_value("protocol_version: \"1.0\"")),
+            Err(ProtocolVersionError::IncompatibleMajor {
+                file: pv(1, 0),
+                supported: SUPPORTED_PROTOCOL_VERSION,
+            })
+        );
+    }
+
+    fn pv(major: u64, minor: u64) -> ProtocolVersion {
+        ProtocolVersion { major, minor }
+    }
+
+    fn yaml_value(content: &str) -> serde_json::Value {
+        serde_saphyr::from_str(content).unwrap()
+    }
+}

--- a/agent-control/src/agent_type/registry/local.rs
+++ b/agent-control/src/agent_type/registry/local.rs
@@ -85,6 +85,7 @@ impl LocalRegistry {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::agent_type::protocol_version::SUPPORTED_PROTOCOL_VERSION;
     use assert_matches::assert_matches;
     use std::fs::File;
     use std::io::Write;
@@ -189,6 +190,7 @@ pub mod tests {
 namespace: {namespace}
 name: {name}
 version: {version}
+protocol_version: "{SUPPORTED_PROTOCOL_VERSION}"
 platform: kubernetes
 variables:
   {variable}:

--- a/agent-control/src/agent_type/registry/local/custom.rs
+++ b/agent-control/src/agent_type/registry/local/custom.rs
@@ -1,4 +1,4 @@
-use crate::agent_type::definition::{AgentTypeDefinition, parse_agent_type_definition};
+use crate::agent_type::definition::AgentTypeDefinition;
 use std::{fs, path::PathBuf};
 use tracing::{debug, error};
 
@@ -33,7 +33,7 @@ pub(super) fn custom_definitions(path: PathBuf) -> Vec<AgentTypeDefinition> {
                 .ok()
                 .and_then(|content| {
                     debug!("Loading Dynamic Agent Type: {file:?}");
-                    parse_agent_type_definition(content.as_slice())
+                    AgentTypeDefinition::from_slice(content.as_slice())
                         .inspect_err(
                             |e| error!(error = %e, "Could not parse Dynamic Agent Type: {file:?}"),
                         )

--- a/agent-control/src/agent_type/registry/local/custom.rs
+++ b/agent-control/src/agent_type/registry/local/custom.rs
@@ -1,4 +1,4 @@
-use crate::agent_type::definition::AgentTypeDefinition;
+use crate::agent_type::definition::{AgentTypeDefinition, parse_agent_type_definition};
 use std::{fs, path::PathBuf};
 use tracing::{debug, error};
 
@@ -33,7 +33,7 @@ pub(super) fn custom_definitions(path: PathBuf) -> Vec<AgentTypeDefinition> {
                 .ok()
                 .and_then(|content| {
                     debug!("Loading Dynamic Agent Type: {file:?}");
-                    serde_saphyr::from_slice::<AgentTypeDefinition>(content.as_slice())
+                    parse_agent_type_definition(content.as_slice())
                         .inspect_err(
                             |e| error!(error = %e, "Could not parse Dynamic Agent Type: {file:?}"),
                         )
@@ -47,6 +47,7 @@ pub(super) fn custom_definitions(path: PathBuf) -> Vec<AgentTypeDefinition> {
 mod tests {
     use super::*;
     use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::agent_type::protocol_version::SUPPORTED_PROTOCOL_VERSION;
     use std::fs::File;
     use std::io::Write;
     use std::path::Path;
@@ -59,6 +60,7 @@ mod tests {
 namespace: ns
 name: {name}
 version: 0.0.0
+protocol_version: "{SUPPORTED_PROTOCOL_VERSION}"
 platform: kubernetes
 variables: {{}}
 deployment:

--- a/agent-control/src/agent_type/registry/local/embedded.rs
+++ b/agent-control/src/agent_type/registry/local/embedded.rs
@@ -1,4 +1,4 @@
-use crate::agent_type::definition::{AgentTypeDefinition, parse_agent_type_definition};
+use crate::agent_type::definition::AgentTypeDefinition;
 use crate::environment::Environment;
 
 // Include generated code
@@ -20,7 +20,7 @@ pub(super) fn embedded_definitions(env: Environment) -> impl Iterator<Item = Age
         .iter()
         .map(|file_content_ref| {
             // Definitions in files are expected to be valid and protocol-compatible.
-            parse_agent_type_definition(file_content_ref)
+            AgentTypeDefinition::from_slice(file_content_ref)
                 .expect("Invalid or incompatible embedded agent type")
         })
         .filter(move |def| def.metadata.environment == env)

--- a/agent-control/src/agent_type/registry/local/embedded.rs
+++ b/agent-control/src/agent_type/registry/local/embedded.rs
@@ -1,4 +1,4 @@
-use crate::agent_type::definition::AgentTypeDefinition;
+use crate::agent_type::definition::{AgentTypeDefinition, parse_agent_type_definition};
 use crate::environment::Environment;
 
 // Include generated code
@@ -19,9 +19,9 @@ pub(super) fn embedded_definitions(env: Environment) -> impl Iterator<Item = Age
     AGENT_TYPE_REGISTRY_FILES
         .iter()
         .map(|file_content_ref| {
-            // Definitions in files are expected to be valid
-            serde_saphyr::from_reader::<_, AgentTypeDefinition>(file_content_ref.to_owned())
-                .expect("Invalid yaml in default agent types")
+            // Definitions in files are expected to be valid and protocol-compatible.
+            parse_agent_type_definition(file_content_ref)
+                .expect("Invalid or incompatible embedded agent type")
         })
         .filter(move |def| def.metadata.environment == env)
 }

--- a/agent-control/tests/k8s/data/bar_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/bar_cr_agent_type.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.bar-cr-agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   data:
     description: "bar data"

--- a/agent-control/tests/k8s/data/bar_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/bar_cr_agent_type.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.bar-cr-agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   data:
     description: "bar data"

--- a/agent-control/tests/k8s/data/config_map_type.yml
+++ b/agent-control/tests/k8s/data/config_map_type.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.test_config_map
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     cm_content:

--- a/agent-control/tests/k8s/data/config_map_type.yml
+++ b/agent-control/tests/k8s/data/config_map_type.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.test_config_map
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     cm_content:

--- a/agent-control/tests/k8s/data/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/custom_agent_type_direct_checks.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_direct_checks.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables: {}
 deployment:
   health:

--- a/agent-control/tests/k8s/data/custom_agent_type_direct_checks.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_direct_checks.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables: {}
 deployment:
   health:

--- a/agent-control/tests/k8s/data/custom_agent_type_secrets.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_secrets.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/custom_agent_type_secrets.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_secrets.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
+++ b/agent-control/tests/k8s/data/custom_agent_type_split_ns.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.custom_agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     description: "chart_values"

--- a/agent-control/tests/k8s/data/foo_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/foo_cr_agent_type.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.foo-cr-agent
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   data:
     description: "foo data"

--- a/agent-control/tests/k8s/data/foo_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/foo_cr_agent_type.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.foo-cr-agent
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   data:
     description: "foo data"

--- a/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/custom_agent_type.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: com.newrelic.test
 version: 0.0.1
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   required_var:
     description: "required_var"

--- a/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/custom_agent_type.yml
+++ b/agent-control/tests/k8s/data/k8s_fail_remote_config_missing_required_values/custom_agent_type.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: com.newrelic.test
 version: 0.0.1
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   required_var:
     description: "required_var"

--- a/agent-control/tests/on_host/id.rs
+++ b/agent-control/tests/on_host/id.rs
@@ -180,6 +180,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables: {}
 deployment:
   executables:
@@ -204,6 +205,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: windows
+protocol_version: "0.1"
 variables: {}
 deployment:
   executables:

--- a/agent-control/tests/on_host/id.rs
+++ b/agent-control/tests/on_host/id.rs
@@ -180,7 +180,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables: {}
 deployment:
   executables:
@@ -205,7 +205,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: windows
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables: {}
 deployment:
   executables:

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -26,7 +26,7 @@ name: file-logging-agent
 version: 0.0.0
 platform: host
 operating_system: linux
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   message:
     description: "Message to echo to stdout"
@@ -53,7 +53,7 @@ name: file-logging-agent
 version: 0.0.0
 platform: host
 operating_system: windows
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   message:
     description: "Message to echo to stdout"

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -26,6 +26,7 @@ name: file-logging-agent
 version: 0.0.0
 platform: host
 operating_system: linux
+protocol_version: "0.1"
 variables:
   message:
     description: "Message to echo to stdout"
@@ -52,6 +53,7 @@ name: file-logging-agent
 version: 0.0.0
 platform: host
 operating_system: windows
+protocol_version: "0.1"
 variables:
   message:
     description: "Message to echo to stdout"

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -40,7 +40,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables: {{}}
 deployment:
   filesystem:
@@ -141,7 +141,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   yaml_file_contents:
     description: "Contents of the YAML file"
@@ -298,7 +298,7 @@ name: infra-agent
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   config_agent:
     description: "Agent configuration"

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -40,6 +40,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "0.1"
 variables: {{}}
 deployment:
   filesystem:
@@ -140,6 +141,7 @@ name: test
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "0.1"
 variables:
   yaml_file_contents:
     description: "Contents of the YAML file"
@@ -296,6 +298,7 @@ name: infra-agent
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "0.1"
 variables:
   config_agent:
     description: "Agent configuration"

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -5,7 +5,7 @@ use fs::file::LocalFile;
 use fs::file::writer::FileWriter;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
-use newrelic_agent_control::agent_type::definition::AgentTypeDefinition;
+use newrelic_agent_control::agent_type::definition::parse_agent_type_definition;
 pub const DYNAMIC_AGENT_TYPE_FILENAME: &str = "dynamic-agent-types/type.yaml";
 
 /// Helper to build a Custom Agent type with defaults ready to use in integration tests
@@ -53,6 +53,7 @@ impl Display for CustomAgentType {
         version: {}
         platform: host
         operating_system: {}
+        protocol_version: "0.1"
         "#,
             self.agent_type_id.namespace(),
             self.agent_type_id.name(),
@@ -219,14 +220,7 @@ regex: \d+\.\d+\.\d+
     pub fn build(self, local_dir: PathBuf) -> String {
         let agent_type_file_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
 
-        // Fail early in the test if Self cannot parse into an Agent Type definition or even YAML
-        let parsed_yaml = serde_saphyr::from_str::<serde_json::Value>(&self.to_string());
-        assert!(
-            parsed_yaml.is_ok(),
-            "CustomAgentType did not produce valid YAML:\n{}",
-            self
-        );
-        let parsed_agent_type = serde_saphyr::from_str::<AgentTypeDefinition>(&self.to_string());
+        let parsed_agent_type = parse_agent_type_definition(self.to_string().as_bytes());
         assert!(
             parsed_agent_type.is_ok(),
             "CustomAgentType did not produce valid AgentTypeDefinition:\n{}",

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -5,7 +5,7 @@ use fs::file::LocalFile;
 use fs::file::writer::FileWriter;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
-use newrelic_agent_control::agent_type::definition::parse_agent_type_definition;
+use newrelic_agent_control::agent_type::definition::AgentTypeDefinition;
 pub const DYNAMIC_AGENT_TYPE_FILENAME: &str = "dynamic-agent-types/type.yaml";
 
 /// Helper to build a Custom Agent type with defaults ready to use in integration tests
@@ -220,7 +220,7 @@ regex: \d+\.\d+\.\d+
     pub fn build(self, local_dir: PathBuf) -> String {
         let agent_type_file_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
 
-        let parsed_agent_type = parse_agent_type_definition(self.to_string().as_bytes());
+        let parsed_agent_type = AgentTypeDefinition::from_slice(self.to_string().as_bytes());
         assert!(
             parsed_agent_type.is_ok(),
             "CustomAgentType did not produce valid AgentTypeDefinition:\n{}",

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -53,7 +53,7 @@ impl Display for CustomAgentType {
         version: {}
         platform: host
         operating_system: {}
-        protocol_version: "0.1"
+        protocol_version: "1.0"
         "#,
             self.agent_type_id.namespace(),
             self.agent_type_id.name(),

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -18,7 +18,7 @@ The version used here is not the version of your agent, but **the version of the
 
 Agent Types are versioned to ensure compatibility with a given configuration values (no breaking changes, see below). As of now, we maintain only one version per agent type and use a fixed `0.1.0` value for it because these definitions are not easily visible to FC, but FC needs to know what are the agent types and their versions to make the metadata visible on New Relic's UI. As of now **we prohibit pushing breaking changes for these definitions, and any exceptions to this need to be validated at least by both AC and FC teams**.
 
-Separately from the agent type `version`, every definition must declare a top-level `protocol_version`. This is **not** a metadata field — it is parsed on its own and versions the **agent-type schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata block described here*. It is decoupled from both the agent type `version` (semver) and the Agent Control release version. It is a quoted `MAJOR.MINOR` string (for example `"0.1"`); the value **must be quoted**, otherwise YAML interprets `0.1` as a float and the field is rejected.
+Separately from the agent type `version`, every definition must declare a top-level `protocol_version`. This is **not** a metadata field — it is parsed on its own and versions the **agent-type schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata block described here*. It is decoupled from both the agent type `version` (semver) and the Agent Control release version. It is a quoted `MAJOR.MINOR` string (for example `"1.0"`); the value **must be quoted**, otherwise YAML interprets `0.1` as a float and the field is rejected.
 
 Because it gates the rest of the document, Agent Control reads and validates `protocol_version` first, at the registry ingestion boundary, *before* the metadata and the other sections are interpreted. Each Agent Control release understands a single maximum protocol version. The compatibility rules are:
 
@@ -42,7 +42,7 @@ This is an example section for the metadata fields, using the Kubernetes definit
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
-protocol_version: "0.1"
+protocol_version: "1.0"
 platform: kubernetes
 # ...
 ```
@@ -53,7 +53,7 @@ The Linux and Windows host variants share the same `namespace`/`name`/`version` 
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
-protocol_version: "0.1"
+protocol_version: "1.0"
 platform: host
 operating_system: linux
 # ...

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -18,6 +18,16 @@ The version used here is not the version of your agent, but **the version of the
 
 Agent Types are versioned to ensure compatibility with a given configuration values (no breaking changes, see below). As of now, we maintain only one version per agent type and use a fixed `0.1.0` value for it because these definitions are not easily visible to FC, but FC needs to know what are the agent types and their versions to make the metadata visible on New Relic's UI. As of now **we prohibit pushing breaking changes for these definitions, and any exceptions to this need to be validated at least by both AC and FC teams**.
 
+Separately from the agent type `version`, every definition must declare a top-level `protocol_version`. This is **not** a metadata field — it is parsed on its own and versions the **agent-type schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata block described here*. It is decoupled from both the agent type `version` (semver) and the Agent Control release version. It is a quoted `MAJOR.MINOR` string (for example `"0.1"`); the value **must be quoted**, otherwise YAML interprets `0.1` as a float and the field is rejected.
+
+Because it gates the rest of the document, Agent Control reads and validates `protocol_version` first, at the registry ingestion boundary, *before* the metadata and the other sections are interpreted. Each Agent Control release understands a single maximum protocol version. The compatibility rules are:
+
+- Different `major` (in either direction): rejected. A major bump is a breaking schema change.
+- Same `major`, higher `minor`: rejected. The file is newer than this Agent Control understands.
+- Same `major`, equal or lower `minor`: accepted. Minor bumps are additive and backward-compatible.
+
+For example, an Agent Control that supports protocol version `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new), and rejects `0.9` and `2.0` (wrong major).
+
 The `platform` field is required, and `operating_system` is required when `platform: host`. The supported combinations are:
 
 - `platform: kubernetes` (no `operating_system`).
@@ -32,6 +42,7 @@ This is an example section for the metadata fields, using the Kubernetes definit
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
+protocol_version: "0.1"
 platform: kubernetes
 # ...
 ```
@@ -42,6 +53,7 @@ The Linux and Windows host variants share the same `namespace`/`name`/`version` 
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
+protocol_version: "0.1"
 platform: host
 operating_system: linux
 # ...

--- a/test/k8s-e2e/apm/ac-values-apm.yml
+++ b/test/k8s-e2e/apm/ac-values-apm.yml
@@ -36,7 +36,7 @@ agentControlDeployment:
           agent_type: newrelic/com.newrelic.apm_dotnet:0.1.0
     agentsConfig:
       operator:
-        chart_version: "*"
+        chart_version: "0.43.1"
       # One agent per language
       java-agent:
         podLabelSelector:

--- a/test/k8s-e2e/dynamic/dynamic-agent-type-logging.yml
+++ b/test/k8s-e2e/dynamic/dynamic-agent-type-logging.yml
@@ -2,6 +2,7 @@ namespace: newrelic
 name: io.fluentbit
 version: 0.1.0
 platform: kubernetes
+protocol_version: "0.1"
 variables:
   chart_values:
     newrelic-logging:

--- a/test/k8s-e2e/dynamic/dynamic-agent-type-logging.yml
+++ b/test/k8s-e2e/dynamic/dynamic-agent-type-logging.yml
@@ -2,7 +2,7 @@ namespace: newrelic
 name: io.fluentbit
 version: 0.1.0
 platform: kubernetes
-protocol_version: "0.1"
+protocol_version: "1.0"
 variables:
   chart_values:
     newrelic-logging:


### PR DESCRIPTION
## Summary
Introduces a schema **protocol version** for agent-type definitions, decoupled from both the agent-type `version` (semver) and the Agent Control release version. 

Every agent-type file **must** now declare a quoted `protocol_version: "MAJOR.MINOR"`, which is validated at the registry ingestion boundary before the rest of the file is parsed.

Agent Control declares a single `SUPPORTED_PROTOCOL_VERSION` (the max it understands). 

## Changes
- New `agent_type/protocol_version.rs`: `ProtocolVersion` parsing + compatibility check.
- `parse_agent_type_definition` validates `protocol_version` first; an incompatible/missing/malformed version is rejected with a clear error.
- All embedded agent-type YAMLs declare `protocol_version: "0.1"`.

## Notes
- The check runs for both embedded and dynamic (custom) agent types.
- Bumping `SUPPORTED_PROTOCOL_VERSION` is the single knob for widening what AC accepts.