### PR TITLE
chore: pin pipeline tool dependencies to explicit versions

### DIFF
--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -74,6 +74,8 @@ jobs:
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          version: v0.34.1
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:

--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Install cargo-xwin and go-winres
         run: |
-          cargo install --locked cargo-xwin --force
-          go install github.com/tc-hib/go-winres@latest
+          cargo install --locked cargo-xwin --version 0.22.0 --force
+          go install github.com/tc-hib/go-winres@v0.3.3
 
       - name: If pre-release, set tag and verify it matches Cargo.toml version
         if: ${{ inputs.pre-release}}

--- a/.github/workflows/on_demand_dhat_heap_build.yml
+++ b/.github/workflows/on_demand_dhat_heap_build.yml
@@ -73,8 +73,8 @@ jobs:
 
       - name: Install cargo-xwin and go-winres
         run: |
-          cargo install --locked cargo-xwin --force
-          go install github.com/tc-hib/go-winres@latest
+          cargo install --locked cargo-xwin --version 0.22.0 --force
+          go install github.com/tc-hib/go-winres@v0.3.3
 
       - name: Build dhat-heap Windows binaries
         env:

--- a/.github/workflows/on_demand_dhat_heap_image.yml
+++ b/.github/workflows/on_demand_dhat_heap_image.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          version: v0.34.1
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:

--- a/.github/workflows/on_demand_push_internal_image.yml
+++ b/.github/workflows/on_demand_push_internal_image.yml
@@ -70,6 +70,8 @@ jobs:
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          version: v0.34.1
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:

--- a/.github/workflows/post-release-agent-metadata.yml
+++ b/.github/workflows/post-release-agent-metadata.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -104,9 +104,6 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@71765c00dd3e08a5484a5b9e82a4c88b86520e0e # 71765c00dd3e08a5484a5b9e82a4c88b86520e0e
-        # uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
@@ -371,7 +368,7 @@ jobs:
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # 05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           # allowed-failures: docs, linters
           # allowed-skips: non-voting-flaky-job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          version: v0.34.1
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:


### PR DESCRIPTION
Following a prior memory leak incident where an action was version-pinned but its internal dependencies were not, this PR audits all CI workflow files and pins every tool installed without an explicit version.

**Changes:**
- pin `cargo-xwin` to `0.22.0` and `go-winres` to `v0.3.3`
- pin `docker/setup-buildx-action` internal version to `v0.34.1`

There are other dependencies we could pin but I decided they were not important. For example, `cargo-audit`, `tilt` or `commitlint`. The reason being that these are **not** used for building the binary.