### PR TITLE
feat: introduce remote registry for Agent Types [NR-568047]

### DIFF
--- a/agent-control/src/agent_type/oci/downloader.rs
+++ b/agent-control/src/agent_type/oci/downloader.rs
@@ -23,9 +23,13 @@ pub struct OCIAgentTypeDownloaderError(String);
 
 /// An interface for downloading Agent Type definitions from a configured OCI remote.
 pub trait OCIAgentTypeDownloader: Send + Sync {
+    /// Error returned when a download fails. Consumers only rely on its `Display` representation,
+    /// so each implementation (and its mock) can use its own error type.
+    type Error: std::error::Error;
+
     /// Downloads and verifies the agent type artifact identified by `tag`, returning the raw bytes
     /// of the single agent type definition it contains.
-    fn download(&self, tag: &str) -> Result<Vec<u8>, OCIAgentTypeDownloaderError>;
+    fn download(&self, tag: &str) -> Result<Vec<u8>, Self::Error>;
 }
 
 /// Downloads agent type definitions from a configured OCI remote into memory.
@@ -47,6 +51,8 @@ pub struct OCIAgentTypeArtifactDownloader {
 }
 
 impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
+    type Error = OCIAgentTypeDownloaderError;
+
     /// Downloads the agent type artifact at `<registry>/<repository>:<tag>`.
     ///
     /// If signature verification is enabled and a `public_key_url` is configured, it first verifies
@@ -184,10 +190,17 @@ pub mod tests {
     use oci_client::client::{ClientConfig, ClientProtocol};
     use std::str::FromStr;
 
+    /// A trivially-constructible error for the mock downloader, so consumers (e.g. the remote
+    /// registry) can exercise the failure path without access to the real downloader's internals.
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    pub struct FakeDownloaderError(pub String);
+
     mock! {
         pub OCIAgentTypeDownloader {}
         impl OCIAgentTypeDownloader for OCIAgentTypeDownloader {
-            fn download(&self, tag: &str) -> Result<Vec<u8>, OCIAgentTypeDownloaderError>;
+            type Error = FakeDownloaderError;
+            fn download(&self, tag: &str) -> Result<Vec<u8>, FakeDownloaderError>;
         }
     }
 

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -1,5 +1,5 @@
 mod local;
-mod remote;
+pub mod remote;
 
 use std::path::PathBuf;
 
@@ -22,6 +22,13 @@ pub enum AgentTypeRegistryError {
     ValueConversion(#[from] serde_json::Error),
     #[error("remote registry error: {0}")]
     Remote(String),
+    #[error(
+        "agent type definition os/platform '{found}' does not match the requested '{requested}'"
+    )]
+    EnvironmentMismatch {
+        requested: Environment,
+        found: Environment,
+    },
 }
 
 /// Defines how to return an [AgentTypeDefinition] given an identifier.

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 use self::local::LocalRegistry;
 use super::agent_type_id::AgentTypeID;
 use super::definition::AgentTypeDefinition;
+use crate::agent_type::definition::AgentTypeDefinitionParseError;
 use crate::environment::Environment;
 
 #[derive(Error, Debug)]
