### PR TITLE
feat: add new restart policy for windows and linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Remember that the keywords that you can use are the following:
 
 ## Unreleased
 
+### enhancement
+- Hardens service restart policies on Linux and Windows (systemd rate limiting: 5 restarts max in 60s) to prevent
+  crash-looping from saturating CPU.
+
 ## v1.17.0 - 2026-06-16
 
 ### 🚀 Enhancements

--- a/build/package/newrelic-agent-control.service
+++ b/build/package/newrelic-agent-control.service
@@ -8,6 +8,13 @@ EnvironmentFile=/etc/newrelic-agent-control/systemd-env.conf
 ExecStart=/usr/bin/newrelic-agent-control
 KillMode=mixed
 Restart=always
+# Restart rate limiting to prevent crash-looping from saturating CPU
+# Wait 5s between attempts; tolerate up to 5 starts per rolling
+# 60s; the 6th crash inside that window stops the loop instead of spinning
+# forever. A pathological crash-loop is bounded to ~5 restarts/minute.
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=5
 Type=simple
 
 [Install]

--- a/build/package/windows/install.ps1
+++ b/build/package/windows/install.ps1
@@ -189,8 +189,11 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-# Configure failure actions: restart after 30 seconds; reset failure count daily
-sc.exe failure $serviceName reset= 86400 actions= restart/30000 | Out-Null
+# Configure failure actions to prevent crash-looping from saturating CPU.
+# After 5 failures within 60 seconds, the service will stop and requires manual intervention.
+#
+# NOTE: The empty action (//) means "take no action" - this stops the restart cycle.
+sc.exe failure $serviceName reset= 60 actions= restart/5000/restart/5000/restart/5000/restart/5000/restart/5000//0 | Out-Null
 # Ensure failure flag is set to enable the configured actions
 sc.exe failureflag $serviceName 1 | Out-Null
 


### PR DESCRIPTION
Hardens service restart policies on Linux and Windows (systemd rate limiting: 5 restarts max in 60s) to prevent crash-looping from saturating CPU, it adds startup validation to detect misconfigured restart policies and log warnings.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
