### PR TITLE
feat: enforce format constraints on agent type metadata (NR-568040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@ Remember that the keywords that you can use are the following:
 
 ### enhancement
 - Added support for JP endpoints.
-- Agent type definitions now use a flat per-platform schema (one YAML file per `(platform, operating_system)` pair). 
-  Agent type FQNs and configuration values are unchanged, so this is **not a breaking change** for end users.
-  Internal authors of custom agent type definitions need to migrate their YAMLs — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
-- Agent type definitions now declare a top-level `protocol_version` (a quoted `MAJOR.MINOR` string) that versions the
-  agent-type schema language itself. It is validated against the version Agent Control supports at registry ingestion,
-  so definitions targeting an incompatible schema are rejected early. Internal authors of custom agent type definitions
-  must add this field — see [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
+- Agent type definitions changed: flat per-platform schema (one YAML per `(platform, operating_system)` pair), a new
+  top-level `protocol_version` field (quoted `MAJOR.MINOR`, validated at registry ingestion), and stricter `name`/`namespace`
+  validation (no `-`) and `version` (plain `Major.Minor.Patch` semver). FQNs and configuration values are unchanged, so this
+  is **not a breaking change** for end users; internal authors of custom definitions must migrate — see
+  [docs/INTEGRATING_AGENTS.md](docs/INTEGRATING_AGENTS.md).
 
 ### bugfix
 - Validate version coming from remote.

--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -1441,7 +1441,7 @@ agents:
         let remote_config: &str = r#"
 agents:
   remote-id1: # not actually used, we rely on a mock
-    agent_type: "non-existent/invalid:0.0.1"
+    agent_type: "nonexistent/invalid:0.0.1"
 chart_version: 0.0.2 # not actually used, we rely on a mock
 "#;
         let opamp_remote_config = t.build_ac_remote_config(remote_config);

--- a/agent-control/src/agent_control/http_server/status_handler.rs
+++ b/agent-control/src/agent_control/http_server/status_handler.rs
@@ -39,7 +39,7 @@ mod tests {
         // Given there is a healthy Sub Agent registered
         let agent_identity = AgentIdentity::from((
             AgentID::try_from("some-agent-id").unwrap(),
-            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+            AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
         ));
         let mut sub_agent_status = SubAgentStatus::with_identity(agent_identity.clone());
 
@@ -70,7 +70,7 @@ mod tests {
         let request = TestRequest::default().to_http_request();
         let response = responder.respond_to(&request);
 
-        let expected_body = r#"{"agent_control":{"healthy":true},"fleet":{"enabled":true,"endpoint":"http://127.0.0.1/","reachable":true},"agents":{"some-agent-id":{"agent_id":"some-agent-id","agent_type":"namespace/some-agent-type:0.0.1","agent_start_time_unix_nano":0,"health_info":{"healthy":true,"start_time_unix_nano":0,"status_time_unix_nano":0}}}}"#;
+        let expected_body = r#"{"agent_control":{"healthy":true},"fleet":{"enabled":true,"endpoint":"http://127.0.0.1/","reachable":true},"agents":{"some-agent-id":{"agent_id":"some-agent-id","agent_type":"namespace/some_agent_type:0.0.1","agent_start_time_unix_nano":0,"health_info":{"healthy":true,"start_time_unix_nano":0,"status_time_unix_nano":0}}}}"#;
 
         assert_eq!(
             expected_body,
@@ -87,7 +87,7 @@ mod tests {
         // Given there is a healthy Sub Agent registered
         let agent_identity = AgentIdentity::from((
             AgentID::try_from("some-agent-id").unwrap(),
-            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+            AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
         ));
         let mut sub_agent_status = SubAgentStatus::with_identity(agent_identity.clone());
         sub_agent_status.update_health(HealthWithStartTime::new(
@@ -119,7 +119,7 @@ mod tests {
         let request = TestRequest::default().to_http_request();
         let response = responder.respond_to(&request);
 
-        let expected_body = r#"{"agent_control":{"healthy":false,"last_error":"agent control error"},"fleet":{"enabled":true,"endpoint":"http://127.0.0.1/","reachable":true},"agents":{"some-agent-id":{"agent_id":"some-agent-id","agent_type":"namespace/some-agent-type:0.0.1","agent_start_time_unix_nano":0,"health_info":{"healthy":false,"last_error":"some error","start_time_unix_nano":0,"status_time_unix_nano":0}}}}"#;
+        let expected_body = r#"{"agent_control":{"healthy":false,"last_error":"agent control error"},"fleet":{"enabled":true,"endpoint":"http://127.0.0.1/","reachable":true},"agents":{"some-agent-id":{"agent_id":"some-agent-id","agent_type":"namespace/some_agent_type:0.0.1","agent_start_time_unix_nano":0,"health_info":{"healthy":false,"last_error":"some error","start_time_unix_nano":0,"status_time_unix_nano":0}}}}"#;
 
         assert_eq!(
             expected_body,

--- a/agent-control/src/agent_control/http_server/status_updater.rs
+++ b/agent-control/src/agent_control/http_server/status_updater.rs
@@ -178,7 +178,7 @@ mod tests {
     fn agent_identity(id: &str) -> AgentIdentity {
         AgentIdentity::from((
             AgentID::try_from(id).unwrap(),
-            AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+            AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
         ))
     }
 
@@ -249,7 +249,7 @@ mod tests {
                     AgentID::try_from("some-agent-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
@@ -258,7 +258,7 @@ mod tests {
                     AgentID::try_from("some-other-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-other-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
@@ -272,7 +272,7 @@ mod tests {
                 AgentID::try_from("some-other-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-other-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 ),
@@ -390,7 +390,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 ),
@@ -419,7 +419,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(
                         String::default(),
@@ -450,7 +450,7 @@ mod tests {
                     AgentID::try_from("some-agent-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
@@ -459,7 +459,7 @@ mod tests {
                     AgentID::try_from("some-other-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-other-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
@@ -474,7 +474,7 @@ mod tests {
                     AgentID::try_from("some-agent-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-agent-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(
                             String::default(),
@@ -489,7 +489,7 @@ mod tests {
                     AgentID::try_from("some-other-id").unwrap(),
                     SubAgentStatus::new(
                         AgentID::try_from("some-other-id").unwrap(),
-                        AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                        AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                         0,
                         HealthInfo::new(String::default(), true, None, 0, 0),
                     ),
@@ -523,7 +523,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 ),
@@ -536,7 +536,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 ),
@@ -555,7 +555,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 ),
@@ -568,7 +568,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )
@@ -591,7 +591,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )
@@ -608,7 +608,7 @@ mod tests {
                 AgentID::try_from("some-agent-id").unwrap(),
                 SubAgentStatus::new(
                     AgentID::try_from("some-agent-id").unwrap(),
-                    AgentTypeID::try_from("namespace/some-agent-type:0.0.1").unwrap(),
+                    AgentTypeID::try_from("namespace/some_agent_type:0.0.1").unwrap(),
                     0,
                     HealthInfo::new(String::default(), true, None, 0, 0),
                 )

--- a/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
+++ b/agent-control/src/agent_control/resource_cleaner/k8s_garbage_collector.rs
@@ -332,7 +332,7 @@ mod tests {
         };
         let ac_id = &AgentID::AgentControl;
         let ac_type_id =
-            &AgentTypeID::try_from("newrelic/com.newrelic.agent-control:0.0.1").unwrap();
+            &AgentTypeID::try_from("newrelic/com.newrelic.agent_control:0.0.1").unwrap();
 
         assert!(matches!(
             garbage_collector.collect(ac_id, ac_type_id),

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -39,11 +39,13 @@ version: 0.0.1
 platform: kubernetes
 ```
 
-* The name and namespace should:
-  * Start by an alphabetical character.
-  * Only encompass `alphanumeric characters`, `.`, `_` or `-`.
-  * Be in lowercase.
-* The version field should adhere to [semantic versioning](https://semver.org/).
+* The name and namespace must:
+  * Start with an ASCII letter and end with a letter or digit.
+  * Only contain lowercase letters, digits, `.` or `_` (note: `-` is **not** allowed).
+  * Be at most 64 characters long.
+* The version must be a plain `Major.Minor.Patch` semver (e.g. `0.1.0`). Pre-release
+  (`-alpha.1`) and build-metadata (`+build`) suffixes are **not** allowed, and the version
+  must be at most 14 characters long (keeps the derived OCI tag bounded).
 * `platform`: the target platform. One of `host` or `kubernetes`.
 * `operating_system`: required when `platform: host`. One of `linux` or `windows`. Must be omitted for `platform: kubernetes`.
 

--- a/agent-control/src/agent_type/agent_type_id.rs
+++ b/agent-control/src/agent_type/agent_type_id.rs
@@ -4,16 +4,39 @@ use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
 const NAME_NAMESPACE_MIN_LENGTH: usize = 1;
-const NAME_NAMESPACE_MAX_LENGTH: usize = 64;
+pub(crate) const NAME_NAMESPACE_MAX_LENGTH: usize = 64;
+/// Bounds the version length so a version bump (e.g. `9999.9999.999` -> `9999.9999.1000`)
+/// cannot overflow external constraints like the OCI tag built using this metadata.
+pub(crate) const VERSION_MAX_LENGTH: usize = 14;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum AgentTypeIDError {
-    #[error("invalid AgentType namespace")]
-    InvalidNamespace,
-    #[error("invalid AgentType name")]
-    InvalidName,
-    #[error("invalid AgentType version")]
-    InvalidVersion,
+    #[error("invalid namespace: {0}")]
+    InvalidNamespace(NameFormatError),
+    #[error("invalid name: {0}")]
+    InvalidName(NameFormatError),
+    #[error("invalid version: {0}")]
+    InvalidVersion(String),
+    #[error("only Major.Minor.Patch semver format is allowed")]
+    ForbiddenSemVer,
+    #[error("version must not be longer than {max} characters, but it is {length}")]
+    VersionTooLong { length: usize, max: usize },
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum NameFormatError {
+    #[error("must not be empty")]
+    Empty,
+    #[error("must be at most {max} characters, but it is {length}")]
+    TooLong { length: usize, max: usize },
+    #[error("must start with an ASCII letter")]
+    InvalidStart,
+    #[error("must end with a letter or a digit")]
+    InvalidEnd,
+    #[error(
+        "contains invalid character '{0}', only lowercase letters, digits, '.' and '_' are allowed"
+    )]
+    InvalidCharacter(char),
 }
 
 /// Holds agent type metadata that uniquely identifies an agent type.
@@ -36,18 +59,61 @@ impl AgentTypeID {
         &self.version
     }
 
-    fn has_valid_format(s: &str) -> bool {
-        s.len() >= NAME_NAMESPACE_MIN_LENGTH
-            && s.len() <= NAME_NAMESPACE_MAX_LENGTH
-            && s.starts_with(|c: char| c.is_ascii_alphabetic())
-            && s.ends_with(|c: char| c.is_ascii_alphanumeric())
-            && s.chars().all(|c| {
-                c.eq(&'-')
-                    || c.eq(&'_')
-                    || c.eq(&'.')
-                    || c.is_ascii_digit()
-                    || c.is_ascii_lowercase()
-            })
+    /// Parses a semver version, additionally rejecting anything that isn't a digit or `.`.
+    /// This constraint relates to the OCI tag built from this metadata.
+    fn parse_version(s: &str) -> Result<Version, AgentTypeIDError> {
+        if !s.chars().all(|c| c.is_ascii_digit() || c.eq(&'.')) {
+            return Err(AgentTypeIDError::ForbiddenSemVer);
+        }
+        if s.len() > VERSION_MAX_LENGTH {
+            return Err(AgentTypeIDError::VersionTooLong {
+                length: s.len(),
+                max: VERSION_MAX_LENGTH,
+            });
+        }
+        Version::parse(s).map_err(|e| AgentTypeIDError::InvalidVersion(e.to_string()))
+    }
+
+    /// Limits the characters allowed so this could be used as identifier for k8s resources and other
+    /// places like OCI tags. Returns the specific [NameFormatError] on the first rule violated.
+    fn validate_format(s: &str) -> Result<(), NameFormatError> {
+        if s.len() < NAME_NAMESPACE_MIN_LENGTH {
+            return Err(NameFormatError::Empty);
+        }
+        if s.len() > NAME_NAMESPACE_MAX_LENGTH {
+            return Err(NameFormatError::TooLong {
+                length: s.len(),
+                max: NAME_NAMESPACE_MAX_LENGTH,
+            });
+        }
+        if !s.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return Err(NameFormatError::InvalidStart);
+        }
+        if !s.ends_with(|c: char| c.is_ascii_alphanumeric()) {
+            return Err(NameFormatError::InvalidEnd);
+        }
+        if let Some(invalid) = s
+            .chars()
+            .find(|c| !(c.eq(&'_') || c.eq(&'.') || c.is_ascii_digit() || c.is_ascii_lowercase()))
+        {
+            return Err(NameFormatError::InvalidCharacter(invalid));
+        }
+        Ok(())
+    }
+
+    fn from_parts(
+        name: String,
+        namespace: String,
+        version: &str,
+    ) -> Result<Self, AgentTypeIDError> {
+        Self::validate_format(namespace.as_str()).map_err(AgentTypeIDError::InvalidNamespace)?;
+        Self::validate_format(name.as_str()).map_err(AgentTypeIDError::InvalidName)?;
+        let version = Self::parse_version(version)?;
+        Ok(Self {
+            name,
+            namespace,
+            version,
+        })
     }
 
     /// Deserializes an AgentTypeID from a fully qualified name string using the TryFrom<str> implementation.
@@ -86,30 +152,15 @@ impl TryFrom<&str> for AgentTypeID {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let namespace: String = value.chars().take_while(|&i| i != '/').collect();
-        if !AgentTypeID::has_valid_format(namespace.as_str()) {
-            return Err(AgentTypeIDError::InvalidNamespace);
-        }
-
         let name: String = value
             .chars()
             .skip_while(|&i| i != '/')
             .skip(1)
             .take_while(|&i| i != ':')
             .collect();
-        if !AgentTypeID::has_valid_format(name.as_str()) {
-            return Err(AgentTypeIDError::InvalidName);
-        }
+        let version: String = value.chars().skip_while(|&i| i != ':').skip(1).collect();
 
-        let version_str: String = value.chars().skip_while(|&i| i != ':').skip(1).collect();
-
-        let version =
-            Version::parse(version_str.as_str()).map_err(|_| AgentTypeIDError::InvalidVersion)?;
-
-        Ok(Self {
-            name,
-            namespace,
-            version,
-        })
+        Self::from_parts(name, namespace, version.as_str())
     }
 }
 
@@ -134,29 +185,18 @@ impl<'de> Deserialize<'de> for AgentTypeID {
             version,
         } = IntermediateAgentMetadata::deserialize(deserializer)?;
 
-        let name = name.unwrap_or_default();
-        if !Self::has_valid_format(name.as_str()) {
-            return Err(Error::custom(AgentTypeIDError::InvalidName));
-        }
-
-        let namespace = namespace.unwrap_or_default();
-        if !Self::has_valid_format(namespace.as_str()) {
-            return Err(Error::custom(AgentTypeIDError::InvalidNamespace));
-        }
-
-        let version = Version::parse(version.unwrap_or_default().as_str())
-            .map_err(|_| Error::custom(AgentTypeIDError::InvalidVersion))?;
-
-        Ok(AgentTypeID {
-            name,
-            namespace,
-            version,
-        })
+        Self::from_parts(
+            name.unwrap_or_default(),
+            namespace.unwrap_or_default(),
+            version.unwrap_or_default().as_str(),
+        )
+        .map_err(Error::custom)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use serde::Serialize;
 
     use super::*;
@@ -165,166 +205,64 @@ mod tests {
     fn test_correct_agent_type_metadata() {
         let actual = serde_saphyr::from_str::<AgentTypeID>(
             r#"
-name: nrdot_special-with-all.characters
-namespace: newrelic_special-with-all.characters
-version: 0.1.0-alpha.1
+name: nrdot_special.with.all.characters
+namespace: newrelic_special.with.all.characters
+version: 0.1.0
 "#,
         )
         .unwrap();
 
-        assert_eq!("nrdot_special-with-all.characters", actual.name);
-        assert_eq!("newrelic_special-with-all.characters", actual.namespace);
-        assert_eq!("0.1.0-alpha.1", actual.version.to_string());
+        assert_eq!("nrdot_special.with.all.characters", actual.name);
+        assert_eq!("newrelic_special.with.all.characters", actual.namespace);
+        assert_eq!("0.1.0", actual.version.to_string());
+    }
+
+    /// A name/namespace longer than the allowed maximum (69 > 64 characters).
+    const TOO_LONG_NAME_FQN: &str =
+        "ns/test_test_test_test_test_test_test_test_test_test_test_test_test_test:0.1.0";
+    const TOO_LONG_NAMESPACE_FQN: &str =
+        "test_test_test_test_test_test_test_test_test_test_test_test_test_test/nrdot:0.1.0";
+
+    /// Matches the expected [AgentTypeIDError] variant. Lets each [rstest] case carry the variant it
+    /// expects without comparing against the (semver-derived) error message.
+    type ErrorMatcher = fn(AgentTypeIDError) -> bool;
+
+    #[rstest]
+    #[case::empty_name("ns/:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::Empty))) as ErrorMatcher)]
+    #[case::name_does_not_start_with_letter("ns/1nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidStart))) as ErrorMatcher)]
+    #[case::name_does_not_end_with_alphanumeric("ns/nrdot.:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidEnd))) as ErrorMatcher)]
+    #[case::name_with_invalid_char("ns/nr@dot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('@')))) as ErrorMatcher)]
+    #[case::name_with_dash("ns/nr-dot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('-')))) as ErrorMatcher)]
+    #[case::name_too_long(TOO_LONG_NAME_FQN, (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::TooLong { .. }))) as ErrorMatcher)]
+    #[case::empty_namespace("/nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::Empty))) as ErrorMatcher)]
+    #[case::namespace_with_invalid_char("n@s/nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter('@')))) as ErrorMatcher)]
+    // Without a `/`, the whole input is taken as the namespace and `:` is not an allowed character.
+    #[case::missing_name_separator("aa:1.1.3", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter(':')))) as ErrorMatcher)]
+    #[case::namespace_too_long(TOO_LONG_NAMESPACE_FQN, (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::TooLong { .. }))) as ErrorMatcher)]
+    #[case::empty_version("ns/nrdot:", (|e| matches!(e, AgentTypeIDError::InvalidVersion(_))) as ErrorMatcher)]
+    #[case::incomplete_version("ns/nrdot:0", (|e| matches!(e, AgentTypeIDError::InvalidVersion(_))) as ErrorMatcher)]
+    #[case::non_numeric_version("ns/nrdot:adsf", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
+    #[case::pre_release_version("ns/nrdot:0.1.0-alpha.1", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
+    #[case::build_metadata_version("ns/nrdot:0.1.0+build", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
+    #[case::version_too_long("ns/nrdot:1111.1111.11111", (|e| matches!(e, AgentTypeIDError::VersionTooLong { length: 15, max: 14 })) as ErrorMatcher)]
+    fn try_from_invalid_fqn(#[case] fqn: &str, #[case] is_expected_error: ErrorMatcher) {
+        let error = AgentTypeID::try_from(fqn).unwrap_err();
+        let rendered = format!("{error:?}");
+        assert!(
+            is_expected_error(error),
+            "unexpected error variant: {rendered}"
+        );
     }
 
     #[test]
-    fn test_invalid_agent_type_metadata() {
-        struct TestCase {
-            name: &'static str,
-            metadata: &'static str,
-            expected_error: AgentTypeIDError,
-        }
-        impl TestCase {
-            fn run(self) {
-                let actual_err =
-                    serde_saphyr::from_str::<AgentTypeID>(self.metadata).expect_err(self.name);
-
-                assert!(
-                    actual_err
-                        .to_string()
-                        .eq(self.expected_error.to_string().as_str()),
-                    "TestCase: {} Expected error: {:?}, got: {:?}",
-                    self.name,
-                    self.expected_error,
-                    actual_err
-                );
-            }
-        }
-        let test_cases = vec![
-            TestCase {
-                name: "empty name",
-                expected_error: AgentTypeIDError::InvalidName,
-                metadata: r#"
-            name:
-            namespace: newrelic
-            version: 0.1.0
-            "#,
-            },
-            TestCase {
-                name: "empty namespace",
-                expected_error: AgentTypeIDError::InvalidNamespace,
-                metadata: r#"
-            name: nrdot
-            namespace:
-            version: 0.1.0
-            "#,
-            },
-            TestCase {
-                name: "empty version",
-                expected_error: AgentTypeIDError::InvalidVersion,
-                metadata: r#"
-            name: nrdot
-            namespace: newrelic
-            version:
-            "#,
-            },
-            TestCase {
-                name: "error wrong version 1",
-                expected_error: AgentTypeIDError::InvalidVersion,
-                metadata: r#"
-            name: nrdot
-            namespace: newrelic
-            version: 0
-            "#,
-            },
-            TestCase {
-                name: "error wrong version 2",
-                expected_error: AgentTypeIDError::InvalidVersion,
-                metadata: r#"
-            name: nrdot
-            namespace: newrelic
-            version: adsf
-            "#,
-            },
-            TestCase {
-                name: "invalid characters on name",
-                expected_error: AgentTypeIDError::InvalidName,
-                metadata: r#"
-            name: invalid/slash
-            namespace: newrelic
-            version: 0.1.0
-            "#,
-            },
-            TestCase {
-                name: "invalid characters on namespace",
-                expected_error: AgentTypeIDError::InvalidNamespace,
-                metadata: r#"
-            name: nrdot
-            namespace: invalid/slash
-            version: 0.1.0
-            "#,
-            },
-            TestCase {
-                name: "name exceeding allowed number of chars",
-                expected_error: AgentTypeIDError::InvalidName,
-                metadata: r#"
-            name: test_test_test_test_test_test_test_test_test_test_test_test_test_test
-            namespace: newrelic
-            version: 0.1.0
-            "#,
-            },
-            TestCase {
-                name: "namespace exceeding allowed number of chars",
-                expected_error: AgentTypeIDError::InvalidNamespace,
-                metadata: r#"
-            name: nrdot
-            namespace: test_test_test_test_test_test_test_test_test_test_test_test_test_test
-            version: 0.1.0
-            "#,
-            },
-        ];
-
-        for test_case in test_cases {
-            test_case.run();
-        }
-    }
-
-    #[test]
-    fn try_from_fqn_str() {
+    fn try_from_valid_fqn() {
         let agent_id = AgentTypeID::try_from("ns/aa:1.1.3").unwrap();
         assert_eq!(agent_id.name, "aa");
         assert_eq!(agent_id.namespace, "ns");
         assert_eq!(agent_id.version.to_string(), "1.1.3".to_string());
 
-        assert_eq!(
-            AgentTypeID::try_from("aa").unwrap_err(),
-            AgentTypeIDError::InvalidName
-        );
-
-        assert_eq!(
-            AgentTypeID::try_from("aa:1.1.3").unwrap_err(),
-            AgentTypeIDError::InvalidNamespace
-        );
-
-        assert_eq!(
-            AgentTypeID::try_from("ns/-").unwrap_err(),
-            AgentTypeIDError::InvalidName
-        );
-
-        assert_eq!(
-            AgentTypeID::try_from("ns/aa:").unwrap_err(),
-            AgentTypeIDError::InvalidVersion
-        );
-
-        assert_eq!(
-            AgentTypeID::try_from("ns/:1.1.3").unwrap_err(),
-            AgentTypeIDError::InvalidName
-        );
-
-        assert_eq!(
-            AgentTypeID::try_from("/:").unwrap_err(),
-            AgentTypeIDError::InvalidNamespace
-        );
+        // A plain Major.Minor.Patch version at the maximum allowed length is accepted.
+        assert!(AgentTypeID::try_from("ns/aa:1111.1111.1111").is_ok());
     }
 
     #[test]
@@ -354,7 +292,7 @@ agent_type_id: namespace/name:invalid_version
         assert!(
             foo.unwrap_err()
                 .to_string()
-                .contains("invalid AgentType version")
+                .contains("only Major.Minor.Patch semver format is allowed")
         );
     }
 }

--- a/agent-control/src/agent_type/agent_type_id.rs
+++ b/agent-control/src/agent_type/agent_type_id.rs
@@ -229,8 +229,7 @@ version: 0.1.0
     #[case::name_too_long(TOO_LONG_NAME_FQN, |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::TooLong { .. })))]
     #[case::empty_namespace("/nrdot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::Empty)))]
     #[case::namespace_with_invalid_char("n@s/nrdot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter('@'))))]
-    // Without a `/`, the whole input is taken as the namespace and `:` is not an allowed character.
-    #[case::missing_name_separator("aa:1.1.3", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter(':'))))]
+    #[case::missing_name_separator("aa:1.1.3", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::Empty)))]
     #[case::namespace_too_long(TOO_LONG_NAMESPACE_FQN, |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::TooLong { .. })))]
     #[case::empty_version("ns/nrdot:", |e| matches!(e, AgentTypeIDError::InvalidVersion(_)))]
     #[case::incomplete_version("ns/nrdot:0", |e| matches!(e, AgentTypeIDError::InvalidVersion(_)))]

--- a/agent-control/src/agent_type/agent_type_id.rs
+++ b/agent-control/src/agent_type/agent_type_id.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Deserializer, Serializer};
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
-const NAME_NAMESPACE_MIN_LENGTH: usize = 1;
 pub(crate) const NAME_NAMESPACE_MAX_LENGTH: usize = 64;
 /// Bounds the version length so a version bump (e.g. `9999.9999.999` -> `9999.9999.1000`)
 /// cannot overflow external constraints like the OCI tag built using this metadata.
@@ -62,7 +61,7 @@ impl AgentTypeID {
     /// Parses a semver version, additionally rejecting anything that isn't a digit or `.`.
     /// This constraint relates to the OCI tag built from this metadata.
     fn parse_version(s: &str) -> Result<Version, AgentTypeIDError> {
-        if !s.chars().all(|c| c.is_ascii_digit() || c.eq(&'.')) {
+        if !s.chars().all(|c| c.is_ascii_digit() || c == '.') {
             return Err(AgentTypeIDError::ForbiddenSemVer);
         }
         if s.len() > VERSION_MAX_LENGTH {
@@ -74,10 +73,10 @@ impl AgentTypeID {
         Version::parse(s).map_err(|e| AgentTypeIDError::InvalidVersion(e.to_string()))
     }
 
-    /// Limits the characters allowed so this could be used as identifier for k8s resources and other
+    /// Limits the characters allowed so this could be used as k8s labels and other
     /// places like OCI tags. Returns the specific [NameFormatError] on the first rule violated.
     fn validate_format(s: &str) -> Result<(), NameFormatError> {
-        if s.len() < NAME_NAMESPACE_MIN_LENGTH {
+        if s.is_empty() {
             return Err(NameFormatError::Empty);
         }
         if s.len() > NAME_NAMESPACE_MAX_LENGTH {
@@ -104,11 +103,11 @@ impl AgentTypeID {
     fn from_parts(
         name: String,
         namespace: String,
-        version: &str,
+        version: String,
     ) -> Result<Self, AgentTypeIDError> {
         Self::validate_format(namespace.as_str()).map_err(AgentTypeIDError::InvalidNamespace)?;
         Self::validate_format(name.as_str()).map_err(AgentTypeIDError::InvalidName)?;
-        let version = Self::parse_version(version)?;
+        let version = Self::parse_version(version.as_str())?;
         Ok(Self {
             name,
             namespace,
@@ -151,16 +150,10 @@ impl TryFrom<&str> for AgentTypeID {
     type Error = AgentTypeIDError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let namespace: String = value.chars().take_while(|&i| i != '/').collect();
-        let name: String = value
-            .chars()
-            .skip_while(|&i| i != '/')
-            .skip(1)
-            .take_while(|&i| i != ':')
-            .collect();
-        let version: String = value.chars().skip_while(|&i| i != ':').skip(1).collect();
+        let (namespace, rest) = value.split_once('/').unwrap_or_default();
+        let (name, version) = rest.split_once(':').unwrap_or_default();
 
-        Self::from_parts(name, namespace, version.as_str())
+        Self::from_parts(name.to_string(), namespace.to_string(), version.to_string())
     }
 }
 
@@ -188,7 +181,7 @@ impl<'de> Deserialize<'de> for AgentTypeID {
         Self::from_parts(
             name.unwrap_or_default(),
             namespace.unwrap_or_default(),
-            version.unwrap_or_default().as_str(),
+            version.unwrap_or_default(),
         )
         .map_err(Error::custom)
     }
@@ -228,23 +221,23 @@ version: 0.1.0
     type ErrorMatcher = fn(AgentTypeIDError) -> bool;
 
     #[rstest]
-    #[case::empty_name("ns/:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::Empty))) as ErrorMatcher)]
-    #[case::name_does_not_start_with_letter("ns/1nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidStart))) as ErrorMatcher)]
-    #[case::name_does_not_end_with_alphanumeric("ns/nrdot.:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidEnd))) as ErrorMatcher)]
-    #[case::name_with_invalid_char("ns/nr@dot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('@')))) as ErrorMatcher)]
-    #[case::name_with_dash("ns/nr-dot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('-')))) as ErrorMatcher)]
-    #[case::name_too_long(TOO_LONG_NAME_FQN, (|e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::TooLong { .. }))) as ErrorMatcher)]
-    #[case::empty_namespace("/nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::Empty))) as ErrorMatcher)]
-    #[case::namespace_with_invalid_char("n@s/nrdot:0.1.0", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter('@')))) as ErrorMatcher)]
+    #[case::empty_name("ns/:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::Empty)))]
+    #[case::name_does_not_start_with_letter("ns/1nrdot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidStart)))]
+    #[case::name_does_not_end_with_alphanumeric("ns/nrdot.:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidEnd)))]
+    #[case::name_with_invalid_char("ns/nr@dot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('@'))))]
+    #[case::name_with_dash("ns/nr-dot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::InvalidCharacter('-'))))]
+    #[case::name_too_long(TOO_LONG_NAME_FQN, |e| matches!(e, AgentTypeIDError::InvalidName(NameFormatError::TooLong { .. })))]
+    #[case::empty_namespace("/nrdot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::Empty)))]
+    #[case::namespace_with_invalid_char("n@s/nrdot:0.1.0", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter('@'))))]
     // Without a `/`, the whole input is taken as the namespace and `:` is not an allowed character.
-    #[case::missing_name_separator("aa:1.1.3", (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter(':')))) as ErrorMatcher)]
-    #[case::namespace_too_long(TOO_LONG_NAMESPACE_FQN, (|e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::TooLong { .. }))) as ErrorMatcher)]
-    #[case::empty_version("ns/nrdot:", (|e| matches!(e, AgentTypeIDError::InvalidVersion(_))) as ErrorMatcher)]
-    #[case::incomplete_version("ns/nrdot:0", (|e| matches!(e, AgentTypeIDError::InvalidVersion(_))) as ErrorMatcher)]
-    #[case::non_numeric_version("ns/nrdot:adsf", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
-    #[case::pre_release_version("ns/nrdot:0.1.0-alpha.1", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
-    #[case::build_metadata_version("ns/nrdot:0.1.0+build", (|e| matches!(e, AgentTypeIDError::ForbiddenSemVer)) as ErrorMatcher)]
-    #[case::version_too_long("ns/nrdot:1111.1111.11111", (|e| matches!(e, AgentTypeIDError::VersionTooLong { length: 15, max: 14 })) as ErrorMatcher)]
+    #[case::missing_name_separator("aa:1.1.3", |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::InvalidCharacter(':'))))]
+    #[case::namespace_too_long(TOO_LONG_NAMESPACE_FQN, |e| matches!(e, AgentTypeIDError::InvalidNamespace(NameFormatError::TooLong { .. })))]
+    #[case::empty_version("ns/nrdot:", |e| matches!(e, AgentTypeIDError::InvalidVersion(_)))]
+    #[case::incomplete_version("ns/nrdot:0", |e| matches!(e, AgentTypeIDError::InvalidVersion(_)))]
+    #[case::non_numeric_version("ns/nrdot:adsf", |e| matches!(e, AgentTypeIDError::ForbiddenSemVer))]
+    #[case::pre_release_version("ns/nrdot:0.1.0-alpha.1", |e| matches!(e, AgentTypeIDError::ForbiddenSemVer))]
+    #[case::build_metadata_version("ns/nrdot:0.1.0+build", |e| matches!(e, AgentTypeIDError::ForbiddenSemVer))]
+    #[case::version_too_long("ns/nrdot:1111.1111.11111", |e| matches!(e, AgentTypeIDError::VersionTooLong { length: 15, max: 14 }))]
     fn try_from_invalid_fqn(#[case] fqn: &str, #[case] is_expected_error: ErrorMatcher) {
         let error = AgentTypeID::try_from(fqn).unwrap_err();
         let rendered = format!("{error:?}");

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -675,7 +675,7 @@ platform: host
     }
 
     const GIVEN_NEWRELIC_INFRA_YAML: &str = r#"
-name: newrelic-infra
+name: newrelic_infra
 namespace: newrelic
 version: 1.39.1
 platform: host
@@ -764,7 +764,7 @@ status_server_port: 8004
     }
 
     const AGENT_TYPE_WITH_VARIANTS: &str = r#"
-name: variant-values
+name: variant_values
 namespace: newrelic
 version: 0.0.1
 platform: host

--- a/agent-control/src/agent_type/oci.rs
+++ b/agent-control/src/agent_type/oci.rs
@@ -1,1 +1,88 @@
 pub mod downloader;
+
+use crate::agent_type::agent_type_id::AgentTypeID;
+use crate::environment::Environment;
+use std::fmt::{Display, Formatter};
+
+/// The OCI image tag that identifies an agent type artifact in a remote registry.
+///
+/// Composed as `<platform>-<operating_system>-<name>-<version>`, omitting the operating system for
+/// environments that don't have one (Kubernetes). The result is a valid OCI tag by construction:
+/// the prefix is a fixed lowercase string, [AgentTypeID] constrains the name to `[a-z0-9._]` and
+/// the version to `[0-9.]`, and the bounded name/version lengths keep it within the OCI length
+/// limit (see the `longest_tag_never_overflows` test).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTypeTag(String);
+
+impl AgentTypeTag {
+    /// Builds the tag used to pull `agent_type_id` for the given running `environment`.
+    pub fn new(agent_type_id: &AgentTypeID, environment: Environment) -> Self {
+        Self(format!(
+            "{}-{}-{}",
+            environment_prefix(environment),
+            agent_type_id.name(),
+            agent_type_id.version()
+        ))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentTypeTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// The fixed `<platform>-<operating_system>` prefix for an environment.
+fn environment_prefix(environment: Environment) -> &'static str {
+    match environment {
+        Environment::Linux => "host-linux",
+        Environment::Windows => "host-windows",
+        Environment::K8s => "kubernetes",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::agent_type_id::{NAME_NAMESPACE_MAX_LENGTH, VERSION_MAX_LENGTH};
+
+    /// Maximum length of an OCI image tag (see the OCI distribution spec).
+    const MAX_TAG_LENGTH: usize = 128;
+    /// Amount of separator '-' without counting the one inside Environment
+    const SEPARATORS_COUNT: usize = 2;
+
+    #[rstest::rstest]
+    #[case::linux(Environment::Linux, "host-linux-com.fake_name-0.1.0")]
+    #[case::windows(Environment::Windows, "host-windows-com.fake_name-0.1.0")]
+    #[case::kubernetes(Environment::K8s, "kubernetes-com.fake_name-0.1.0")]
+    fn builds_tag_per_environment(#[case] environment: Environment, #[case] expected_tag: &str) {
+        let agent_type_id = AgentTypeID::try_from("fake_ns/com.fake_name:0.1.0").unwrap();
+
+        assert_eq!(
+            AgentTypeTag::new(&agent_type_id, environment).as_str(),
+            expected_tag
+        );
+    }
+
+    /// Guards the only way the by-construction validity of [AgentTypeTag] can break: adding an
+    /// [Environment] whose prefix is long enough that the longest possible tag
+    /// `<prefix>-<name>-<version>` overflows [MAX_TAG_LENGTH]. The exhaustive match fails to
+    /// compile when a variant is added, forcing a re-check here.
+    #[test]
+    fn longest_tag_never_overflows() {
+        for environment in Environment::all() {
+            let longest_tag_length = environment_prefix(environment).len()
+                + SEPARATORS_COUNT
+                + NAME_NAMESPACE_MAX_LENGTH
+                + VERSION_MAX_LENGTH;
+            assert!(
+                longest_tag_length <= MAX_TAG_LENGTH,
+                "environment {environment} can overflow the tag length: {longest_tag_length} > {MAX_TAG_LENGTH}"
+            );
+        }
+    }
+}

--- a/agent-control/src/agent_type/oci/downloader.rs
+++ b/agent-control/src/agent_type/oci/downloader.rs
@@ -6,6 +6,7 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::agent_control::config::{OciAuth, Registry};
+use crate::agent_type::oci::AgentTypeTag;
 use crate::agent_type::runtime_config::on_host::package::rendered::Repository;
 use crate::oci::artifact_definitions::LocalAgentType;
 use crate::oci::{Client, OciArtifactFetcher, OciClientError};
@@ -21,7 +22,7 @@ pub trait OCIAgentTypeDownloader: Send + Sync {
 
     /// Downloads and verifies the agent type artifact identified by `tag`, returning the raw bytes
     /// of the single agent type definition it contains.
-    fn download(&self, tag: &str) -> Result<Vec<u8>, Self::Error>;
+    fn download(&self, tag: &AgentTypeTag) -> Result<Vec<u8>, Self::Error>;
 }
 
 /// Downloads agent type definitions from a configured OCI remote into memory.
@@ -50,11 +51,11 @@ impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
     ///
     /// On failure the operation is retried as configured; if all attempts are exhausted it returns
     /// an error.
-    fn download(&self, tag: &str) -> Result<Vec<u8>, OciClientError> {
+    fn download(&self, tag: &AgentTypeTag) -> Result<Vec<u8>, OciClientError> {
         let base_reference = Reference::with_tag(
             self.registry.to_string(),
             self.repository.to_string(),
-            tag.to_string(),
+            tag.as_str().to_string(),
         );
         debug!(
             oci_reference = base_reference.to_string(),
@@ -144,6 +145,8 @@ impl OCIAgentTypeArtifactDownloader {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::environment::Environment;
     use crate::http::config::ProxyConfig;
     use crate::oci::artifact_definitions::{LayerMediaType, ManifestArtifactType};
     use crate::oci::tests::FakeOciServer;
@@ -163,7 +166,7 @@ pub mod tests {
         pub OCIAgentTypeDownloader {}
         impl OCIAgentTypeDownloader for OCIAgentTypeDownloader {
             type Error = FakeDownloaderError;
-            fn download(&self, tag: &str) -> Result<Vec<u8>, FakeDownloaderError>;
+            fn download(&self, tag: &AgentTypeTag) -> Result<Vec<u8>, FakeDownloaderError>;
         }
     }
 
@@ -180,6 +183,15 @@ pub mod tests {
     const DEFINITION: &[u8] = b"namespace: some.namespace\nname: some.agent.type\n";
     const REPOSITORY: &str = "my-org/agent-types-repository";
     const TAG: &str = "host-linux-some.agent.type-0.0.42";
+
+    /// An [AgentTypeTag] whose string equals [TAG], so it matches the artifact the mock server
+    /// serves under that tag.
+    fn agent_type_tag() -> AgentTypeTag {
+        AgentTypeTag::new(
+            &AgentTypeID::try_from("newrelic/some.agent.type:0.0.42").unwrap(),
+            Environment::Linux,
+        )
+    }
 
     /// Builds an in-memory gzipped tar containing a single file with the given content.
     fn tar_gz_with_definition(file_name: &str, content: &[u8]) -> Vec<u8> {
@@ -227,7 +239,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None);
-        let definition = downloader.download(TAG).unwrap();
+        let definition = downloader.download(&agent_type_tag()).unwrap();
         assert_eq!(definition, DEFINITION);
     }
 
@@ -240,7 +252,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None);
-        assert_matches!(downloader.download(TAG), Err(OciClientError::AttemptsExceeded(msg)) => {
+        assert_matches!(downloader.download(&agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
             assert!(msg.contains("validating agent type manifest"), "{msg}");
         });
     }
@@ -254,7 +266,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None).with_max_size_bytes(10);
-        assert_matches!(downloader.download(TAG), Err(OciClientError::AttemptsExceeded(msg)) => {
+        assert_matches!(downloader.download(&agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
             assert!(msg.contains("exceeds maximum"), "{msg}");
         });
     }

--- a/agent-control/src/agent_type/oci/downloader.rs
+++ b/agent-control/src/agent_type/oci/downloader.rs
@@ -55,7 +55,7 @@ impl OCIAgentTypeDownloader for OCIAgentTypeArtifactDownloader {
         let base_reference = Reference::with_tag(
             self.registry.to_string(),
             self.repository.to_string(),
-            tag.as_str().to_string(),
+            tag.to_string(),
         );
         debug!(
             oci_reference = base_reference.to_string(),
@@ -186,7 +186,7 @@ pub mod tests {
 
     /// An [AgentTypeTag] whose string equals [TAG], so it matches the artifact the mock server
     /// serves under that tag.
-    fn agent_type_tag() -> AgentTypeTag {
+    fn test_agent_type_tag() -> AgentTypeTag {
         AgentTypeTag::new(
             &AgentTypeID::try_from("newrelic/some.agent.type:0.0.42").unwrap(),
             Environment::Linux,
@@ -239,7 +239,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None);
-        let definition = downloader.download(&agent_type_tag()).unwrap();
+        let definition = downloader.download(&test_agent_type_tag()).unwrap();
         assert_eq!(definition, DEFINITION);
     }
 
@@ -252,7 +252,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None);
-        assert_matches!(downloader.download(&agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
+        assert_matches!(downloader.download(&test_agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
             assert!(msg.contains("validating agent type manifest"), "{msg}");
         });
     }
@@ -266,7 +266,7 @@ pub mod tests {
             .build();
 
         let downloader = create_downloader(server.registry(), None).with_max_size_bytes(10);
-        assert_matches!(downloader.download(&agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
+        assert_matches!(downloader.download(&test_agent_type_tag()), Err(OciClientError::AttemptsExceeded(msg)) => {
             assert!(msg.contains("exceeds maximum"), "{msg}");
         });
     }

--- a/agent-control/src/agent_type/registry/local.rs
+++ b/agent-control/src/agent_type/registry/local.rs
@@ -137,29 +137,28 @@ pub mod tests {
     fn test_get() {
         let definitions = vec![
             AgentTypeDefinition::empty_with_metadata(
-                AgentTypeID::try_from("ns/agent-1:0.0.0").unwrap(),
+                AgentTypeID::try_from("ns/agent_1:0.0.0").unwrap(),
             ),
             AgentTypeDefinition::empty_with_metadata(
-                AgentTypeID::try_from("ns/agent-2:0.0.0").unwrap(),
+                AgentTypeID::try_from("ns/agent_2:0.0.0").unwrap(),
             ),
         ];
 
         let registry = LocalRegistry::try_new(definitions.clone()).unwrap();
 
         let agent_1 = registry
-            .get(&AgentTypeID::try_from("ns/agent-1:0.0.0").unwrap())
+            .get(&AgentTypeID::try_from("ns/agent_1:0.0.0").unwrap())
             .unwrap();
         assert_eq!(definitions[0], agent_1);
         let agent_2 = registry
-            .get(&AgentTypeID::try_from("ns/agent-2:0.0.0").unwrap())
+            .get(&AgentTypeID::try_from("ns/agent_2:0.0.0").unwrap())
             .unwrap();
         assert_eq!(definitions[1], agent_2);
 
         assert_matches!(
-            registry
-                .get(&AgentTypeID::try_from("ns/not-existent:0.0.0").unwrap()),
+            registry.get(&AgentTypeID::try_from("ns/not_existent:0.0.0").unwrap()),
             Err(AgentTypeRegistryError::NotFound(s)) => {
-                assert_eq!(s, "ns/not-existent:0.0.0".to_string());
+                assert_eq!(s, "ns/not_existent:0.0.0".to_string());
             }
         );
     }

--- a/agent-control/src/agent_type/registry/remote.rs
+++ b/agent-control/src/agent_type/registry/remote.rs
@@ -1,6 +1,7 @@
 use super::{AgentTypeRegistry, AgentTypeRegistryError};
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::agent_type::definition::{AgentTypeDefinition, AgentTypeMetadata};
+use crate::agent_type::oci::AgentTypeTag;
 use crate::agent_type::oci::downloader::OCIAgentTypeDownloader;
 use crate::environment::Environment;
 
@@ -23,20 +24,6 @@ impl<D: OCIAgentTypeDownloader> RemoteRegistry<D> {
             environment,
             downloader,
         }
-    }
-
-    /// Builds the OCI tag for the given id according to the running environment.
-    fn artifact_tag(&self, agent_type_id: &AgentTypeID) -> String {
-        let target = match self.environment {
-            Environment::Linux => "host-linux",
-            Environment::Windows => "host-windows",
-            Environment::K8s => "kubernetes",
-        };
-        format!(
-            "{target}-{}-{}",
-            agent_type_id.name(),
-            agent_type_id.version()
-        )
     }
 
     /// Verifies that the downloaded definition's metadata matches what was requested: its
@@ -68,7 +55,7 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
         &self,
         agent_type_id: &AgentTypeID,
     ) -> Result<AgentTypeDefinition, AgentTypeRegistryError> {
-        let tag = self.artifact_tag(agent_type_id);
+        let tag = AgentTypeTag::new(agent_type_id, self.environment);
         let raw = self
             .downloader
             .download(&tag)
@@ -81,7 +68,10 @@ impl<D: OCIAgentTypeDownloader> AgentTypeRegistry for RemoteRegistry<D> {
         // remote returned an artifact we did not ask for. Reject it rather than supervise an
         // agent type meant for another platform.
         self.check_metadata(&definition.metadata, agent_type_id)
-            .map_err(|details| AgentTypeRegistryError::MetadataMismatch { tag, details })?;
+            .map_err(|details| AgentTypeRegistryError::MetadataMismatch {
+                tag: tag.to_string(),
+                details,
+            })?;
 
         Ok(definition)
     }
@@ -121,21 +111,12 @@ deployment:
         AgentTypeID::try_from("newrelic/com.newrelic.infrastructure:0.1.0").unwrap()
     }
 
-    #[rstest::rstest]
-    #[case::linux(Environment::Linux, "host-linux-com.newrelic.infrastructure-0.1.0")]
-    #[case::windows(Environment::Windows, "host-windows-com.newrelic.infrastructure-0.1.0")]
-    #[case::kubernetes(Environment::K8s, "kubernetes-com.newrelic.infrastructure-0.1.0")]
-    fn test_artifact_tag(#[case] environment: Environment, #[case] expected_tag: &str) {
-        let registry = RemoteRegistry::new(environment, MockOCIAgentTypeDownloader::new());
-        assert_eq!(registry.artifact_tag(&agent_type_id()), expected_tag);
-    }
-
     #[test]
     fn test_get_downloads_parses_and_returns_definition() {
         let mut downloader = MockOCIAgentTypeDownloader::new();
         downloader
             .expect_download()
-            .withf(|tag| tag == "kubernetes-com.newrelic.infrastructure-0.1.0")
+            .withf(|tag| tag.as_str() == "kubernetes-com.newrelic.infrastructure-0.1.0")
             .once()
             .returning(|_| Ok(K8S_DEFINITION.as_bytes().to_vec()));
 

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -479,7 +479,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
         let agent_id = AgentID::try_from("some-agent-id").unwrap();
         let agent_type = AgentType::build_for_testing(
             r#"
-name: k8s-agent-type
+name: k8s_agent_type
 namespace: newrelic
 version: 0.0.1
 platform: kubernetes
@@ -708,7 +708,7 @@ backoff:
 "#;
 
     const K8S_AGENT_TYPE_YAML_VARIABLES: &str = r#"
-name: k8s-agent-type
+name: k8s_agent_type
 namespace: newrelic
 version: 0.0.1
 platform: kubernetes
@@ -739,7 +739,7 @@ deployment:
 "#;
 
     const K8S_AGENT_TYPE_YAML_ENVIRONMENT_VARIABLES: &str = r#"
-name: k8s-agent-type
+name: k8s_agent_type
 namespace: newrelic
 version: 0.0.1
 platform: kubernetes

--- a/agent-control/src/config_migrate/migration/agent_config_getter.rs
+++ b/agent-control/src/config_migrate/migration/agent_config_getter.rs
@@ -269,7 +269,7 @@ agents:
             TestCase {
                 name: "error no agents of namespace",
                 agent_type_id: AgentTypeID::try_from(
-                    "francisco-partners/com.newrelic.infrastructure:0.0.1",
+                    "francisco_partners/com.newrelic.infrastructure:0.0.1",
                 )
                 .unwrap(),
                 next: None,

--- a/agent-control/src/config_migrate/migration/config.rs
+++ b/agent-control/src/config_migrate/migration/config.rs
@@ -221,7 +221,7 @@ configs:
           - "yml"
 
   -
-    agent_type_fqn: francisco-partners/com.newrelic.another:0.0.2
+    agent_type_fqn: francisco_partners/com.newrelic.another:0.0.2
     filesystem_mappings:
       config_agent:
         file_path: /etc/another.yml
@@ -255,7 +255,7 @@ configs:
 "#;
 
         let expected_fqns_in_order = [
-            "francisco-partners/com.newrelic.another:0.0.2"
+            "francisco_partners/com.newrelic.another:0.0.2"
                 .try_into()
                 .unwrap(),
             "newrelic/com.newrelic.another:0.0.1".try_into().unwrap(),

--- a/agent-control/src/environment.rs
+++ b/agent-control/src/environment.rs
@@ -16,3 +16,23 @@ impl Display for Environment {
         }
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    impl Environment {
+        /// Iterates over every [Environment] variant.
+        pub fn all() -> impl Iterator<Item = Environment> {
+            std::iter::successors(Some(Environment::Linux), Environment::succeeding)
+        }
+
+        fn succeeding(current: &Environment) -> Option<Environment> {
+            match current {
+                Environment::Linux => Some(Environment::Windows),
+                Environment::Windows => Some(Environment::K8s),
+                Environment::K8s => None,
+            }
+        }
+    }
+}

--- a/agent-control/src/sub_agent/identity.rs
+++ b/agent-control/src/sub_agent/identity.rs
@@ -1,11 +1,11 @@
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::defaults::{
-    AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE, AGENT_CONTROL_VERSION,
-};
+use crate::agent_control::defaults::{AGENT_CONTROL_NAMESPACE, AGENT_CONTROL_TYPE};
 use crate::agent_type::agent_type_id::AgentTypeID;
 use std::fmt::{Display, Formatter};
 
 pub const ID_ATTRIBUTE_NAME: &str = "id";
+
+const AC_AGENT_TYPE_VERSION: &str = "0.1.0";
 
 // This could be SubAgentIdentity
 #[derive(Clone, Debug, PartialEq)]
@@ -15,9 +15,11 @@ pub struct AgentIdentity {
 }
 
 impl AgentIdentity {
+    /// AC doesn't have a real identity as agent since there is no Agent type for it. In order to build one and
+    /// make possible to reuse some components that are based on this we use a fake [AgentTypeID] for AC.
     pub fn new_agent_control_identity() -> Self {
         let ac_agent_type_id =
-            format!("{AGENT_CONTROL_NAMESPACE}/{AGENT_CONTROL_TYPE}:{AGENT_CONTROL_VERSION}");
+            format!("{AGENT_CONTROL_NAMESPACE}/{AGENT_CONTROL_TYPE}:{AC_AGENT_TYPE_VERSION}");
         Self::from((
             AgentID::AgentControl,
             // This is a safe unwrap because we are creating the AgentTypeID from a string that we know is valid.

--- a/agent-control/tests/k8s/data/bar_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/bar_cr_agent_type.yml
@@ -1,5 +1,5 @@
 namespace: newrelic
-name: com.newrelic.bar-cr-agent
+name: com.newrelic.bar_cr_agent
 version: 0.0.1
 platform: kubernetes
 protocol_version: "1.0"

--- a/agent-control/tests/k8s/data/foo_cr_agent_type.yml
+++ b/agent-control/tests/k8s/data/foo_cr_agent_type.yml
@@ -1,5 +1,5 @@
 namespace: newrelic
-name: com.newrelic.foo-cr-agent
+name: com.newrelic.foo_cr_agent
 version: 0.0.1
 platform: kubernetes
 protocol_version: "1.0"

--- a/agent-control/tests/k8s/scenarios/cr_based_agents.rs
+++ b/agent-control/tests/k8s/scenarios/cr_based_agents.rs
@@ -58,7 +58,7 @@ fn k8s_opamp_foo_cr_subagent() {
         r#"
 agents:
   foo-agent:
-    agent_type: "newrelic/com.newrelic.foo-cr-agent:0.0.1"
+    agent_type: "newrelic/com.newrelic.foo_cr_agent:0.0.1"
             "#,
     );
 
@@ -141,7 +141,7 @@ fn k8s_opamp_cr_subagent_installed_before_crd() {
         r#"
 agents:
   bar-agent:
-    agent_type: "newrelic/com.newrelic.bar-cr-agent:0.0.1"
+    agent_type: "newrelic/com.newrelic.bar_cr_agent:0.0.1"
             "#,
     );
 

--- a/agent-control/tests/k8s/store.rs
+++ b/agent-control/tests/k8s/store.rs
@@ -106,7 +106,7 @@ fn k8s_hash_in_config_map() {
         .store_remote(
             &agent_id_1,
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.1").unwrap(),
             ),
             &remote_config_1,
         )
@@ -128,7 +128,7 @@ fn k8s_hash_in_config_map() {
         .store_remote(
             &agent_id_2,
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.2").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.2").unwrap(),
             ),
             &remote_config_2,
         )
@@ -190,7 +190,7 @@ fn k8s_value_repository_config_map() {
         .store_remote(
             &agent_id_1,
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.1").unwrap(),
             ),
             &remote_values,
         )
@@ -230,7 +230,7 @@ fn k8s_value_repository_config_map() {
         .store_remote(
             &agent_id_2,
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.1").unwrap(),
             ),
             &remote_values_agent_2,
         )
@@ -343,7 +343,7 @@ fn k8s_multiple_store_entries() {
         .store_remote(
             &agent_id,
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.1").unwrap(),
             ),
             &remote_config,
         )

--- a/agent-control/tests/on_host/config_repository.rs
+++ b/agent-control/tests/on_host/config_repository.rs
@@ -52,7 +52,7 @@ fn test_store_remote_no_mocks() {
         .store_remote(
             &agent_id.clone(),
             ResourceOwnership::SubAgent(
-                AgentTypeID::try_from("test/test-agent-type:0.0.1").unwrap(),
+                AgentTypeID::try_from("test/test_agent_type:0.0.1").unwrap(),
             ),
             &agent_values,
         )

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -22,7 +22,7 @@ use tempfile::tempdir;
 #[cfg(target_family = "unix")]
 const LOGGING_AGENT_TYPE_YAML: &str = r#"
 namespace: test
-name: file-logging-agent
+name: file_logging_agent
 version: 0.0.0
 platform: host
 operating_system: linux
@@ -49,7 +49,7 @@ deployment:
 #[cfg(target_family = "windows")]
 const LOGGING_AGENT_TYPE_YAML: &str = r#"
 namespace: test
-name: file-logging-agent
+name: file_logging_agent
 version: 0.0.0
 platform: host
 operating_system: windows
@@ -142,7 +142,7 @@ fn run_file_logging_scenario(
     let agents = format!(
         r#"
   {agent_id}:
-    agent_type: "test/file-logging-agent:0.0.0"
+    agent_type: "test/file_logging_agent:0.0.0"
 "#
     );
     create_agent_control_config(

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -294,7 +294,7 @@ fn filesystem_persists_across_restarts() {
         format!(
             r#"
 namespace: test
-name: infra-agent
+name: infra_agent
 version: 0.0.0
 platform: host
 operating_system: {AGENT_CONTROL_MODE_ON_HOST}
@@ -333,7 +333,7 @@ deployment:
     let agents = format!(
         r#"
   {agent_id}:
-    agent_type: "test/infra-agent:0.0.0"
+    agent_type: "test/infra_agent:0.0.0"
 "#
     );
 


### PR DESCRIPTION
## Summary

Agent type `name`/`namespace` and `version` allowed values (like `-` separators or arbitrary semver pre-release/build tags) that can't safely become OCI tags. This tightens validation and surfaces precise, field-specific errors at deserialization time.

## Changes

- Reject `-` in name/namespace; require start-letter, end-alphanumeric, and only `[a-z0-9._]`.
- Require plain `Major.Minor.Patch` semver and cap version length (14 chars) to bound OCI tag size.
- Centralize parsing/validation in `AgentTypeID::from_parts`, shared by `TryFrom<&str>` and `Deserialize`.
- Unify the related changelog entries to reduce noise
- Replace the AC version usage on the AC fake agent type , wich didn't make much sense and also it was causing e2e test to fail due to long version values. 
## Notes for reviewers

- All shipped agent types already comply; only internal authors of custom definitions need to migrate.