@@ -16,10 +17,8 @@ pub enum AgentTypeRegistryError {
     NotFound(String),
     #[error("agent {0} already exists")]
     AlreadyExists(String),
-    #[error("serialization error: {0}")]
-    Serialization(#[from] serde_saphyr::Error),
-    #[error("value conversion error: {0}")]
-    ValueConversion(#[from] serde_json::Error),
+    #[error("invalid agent type definition: {0}")]
+    Parsing(AgentTypeDefinitionParseError),
     #[error("remote registry error: {0}")]
     Remote(String),
     #[error(

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -21,13 +21,8 @@ pub enum AgentTypeRegistryError {
     Parsing(AgentTypeDefinitionParseError),
     #[error("remote registry error: {0}")]
     Remote(String),
-    #[error(
-        "agent type definition os/platform '{found}' does not match the requested '{requested}'"
-    )]
-    EnvironmentMismatch {
-        requested: Environment,
-        found: Environment,
-    },
+    #[error("metadata mismatch for '{tag}': {details}")]
+    MetadataMismatch { tag: String, details: String },
 }
 
 /// Defines how to return an [AgentTypeDefinition] given an identifier.

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -1,4 +1,5 @@
 mod local;
+mod remote;
 
 use std::path::PathBuf;
 
@@ -19,6 +20,8 @@ pub enum AgentTypeRegistryError {
     Serialization(#[from] serde_saphyr::Error),
     #[error("value conversion error: {0}")]
     ValueConversion(#[from] serde_json::Error),
+    #[error("remote registry error: {0}")]
+    Remote(String),
 }
 
 /// Defines how to return an [AgentTypeDefinition] given an identifier.

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -11,15 +11,12 @@ use crate::environment::Environment;
 /// resolves them from its own running [Environment], which is used to build the OCI tag
 /// `<platform>-<operating_system>-<name>-<version>` (the operating system segment is omitted on
 /// kubernetes, matching how agent type metadata maps platform/os to [Environment]).
-// TODO: not yet wired into `Registry`; remove the `allow(dead_code)` once the composite registry
-// consumes it (see the precedence TODO in `Registry`).
-#[allow(dead_code)]
+// TODO: not yet wired into the composite `Registry` (see its precedence TODO).
 pub struct RemoteRegistry<D> {
     environment: Environment,
     downloader: D,
 }
 
-#[allow(dead_code)]
 impl<D: OCIAgentTypeDownloader> RemoteRegistry<D> {
     pub fn new(environment: Environment, downloader: D) -> Self {
         Self {
@@ -49,13 +46,24 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
         agent_type_id: &AgentTypeID,
     ) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
         let tag = self.artifact_tag(agent_type_id);
-        let definition = self
+        let raw = self
             .downloader
             .download(&tag)
             .map_err(|err| AgentTypeRegistryError::Remote(err.to_string()))?;
-        Ok(serde_saphyr::from_slice::<AgentTypeDefinition>(
-            &definition,
-        )?)
+        let definition = serde_saphyr::from_slice::<AgentTypeDefinition>(&raw)?;
+
+        // The tag targets a single environment, so a definition for a different one means the
+        // remote returned an artifact we did not ask for. Reject it rather than supervise an
+        // agent type meant for another platform.
+        let found = definition.metadata.environment;
+        if found != self.environment {
+            return Err(AgentTypeRegistryError::EnvironmentMismatch {
+                requested: self.environment,
+                found,
+            });
+        }
+
+        Ok(definition)
     }
 }
 
@@ -102,6 +110,24 @@ deployment:
         let definition = registry.get(&agent_type_id()).unwrap();
 
         assert_eq!(definition.metadata.environment, Environment::K8s);
+    }
+
+    #[test]
+    fn test_get_rejects_definition_for_a_different_environment() {
+        let mut downloader = MockOCIAgentTypeDownloader::new();
+        // The downloader returns a kubernetes definition while the registry runs on Linux.
+        downloader
+            .expect_download()
+            .returning(|_| Ok(K8S_DEFINITION.as_bytes().to_vec()));
+
+        let registry = RemoteRegistry::new(Environment::Linux, downloader);
+        assert_matches!(
+            registry.get(&agent_type_id()),
+            Err(AgentTypeRegistryError::EnvironmentMismatch {
+                requested: Environment::Linux,
+                found: Environment::K8s,
+            })
+        );
     }
 
     #[test]

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -46,25 +46,18 @@ impl<D: OCIAgentTypeDownloader> RemoteRegistry<D> {
         &self,
         metadata: &AgentTypeMetadata,
         expected_id: &AgentTypeID,
-        tag: &str,
-    ) -> Result<(), AgentTypeRegistryError> {
+    ) -> Result<(), String> {
         if metadata.environment != self.environment {
-            return Err(AgentTypeRegistryError::MetadataMismatch {
-                tag: tag.to_string(),
-                details: format!(
-                    "expected environment '{}', found '{}'",
-                    self.environment, metadata.environment
-                ),
-            });
+            return Err(format!(
+                "expected environment '{}', found '{}'",
+                self.environment, metadata.environment
+            ));
         }
         if &metadata.id != expected_id {
-            return Err(AgentTypeRegistryError::MetadataMismatch {
-                tag: tag.to_string(),
-                details: format!(
-                    "expected <namespace/name:version> '{}', found  {}",
-                    expected_id, metadata.id
-                ),
-            });
+            return Err(format!(
+                "expected <namespace/name:version> '{}', found  {}",
+                expected_id, metadata.id
+            ));
         }
         Ok(())
     }
@@ -87,7 +80,8 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
         // The tag targets a specific metadata, so a definition for a different one means the
         // remote returned an artifact we did not ask for. Reject it rather than supervise an
         // agent type meant for another platform.
-        self.check_metadata(&definition.metadata, agent_type_id, &tag)?;
+        self.check_metadata(&definition.metadata, agent_type_id)
+            .map_err(|details| AgentTypeRegistryError::MetadataMismatch { tag, details })?;
 
         Ok(definition)
     }

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -1,6 +1,6 @@
 use super::{AgentTypeRegistry, AgentTypeRegistryError};
 use crate::agent_type::agent_type_id::AgentTypeID;
-use crate::agent_type::definition::AgentTypeDefinition;
+use crate::agent_type::definition::{AgentTypeDefinition, AgentTypeMetadata};
 use crate::agent_type::oci::downloader::OCIAgentTypeDownloader;
 use crate::environment::Environment;
 
@@ -38,6 +38,36 @@ impl<D: OCIAgentTypeDownloader> RemoteRegistry<D> {
             agent_type_id.version()
         )
     }
