### PR TITLE
refactor: use common oci fetcher for downloaders

### DIFF
--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -37,7 +37,7 @@ use crate::opamp::instance_id::storer::Storer;
 use crate::opamp::operations::agent_description;
 use crate::opamp::remote_config::validators::SupportedRemoteConfigValidator;
 use crate::opamp::remote_config::validators::regexes::RegexValidator;
-use crate::package::oci::downloader::OCIArtifactDownloader;
+use crate::package::oci::downloader::OCIPackageArtifactDownloader;
 use crate::package::oci::package_manager::OCIPackageManager;
 use crate::secret_retriever::on_host::retrieve::OnHostSecretRetriever;
 use crate::secrets_provider::SecretsProviders;
@@ -178,7 +178,7 @@ impl AgentControlRunner {
             .map_err(|err| RunError(format!("failed to create the OciClient: {err}")))?;
 
         let agents_package_manager = OCIPackageManager::new(
-            OCIArtifactDownloader::new(
+            OCIPackageArtifactDownloader::new(
                 oci_client.clone(),
                 self.bootstrap_config.oci.registry.clone(),
                 self.bootstrap_config.oci.auth.clone(),
@@ -229,7 +229,7 @@ impl AgentControlRunner {
         let (agent_control_internal_publisher, agent_control_internal_consumer) = pub_sub();
 
         let agent_control_package_manager = OCIPackageManager::new(
-            OCIArtifactDownloader::new(
+            OCIPackageArtifactDownloader::new(
                 oci_client.clone(),
                 self.bootstrap_config.oci.registry.clone(),
                 self.bootstrap_config.oci.auth.clone(),

--- a/agent-control/src/agent_type/oci/downloader.rs
+++ b/agent-control/src/agent_type/oci/downloader.rs
@@ -2,24 +2,16 @@ use std::time::Duration;
 
 use oci_client::Reference;
 use oci_client::secrets::RegistryAuth;
-use thiserror::Error;
 use tracing::{debug, warn};
 use url::Url;
 
 use crate::agent_control::config::{OciAuth, Registry};
 use crate::agent_type::runtime_config::on_host::package::rendered::Repository;
-use crate::oci::Client;
 use crate::oci::artifact_definitions::LocalAgentType;
-use crate::utils::retry::retry;
-
-const DEFAULT_RETRIES: usize = 0;
+use crate::oci::{Client, OciArtifactFetcher, OciClientError};
 
 /// Maximum size of an agent type artifact blob (generous upper bound).
 const MAX_ARTIFACT_SIZE_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
-
-#[derive(Debug, Error)]
-#[error("downloading agent type OCI artifact: {0}")]
-pub struct OCIAgentTypeDownloaderError(String);
 
 /// An interface for downloading Agent Type definitions from a configured OCI remote.
 pub trait OCIAgentTypeDownloader: Send + Sync {
@@ -40,18 +32,15 @@ pub trait OCIAgentTypeDownloader: Send + Sync {
 /// The artifact content is never written to disk, so resolution does not depend on a writable
 /// filesystem location (relevant on Kubernetes). Blobs larger than `max_size_bytes` are rejected.
 pub struct OCIAgentTypeArtifactDownloader {
-    client: Client,
+    fetcher: OciArtifactFetcher,
     registry: Registry,
     repository: Repository,
-    auth: RegistryAuth,
     public_key_url: Option<Url>,
-    max_retries: usize,
-    retry_interval: Duration,
     max_size_bytes: usize,
 }
 
 impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
-    type Error = OCIAgentTypeDownloaderError;
+    type Error = OciClientError;
 
     /// Downloads the agent type artifact at `<registry>/<repository>:<tag>`.
     ///
@@ -61,7 +50,7 @@ impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
     ///
     /// On failure the operation is retried as configured; if all attempts are exhausted it returns
     /// an error.
-    fn download(&self, tag: &str) -> Result<Vec<u8>, OCIAgentTypeDownloaderError> {
+    fn download(&self, tag: &str) -> Result<Vec<u8>, OciClientError> {
         let base_reference = Reference::with_tag(
             self.registry.to_string(),
             self.repository.to_string(),
@@ -71,18 +60,15 @@ impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
             oci_reference = base_reference.to_string(),
             "Downloading Agent Type from remote repository"
         );
-        retry(self.max_retries, self.retry_interval, || {
-            let reference = if let Some(pk_url) = self.should_verify_signature() {
-                &self.verified_reference(&base_reference, pk_url)?
-            } else {
-                &base_reference
-            };
-            self.download_definition(reference)
-                .inspect_err(|e| debug!("Download '{reference}' failed with error: {e}"))
-        })
-        .map_err(|e| {
-            OCIAgentTypeDownloaderError(format!("download attempts exceeded, last error: {e}"))
-        })
+        let public_key_url = self.should_verify_signature();
+        let max_size_bytes = self.max_size_bytes;
+        self.fetcher.fetch(
+            &base_reference,
+            public_key_url,
+            |client, reference, auth| {
+                Self::download_definition(client, reference, auth, max_size_bytes)
+            },
+        )
     }
 }
 
@@ -96,16 +82,10 @@ impl OCIAgentTypeArtifactDownloader {
         public_key_url: Option<Url>,
     ) -> Self {
         Self {
-            client,
+            fetcher: OciArtifactFetcher::new(client, auth),
             registry,
             repository,
-            auth: auth
-                .as_ref()
-                .map(RegistryAuth::from)
-                .unwrap_or(RegistryAuth::Anonymous),
             public_key_url,
-            max_retries: DEFAULT_RETRIES,
-            retry_interval: Duration::default(),
             max_size_bytes: MAX_ARTIFACT_SIZE_BYTES,
         }
     }
@@ -113,8 +93,7 @@ impl OCIAgentTypeArtifactDownloader {
     /// Returns a new downloader with the provided retry configuration.
     pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
         Self {
-            max_retries: retries,
-            retry_interval,
+            fetcher: self.fetcher.with_retries(retries, retry_interval),
             ..self
         }
     }
@@ -132,46 +111,32 @@ impl OCIAgentTypeArtifactDownloader {
         self.public_key_url.as_ref()
     }
 
-    /// Returns the [Reference] after verifying its signature. The returned reference always includes
-    /// the `digest` to assure it is the same reference whose signature was verified.
-    fn verified_reference(
-        &self,
-        reference: &Reference,
-        public_key_url: &Url,
-    ) -> Result<Reference, OCIAgentTypeDownloaderError> {
-        self.client
-            .verify_signature(reference, public_key_url, &self.auth)
-            .map_err(|err| OCIAgentTypeDownloaderError(err.to_string()))
-    }
-
     /// Pulls the manifest, validates it is an agent type artifact, pulls its single layer into
     /// memory and returns the agent type definition it contains.
     fn download_definition(
-        &self,
+        client: &Client,
         reference: &Reference,
-    ) -> Result<Vec<u8>, OCIAgentTypeDownloaderError> {
-        let (manifest, _) = self
-            .client
-            .pull_image_manifest(reference, &self.auth)
-            .map_err(|err| {
-                OCIAgentTypeDownloaderError(format!("pull artifact manifest failure: {err}"))
-            })?;
-
-        let layer = LocalAgentType::get_layer(&manifest).map_err(|err| {
-            OCIAgentTypeDownloaderError(format!("validating agent type manifest: {err}"))
+        auth: &RegistryAuth,
+        max_size_bytes: usize,
+    ) -> Result<Vec<u8>, OciClientError> {
+        let (manifest, _) = client.pull_image_manifest(reference, auth).map_err(|err| {
+            OciClientError::FetchArtifact(format!("downloading agent type manifest: {err}"))
         })?;
 
-        let blob = self
-            .client
-            .pull_blob(reference, &layer, self.max_size_bytes)
+        let layer = LocalAgentType::get_layer(&manifest).map_err(|err| {
+            OciClientError::FetchArtifact(format!("validating agent type manifest: {err}"))
+        })?;
+
+        let blob = client
+            .pull_blob(reference, &layer, max_size_bytes)
             .map_err(|err| {
-                OCIAgentTypeDownloaderError(format!("download artifact failure: {err}"))
+                OciClientError::FetchArtifact(format!("downloading agent type reference: {err}"))
             })?;
 
         LocalAgentType::new(blob)
             .extract_definition()
             .map_err(|err| {
-                OCIAgentTypeDownloaderError(format!("extracting agent type definition: {err}"))
+                OciClientError::FetchArtifact(format!("extracting agent type definition: {err}"))
             })
     }
 }
@@ -182,8 +147,6 @@ pub mod tests {
     use crate::http::config::ProxyConfig;
     use crate::oci::artifact_definitions::{LayerMediaType, ManifestArtifactType};
     use crate::oci::tests::FakeOciServer;
-    use crate::signature::public_key::tests::TestKeyPair;
-    use crate::signature::public_key_fetcher::tests::JwksMockServer;
     use crate::utils::test_runtime::tokio_runtime;
     use assert_matches::assert_matches;
     use mockall::mock;
@@ -256,24 +219,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_download_success_with_signature() {
-        let key_pair = TestKeyPair::new(0);
-        let jwks_server = JwksMockServer::new(vec![
-            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
-        ]);
-        let tar_gz = tar_gz_with_definition(&format!("{TAG}.yaml"), DEFINITION);
-        let server = FakeOciServer::new(REPOSITORY, TAG)
-            .with_artifact_type(&ManifestArtifactType::AgentType.to_string())
-            .with_layer(&tar_gz, &LayerMediaType::AgentType.to_string())
-            .with_signature(&key_pair)
-            .build();
-
-        let downloader = create_downloader(server.registry(), Some(jwks_server.url));
-        let definition = downloader.download(TAG).unwrap();
-        assert_eq!(definition, DEFINITION);
-    }
-
-    #[test]
     fn test_download_success_signature_disabled() {
         let tar_gz = tar_gz_with_definition(&format!("{TAG}.yaml"), DEFINITION);
         let server = FakeOciServer::new(REPOSITORY, TAG)
@@ -295,26 +240,8 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None);
-        assert_matches!(downloader.download(TAG), Err(OCIAgentTypeDownloaderError(msg)) => {
+        assert_matches!(downloader.download(TAG), Err(OciClientError::AttemptsExceeded(msg)) => {
             assert!(msg.contains("validating agent type manifest"), "{msg}");
-        });
-    }
-
-    #[test]
-    fn test_download_unsigned_but_verification_enabled() {
-        let key_pair = TestKeyPair::new(0);
-        let jwks_server = JwksMockServer::new(vec![
-            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
-        ]);
-        let tar_gz = tar_gz_with_definition(&format!("{TAG}.yaml"), DEFINITION);
-        let server = FakeOciServer::new(REPOSITORY, TAG)
-            .with_artifact_type(&ManifestArtifactType::AgentType.to_string())
-            .with_layer(&tar_gz, &LayerMediaType::AgentType.to_string())
-            .build(); // not signed
-
-        let downloader = create_downloader(server.registry(), Some(jwks_server.url));
-        assert_matches!(downloader.download(TAG), Err(OCIAgentTypeDownloaderError(msg)) => {
-            assert!(msg.contains("signature verification failed"), "{msg}");
         });
     }
 
@@ -327,8 +254,8 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None).with_max_size_bytes(10);
-        assert_matches!(downloader.download(TAG), Err(OCIAgentTypeDownloaderError(msg)) => {
-            assert!(msg.contains("download artifact failure"), "{msg}");
+        assert_matches!(downloader.download(TAG), Err(OciClientError::AttemptsExceeded(msg)) => {
+            assert!(msg.contains("exceeds maximum"), "{msg}");
         });
     }
 }

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -1,7 +1,10 @@
 //! This module provides an [oci_client] wrapper.
 
+use std::time::Duration;
 use std::{path::Path, sync::Arc};
 
+use crate::agent_control::config::OciAuth;
+use crate::utils::retry::retry;
 use crate::{http::config::ProxyConfig, signature::public_key_fetcher::PublicKeyFetcher};
 
 use futures::TryStreamExt;
@@ -12,6 +15,7 @@ use oci_client::{
     secrets::RegistryAuth,
 };
 use tokio::runtime::Runtime;
+use tracing::debug;
 use url::Url;
 
 pub mod artifact_definitions;
@@ -20,6 +24,8 @@ mod proxy;
 mod signature_verification;
 
 pub use error::OciClientError;
+
+const DEFAULT_RETRIES: usize = 0;
 
 /// [oci_client::Client] wrapper with extended functionality.
 /// It also wraps all _async_ operations using the underlying runtime, all functions will
@@ -167,6 +173,83 @@ impl Client {
             .map_err(|err| OciClientError::Verify(format!("could not fetch public keys: {err}")))?;
         self.runtime
             .block_on(self.verify_signature_with_public_keys(reference, &public_keys, auth))
+    }
+
+    /// Returns the [Reference] to download from, verifying its signature when required.
+    ///
+    /// When `public_key_url` is `Some`, the artifact's signature is verified via
+    /// [Self::verify_signature] and the returned reference is digest-pinned (assuring the artifact
+    /// downloaded is the one verified). When it is `None`, signature verification is skipped and the
+    /// `base` reference is returned unchanged.
+    pub fn verified_reference(
+        &self,
+        base: &Reference,
+        public_key_url: Option<&Url>,
+        auth: &RegistryAuth,
+    ) -> Result<Reference, OciClientError> {
+        match public_key_url {
+            Some(public_key_url) => self.verify_signature(base, public_key_url, auth),
+            None => Ok(base.clone()),
+        }
+    }
+}
+
+/// Retrying "verify-then-fetch" orchestration to be shared among different components.
+///
+/// It owns a [Client] together with the registry authentication and retry policy, so the
+/// artifact-specific downloaders only need to build a reference and supply how to materialize the
+/// artifact once a verified reference is resolved.
+pub struct OciArtifactFetcher {
+    client: Client,
+    auth: RegistryAuth,
+    max_retries: usize,
+    retry_interval: Duration,
+}
+
+impl OciArtifactFetcher {
+    /// Returns a fetcher with default (no) retries.
+    pub fn new(client: Client, auth: Option<OciAuth>) -> Self {
+        Self {
+            client,
+            auth: auth
+                .as_ref()
+                .map(RegistryAuth::from)
+                .unwrap_or(RegistryAuth::Anonymous),
+            max_retries: DEFAULT_RETRIES,
+            retry_interval: Duration::default(),
+        }
+    }
+
+    /// Returns a new fetcher with the provided retry configuration.
+    pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
+        Self {
+            max_retries: retries,
+            retry_interval,
+            ..self
+        }
+    }
+
+    /// Resolves the reference (verifying its signature when `public_key_url` is `Some`) and fetches
+    /// the artifact from it, retrying the whole operation per the configured policy.
+    ///
+    /// `fetch_artifact` performs the artifact-specific work (manifest validation, layer selection
+    /// and blob retrieval) once a verified reference is resolved. On exhaustion the last error of
+    /// the retried operation is returned, wrapped to signal that all attempts were used.
+    pub fn fetch<T>(
+        &self,
+        base_reference: &Reference,
+        public_key_url: Option<&Url>,
+        fetch_artifact: impl Fn(&Client, &Reference, &RegistryAuth) -> Result<T, OciClientError>,
+    ) -> Result<T, OciClientError> {
+        retry(self.max_retries, self.retry_interval, || {
+            let reference =
+                self.client
+                    .verified_reference(base_reference, public_key_url, &self.auth)?;
+
+            fetch_artifact(&self.client, &reference, &self.auth)
+                .inspect_err(|e| debug!("Download '{reference}' failed with error: {e}"))
+        })
+        .map_err(|e| OciClientError::AttemptsExceeded(e.to_string()))
     }
 }
 
@@ -321,6 +404,169 @@ pub mod tests {
         assert_matches!(result, Err(OciClientError::PullBlob(msg)) => {
             assert!(msg.to_string().contains("exceeds maximum"), "{msg}");
         });
+    }
+
+    /// Minimal `fetch_artifact` step for fetcher tests: pulls the manifest's first layer into memory.
+    fn pull_first_layer(
+        client: &Client,
+        reference: &Reference,
+        auth: &RegistryAuth,
+    ) -> Result<Vec<u8>, OciClientError> {
+        let (manifest, _) = client.pull_image_manifest(reference, auth)?;
+        let layer = manifest
+            .layers
+            .first()
+            .expect("test manifest should have at least one layer");
+        client.pull_blob(reference, layer, 10 * 1024 * 1024)
+    }
+
+    fn create_fetcher() -> OciArtifactFetcher {
+        OciArtifactFetcher::new(create_test_client(), None)
+    }
+
+    #[test]
+    fn test_fetch_verifies_signature_and_materializes() {
+        let key_pair = TestKeyPair::new(0);
+        let jwks_server = JwksMockServer::new(vec![
+            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
+        ]);
+        let server = FakeOciServer::new("repo", "v1")
+            .with_layer(b"content", "fake-media_type")
+            .with_signature(&key_pair)
+            .build();
+
+        let fetcher = create_fetcher();
+        let blob = fetcher
+            .fetch(
+                &server.reference(),
+                Some(&jwks_server.url),
+                pull_first_layer,
+            )
+            .unwrap();
+        assert_eq!(blob, b"content");
+    }
+
+    #[test]
+    fn test_fetch_skips_verification_when_no_public_key() {
+        let server = FakeOciServer::new("repo", "v1")
+            .with_layer(b"content", "fake-media_type")
+            .build();
+
+        let fetcher = create_fetcher();
+        let blob = fetcher
+            .fetch(&server.reference(), None, pull_first_layer)
+            .unwrap();
+        assert_eq!(blob, b"content");
+    }
+
+    #[test]
+    fn test_fetch_fails_when_verification_enabled_but_unsigned() {
+        let key_pair = TestKeyPair::new(0);
+        let jwks_server = JwksMockServer::new(vec![
+            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
+        ]);
+        let server = FakeOciServer::new("repo", "v1")
+            .with_layer(b"content", "fake-media_type")
+            .build(); // unsigned
+
+        let fetcher = create_fetcher();
+        let err = fetcher
+            .fetch(
+                &server.reference(),
+                Some(&jwks_server.url),
+                pull_first_layer,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("signature verification failed"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_returns_last_error_on_missing_manifest() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/repo/manifests/v1");
+            then.status(404).json_body(serde_json::json!({
+                "errors": [{"code": "MANIFEST_UNKNOWN", "message": "manifest unknown"}]
+            }));
+        });
+        let reference = Reference::with_tag(
+            server.address().to_string(),
+            "repo".to_string(),
+            "v1".to_string(),
+        );
+
+        let fetcher = create_fetcher();
+        let result = fetcher.fetch(&reference, None, pull_first_layer);
+        assert_matches!(result, Err(OciClientError::AttemptsExceeded(msg)) => {
+            assert!(msg.contains("pulling image manifest"), "{msg}");
+        });
+    }
+
+    #[test]
+    fn test_fetch_detects_content_not_matching_digest() {
+        // The manifest served at the pinned digest does not match that digest (MITM).
+        let oci_mock =
+            FakeOciServer::new("repo", "v1").with_layer(b"some content", "fake-media_type");
+        let server = MockServer::start();
+        oci_mock.mock_manifest(
+            &server,
+            &oci_mock.manifest_digest(),
+            b"malicious content".to_vec(),
+        );
+        let reference = Reference::with_digest(
+            server.address().to_string(),
+            "repo".to_string(),
+            oci_mock.manifest_digest(),
+        );
+
+        let fetcher = create_fetcher();
+        let err = fetcher
+            .fetch(&reference, None, pull_first_layer)
+            .unwrap_err();
+        assert!(err.to_string().contains("Digest error"), "{err}");
+    }
+
+    #[test]
+    fn test_fetch_pins_digest_against_toctou() {
+        const ORIGINAL: &[u8] = b"A";
+        const MALICIOUS: &[u8] = b"B";
+
+        let key_pair = TestKeyPair::new(0);
+        let jwks_server = JwksMockServer::new(vec![
+            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
+        ]);
+        let oci_mock_a = FakeOciServer::new("repo", "v1")
+            .with_layer(ORIGINAL, "fake-media_type")
+            .with_signature(&key_pair);
+        let server = MockServer::start();
+        oci_mock_a.setup_mocks_on(&server);
+
+        // Verify the signature to obtain a digest-pinned reference.
+        let reference = oci_mock_a.reference_on_server(&server);
+        let fetcher = create_fetcher();
+        let verified_reference = fetcher
+            .client
+            .verified_reference(&reference, Some(&jwks_server.url), &RegistryAuth::Anonymous)
+            .expect("signature should verify");
+
+        // Move the tag after verification (TOCTOU attack).
+        let oci_mock_b = FakeOciServer::new("repo", "v1").with_layer(MALICIOUS, "fake-media_type");
+        server.reset();
+        oci_mock_b.setup_mocks_on(&server); // new tag takes precedence
+        oci_mock_a.setup_mocks_on(&server); // keep the previous digest and blobs reachable
+
+        // Sanity check: pulling by tag now yields the malicious content.
+        let malicious = fetcher.fetch(&reference, None, pull_first_layer).unwrap();
+        assert_eq!(malicious, MALICIOUS);
+
+        // The pinned reference still resolves to the originally verified content.
+        let original = fetcher
+            .fetch(&verified_reference, None, pull_first_layer)
+            .unwrap();
+        assert_eq!(original, ORIGINAL);
     }
 
     pub struct FakeOciServer {

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -174,24 +174,6 @@ impl Client {
         self.runtime
             .block_on(self.verify_signature_with_public_keys(reference, &public_keys, auth))
     }
-
-    /// Returns the [Reference] to download from, verifying its signature when required.
-    ///
-    /// When `public_key_url` is `Some`, the artifact's signature is verified via
-    /// [Self::verify_signature] and the returned reference is digest-pinned (assuring the artifact
-    /// downloaded is the one verified). When it is `None`, signature verification is skipped and the
-    /// `base` reference is returned unchanged.
-    pub fn verified_reference(
-        &self,
-        base: &Reference,
-        public_key_url: Option<&Url>,
-        auth: &RegistryAuth,
-    ) -> Result<Reference, OciClientError> {
-        match public_key_url {
-            Some(public_key_url) => self.verify_signature(base, public_key_url, auth),
-            None => Ok(base.clone()),
-        }
-    }
 }
 
 /// Retrying "verify-then-fetch" orchestration to be shared among different components.
@@ -242,14 +224,31 @@ impl OciArtifactFetcher {
         fetch_artifact: impl Fn(&Client, &Reference, &RegistryAuth) -> Result<T, OciClientError>,
     ) -> Result<T, OciClientError> {
         retry(self.max_retries, self.retry_interval, || {
-            let reference =
-                self.client
-                    .verified_reference(base_reference, public_key_url, &self.auth)?;
+            let reference = self.verified_reference(base_reference, public_key_url)?;
 
             fetch_artifact(&self.client, &reference, &self.auth)
                 .inspect_err(|e| debug!("Download '{reference}' failed with error: {e}"))
         })
         .map_err(|e| OciClientError::AttemptsExceeded(e.to_string()))
+    }
+
+    /// Returns the [Reference] to download from, verifying its signature when required.
+    ///
+    /// When `public_key_url` is `Some`, the artifact's signature is verified via
+    /// [Client::verify_signature] and the returned reference is digest-pinned (assuring the artifact
+    /// downloaded is the one verified). When it is `None`, signature verification is skipped and the
+    /// `base` reference is returned unchanged.
+    fn verified_reference(
+        &self,
+        base: &Reference,
+        public_key_url: Option<&Url>,
+    ) -> Result<Reference, OciClientError> {
+        match public_key_url {
+            Some(public_key_url) => self
+                .client
+                .verify_signature(base, public_key_url, &self.auth),
+            None => Ok(base.clone()),
+        }
     }
 }
 
@@ -548,8 +547,7 @@ pub mod tests {
         let reference = oci_mock_a.reference_on_server(&server);
         let fetcher = create_fetcher();
         let verified_reference = fetcher
-            .client
-            .verified_reference(&reference, Some(&jwks_server.url), &RegistryAuth::Anonymous)
+            .verified_reference(&reference, Some(&jwks_server.url))
             .expect("signature should verify");
 
         // Move the tag after verification (TOCTOU attack).

--- a/agent-control/src/oci/error.rs
+++ b/agent-control/src/oci/error.rs
@@ -17,6 +17,10 @@ pub enum OciClientError {
     Verify(String),
     #[error("failed to fetch public key: {0}")]
     KeyFetch(String),
+    #[error("failed to fetch artifact: {0}")]
+    FetchArtifact(String),
+    #[error("download attempts exceeded, last error: {0}")]
+    AttemptsExceeded(String),
 }
 
 /// Simple string wrapper to represent curated messages coming from [oci_client].

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -1,43 +1,34 @@
 use crate::agent_control::config::OciAuth;
 use crate::agent_control::config::Registry;
-use crate::oci::Client;
 use crate::oci::artifact_definitions::LocalAgentPackage;
+use crate::oci::{Client, OciArtifactFetcher, OciClientError};
 use crate::package::manager::PackageData;
-use crate::utils::retry::retry;
 use oci_client::Reference;
 use oci_client::secrets::RegistryAuth;
 use std::path::Path;
 use std::time::Duration;
-use thiserror::Error;
 use tracing::{debug, warn};
 use url::Url;
 
-#[derive(Debug, Error)]
-#[error("downloading OCI artifact: {0}")]
-pub struct OCIDownloaderError(pub(super) String);
-
 /// An interface for downloading Agent Packages from an OCI registry.
-pub trait OCIAgentDownloader: Send + Sync {
+pub trait OCIPackageDownloader: Send + Sync {
     fn download(
         &self,
         package_data: &PackageData,
         destination_dir: &Path,
-    ) -> Result<LocalAgentPackage, OCIDownloaderError>;
+    ) -> Result<LocalAgentPackage, OciClientError>;
 }
 
 // This is expected to be thread-safe since it is used in the package manager.
 // Make sure that we are not writing to disk to the same location from multiple threads.
 // This implementation avoids that since each download is expected to be done in a separate package directory.
-pub struct OCIArtifactDownloader {
-    client: Client,
-    auth: RegistryAuth,
+pub struct OCIPackageArtifactDownloader {
+    fetcher: OciArtifactFetcher,
     signature_verification_enabled: bool,
-    max_retries: usize,
-    retry_interval: Duration,
     registry: Registry,
 }
 
-impl OCIAgentDownloader for OCIArtifactDownloader {
+impl OCIPackageDownloader for OCIPackageArtifactDownloader {
     /// Download the artifact contained in the provided `package_data` and store its content to `package_dir`.
     ///
     /// If signature verification is enabled and a public key url is provided in `package_data`, it first verifies the artifact's
@@ -51,33 +42,24 @@ impl OCIAgentDownloader for OCIArtifactDownloader {
         &self,
         package_data: &PackageData,
         package_dir: &Path,
-    ) -> Result<LocalAgentPackage, OCIDownloaderError> {
+    ) -> Result<LocalAgentPackage, OciClientError> {
         debug!(
             "Downloading from repository '{}' with version '{}'",
             package_data.oci.repository, package_data.oci.version
         );
-        retry(self.max_retries, self.retry_interval, || {
-            // Verify signature when needed
-            let base_reference = package_data.oci.to_reference(&self.registry);
-
-            let reference = if let Some(pk_url) =
-                self.should_verify_signature(&package_data.oci.public_key_url)
-            {
-                &self.verified_package_signature_reference(&base_reference, pk_url)?
-            } else {
-                &base_reference
-            };
-            // Download the package
-            self.download_package_artifact(reference, package_dir)
-                .inspect_err(|e| debug!("Download '{reference}' failed with error: {e}"))
-        })
-        .map_err(|e| OCIDownloaderError(format!("download attempts exceeded. Last error: {e}")))
+        let base_reference = package_data.oci.to_reference(&self.registry);
+        let public_key_url = self.should_verify_signature(&package_data.oci.public_key_url);
+        self.fetcher.fetch(
+            &base_reference,
+            public_key_url,
+            |client, reference, auth| {
+                Self::download_package_artifact(client, reference, auth, package_dir)
+            },
+        )
     }
 }
 
-const DEFAULT_RETRIES: usize = 0;
-
-impl OCIArtifactDownloader {
+impl OCIPackageArtifactDownloader {
     /// Returns an artifact downloader with default retries setup.
     pub fn new(
         client: Client,
@@ -85,15 +67,9 @@ impl OCIArtifactDownloader {
         auth: Option<OciAuth>,
         signature_verification_enabled: bool,
     ) -> Self {
-        OCIArtifactDownloader {
-            client,
-            auth: auth
-                .as_ref()
-                .map(RegistryAuth::from)
-                .unwrap_or(RegistryAuth::Anonymous),
+        OCIPackageArtifactDownloader {
+            fetcher: OciArtifactFetcher::new(client, auth),
             signature_verification_enabled,
-            max_retries: DEFAULT_RETRIES,
-            retry_interval: Duration::default(),
             registry,
         }
     }
@@ -101,8 +77,7 @@ impl OCIArtifactDownloader {
     /// Returns a new downloader with the provided retry configuration.
     pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
         Self {
-            max_retries: retries,
-            retry_interval,
+            fetcher: self.fetcher.with_retries(retries, retry_interval),
             ..self
         }
     }
@@ -120,36 +95,28 @@ impl OCIArtifactDownloader {
         Some(pk_url)
     }
 
-    /// Returns the [Reference] after verifying its signature. The reference always includes the `digest` to
-    /// assure it is the same reference whose signature was verified.
-    /// It returns an error if signature verification fails.
-    fn verified_package_signature_reference(
-        &self,
-        reference: &Reference,
-        public_key_url: &Url,
-    ) -> Result<Reference, OCIDownloaderError> {
-        self.client
-            .verify_signature(reference, public_key_url, &self.auth)
-            .map_err(|err| OCIDownloaderError(err.to_string()))
-    }
-
+    /// Pulls the manifest, validates it is an agent package artifact and pulls its layer to a file
+    /// under `package_dir`, returning the resulting [LocalAgentPackage].
     fn download_package_artifact(
-        &self,
+        client: &Client,
         reference: &Reference,
+        auth: &RegistryAuth,
         package_dir: &Path,
-    ) -> Result<LocalAgentPackage, OCIDownloaderError> {
-        let (image_manifest, _) = self
-            .client
-            .pull_image_manifest(reference, &self.auth)
-            .map_err(|err| OCIDownloaderError(format!("pull artifact manifest failure: {err}")))?;
+    ) -> Result<LocalAgentPackage, OciClientError> {
+        let (image_manifest, _) = client.pull_image_manifest(reference, auth).map_err(|err| {
+            OciClientError::FetchArtifact(format!("downloading package manifest: {err}"))
+        })?;
 
-        let (layer, media_type) = LocalAgentPackage::get_layer(&image_manifest)
-            .map_err(|err| OCIDownloaderError(format!("validating package manifest: {err}")))?;
+        let (layer, media_type) = LocalAgentPackage::get_layer(&image_manifest).map_err(|err| {
+            OciClientError::FetchArtifact(format!("validating package manifest: {err}"))
+        })?;
 
         let layer_path = package_dir.join(layer.digest.replace(':', "_"));
-        self.client
+        client
             .pull_blob_to_file(reference, &layer, &layer_path)
-            .map_err(|err| OCIDownloaderError(format!("download artifact failure: {err}")))?;
+            .map_err(|err| {
+                OciClientError::FetchArtifact(format!("downloading package artifact: {err}"))
+            })?;
 
         debug!("Artifact written to {}", layer_path.display());
 
@@ -173,23 +140,20 @@ pub mod tests {
     use crate::utils::test_runtime::tokio_runtime;
 
     use super::*;
-    use assert_matches::assert_matches;
-    use httpmock::prelude::*;
     use mockall::mock;
 
     use oci_client::client::{ClientConfig, ClientProtocol};
-    use serde_json::json;
 
     use tempfile::tempdir;
 
     mock! {
         pub OCIDownloader {}
-        impl OCIAgentDownloader for OCIDownloader {
+        impl OCIPackageDownloader for OCIDownloader {
             fn download(
                 &self,
                 package_data: &PackageData,
                 package_dir: &Path,
-            ) -> Result<LocalAgentPackage, OCIDownloaderError>;
+            ) -> Result<LocalAgentPackage, OciClientError>;
         }
     }
 
@@ -324,177 +288,10 @@ pub mod tests {
         assert!(err.to_string().contains("validating package manifest"));
     }
 
-    #[test]
-    fn test_download_with_missing_manifest() {
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(GET).path("/v2/test-repo/manifests/v1.0.0");
-            then.status(404).json_body(json!({
-                "errors": [{"code": "MANIFEST_UNKNOWN", "message": "manifest unknown"}]
-            }));
-        });
-
-        let downloader = create_downloader(server.address().to_string(), false);
-        let dest_dir = tempdir().unwrap();
-        let package_data = test_package_data(None);
-        let err = downloader
-            .download(&package_data, dest_dir.path())
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("download attempts exceeded"),
-            "{err}"
-        );
-    }
-
-    #[test]
-    fn test_download_with_unsigned_package() {
-        let key_pair = TestKeyPair::new(0);
-        let jwks_server = JwksMockServer::new(vec![
-            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
-        ]);
-        let server = FakeOciServer::new(REPOSITORY, VERSION)
-            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
-            .with_layer(
-                b"test agent package content",
-                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
-            )
-            .build(); // No signature
-
-        let downloader = create_downloader(server.registry(), true);
-        let dest_dir = tempdir().unwrap();
-        let package_data = test_package_data(Some(jwks_server.url.clone()));
-        let err = downloader
-            .download(&package_data, dest_dir.path())
-            .unwrap_err();
-        assert!(err.to_string().contains("signature verification"), "{err}");
-    }
-
-    #[test]
-    fn test_download_toctou_attack() {
-        const ORIGINAL_CONTENT: &[u8] = b"A";
-        const MALICIOUS_CONTENT: &[u8] = b"B";
-
-        // Setup mock server with tag v1.0.0
-        let key_pair = TestKeyPair::new(0);
-        let jwks_server = JwksMockServer::new(vec![
-            serde_json::to_value(key_pair.public_key_jwk()).unwrap(),
-        ]);
-        let oci_mock_a = FakeOciServer::new(REPOSITORY, VERSION)
-            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
-            .with_layer(
-                ORIGINAL_CONTENT,
-                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
-            )
-            .with_signature(&key_pair);
-        let server = MockServer::start();
-        oci_mock_a.setup_mocks_on(&server);
-
-        // Verify signature
-        let reference = oci_mock_a.reference_on_server(&server);
-        let downloader = create_downloader(server.address().to_string(), true);
-        let verified_reference = downloader
-            .verified_package_signature_reference(&reference, &jwks_server.url)
-            .expect("Signature should be verified successfully");
-
-        // Move tag v1.0.0 after signature is verified (TOCTOU attack)
-        let oci_mock_b = FakeOciServer::new(REPOSITORY, VERSION)
-            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
-            .with_layer(
-                MALICIOUS_CONTENT,
-                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
-            );
-        server.reset();
-        oci_mock_b.setup_mocks_on(&server); // Setup the new tag first (takes precedence)
-        oci_mock_a.setup_mocks_on(&server); // Also setup the previous (we need the previous digest and blobs)
-        // Sanity check to assure that the tag was effectively moved
-        let malicious_dest = tempdir().unwrap();
-        let malicious_pkg = downloader
-            .download_package_artifact(&reference, malicious_dest.path())
-            .unwrap();
-        assert_eq!(
-            std::fs::read(malicious_pkg.path()).unwrap(),
-            MALICIOUS_CONTENT
-        );
-
-        // The verified reference should still point to the original content
-        let dest_dir = tempdir().unwrap();
-        let local_agent_package = downloader
-            .download_package_artifact(&verified_reference, dest_dir.path())
-            .expect("Download should succeed");
-
-        assert_eq!(
-            std::fs::read(local_agent_package.path()).unwrap(),
-            ORIGINAL_CONTENT
-        );
-    }
-
-    #[test]
-    fn test_download_man_in_the_middle_attack() {
-        let oci_mock = FakeOciServer::new(REPOSITORY, VERSION)
-            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
-            .with_layer(
-                b"some content",
-                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
-            );
-        let server = MockServer::start();
-        // Content doesn't match the digest
-        oci_mock.mock_manifest(
-            &server,
-            &oci_mock.manifest_digest(),
-            b"malicious content".to_vec(),
-        );
-        let package_data = PackageData {
-            id: "test-package".to_string(),
-            oci: Oci {
-                repository: Repository::from_str("test-repo").unwrap(),
-                version: Version::from_str(&format!("v1.0.0@{}", oci_mock.manifest_digest()))
-                    .unwrap(),
-                public_key_url: None,
-            },
-        };
-
-        let downloader = create_downloader(server.address().to_string(), false);
-        let dest_dir = tempdir().unwrap();
-        let result = downloader.download(&package_data, dest_dir.path());
-        assert_matches!(result, Err(OCIDownloaderError(msg)) => {
-            assert!(msg.contains("Digest error"));
-        });
-    }
-
-    #[test]
-    fn test_none_auth_defaults_to_anonymous() {
-        let server = FakeOciServer::new(REPOSITORY, VERSION)
-            .with_artifact_type(&ManifestArtifactType::AgentPackage.to_string())
-            .with_layer(
-                b"content",
-                &LayerMediaType::AgentPackage(PackageMediaType::AgentPackageLayerTarGz).to_string(),
-            )
-            .build();
-        let package_data = test_package_data(None);
-
-        let client = Client::try_new(
-            ClientConfig {
-                protocol: ClientProtocol::Http,
-                ..Default::default()
-            },
-            ProxyConfig::default(),
-            tokio_runtime(),
-        )
-        .unwrap();
-        let downloader = OCIArtifactDownloader::new(
-            client,
-            Registry::from_str(&server.registry()).unwrap(),
-            None,
-            false,
-        );
-        let dest_dir = tempdir().unwrap();
-        assert!(downloader.download(&package_data, dest_dir.path()).is_ok());
-    }
-
     fn create_downloader(
         registry: String,
         signature_verification_enabled: bool,
-    ) -> OCIArtifactDownloader {
+    ) -> OCIPackageArtifactDownloader {
         let client = Client::try_new(
             ClientConfig {
                 protocol: ClientProtocol::Http,
@@ -504,7 +301,7 @@ pub mod tests {
             tokio_runtime(),
         )
         .unwrap();
-        OCIArtifactDownloader::new(
+        OCIPackageArtifactDownloader::new(
             client,
             Registry::from_str(&registry).unwrap(),
             None,

--- a/agent-control/src/package/oci/package_manager.rs
+++ b/agent-control/src/package/oci/package_manager.rs
@@ -1,9 +1,10 @@
-use super::downloader::{OCIAgentDownloader, OCIDownloaderError};
+use super::downloader::OCIPackageDownloader;
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::PACKAGES_FOLDER_NAME;
+use crate::oci::OciClientError;
 use crate::oci::artifact_definitions::LocalAgentPackage;
 use crate::package::manager::{InstalledPackageData, PackageData, PackageManager};
-use crate::package::oci::downloader::OCIArtifactDownloader;
+use crate::package::oci::downloader::OCIPackageArtifactDownloader;
 use fs::directory_manager::{DirectoryManager, DirectoryManagerFs};
 use fs::file::LocalFile;
 use fs::file::reader::FileReader;
@@ -15,12 +16,13 @@ use std::sync::Mutex;
 use thiserror::Error;
 use tracing::{debug, error, warn};
 
-pub type DefaultOCIPackageManager = OCIPackageManager<OCIArtifactDownloader, DirectoryManagerFs>;
+pub type DefaultOCIPackageManager =
+    OCIPackageManager<OCIPackageArtifactDownloader, DirectoryManagerFs>;
 
 // This is expected to be thread-safe
 pub struct OCIPackageManager<D, DM>
 where
-    D: OCIAgentDownloader,
+    D: OCIPackageDownloader,
     DM: DirectoryManager,
 {
     downloader: D,
@@ -32,7 +34,7 @@ where
 #[derive(Debug, Error)]
 pub enum OCIPackageManagerError {
     #[error("error attempting to download OCI artifact: {0}")]
-    Download(OCIDownloaderError),
+    Download(OciClientError),
     #[error("error attempting to install OCI artifact: {0}")]
     Install(io::Error),
     #[error("error attempting to uninstall OCI artifact: {0}")]
@@ -74,7 +76,7 @@ const INSTALLED_PCK_LOCATION: &str = "stored_packages";
 
 impl<D, DM> OCIPackageManager<D, DM>
 where
-    D: OCIAgentDownloader,
+    D: OCIPackageDownloader,
     DM: DirectoryManager,
 {
     pub fn new(downloader: D, directory_manager: DM, remote_dir: PathBuf) -> Self {
@@ -307,7 +309,7 @@ fn compute_path_suffix(package_data: &PackageData) -> Result<PathBuf, OCIPackage
 
 impl<D, DM> PackageManager for OCIPackageManager<D, DM>
 where
-    D: OCIAgentDownloader,
+    D: OCIPackageDownloader,
     DM: DirectoryManager,
 {
     /// Installs the given OCI package for the specified agent.
@@ -691,7 +693,7 @@ mod tests {
             .expect_download()
             .with(eq(package_data.clone()), eq(download_dir))
             .once()
-            .returning(|_, _| Err(OCIDownloaderError("download failed".into())));
+            .returning(|_, _| Err(OciClientError::FetchArtifact("download failed".into())));
 
         let pm = OCIPackageManager::new(downloader, directory_manager, remote_dir);
 

--- a/agent-control/tests/on_host/oci_artifact_downloader.rs
+++ b/agent-control/tests/on_host/oci_artifact_downloader.rs
@@ -9,7 +9,9 @@ use newrelic_agent_control::agent_type::runtime_config::on_host::package::render
 use newrelic_agent_control::http::config::ProxyConfig;
 use newrelic_agent_control::oci;
 use newrelic_agent_control::package::manager::PackageData;
-use newrelic_agent_control::package::oci::downloader::{OCIAgentDownloader, OCIArtifactDownloader};
+use newrelic_agent_control::package::oci::downloader::{
+    OCIPackageArtifactDownloader, OCIPackageDownloader,
+};
 use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_test_utils::{PackageMediaType, PackagePublisher, blob_digest};
 use std::str::FromStr;
@@ -50,7 +52,7 @@ fn test_download_artifact_from_local_registry_with_oci_registry() {
 
     let client = create_client_with_proxy(ProxyConfig::default());
 
-    let downloader = OCIArtifactDownloader::new(
+    let downloader = OCIPackageArtifactDownloader::new(
         client,
         Registry::from_str(OCI_TEST_REGISTRY_URL).unwrap(),
         Default::default(),
@@ -122,7 +124,7 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
 
     let client = create_client_with_proxy(proxy_config);
 
-    let downloader = OCIArtifactDownloader::new(
+    let downloader = OCIPackageArtifactDownloader::new(
         client,
         Registry::from_str(OCI_TEST_REGISTRY_URL).unwrap(),
         Default::default(),

--- a/agent-control/tests/on_host/tools/oci_package_manager.rs
+++ b/agent-control/tests/on_host/tools/oci_package_manager.rs
@@ -6,7 +6,7 @@ use newrelic_agent_control::{
     agent_control::config::Registry,
     http::config::ProxyConfig,
     oci,
-    package::oci::{downloader::OCIArtifactDownloader, package_manager::OCIPackageManager},
+    package::oci::{downloader::OCIPackageArtifactDownloader, package_manager::OCIPackageManager},
 };
 use oci_client::client::{ClientConfig, ClientProtocol};
 use std::path::Path;
@@ -16,7 +16,7 @@ use std::{fs::File, str::FromStr};
 pub fn new_testing_oci_package_manager(
     base_path: PathBuf,
     registry: String,
-) -> OCIPackageManager<OCIArtifactDownloader, DirectoryManagerFs> {
+) -> OCIPackageManager<OCIPackageArtifactDownloader, DirectoryManagerFs> {
     let client = oci::Client::try_new(
         ClientConfig {
             protocol: ClientProtocol::Http,
@@ -26,7 +26,7 @@ pub fn new_testing_oci_package_manager(
         tokio_runtime(),
     )
     .unwrap();
-    let downloader = OCIArtifactDownloader::new(
+    let downloader = OCIPackageArtifactDownloader::new(
         client,
         Registry::from_str(&registry).unwrap(),
         Default::default(),


### PR DESCRIPTION
> [!NOTE]
> On top of #2590
> Addresses: https://github.com/newrelic/newrelic-agent-control/pull/2580#discussion_r3379489541

## Summary

The agent-type and package OCI downloaders each carried their own copy of the "verify signature, then pull, with retries" flow and their own string error type. This extracts that orchestration into a single `OciArtifactFetcher` in the `oci` module and folds both bespoke error types into the shared `OciClientError`, so the two downloaders now only describe how to materialize their specific artifact.

## Changes

- Add `OciArtifactFetcher` (owns the client, auth, and retry policy) and `Client::verified_reference`, which collapses the old `Some(pk)/None` signature-verification branching.
- Rename the package types for clarity now that an agent-type downloader exists: `OCIArtifactDownloader` to `OCIPackageArtifactDownloader`, trait `OCIAgentDownloader` to `OCIPackageDownloader`.
- Replace `OCIDownloaderError` and `OCIAgentTypeDownloaderError` with `OciClientError`.
-  Add `OciClientError::AttemptsExceeded` so retry exhaustion is a typed variant rather than a nested string wrap.
- Move the shared verify-then-fetch tests (TOCTOU, MITM, missing manifest, unsigned-but-verification-enabled) into the fetcher's test module, since the logic now lives there.

