### PR TITLE
fix: validate version on deserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Remember that the keywords that you can use are the following:
   so definitions targeting an incompatible schema are rejected early. Internal authors of custom agent type definitions
   must add this field — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
 
+### bugfix
+- Validate version coming from remote.
+
 ## v1.16.1 - 2026-06-04
 
 ### 🐞 Bug fixes

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -879,7 +879,7 @@ agents: {}
 
     #[test]
     fn dynamic_config_invalid_version_fails_to_deserialize() {
-        let yaml = "agents: {{}}\nversion: invalid-version; rm -rf /\n";
+        let yaml = "agents: {}\nversion: invalid-version; rm -rf /\n";
         assert!(serde_saphyr::from_str::<AgentControlDynamicConfig>(yaml).is_err());
     }
 

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -878,6 +878,12 @@ agents: {}
     }
 
     #[test]
+    fn dynamic_config_invalid_version_fails_to_deserialize() {
+        let yaml = "agents: {{}}\nversion: invalid-version; rm -rf /\n";
+        assert!(serde_saphyr::from_str::<AgentControlDynamicConfig>(yaml).is_err());
+    }
+
+    #[test]
     fn basic_parse_with_windows_crlf() {
         [
             EXAMPLE_AGENTCONTROL_CONFIG,

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -109,7 +109,8 @@ fn validate_repository_char(c: char) -> Result<(), InvalidRepository> {
 #[error("{0}")]
 pub struct InvalidVersion(String);
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(try_from = "String")]
 pub struct Version(String);
 
 impl Display for Version {
@@ -118,13 +119,11 @@ impl Display for Version {
     }
 }
 
-impl<'de> Deserialize<'de> for Version {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Version::from_str(&s).map_err(serde::de::Error::custom)
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Version::from_str(&value)
     }
 }
 

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -109,12 +109,22 @@ fn validate_repository_char(c: char) -> Result<(), InvalidRepository> {
 #[error("{0}")]
 pub struct InvalidVersion(String);
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Version(String);
 
 impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Version::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Validates the version on deserialize, not only when calling `from_str`. In other words, now we validate the version that comes from remote too. Tested with a regression test.

Versions are still compared based on it's string version because we are not using SemVer but the OCI format, which can include tags and/or digests.

```rust
if new_version.to_string() == AGENT_CONTROL_VERSION {
```