+
+    /// Verifies that the downloaded definition's metadata matches what was requested: its
+    /// environment must equal the running one and its id must equal `expected_id`. A mismatch
+    /// means the remote returned an artifact we did not ask for, so it is rejected.
+    fn check_metadata(
+        &self,
+        metadata: &AgentTypeMetadata,
+        expected_id: &AgentTypeID,
+        tag: &str,
+    ) -> Result<(), AgentTypeRegistryError> {
+        if metadata.environment != self.environment {
+            return Err(AgentTypeRegistryError::MetadataMismatch {
+                tag: tag.to_string(),
+                details: format!(
+                    "expected environment '{}', found '{}'",
+                    self.environment, metadata.environment
+                ),
+            });
+        }
+        if &metadata.id != expected_id {
+            return Err(AgentTypeRegistryError::MetadataMismatch {
+                tag: tag.to_string(),
+                details: format!(
+                    "expected <namespace/name:version> '{}', found  {}",
+                    expected_id, metadata.id
+                ),
+            });
+        }
+        Ok(())
+    }
 }
 
 impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
@@ -54,16 +84,10 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
         let definition =
             AgentTypeDefinition::from_slice(&raw).map_err(AgentTypeRegistryError::Parsing)?;
 
-        // The tag targets a single environment, so a definition for a different one means the
+        // The tag targets a specific metadata, so a definition for a different one means the
         // remote returned an artifact we did not ask for. Reject it rather than supervise an
         // agent type meant for another platform.
-        let found = definition.metadata.environment;
-        if found != self.environment {
-            return Err(AgentTypeRegistryError::EnvironmentMismatch {
-                requested: self.environment,
-                found,
-            });
-        }
+        self.check_metadata(&definition.metadata, agent_type_id, &tag)?;
 
         Ok(definition)
     }
