### PR TITLE
fix: cache windows artifacts for pipeline

### DIFF
--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -202,11 +202,22 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
 
-      - uses: ./.github/actions/rust-cache
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: ./.github/actions/rust-cache
         with:
           identifier: 'test-dev'
           restore-strategy: 'nearest'
           save-cache: false
+      
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: ./.github/actions/rust-cache
+        # We have faced issues 'hashFiles('**/Cargo.lock') failed.' in this job. As we couldn't pinpoint
+        # the exact cause, we are adding continue-on-error to avoid blocking merges.
+        continue-on-error: true
+        with:
+          identifier: 'test-dev'
+          restore-strategy: ${{ github.ref == 'refs/heads/main' && 'exact' || 'nearest' }}
+          save-cache: true
 
       - name: Run workspace tests excluding the agent control pkg (includes -winAdmin- ignored because it doesn't apply)
         run: cargo test --workspace --exclude 'newrelic_agent_control' --all-targets -- --include-ignored


### PR DESCRIPTION
Windows build aren't cached. This PR solves this. I don't think it will have a big impact, but it was easy to fix.

<img width="479" height="79" alt="Captura de pantalla 2026-06-11 a las 16 03 36" src="https://github.com/user-attachments/assets/4ca029b3-8a90-4e22-8d11-cf07b3159e84" />

<img width="467" height="76" alt="Captura de pantalla 2026-06-11 a las 16 03 21" src="https://github.com/user-attachments/assets/eebc1ec6-8a5a-4d9b-8874-eb9e93e5e39e" />

