### PR TITLE
Revert "chore: upload trivy scan results to github security (#2592)"

### DIFF
--- a/.github/workflows/component_image_security.yml
+++ b/.github/workflows/component_image_security.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 env:
   DOCKER_IMAGE: newrelic/newrelic-agent-control
@@ -53,7 +52,5 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: 'trivy-results.sarif'
+      # TODO Upload Trivy scan results to GitHub Security tab when the repo gets public state.
+      # more info about current limitation https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/advanced-security-must-be-enabled


### PR DESCRIPTION
This reverts commit a5e5afa32352bab345445fb08f6cfc62a244decf.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