@@ -81,6 +105,18 @@ mod tests {
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
+protocol_version: "1.0"
+platform: kubernetes
+deployment:
+  objects: {}
+"#;
+
+    // Same environment as the requested id, but a different version: the remote returned an
+    // artifact whose metadata id does not match what we asked for.
+    const K8S_DEFINITION_MISMATCHED_ID: &str = r#"
+namespace: newrelic
+name: com.newrelic.infrastructure
+version: 0.2.0
 protocol_version: "1.0"
 platform: kubernetes
 deployment:
@@ -126,10 +162,27 @@ deployment:
         let registry = RemoteRegistry::new(Environment::Linux, downloader);
         assert_matches!(
             registry.get(&agent_type_id()),
-            Err(AgentTypeRegistryError::EnvironmentMismatch {
-                requested: Environment::Linux,
-                found: Environment::K8s,
-            })
+            Err(AgentTypeRegistryError::MetadataMismatch { tag, details })
+                if tag == "host-linux-com.newrelic.infrastructure-0.1.0"
+                    && details.contains("environment")
+        );
+    }
+
+    #[test]
+    fn test_get_rejects_definition_with_a_mismatched_id() {
+        let mut downloader = MockOCIAgentTypeDownloader::new();
+        // The environment matches, but the returned definition's id (version 0.2.0) differs from
+        // the requested one (0.1.0).
+        downloader
+            .expect_download()
+            .returning(|_| Ok(K8S_DEFINITION_MISMATCHED_ID.as_bytes().to_vec()));
+
+        let registry = RemoteRegistry::new(Environment::K8s, downloader);
+        assert_matches!(
+            registry.get(&agent_type_id()),
+            Err(AgentTypeRegistryError::MetadataMismatch { tag, details })
+                if tag == "kubernetes-com.newrelic.infrastructure-0.1.0"
+                    && details.contains("newrelic/com.newrelic.infrastructure:0.2.0")
         );
     }
 

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -1,0 +1,134 @@
+use super::{AgentTypeRegistry, AgentTypeRegistryError};
+use crate::agent_type::agent_type_id::AgentTypeID;
+use crate::agent_type::definition::AgentTypeDefinition;
+use crate::agent_type::oci::downloader::OCIAgentTypeDownloader;
+use crate::environment::Environment;
+
+/// An [AgentTypeRegistry] that resolves agent types by pulling them from a remote OCI registry
+/// through an [OCIAgentTypeDownloader].
+///
+/// The agent type fully qualified name does not carry the platform/operating system; Agent Control
+/// resolves them from its own running [Environment], which is used to build the OCI tag
+/// `<platform>-<operating_system>-<name>-<version>` (the operating system segment is omitted on
+/// kubernetes, matching how agent type metadata maps platform/os to [Environment]).
+// TODO: not yet wired into `Registry`; remove the `allow(dead_code)` once the composite registry
+// consumes it (see the precedence TODO in `Registry`).
+#[allow(dead_code)]
+pub struct RemoteRegistry<D> {
+    environment: Environment,
+    downloader: D,
+}
+
+#[allow(dead_code)]
+impl<D: OCIAgentTypeDownloader> RemoteRegistry<D> {
+    pub fn new(environment: Environment, downloader: D) -> Self {
+        Self {
+            environment,
+            downloader,
+        }
+    }
+
+    /// Builds the OCI tag for the given id according to the running environment.
+    fn artifact_tag(&self, agent_type_id: &AgentTypeID) -> String {
+        let target = match self.environment {
+            Environment::Linux => "host-linux",
+            Environment::Windows => "host-windows",
+            Environment::K8s => "kubernetes",
+        };
+        format!(
+            "{target}-{}-{}",
+            agent_type_id.name(),
+            agent_type_id.version()
+        )
+    }
+}
+
+impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
+    fn get(
+        &self,
+        agent_type_id: &AgentTypeID,
+    ) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
+        let tag = self.artifact_tag(agent_type_id);
+        let definition = self
+            .downloader
+            .download(&tag)
+            .map_err(|err| AgentTypeRegistryError::Remote(err.to_string()))?;
+        Ok(serde_saphyr::from_slice::<AgentTypeDefinition>(
+            &definition,
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::oci::downloader::tests::{
+        FakeDownloaderError, MockOCIAgentTypeDownloader,
+    };
+    use assert_matches::assert_matches;
+
+    const K8S_DEFINITION: &str = r#"
+namespace: newrelic
+name: com.newrelic.infrastructure
+version: 0.1.0
+platform: kubernetes
+deployment:
+  objects: {}
+"#;
+
+    fn agent_type_id() -> AgentTypeID {
+        AgentTypeID::try_from("newrelic/com.newrelic.infrastructure:0.1.0").unwrap()
+    }
+
+    #[rstest::rstest]
+    #[case::linux(Environment::Linux, "host-linux-com.newrelic.infrastructure-0.1.0")]
+    #[case::windows(Environment::Windows, "host-windows-com.newrelic.infrastructure-0.1.0")]
+    #[case::kubernetes(Environment::K8s, "kubernetes-com.newrelic.infrastructure-0.1.0")]
+    fn test_artifact_tag(#[case] environment: Environment, #[case] expected_tag: &str) {
+        let registry = RemoteRegistry::new(environment, MockOCIAgentTypeDownloader::new());
+        assert_eq!(registry.artifact_tag(&agent_type_id()), expected_tag);
+    }
+
+    #[test]
+    fn test_get_downloads_parses_and_returns_definition() {
+        let mut downloader = MockOCIAgentTypeDownloader::new();
+        downloader
+            .expect_download()
+            .withf(|tag| tag == "kubernetes-com.newrelic.infrastructure-0.1.0")
+            .once()
+            .returning(|_| Ok(K8S_DEFINITION.as_bytes().to_vec()));
+
+        let registry = RemoteRegistry::new(Environment::K8s, downloader);
+        let definition = registry.get(&agent_type_id()).unwrap();
+
+        assert_eq!(definition.metadata.environment, Environment::K8s);
+    }
+
+    #[test]
+    fn test_get_maps_download_failure_to_remote_error() {
+        let mut downloader = MockOCIAgentTypeDownloader::new();
+        downloader
+            .expect_download()
+            .returning(|_| Err(FakeDownloaderError("boom".to_string())));
+
+        let registry = RemoteRegistry::new(Environment::K8s, downloader);
+        assert_matches!(
+            registry.get(&agent_type_id()),
+            Err(AgentTypeRegistryError::Remote(_))
+        );
+    }
+
+    #[test]
+    fn test_get_maps_invalid_definition_to_serialization_error() {
+        let mut downloader = MockOCIAgentTypeDownloader::new();
+        downloader
+            .expect_download()
+            .returning(|_| Ok(b"this is not a valid agent type".to_vec()));
+
+        let registry = RemoteRegistry::new(Environment::K8s, downloader);
+        assert_matches!(
+            registry.get(&agent_type_id()),
+            Err(AgentTypeRegistryError::Serialization(_))
+        );
+    }
+}

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -50,7 +50,9 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
             .downloader
             .download(&tag)
             .map_err(|err| AgentTypeRegistryError::Remote(err.to_string()))?;
-        let definition = serde_saphyr::from_slice::<AgentTypeDefinition>(&raw)?;
+
+        let definition =
+            AgentTypeDefinition::from_slice(&raw).map_err(AgentTypeRegistryError::Parsing)?;
 
         // The tag targets a single environment, so a definition for a different one means the
         // remote returned an artifact we did not ask for. Reject it rather than supervise an
@@ -79,6 +81,7 @@ mod tests {
 namespace: newrelic
 name: com.newrelic.infrastructure
 version: 0.1.0
+protocol_version: "1.0"
 platform: kubernetes
 deployment:
   objects: {}
@@ -154,7 +157,7 @@ deployment:
         let registry = RemoteRegistry::new(Environment::K8s, downloader);
         assert_matches!(
             registry.get(&agent_type_id()),
-            Err(AgentTypeRegistryError::Serialization(_))
+            Err(AgentTypeRegistryError::Parsing(_))
         );
     }
 }

--- a/agent-control/tests/on_host/agent_type_remote_registry.rs
+++ b/agent-control/tests/on_host/agent_type_remote_registry.rs
@@ -25,6 +25,7 @@ fn agent_type_definition_yaml(name: &str, version: &str) -> String {
 namespace: example
 name: {name}
 version: {version}
+protocol_version: "1.0"
 platform: kubernetes
 deployment:
   objects: {{}}

--- a/agent-control/tests/on_host/agent_type_remote_registry.rs
+++ b/agent-control/tests/on_host/agent_type_remote_registry.rs
@@ -1,0 +1,149 @@
+use crate::common::runtime::tokio_runtime;
+use crate::on_host::tools::oci_package_manager::TestDataHelper;
+use assert_matches::assert_matches;
+use newrelic_agent_control::agent_control::config::Registry;
+use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
+use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
+use newrelic_agent_control::agent_type::oci::downloader::OCIAgentTypeArtifactDownloader;
+use newrelic_agent_control::agent_type::registry::remote::RemoteRegistry;
+use newrelic_agent_control::agent_type::registry::{AgentTypeRegistry, AgentTypeRegistryError};
+use newrelic_agent_control::agent_type::runtime_config::on_host::package::rendered::Repository;
+use newrelic_agent_control::environment::Environment;
+use newrelic_agent_control::http::config::ProxyConfig;
+use newrelic_agent_control::oci;
+use oci_client::Reference;
+use oci_client::client::{ClientConfig, ClientProtocol};
+use oci_test_utils::{AgentTypeArtifact, OCISigner, PackagePublisher};
+use std::str::FromStr;
+use tempfile::tempdir;
+use url::Url;
+
+/// A minimal but valid kubernetes agent type definition.
+fn agent_type_definition_yaml(name: &str, version: &str) -> String {
+    format!(
+        r#"
+namespace: example
+name: {name}
+version: {version}
+platform: kubernetes
+deployment:
+  objects: {{}}
+"#
+    )
+}
+
+/// Publishes an agent type artifact (a gzipped tar with the single definition file) to the test
+/// registry under `tag`, optionally signing it, and returns the pushed reference.
+fn push_agent_type(signer: Option<&OCISigner>, name: &str, version: &str, tag: &str) -> Reference {
+    let source_dir = tempdir().unwrap();
+    let archive_dir = tempdir().unwrap();
+    let archive = archive_dir.path().join("agent-type.tar.gz");
+    TestDataHelper::compress_tar_gz(
+        source_dir.path(),
+        &archive,
+        &agent_type_definition_yaml(name, version),
+        &format!("{tag}.yaml"),
+    );
+
+    let reference = PackagePublisher::new(tokio_runtime().handle().clone(), OCI_TEST_REGISTRY_URL)
+        .push_with_tag(&archive, AgentTypeArtifact, tag);
+
+    if let Some(signer) = signer {
+        signer.sign_artifact(&reference);
+    }
+    reference
+}
+
+/// Builds a [RemoteRegistry] backed by a real downloader pointed at the test registry for the
+/// kubernetes environment.
+fn remote_registry(
+    reference: &Reference,
+    public_key_url: Url,
+) -> RemoteRegistry<OCIAgentTypeArtifactDownloader> {
+    let client = oci::Client::try_new(
+        ClientConfig {
+            protocol: ClientProtocol::Http,
+            ..Default::default()
+        },
+        ProxyConfig::default(),
+        tokio_runtime(),
+    )
+    .unwrap();
+
+    let downloader = OCIAgentTypeArtifactDownloader::new(
+        client,
+        Registry::from_str(OCI_TEST_REGISTRY_URL).unwrap(),
+        Repository::from_str(reference.repository()).unwrap(),
+        None,
+        Some(public_key_url),
+    );
+
+    RemoteRegistry::new(Environment::K8s, downloader)
+}
+
+#[test]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+fn test_remote_registry_resolves_signed_agent_type_with_oci_registry() {
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+    let id = AgentTypeID::try_from("example/some.agent.type:0.0.123").unwrap();
+    let reference = push_agent_type(
+        Some(&signer),
+        "some.agent.type",
+        "0.0.123",
+        "kubernetes-some.agent.type-0.0.123",
+    );
+
+    let registry = remote_registry(
+        &reference,
+        Url::parse(&signer.jwks_url().to_string()).unwrap(),
+    );
+
+    let definition = registry.get(&id).expect("signed agent type should resolve");
+    assert_eq!(definition.metadata.id, id);
+    assert_eq!(definition.metadata.environment, Environment::K8s);
+}
+
+#[test]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+fn test_remote_registry_rejects_unsigned_agent_type_when_verification_enabled_with_oci_registry() {
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+    let id = AgentTypeID::try_from("example/some.agent.type:0.0.124").unwrap();
+    // Pushed without signing while verification is enabled below.
+    let reference = push_agent_type(
+        None,
+        "some.agent.type",
+        "0.0.124",
+        "kubernetes-some.agent.type-0.0.124",
+    );
+
+    let registry = remote_registry(
+        &reference,
+        Url::parse(&signer.jwks_url().to_string()).unwrap(),
+    );
+
+    assert_matches!(registry.get(&id), Err(AgentTypeRegistryError::Remote(_)));
+}
+
+#[test]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+fn test_remote_registry_errors_on_missing_agent_type_with_oci_registry() {
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+    // Publish one agent type so the repository exists, then request a different, absent one.
+    let reference = push_agent_type(
+        Some(&signer),
+        "some.agent.type",
+        "0.0.125",
+        "kubernetes-some.agent.type-0.0.125",
+    );
+
+    let registry = remote_registry(
+        &reference,
+        Url::parse(&signer.jwks_url().to_string()).unwrap(),
+    );
+
+    let missing = AgentTypeID::try_from("example/another.agent.type:9.9.9").unwrap();
+    assert_matches!(
+        registry.get(&missing),
+        Err(AgentTypeRegistryError::Remote(_))
+    );
+}

--- a/agent-control/tests/on_host/mod.rs
+++ b/agent-control/tests/on_host/mod.rs
@@ -1,4 +1,5 @@
 mod agent_control_cli;
+mod agent_type_remote_registry;
 mod cli;
 mod command;
 mod config_repository;

--- a/test/crates/oci-test-utils/src/lib.rs
+++ b/test/crates/oci-test-utils/src/lib.rs
@@ -3,7 +3,7 @@ use aws_lc_rs::digest::{SHA256, digest};
 mod publisher;
 mod signer;
 
-pub use publisher::{PackageMediaType, PackagePublisher};
+pub use publisher::{AgentTypeArtifact, ArtifactKind, PackageMediaType, PackagePublisher};
 pub use signer::OCISigner;
 
 /// Port to be used for plain http testing registries

--- a/test/crates/oci-test-utils/src/publisher.rs
+++ b/test/crates/oci-test-utils/src/publisher.rs
@@ -22,20 +22,46 @@ use tokio::runtime::Handle;
 const AGENT_PACKAGE_MANIFEST_ARTIFACT_TYPE: &str = "application/vnd.newrelic.agent.v1";
 const AGENT_PACKAGE_LAYER_TAR_GZ: &str = "application/vnd.newrelic.agent.content.v1.tar+gzip";
 const AGENT_PACKAGE_LAYER_ZIP: &str = "application/vnd.newrelic.agent.content.v1.zip";
+const AGENT_TYPE_MANIFEST_ARTIFACT_TYPE: &str = "application/vnd.newrelic.agent-type.v1";
+const AGENT_TYPE_LAYER_TAR_GZ: &str = "application/vnd.newrelic.agent-type.content.v1.tar+gzip";
 
 const REPOSITORY_NAME: &str = "test";
+
+/// Describes the OCI manifest artifact type and layer media type of a published artifact, so the
+/// publisher can emit both agent packages and agent types.
+pub trait ArtifactKind {
+    fn manifest_artifact_type(&self) -> &'static str;
+    fn layer_media_type(&self) -> &'static str;
+}
 
 pub enum PackageMediaType {
     TarGz,
     Zip,
 }
 
-impl PackageMediaType {
+impl ArtifactKind for PackageMediaType {
+    fn manifest_artifact_type(&self) -> &'static str {
+        AGENT_PACKAGE_MANIFEST_ARTIFACT_TYPE
+    }
+
     fn layer_media_type(&self) -> &'static str {
         match self {
             PackageMediaType::TarGz => AGENT_PACKAGE_LAYER_TAR_GZ,
             PackageMediaType::Zip => AGENT_PACKAGE_LAYER_ZIP,
         }
+    }
+}
+
+/// An agent type artifact: a single gzipped tar containing the agent type definition.
+pub struct AgentTypeArtifact;
+
+impl ArtifactKind for AgentTypeArtifact {
+    fn manifest_artifact_type(&self) -> &'static str {
+        AGENT_TYPE_MANIFEST_ARTIFACT_TYPE
+    }
+
+    fn layer_media_type(&self) -> &'static str {
+        AGENT_TYPE_LAYER_TAR_GZ
     }
 }
 
@@ -72,30 +98,50 @@ impl PackagePublisher {
         self
     }
 
-    /// Pushes `file` as an OCI agent package artifact and returns the index manifest reference.
-    /// The artifact is structured as a manifest index (multiarch) with a single entry for the
-    /// current platform.
-    pub fn push(&self, file: &Path, media_type: PackageMediaType) -> Reference {
-        self.push_with_tag(file, media_type, &unique_tag())
+    /// Pushes `file` as an OCI artifact of the given [ArtifactKind] and returns the index manifest
+    /// reference. The artifact is structured as a manifest index (multiarch) with a single entry
+    /// for the current platform.
+    pub fn push<A: ArtifactKind>(&self, file: &Path, kind: A) -> Reference {
+        self.push_with_tag(file, kind, &unique_tag())
     }
 
     /// Same as [`push`] but uses `tag` instead of a generated unique tag.
-    pub fn push_with_tag(&self, file: &Path, media_type: PackageMediaType, tag: &str) -> Reference {
-        self.runtime_handle
-            .block_on(async { self.push_async(file, media_type, tag).await })
+    pub fn push_with_tag<A: ArtifactKind>(&self, file: &Path, kind: A, tag: &str) -> Reference {
+        self.runtime_handle.block_on(async {
+            self.push_async(
+                file,
+                kind.layer_media_type(),
+                kind.manifest_artifact_type(),
+                tag,
+            )
+            .await
+        })
     }
 
-    async fn push_async(&self, file: &Path, media_type: PackageMediaType, tag: &str) -> Reference {
+    async fn push_async(
+        &self,
+        file: &Path,
+        layer_media_type: &str,
+        manifest_artifact_type: &str,
+        tag: &str,
+    ) -> Reference {
         let index_reference: Reference = format!("{}/{REPOSITORY_NAME}:{tag}", self.registry_url)
             .parse()
             .unwrap();
 
         let file_name = file.file_name().unwrap().to_string_lossy().to_string();
 
-        let blob_descriptor = self.push_blob(&index_reference, file, &media_type).await;
+        let blob_descriptor = self
+            .push_blob(&index_reference, file, layer_media_type)
+            .await;
 
         let (manifest_digest, manifest_size) = self
-            .push_package_manifest(&index_reference, blob_descriptor, file_name)
+            .push_package_manifest(
+                &index_reference,
+                blob_descriptor,
+                file_name,
+                manifest_artifact_type,
+            )
             .await;
 
         self.push_package_index(&index_reference, manifest_digest, manifest_size)
@@ -109,6 +155,7 @@ impl PackagePublisher {
         index_reference: &Reference,
         blob_descriptor: OciDescriptor,
         file_name: String,
+        manifest_artifact_type: &str,
     ) -> (String, i64) {
         // Pushed under a tagged reference because the client's local digest calculation does not
         // always match the registry's canonical JSON. The tag is not used in production scenarios.
@@ -124,7 +171,7 @@ impl PackagePublisher {
 
         let pkg_manifest = OciImageManifest {
             media_type: Some(OCI_IMAGE_MEDIA_TYPE.to_string()),
-            artifact_type: Some(AGENT_PACKAGE_MANIFEST_ARTIFACT_TYPE.to_string()),
+            artifact_type: Some(manifest_artifact_type.to_string()),
             layers: vec![blob_descriptor],
             config,
             annotations: Some(title_annotation),
@@ -214,7 +261,7 @@ impl PackagePublisher {
         &self,
         reference: &Reference,
         file: &Path,
-        media_type: &PackageMediaType,
+        layer_media_type: &str,
     ) -> OciDescriptor {
         let mut f = File::open(file).await.unwrap();
         let mut data = Vec::new();
@@ -229,7 +276,7 @@ impl PackagePublisher {
             .unwrap();
 
         OciDescriptor {
-            media_type: media_type.layer_media_type().to_string(),
+            media_type: layer_media_type.to_string(),
             digest,
             size,
             ..Default::default()


### PR DESCRIPTION
## Summary

Adds a `RemoteRegistry` that resolves agent type definitions by pulling them from an OCI registry, complementing the existing embedded/local registry. It is not yet wired into the composite `Registry` (gated by an existing TODO), so this PR introduces the resolver and its test scaffolding without changing runtime resolution behavior.

## Changes

- `RemoteRegistry`: builds an environment-targeted OCI tag (`host-linux-<name>-<version>`, `host-windows-...`, or `kubernetes-...`), downloads through `OCIAgentTypeDownloader`, parses the definition, and rejects any whose platform does not match the running environment.
- `OCIAgentTypeDownloader` trait now carries an associated `Error` type so consumers and mocks aren't tied to the concrete downloader error.
- Test publisher (`oci-test-utils`) generalized behind an `ArtifactKind` trait so it can publish agent-type artifacts alongside agent packages; existing `PackageMediaType` callers are unchanged.
- Integration tests actually using the RemoteRegistry.

## Notes for reviewers

- Not yet active: nothing constructs `RemoteRegistry` in production paths, so this is additive.
- The OCI tag uses only `name` and `version`, not the agent type namespace. This is the expected behavior as `namespace` is supposed to be used to support additional remotes.
