### PR TITLE
feat: add retries with backoff and jitter for oci download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Remember that the keywords that you can use are the following:
 - On-host self-update: an empty `version: ""` pushed from Fleet Control now behaves the same as an absent `version` field (no-op, no update attempted). Previously it silently triggered a pull of the `:latest` OCI tag.
 
 ### enhancement
+- Adds exponential backoff + jitter retries to OCI artifact fetches via a new `BackoffPolicy`
+  (configurable under `self_update.download_retry`), replacing the old `with_retries(usize, Duration)` API.
 - Hardens service restart policies on Linux and Windows (systemd rate limiting: 5 restarts max in 60s) to prevent
   crash-looping from saturating CPU.
 - Added support for remote agent type retrieval.

--- a/agent-control/src/agent_control.rs
+++ b/agent-control/src/agent_control.rs
@@ -35,7 +35,7 @@ use agent_id::AgentID;
 use config::{AgentControlConfig, AgentControlDynamicConfig, SubAgentsMap, sub_agents_difference};
 use config_repository::repository::AgentControlDynamicConfigRepository;
 use config_validator::DynamicConfigValidator;
-use crossbeam::channel::never;
+use crossbeam::channel::{never, tick};
 use crossbeam::select;
 use error::{AgentControlError, BuildingSubagentErrors};
 use opamp_client::StartedClient;
@@ -294,6 +294,15 @@ where
 
         let mut current_dynamic_config = self.initial_config.dynamic.clone();
 
+        // Heartbeat that re-drives a pending self-update so a transient registry outage recovers
+        // without a new desired version from Fleet. Inactive unless self-update is enabled.
+        let self_update_config = &self.initial_config.self_update;
+        let self_update_retry_ticker = if self_update_config.enabled() {
+            tick(self_update_config.retry_heartbeat())
+        } else {
+            never()
+        };
+
         // Count the received remote configs during execution
         let mut remote_config_count = 0;
         loop {
@@ -366,6 +375,13 @@ where
                     break GracefulShutdownReason::ExternalRequested;
                 },
                 recv(uptime_reporter.receiver()) -> _tick => { let _ = uptime_reporter.report(); },
+                recv(&self_update_retry_ticker) -> _tick => {
+                    let span = info_span!("self_update_retry", id=AGENT_CONTROL_ID);
+                    let _span_guard = span.enter();
+                    if let Err(err) = self.version_updater.retry() {
+                        debug!(error_msg = %err, "Scheduled self-update retry suppressed or failed");
+                    }
+                },
             }
         }
     }

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -15,10 +15,12 @@ use crate::opamp::client_builder::PollInterval;
 use crate::opamp::remote_config::OpampRemoteConfig;
 use crate::opamp::remote_config::validators::signature::validator::SignatureValidatorConfig;
 use crate::secrets_provider::SecretsProvidersConfig;
+use crate::utils::retry::BackoffPolicy;
 use crate::values::yaml_config::YAMLConfig;
 use crate::{
     agent_type::agent_type_id::AgentTypeID, instrumentation::config::InstrumentationConfig,
 };
+use duration_str::deserialize_duration;
 use http::HeaderMap;
 use kube::api::TypeMeta;
 use oci_client::secrets::RegistryAuth;
@@ -26,6 +28,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::str::FromStr;
+use std::time::Duration;
 use thiserror::Error;
 use tracing::info;
 use url::Url;
@@ -101,12 +104,101 @@ pub struct SelfUpdateConfig {
     pub signature_verification_enabled: SignatureVerificationEnabled,
     /// Package configuration for the self-update mechanism in on-host environments
     pub package: AgentControlPackage,
+    /// how many failures we retry within a single self-update attempt, and the backoff between them
+    pub download_retry: DownloadRetryConfig,
+    /// When an upgrade to a given version fails, how long we wait before re-trying it
+    /// (and how many consecutive failures before we give up entirely until a version change)
+    pub upgrade_backoff: UpgradeBackoffConfig,
 }
 
 const DEFAULT_SELF_UPDATE_CONFIG_ENABLED: bool = false;
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_SELF_UPDATE_CONFIG_ENABLED)]
 pub struct SelfUpdateConfigEnabled(bool);
+
+const DEFAULT_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
+const DEFAULT_DOWNLOAD_BASE_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_DOWNLOAD_MAX_DELAY: Duration = Duration::from_secs(30);
+const DEFAULT_DOWNLOAD_JITTER: bool = true;
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_DOWNLOAD_MAX_ATTEMPTS)]
+pub struct DownloadMaxAttempts(usize);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_DOWNLOAD_BASE_DELAY)]
+pub struct DownloadBaseDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_DOWNLOAD_MAX_DELAY)]
+pub struct DownloadMaxDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_DOWNLOAD_JITTER)]
+pub struct DownloadJitter(bool);
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[serde(default)]
+pub struct DownloadRetryConfig {
+    pub max_attempts: DownloadMaxAttempts,
+    pub base_delay: DownloadBaseDelay,
+    pub max_delay: DownloadMaxDelay,
+    pub jitter: DownloadJitter,
+}
+
+impl From<&DownloadRetryConfig> for BackoffPolicy {
+    fn from(c: &DownloadRetryConfig) -> Self {
+        BackoffPolicy {
+            max_attempts: c.max_attempts.0,
+            base_delay: c.base_delay.0,
+            max_delay: c.max_delay.0,
+            jitter: c.jitter.0,
+        }
+    }
+}
+
+const DEFAULT_UPGRADE_MAX_FAILURES: u32 = 5;
+const DEFAULT_UPGRADE_BASE_DELAY: Duration = Duration::from_secs(30);
+const DEFAULT_UPGRADE_MAX_DELAY: Duration = Duration::from_secs(600);
+const DEFAULT_UPGRADE_JITTER: bool = true;
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_UPGRADE_MAX_FAILURES)]
+pub struct UpgradeMaxConsecutiveFailures(u32);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_UPGRADE_BASE_DELAY)]
+pub struct UpgradeBaseDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_UPGRADE_MAX_DELAY)]
+pub struct UpgradeMaxDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[wrapper_default_value(DEFAULT_UPGRADE_JITTER)]
+pub struct UpgradeJitter(bool);
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[serde(default)]
+pub struct UpgradeBackoffConfig {
+    pub max_consecutive_failures: UpgradeMaxConsecutiveFailures,
+    pub base_delay: UpgradeBaseDelay,
+    pub max_delay: UpgradeMaxDelay,
+    pub jitter: UpgradeJitter,
+}
+
+impl From<&UpgradeBackoffConfig> for BackoffPolicy {
+    fn from(c: &UpgradeBackoffConfig) -> Self {
+        // The gate enforces the consecutive-failure cap via `policy.max_attempts`
+        // (see `BackoffGate::check`), so `max_consecutive_failures` maps onto it.
+        BackoffPolicy {
+            max_attempts: c.max_consecutive_failures.0 as usize,
+            base_delay: c.base_delay.0,
+            max_delay: c.max_delay.0,
+            jitter: c.jitter.0,
+        }
+    }
+}
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct PackagesConfig {

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -106,9 +106,25 @@ pub struct SelfUpdateConfig {
     pub package: AgentControlPackage,
     /// how many failures we retry within a single self-update attempt, and the backoff between them
     pub download_retry: DownloadRetryConfig,
-    /// When an upgrade to a given version fails, how long we wait before re-trying it
-    /// (and how many consecutive failures before we give up entirely until a version change)
+    /// When an upgrade to a given version fails, how long we wait before re-trying it (and how
+    /// many consecutive failures before we escalate to a louder "capped" report). The upgrade is
+    /// re-attempted indefinitely at `max_delay`, so a transient registry outage recovers on its
+    /// own once it clears.
     pub upgrade_backoff: UpgradeBackoffConfig,
+}
+
+impl SelfUpdateConfig {
+    /// Whether the self remote update mechanism is enabled.
+    pub fn enabled(&self) -> bool {
+        self.enabled.0
+    }
+
+    /// Heartbeat interval for re-driving a pending self-update (see
+    /// [`crate::agent_control::version_updater::updater::VersionUpdater::retry`]). Reuses the
+    /// upgrade backoff base delay
+    pub fn retry_heartbeat(&self) -> Duration {
+        self.upgrade_backoff.base_delay.0.max(Duration::from_secs(1))
+    }
 }
 
 const DEFAULT_SELF_UPDATE_CONFIG_ENABLED: bool = false;
@@ -189,8 +205,6 @@ pub struct UpgradeBackoffConfig {
 
 impl From<&UpgradeBackoffConfig> for BackoffPolicy {
     fn from(c: &UpgradeBackoffConfig) -> Self {
-        // The gate enforces the consecutive-failure cap via `policy.max_attempts`
-        // (see `BackoffGate::check`), so `max_consecutive_failures` maps onto it.
         BackoffPolicy {
             max_attempts: c.max_consecutive_failures.0 as usize,
             base_delay: c.base_delay.0,

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -27,6 +27,7 @@ use oci_client::secrets::RegistryAuth;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::time::Duration;
 use thiserror::Error;
@@ -142,7 +143,7 @@ const DEFAULT_DOWNLOAD_JITTER: bool = true;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_DOWNLOAD_MAX_ATTEMPTS)]
-pub struct DownloadMaxAttempts(usize);
+pub struct DownloadMaxAttempts(#[serde(deserialize_with = "deserialize_non_zero_usize")] usize);
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_DOWNLOAD_BASE_DELAY)]
@@ -168,7 +169,8 @@ pub struct DownloadRetryConfig {
 impl From<&DownloadRetryConfig> for BackoffPolicy {
     fn from(c: &DownloadRetryConfig) -> Self {
         BackoffPolicy {
-            max_attempts: c.max_attempts.0,
+            max_attempts: NonZeroUsize::new(c.max_attempts.0)
+                .expect("download max_attempts is validated non-zero at deserialization"),
             base_delay: c.base_delay.0,
             max_delay: c.max_delay.0,
             jitter: c.jitter.0,
@@ -183,7 +185,9 @@ const DEFAULT_UPGRADE_JITTER: bool = true;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_UPGRADE_MAX_FAILURES)]
-pub struct UpgradeMaxConsecutiveFailures(u32);
+pub struct UpgradeMaxConsecutiveFailures(
+    #[serde(deserialize_with = "deserialize_non_zero_u32")] u32,
+);
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_UPGRADE_BASE_DELAY)]
@@ -206,10 +210,36 @@ pub struct UpgradeBackoffConfig {
     pub jitter: UpgradeJitter,
 }
 
+/// Deserializes a `u32` rejecting `0`, so retry/backoff attempt counts are guaranteed `>= 1`
+/// (a [`NonZeroUsize`] downstream) at the config boundary rather than silently coerced later.
+fn deserialize_non_zero_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    match u32::deserialize(deserializer)? {
+        0 => Err(Error::custom("must be greater than zero")),
+        v => Ok(v),
+    }
+}
+
+/// Deserializes a `usize` rejecting `0`. See [`deserialize_non_zero_u32`].
+fn deserialize_non_zero_usize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    match usize::deserialize(deserializer)? {
+        0 => Err(Error::custom("must be greater than zero")),
+        v => Ok(v),
+    }
+}
+
 impl From<&UpgradeBackoffConfig> for BackoffPolicy {
     fn from(c: &UpgradeBackoffConfig) -> Self {
         BackoffPolicy {
-            max_attempts: c.max_consecutive_failures.0 as usize,
+            max_attempts: NonZeroUsize::new(c.max_consecutive_failures.0 as usize)
+                .expect("max_consecutive_failures is validated non-zero at deserialization"),
             base_delay: c.base_delay.0,
             max_delay: c.max_delay.0,
             jitter: c.jitter.0,
@@ -1034,6 +1064,22 @@ agents: {}
     fn dynamic_config_invalid_version_fails_to_deserialize() {
         let yaml = "agents: {}\nversion: \"invalid-version; rm -rf /\"\n";
         assert!(serde_saphyr::from_str::<AgentControlDynamicConfig>(yaml).is_err());
+    }
+
+    #[test]
+    fn backoff_attempt_counts_reject_zero() {
+        // `BackoffPolicy` requires `max_attempts >= 1` (NonZeroUsize); the boundary rejects a
+        // configured `0` at deserialization rather than silently coercing it to 1.
+        assert!(
+            serde_saphyr::from_str::<UpgradeBackoffConfig>("max_consecutive_failures: 0").is_err()
+        );
+        assert!(
+            serde_saphyr::from_str::<UpgradeBackoffConfig>("max_consecutive_failures: 1").is_ok()
+        );
+        assert!(serde_saphyr::from_str::<DownloadRetryConfig>("max_attempts: 0").is_err());
+        assert!(serde_saphyr::from_str::<DownloadRetryConfig>("max_attempts: 1").is_ok());
+        // Omitting the field falls back to the (non-zero) default.
+        assert!(serde_saphyr::from_str::<UpgradeBackoffConfig>("{}").is_ok());
     }
 
     #[test]

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -123,7 +123,10 @@ impl SelfUpdateConfig {
     /// [`crate::agent_control::version_updater::updater::VersionUpdater::retry`]). Reuses the
     /// upgrade backoff base delay
     pub fn retry_heartbeat(&self) -> Duration {
-        self.upgrade_backoff.base_delay.0.max(Duration::from_secs(1))
+        self.upgrade_backoff
+            .base_delay
+            .0
+            .max(Duration::from_secs(1))
     }
 }
 

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -46,6 +46,7 @@ use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::builder::OnHostSubAgentBuilder;
 use crate::sub_agent::on_host::builder::SupervisorBuilderOnHost;
 use crate::sub_agent::remote_config_parser::AgentRemoteConfigParser;
+use crate::utils::time::SystemClock;
 use crate::values::ConfigRepo;
 use fs::directory_manager::DirectoryManagerFs;
 use fs::file::LocalFile;
@@ -222,7 +223,8 @@ impl AgentControlRunner {
                     .self_update
                     .signature_verification_enabled
                     .into(),
-            ),
+            )
+            .with_retry_policy((&agent_control_config.self_update.download_retry).into()),
             DirectoryManagerFs,
             remote_dir.clone(),
         );
@@ -233,6 +235,8 @@ impl AgentControlRunner {
             agent_control_package_manager,
             ProcessVerifyExecutor::default(),
             agent_control_config.self_update.package.clone(),
+            agent_control_config.self_update.upgrade_backoff.clone(),
+            SystemClock,
         );
 
         AgentControl::new(

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -94,13 +94,15 @@ where
     fn retry(&self) -> Result<(), UpdaterError> {
         // The gate's tracked key is the last version we tried to reach; if it is cleared there is
         // nothing pending, otherwise re-drive the normal `update` path for that version.
-        let Some(version) = self.upgrade_gate.current_key() else {
-            return Ok(());
-        };
-        self.update(&AgentControlDynamicConfig {
-            version: Some(version),
+        let version = self.upgrade_gate.current_key();
+        if version.is_some() {
+          self.update(&AgentControlDynamicConfig {
+            version,
             ..Default::default()
-        })
+          })
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -82,13 +82,11 @@ where
         // Cooldown gate: suppress re-attempts that are still within their backoff window, until the
         // window elapses (or the desired version changes). When it permits an attempt the gate runs
         // the upgrade and tracks success/failure itself.
-        match self.upgrade_gate.guarded(new_version, || {
+        self.upgrade_gate.guarded(new_version, || {
             debug!("Starting update process");
             self.try_upgrade(new_version.clone())
-        }) {
-            Ok(result) => result,
-            Err(suppression) => Err(self.suppressed_error(new_version, suppression)),
-        }
+        })
+        .map_err(|e| self.suppressed_error(new_version, e))?
     }
 
     fn retry(&self) -> Result<(), UpdaterError> {

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -1,16 +1,23 @@
 pub mod verify;
 
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::config::{AgentControlDynamicConfig, AgentControlPackage};
+use crate::agent_control::config::{
+    AgentControlDynamicConfig, AgentControlPackage, UpgradeBackoffConfig,
+};
 use crate::agent_control::defaults::AGENT_CONTROL_VERSION;
-use crate::agent_control::version_updater::updater::{UpdaterError, VersionUpdater};
+use crate::agent_control::version_updater::updater::{
+    CooldownReason, UpdaterError, VersionUpdater,
+};
 use crate::agent_type::runtime_config::on_host::package::rendered::{Oci, Repository, Version};
 use crate::event::AgentControlInternalEvent;
 use crate::event::channel::EventPublisher;
 use crate::package::manager::{PackageData, PackageManager};
+use crate::utils::backoff_gate::{BackoffGate, GateDecision};
+use crate::utils::retry::BackoffPolicy;
+use crate::utils::time::Clock;
 use self_replacer::{BinarySelfReplacer, SelfReplacer};
 use thiserror::Error;
-use tracing::{debug, debug_span};
+use tracing::{debug, debug_span, warn};
 use url::Url;
 use verify::VerifyExecutor;
 
@@ -27,10 +34,11 @@ pub enum BuildError {
     InvalidReference(#[from] oci_client::ParseError),
 }
 
-pub struct OnHostACUpdater<P, V>
+pub struct OnHostACUpdater<P, V, C>
 where
     P: PackageManager,
     V: VerifyExecutor,
+    C: Clock,
 {
     ac_remote_update_enabled: bool,
     agent_control_internal_publisher: EventPublisher<AgentControlInternalEvent>,
@@ -38,12 +46,16 @@ where
     verify_executor: V,
     repository: Repository,
     pub_key_url: Url,
+    /// Throttles re-attempts at a failing upgrade so we don't hammer the registry every
+    /// OpAMP poll. Keyed by target [`Version`]: a new desired version resets the cooldown.
+    upgrade_gate: BackoffGate<Version, C>,
 }
 
-impl<P, V> VersionUpdater for OnHostACUpdater<P, V>
+impl<P, V, C> VersionUpdater for OnHostACUpdater<P, V, C>
 where
     P: PackageManager,
     V: VerifyExecutor,
+    C: Clock,
 {
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError> {
         if !self.ac_remote_update_enabled {
@@ -65,12 +77,97 @@ where
 
         if new_version.to_string() == AGENT_CONTROL_VERSION {
             debug!("Desired version is the same as current, skipping update");
+            self.upgrade_gate.reset();
             return Ok(());
+        }
+
+        // Cooldown gate: suppress re-attempts that are still within their backoff window, or
+        // that have exhausted the consecutive-failure budget, until the desired version changes.
+        if let Some(err) = self.cooldown_error(new_version) {
+            return Err(err);
         }
 
         debug!("Starting update process");
 
-        let package_data = self.get_package_data(new_version.clone());
+        match self.try_upgrade(new_version.clone()) {
+            Ok(()) => {
+                self.upgrade_gate.reset();
+                Ok(())
+            }
+            Err(e) => {
+                self.upgrade_gate.record_failure(new_version);
+                Err(e)
+            }
+        }
+    }
+}
+
+impl<P, V, C> OnHostACUpdater<P, V, C>
+where
+    P: PackageManager,
+    V: VerifyExecutor,
+    C: Clock,
+{
+    pub fn new(
+        ac_remote_update_enabled: bool,
+        agent_control_internal_publisher: EventPublisher<AgentControlInternalEvent>,
+        package_manager: P,
+        verify_executor: V,
+        package: AgentControlPackage,
+        backoff: UpgradeBackoffConfig,
+        clock: C,
+    ) -> Self {
+        Self {
+            ac_remote_update_enabled,
+            agent_control_internal_publisher,
+            package_manager,
+            verify_executor,
+            repository: package.download.oci.repository.clone(),
+            pub_key_url: package.download.oci.public_key_url.clone(),
+            // The gate owns the exponential-backoff-plus-jitter schedule (it never sleeps; it
+            // records a "next attempt" instant checked across OpAMP polls).
+            upgrade_gate: BackoffGate::new(BackoffPolicy::from(&backoff), clock),
+        }
+    }
+
+    /// Maps the generic gate verdict for `new_version` onto the OpAMP-facing [`UpdaterError`],
+    /// returning `Some(err)` when the upgrade should be suppressed and `None` to proceed.
+    fn cooldown_error(&self, new_version: &Version) -> Option<UpdaterError> {
+        match self.upgrade_gate.check(new_version) {
+            GateDecision::Proceed => None,
+            GateDecision::CapReached {
+                consecutive_failures,
+            } => {
+                warn!(
+                    version = %new_version,
+                    consecutive_failures,
+                    "Upgrade suppressed: max consecutive failures reached. \
+                     Waiting for desired version to change before retrying.",
+                );
+                Some(UpdaterError::UpdateInCooldown {
+                    version: new_version.to_string(),
+                    reason: CooldownReason::CapReached,
+                })
+            }
+            GateDecision::InCooldown {
+                consecutive_failures,
+            } => {
+                debug!(
+                    version = %new_version,
+                    consecutive_failures,
+                    "Upgrade suppressed: in backoff cooldown window.",
+                );
+                Some(UpdaterError::UpdateInCooldown {
+                    version: new_version.to_string(),
+                    reason: CooldownReason::Backoff,
+                })
+            }
+        }
+    }
+
+    /// Performs a single upgrade attempt: install → verify → self-replace → request restart.
+    fn try_upgrade(&self, new_version: Version) -> Result<(), UpdaterError> {
+        let package_data = self.get_package_data(new_version);
 
         let new_binary_path = self
             .package_manager
@@ -104,29 +201,6 @@ where
 
         Ok(())
     }
-}
-
-impl<P, V> OnHostACUpdater<P, V>
-where
-    P: PackageManager,
-    V: VerifyExecutor,
-{
-    pub fn new(
-        ac_remote_update_enabled: bool,
-        agent_control_internal_publisher: EventPublisher<AgentControlInternalEvent>,
-        package_manager: P,
-        verify_executor: V,
-        package: AgentControlPackage,
-    ) -> Self {
-        Self {
-            ac_remote_update_enabled,
-            agent_control_internal_publisher,
-            package_manager,
-            verify_executor,
-            repository: package.download.oci.repository.clone(),
-            pub_key_url: package.download.oci.public_key_url.clone(),
-        }
-    }
 
     fn get_package_data(&self, new_version: Version) -> PackageData {
         PackageData {
@@ -144,12 +218,19 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_control::config::AgentControlPackage;
+    use crate::agent_control::config::{
+        AgentControlPackage, UpgradeBaseDelay, UpgradeJitter, UpgradeMaxConsecutiveFailures,
+        UpgradeMaxDelay,
+    };
     use crate::event::channel::pub_sub;
     use crate::package::manager::tests::MockPackageManager;
+    use crate::package::oci::package_manager::OCIPackageManagerError;
+    use crate::utils::time::SystemClock;
     use mockall::mock;
     use std::path::Path;
     use std::str::FromStr;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     mock! {
         pub VerifyExecutorMock {}
@@ -158,40 +239,261 @@ mod tests {
         }
     }
 
-    type TestUpdater = OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock>;
+    /// Test clock backed by `Arc<Mutex<Instant>>` so the test body can advance time
+    /// deterministically while the updater holds the clock by value.
+    #[derive(Clone)]
+    struct FakeClock(Arc<std::sync::Mutex<Instant>>);
 
-    fn new_test_updater(ac_remote_update_enabled: bool) -> TestUpdater {
+    impl FakeClock {
+        fn new(initial: Instant) -> Self {
+            Self(Arc::new(std::sync::Mutex::new(initial)))
+        }
+        fn advance(&self, by: Duration) {
+            *self.0.lock().unwrap() += by;
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> Instant {
+            *self.0.lock().unwrap()
+        }
+    }
+
+    type TestUpdater<C> = OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock, C>;
+
+    fn no_jitter_backoff(base: Duration, max: Duration, max_failures: u32) -> UpgradeBackoffConfig {
+        UpgradeBackoffConfig {
+            base_delay: UpgradeBaseDelay::from(base),
+            max_delay: UpgradeMaxDelay::from(max),
+            max_consecutive_failures: UpgradeMaxConsecutiveFailures::from(max_failures),
+            jitter: UpgradeJitter::from(false),
+        }
+    }
+
+    fn install_failure(
+        _id: &AgentID,
+        _pkg: PackageData,
+    ) -> Result<crate::package::manager::InstalledPackageData, OCIPackageManagerError> {
+        Err(OCIPackageManagerError::Install(std::io::Error::other(
+            "simulated registry failure",
+        )))
+    }
+
+    fn new_test_updater_with<C: Clock>(backoff: UpgradeBackoffConfig, clock: C) -> TestUpdater<C> {
         let (publisher, _) = pub_sub();
         OnHostACUpdater::new(
-            ac_remote_update_enabled,
+            true,
             publisher,
             MockPackageManager::new(),
             MockVerifyExecutorMock::new(),
             AgentControlPackage::default(),
+            backoff,
+            clock,
         )
+    }
+
+    fn config_with_version(v: &str) -> AgentControlDynamicConfig {
+        AgentControlDynamicConfig {
+            version: Some(Version::from_str(v).unwrap()),
+            ..Default::default()
+        }
     }
 
     #[test]
     fn update_is_noop_when_remote_update_disabled() {
-        let updater = new_test_updater(false);
+        let (publisher, _) = pub_sub();
+        let updater: TestUpdater<SystemClock> = OnHostACUpdater::new(
+            false,
+            publisher,
+            MockPackageManager::new(),
+            MockVerifyExecutorMock::new(),
+            AgentControlPackage::default(),
+            UpgradeBackoffConfig::default(),
+            SystemClock,
+        );
         let config = AgentControlDynamicConfig::default();
         assert!(updater.update(&config).is_ok());
     }
 
     #[test]
     fn update_is_noop_when_version_not_specified() {
-        let updater = new_test_updater(true);
+        let updater = new_test_updater_with(UpgradeBackoffConfig::default(), SystemClock);
         let config = AgentControlDynamicConfig::default();
         assert!(updater.update(&config).is_ok());
     }
 
     #[test]
     fn update_is_noop_when_version_matches_current() {
-        let updater = new_test_updater(true);
+        let updater = new_test_updater_with(UpgradeBackoffConfig::default(), SystemClock);
         let config = AgentControlDynamicConfig {
             version: Some(Version::from_str(AGENT_CONTROL_VERSION).unwrap()),
             ..Default::default()
         };
         assert!(updater.update(&config).is_ok());
+    }
+
+    #[test]
+    fn first_failure_then_subsequent_call_within_window_is_suppressed() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_secs(30), Duration::from_secs(600), 5),
+            clock.clone(),
+        );
+        // Exactly one real install attempt — second attempt MUST be suppressed.
+        updater
+            .package_manager
+            .expect_install()
+            .times(1)
+            .returning(install_failure);
+
+        let cfg = config_with_version("99.99.99");
+
+        let err = updater.update(&cfg).unwrap_err();
+        assert!(matches!(err, UpdaterError::UpdateFailed(_)), "{:?}", err);
+
+        let err = updater.update(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            UpdaterError::UpdateInCooldown {
+                reason: CooldownReason::Backoff,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cooldown_clears_after_window_elapses_and_re_attempts() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_millis(100), Duration::from_secs(10), 5),
+            clock.clone(),
+        );
+        updater
+            .package_manager
+            .expect_install()
+            .times(2)
+            .returning(install_failure);
+
+        let cfg = config_with_version("99.99.99");
+
+        let _ = updater.update(&cfg).unwrap_err(); // attempt 1: fails
+        let err = updater.update(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            UpdaterError::UpdateInCooldown {
+                reason: CooldownReason::Backoff,
+                ..
+            }
+        ));
+
+        clock.advance(Duration::from_secs(1));
+
+        // Attempt 2 fires (and fails again).
+        let err = updater.update(&cfg).unwrap_err();
+        assert!(matches!(err, UpdaterError::UpdateFailed(_)), "{:?}", err);
+    }
+
+    #[test]
+    fn cap_reached_suppresses_indefinitely() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_millis(1), Duration::from_millis(1), 2),
+            clock.clone(),
+        );
+        // Exactly 2 install calls; never more.
+        updater
+            .package_manager
+            .expect_install()
+            .times(2)
+            .returning(install_failure);
+
+        let cfg = config_with_version("99.99.99");
+
+        let _ = updater.update(&cfg).unwrap_err();
+        clock.advance(Duration::from_secs(1));
+        let _ = updater.update(&cfg).unwrap_err();
+        clock.advance(Duration::from_secs(2));
+
+        for _ in 0..5 {
+            let err = updater.update(&cfg).unwrap_err();
+            assert!(matches!(
+                err,
+                UpdaterError::UpdateInCooldown {
+                    reason: CooldownReason::CapReached,
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn version_change_resets_cooldown_and_allows_immediate_attempt() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_secs(60), Duration::from_secs(600), 5),
+            clock,
+        );
+        // Two real install calls — bad → bad-different.
+        updater
+            .package_manager
+            .expect_install()
+            .times(2)
+            .returning(install_failure);
+
+        let _ = updater
+            .update(&config_with_version("99.99.99"))
+            .unwrap_err();
+        // Without advancing the clock, a different version triggers a real attempt.
+        let _ = updater
+            .update(&config_with_version("88.88.88"))
+            .unwrap_err();
+    }
+
+    #[test]
+    fn reverting_to_current_version_short_circuits_even_when_capped() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_millis(1), Duration::from_millis(1), 1),
+            clock.clone(),
+        );
+        updater
+            .package_manager
+            .expect_install()
+            .times(1)
+            .returning(install_failure);
+
+        let _ = updater
+            .update(&config_with_version("99.99.99"))
+            .unwrap_err();
+        clock.advance(Duration::from_secs(1));
+        let err = updater
+            .update(&config_with_version("99.99.99"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            UpdaterError::UpdateInCooldown {
+                reason: CooldownReason::CapReached,
+                ..
+            }
+        ));
+
+        let cfg = AgentControlDynamicConfig {
+            version: Some(Version::from_str(AGENT_CONTROL_VERSION).unwrap()),
+            ..Default::default()
+        };
+        assert!(updater.update(&cfg).is_ok());
+    }
+
+    #[test]
+    fn cooldown_error_message_is_stable_across_polls() {
+        let err1 = UpdaterError::UpdateInCooldown {
+            version: "99.99.99".into(),
+            reason: CooldownReason::Backoff,
+        };
+        let err2 = UpdaterError::UpdateInCooldown {
+            version: "99.99.99".into(),
+            reason: CooldownReason::Backoff,
+        };
+        assert_eq!(err1.to_string(), err2.to_string());
     }
 }

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -55,6 +55,10 @@ where
     V: VerifyExecutor,
     C: Clock,
 {
+    /// Only `config.version` is consumed from the dynamic config. This contract is what
+    /// lets [`retry`](Self::retry) reconstruct a config from just the gate's tracked version.
+    /// If `update` ever starts reading additional dynamic-config fields, that reconstruction must
+    /// be revisited (or replaced with a stored snapshot of the last config) to not use defaults.
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError> {
         if !self.ac_remote_update_enabled {
             debug!("Remote update is disabled, skipping update process");
@@ -222,7 +226,7 @@ mod tests {
     use mockall::mock;
     use std::path::Path;
     use std::str::FromStr;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
     mock! {
@@ -235,7 +239,7 @@ mod tests {
     /// Test clock backed by `Arc<Mutex<Instant>>` so the test body can advance time
     /// deterministically while the updater holds the clock by value.
     #[derive(Clone)]
-    struct FakeClock(Arc<std::sync::Mutex<Instant>>);
+    struct FakeClock(Arc<Mutex<Instant>>);
 
     impl FakeClock {
         fn new(initial: Instant) -> Self {

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -86,11 +86,12 @@ where
         // Cooldown gate: suppress re-attempts that are still within their backoff window, until the
         // window elapses (or the desired version changes). When it permits an attempt the gate runs
         // the upgrade and tracks success/failure itself.
-        self.upgrade_gate.guarded(new_version, || {
-            debug!("Starting update process");
-            self.try_upgrade(new_version.clone())
-        })
-        .map_err(|e| self.suppressed_error(new_version, e))?
+        self.upgrade_gate
+            .guarded(new_version, || {
+                debug!("Starting update process");
+                self.try_upgrade(new_version.clone())
+            })
+            .map_err(|e| self.suppressed_error(new_version, e))?
     }
 
     fn retry(&self) -> Result<(), UpdaterError> {
@@ -98,10 +99,10 @@ where
         // nothing pending, otherwise re-drive the normal `update` path for that version.
         let version = self.upgrade_gate.current_key();
         if version.is_some() {
-          self.update(&AgentControlDynamicConfig {
-            version,
-            ..Default::default()
-          })
+            self.update(&AgentControlDynamicConfig {
+                version,
+                ..Default::default()
+            })
         } else {
             Ok(())
         }
@@ -138,7 +139,11 @@ where
 
     /// Logs and maps a gate [`SuppressionReason`] verdict for `new_version` onto the OpAMP-facing
     /// [`UpdaterError`].
-    fn suppressed_error(&self, new_version: &Version, suppression: SuppressionReason) -> UpdaterError {
+    fn suppressed_error(
+        &self,
+        new_version: &Version,
+        suppression: SuppressionReason,
+    ) -> UpdaterError {
         match suppression {
             SuppressionReason::CapReached {
                 consecutive_failures,

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -79,9 +79,9 @@ where
             return Ok(());
         }
 
-        // Cooldown gate: suppress re-attempts that are still within their backoff window, or
-        // that have exhausted the consecutive-failure budget, until the desired version changes.
-        // When it permits an attempt the gate runs the upgrade and tracks success/failure itself.
+        // Cooldown gate: suppress re-attempts that are still within their backoff window, until the
+        // window elapses (or the desired version changes). When it permits an attempt the gate runs
+        // the upgrade and tracks success/failure itself.
         match self.upgrade_gate.guarded(new_version, || {
             debug!("Starting update process");
             self.try_upgrade(new_version.clone())
@@ -89,6 +89,18 @@ where
             Ok(result) => result,
             Err(suppression) => Err(self.suppressed_error(new_version, suppression)),
         }
+    }
+
+    fn retry(&self) -> Result<(), UpdaterError> {
+        // The gate's tracked key is the last version we tried to reach; if it is cleared there is
+        // nothing pending, otherwise re-drive the normal `update` path for that version.
+        let Some(version) = self.upgrade_gate.current_key() else {
+            return Ok(());
+        };
+        self.update(&AgentControlDynamicConfig {
+            version: Some(version),
+            ..Default::default()
+        })
     }
 }
 
@@ -375,36 +387,46 @@ mod tests {
     }
 
     #[test]
-    fn cap_reached_suppresses_indefinitely() {
+    fn cap_is_reported_but_keeps_probing_after_window() {
         let clock = FakeClock::new(Instant::now());
         let mut updater = new_test_updater_with(
-            no_jitter_backoff(Duration::from_millis(1), Duration::from_millis(1), 2),
+            no_jitter_backoff(Duration::from_secs(30), Duration::from_secs(30), 2),
             clock.clone(),
         );
-        // Exactly 2 install calls; never more.
+        // The cap is a reporting threshold, not a hard stop: a probe still fires after each
+        // window elapses. We expect 3 real install attempts (the 3rd happens *after* the cap).
         updater
             .package_manager
             .expect_install()
-            .times(2)
+            .times(3)
             .returning(install_failure);
 
         let cfg = config_with_version("99.99.99");
 
+        // Attempt 1, then suppressed within the window.
         let _ = updater.update(&cfg).unwrap_err();
-        clock.advance(Duration::from_secs(1));
-        let _ = updater.update(&cfg).unwrap_err();
-        clock.advance(Duration::from_secs(2));
+        assert!(matches!(
+            updater.update(&cfg).unwrap_err(),
+            UpdaterError::UpdateInCooldown {
+                reason: Suppression::InCooldown { .. },
+                ..
+            }
+        ));
 
-        for _ in 0..5 {
-            let err = updater.update(&cfg).unwrap_err();
-            assert!(matches!(
-                err,
-                UpdaterError::UpdateInCooldown {
-                    reason: Suppression::CapReached { .. },
-                    ..
-                }
-            ));
-        }
+        // Attempt 2 reaches the cap; within the window it now reports CapReached.
+        clock.advance(Duration::from_secs(31));
+        let _ = updater.update(&cfg).unwrap_err();
+        assert!(matches!(
+            updater.update(&cfg).unwrap_err(),
+            UpdaterError::UpdateInCooldown {
+                reason: Suppression::CapReached { .. },
+                ..
+            }
+        ));
+
+        // Once the window elapses the gate probes again despite being capped.
+        clock.advance(Duration::from_secs(31));
+        let _ = updater.update(&cfg).unwrap_err();
     }
 
     #[test]
@@ -434,7 +456,7 @@ mod tests {
     fn reverting_to_current_version_short_circuits_even_when_capped() {
         let clock = FakeClock::new(Instant::now());
         let mut updater = new_test_updater_with(
-            no_jitter_backoff(Duration::from_millis(1), Duration::from_millis(1), 1),
+            no_jitter_backoff(Duration::from_secs(60), Duration::from_secs(600), 1),
             clock.clone(),
         );
         updater
@@ -446,7 +468,7 @@ mod tests {
         let _ = updater
             .update(&config_with_version("99.99.99"))
             .unwrap_err();
-        clock.advance(Duration::from_secs(1));
+        // Still inside the backoff window, so the cap is reported and no second install fires.
         let err = updater
             .update(&config_with_version("99.99.99"))
             .unwrap_err();
@@ -481,5 +503,45 @@ mod tests {
             },
         };
         assert_eq!(err1.to_string(), err2.to_string());
+    }
+
+    #[test]
+    fn retry_is_noop_when_nothing_is_pending() {
+        // No update() has run, so the gate has no tracked version — retry must not touch install.
+        let updater = new_test_updater_with(UpgradeBackoffConfig::default(), SystemClock);
+        assert!(updater.retry().is_ok());
+    }
+
+    #[test]
+    fn retry_re_attempts_the_pending_version_after_the_window() {
+        let clock = FakeClock::new(Instant::now());
+        let mut updater = new_test_updater_with(
+            no_jitter_backoff(Duration::from_secs(30), Duration::from_secs(30), 5),
+            clock.clone(),
+        );
+        // One install from update(), one from the post-window retry() probe.
+        updater
+            .package_manager
+            .expect_install()
+            .times(2)
+            .returning(install_failure);
+
+        // A failed update() leaves the desired version pending in the gate.
+        let _ = updater
+            .update(&config_with_version("99.99.99"))
+            .unwrap_err();
+
+        // Within the window, retry() is suppressed and does not hit the registry.
+        assert!(matches!(
+            updater.retry().unwrap_err(),
+            UpdaterError::UpdateInCooldown {
+                reason: Suppression::InCooldown { .. },
+                ..
+            }
+        ));
+
+        // After the window, retry() drives a fresh attempt against the pending version.
+        clock.advance(Duration::from_secs(31));
+        let _ = updater.retry().unwrap_err();
     }
 }

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -10,7 +10,7 @@ use crate::agent_type::runtime_config::on_host::package::rendered::{Oci, Reposit
 use crate::event::AgentControlInternalEvent;
 use crate::event::channel::EventPublisher;
 use crate::package::manager::{PackageData, PackageManager};
-use crate::utils::backoff_gate::{BackoffGate, Suppression};
+use crate::utils::backoff_gate::{BackoffGate, SuppressionReason};
 use crate::utils::retry::BackoffPolicy;
 use crate::utils::time::Clock;
 use self_replacer::{BinarySelfReplacer, SelfReplacer};
@@ -136,11 +136,11 @@ where
         }
     }
 
-    /// Logs and maps a gate [`Suppression`] verdict for `new_version` onto the OpAMP-facing
+    /// Logs and maps a gate [`SuppressionReason`] verdict for `new_version` onto the OpAMP-facing
     /// [`UpdaterError`].
-    fn suppressed_error(&self, new_version: &Version, suppression: Suppression) -> UpdaterError {
+    fn suppressed_error(&self, new_version: &Version, suppression: SuppressionReason) -> UpdaterError {
         match suppression {
-            Suppression::CapReached {
+            SuppressionReason::CapReached {
                 consecutive_failures,
             } => warn!(
                 version = %new_version,
@@ -148,7 +148,7 @@ where
                 "Upgrade suppressed: max consecutive failures reached. \
                  Waiting for desired version to change before retrying.",
             ),
-            Suppression::InCooldown {
+            SuppressionReason::InCooldown {
                 consecutive_failures,
             } => debug!(
                 version = %new_version,
@@ -352,7 +352,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::InCooldown { .. },
+                reason: SuppressionReason::InCooldown { .. },
                 ..
             }
         ));
@@ -378,7 +378,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::InCooldown { .. },
+                reason: SuppressionReason::InCooldown { .. },
                 ..
             }
         ));
@@ -412,7 +412,7 @@ mod tests {
         assert!(matches!(
             updater.update(&cfg).unwrap_err(),
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::InCooldown { .. },
+                reason: SuppressionReason::InCooldown { .. },
                 ..
             }
         ));
@@ -423,7 +423,7 @@ mod tests {
         assert!(matches!(
             updater.update(&cfg).unwrap_err(),
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::CapReached { .. },
+                reason: SuppressionReason::CapReached { .. },
                 ..
             }
         ));
@@ -479,7 +479,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::CapReached { .. },
+                reason: SuppressionReason::CapReached { .. },
                 ..
             }
         ));
@@ -496,13 +496,13 @@ mod tests {
         // Same variant, different failure counts: the rendered message must not change.
         let err1 = UpdaterError::UpdateInCooldown {
             version: "99.99.99".into(),
-            reason: Suppression::InCooldown {
+            reason: SuppressionReason::InCooldown {
                 consecutive_failures: 1,
             },
         };
         let err2 = UpdaterError::UpdateInCooldown {
             version: "99.99.99".into(),
-            reason: Suppression::InCooldown {
+            reason: SuppressionReason::InCooldown {
                 consecutive_failures: 3,
             },
         };
@@ -539,7 +539,7 @@ mod tests {
         assert!(matches!(
             updater.retry().unwrap_err(),
             UpdaterError::UpdateInCooldown {
-                reason: Suppression::InCooldown { .. },
+                reason: SuppressionReason::InCooldown { .. },
                 ..
             }
         ));

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -5,14 +5,12 @@ use crate::agent_control::config::{
     AgentControlDynamicConfig, AgentControlPackage, UpgradeBackoffConfig,
 };
 use crate::agent_control::defaults::AGENT_CONTROL_VERSION;
-use crate::agent_control::version_updater::updater::{
-    CooldownReason, UpdaterError, VersionUpdater,
-};
+use crate::agent_control::version_updater::updater::{UpdaterError, VersionUpdater};
 use crate::agent_type::runtime_config::on_host::package::rendered::{Oci, Repository, Version};
 use crate::event::AgentControlInternalEvent;
 use crate::event::channel::EventPublisher;
 use crate::package::manager::{PackageData, PackageManager};
-use crate::utils::backoff_gate::{BackoffGate, GateDecision};
+use crate::utils::backoff_gate::{BackoffGate, Suppression};
 use crate::utils::retry::BackoffPolicy;
 use crate::utils::time::Clock;
 use self_replacer::{BinarySelfReplacer, SelfReplacer};
@@ -83,21 +81,13 @@ where
 
         // Cooldown gate: suppress re-attempts that are still within their backoff window, or
         // that have exhausted the consecutive-failure budget, until the desired version changes.
-        if let Some(err) = self.cooldown_error(new_version) {
-            return Err(err);
-        }
-
-        debug!("Starting update process");
-
-        match self.try_upgrade(new_version.clone()) {
-            Ok(()) => {
-                self.upgrade_gate.reset();
-                Ok(())
-            }
-            Err(e) => {
-                self.upgrade_gate.record_failure(new_version);
-                Err(e)
-            }
+        // When it permits an attempt the gate runs the upgrade and tracks success/failure itself.
+        match self.upgrade_gate.guarded(new_version, || {
+            debug!("Starting update process");
+            self.try_upgrade(new_version.clone())
+        }) {
+            Ok(result) => result,
+            Err(suppression) => Err(self.suppressed_error(new_version, suppression)),
         }
     }
 }
@@ -130,38 +120,29 @@ where
         }
     }
 
-    /// Maps the generic gate verdict for `new_version` onto the OpAMP-facing [`UpdaterError`],
-    /// returning `Some(err)` when the upgrade should be suppressed and `None` to proceed.
-    fn cooldown_error(&self, new_version: &Version) -> Option<UpdaterError> {
-        match self.upgrade_gate.check(new_version) {
-            GateDecision::Proceed => None,
-            GateDecision::CapReached {
+    /// Logs and maps a gate [`Suppression`] verdict for `new_version` onto the OpAMP-facing
+    /// [`UpdaterError`].
+    fn suppressed_error(&self, new_version: &Version, suppression: Suppression) -> UpdaterError {
+        match suppression {
+            Suppression::CapReached {
                 consecutive_failures,
-            } => {
-                warn!(
-                    version = %new_version,
-                    consecutive_failures,
-                    "Upgrade suppressed: max consecutive failures reached. \
-                     Waiting for desired version to change before retrying.",
-                );
-                Some(UpdaterError::UpdateInCooldown {
-                    version: new_version.to_string(),
-                    reason: CooldownReason::CapReached,
-                })
-            }
-            GateDecision::InCooldown {
+            } => warn!(
+                version = %new_version,
                 consecutive_failures,
-            } => {
-                debug!(
-                    version = %new_version,
-                    consecutive_failures,
-                    "Upgrade suppressed: in backoff cooldown window.",
-                );
-                Some(UpdaterError::UpdateInCooldown {
-                    version: new_version.to_string(),
-                    reason: CooldownReason::Backoff,
-                })
-            }
+                "Upgrade suppressed: max consecutive failures reached. \
+                 Waiting for desired version to change before retrying.",
+            ),
+            Suppression::InCooldown {
+                consecutive_failures,
+            } => debug!(
+                version = %new_version,
+                consecutive_failures,
+                "Upgrade suppressed: in backoff cooldown window.",
+            ),
+        }
+        UpdaterError::UpdateInCooldown {
+            version: new_version.to_string(),
+            reason: suppression,
         }
     }
 
@@ -355,7 +336,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: CooldownReason::Backoff,
+                reason: Suppression::InCooldown { .. },
                 ..
             }
         ));
@@ -381,7 +362,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: CooldownReason::Backoff,
+                reason: Suppression::InCooldown { .. },
                 ..
             }
         ));
@@ -419,7 +400,7 @@ mod tests {
             assert!(matches!(
                 err,
                 UpdaterError::UpdateInCooldown {
-                    reason: CooldownReason::CapReached,
+                    reason: Suppression::CapReached { .. },
                     ..
                 }
             ));
@@ -472,7 +453,7 @@ mod tests {
         assert!(matches!(
             err,
             UpdaterError::UpdateInCooldown {
-                reason: CooldownReason::CapReached,
+                reason: Suppression::CapReached { .. },
                 ..
             }
         ));
@@ -486,13 +467,18 @@ mod tests {
 
     #[test]
     fn cooldown_error_message_is_stable_across_polls() {
+        // Same variant, different failure counts: the rendered message must not change.
         let err1 = UpdaterError::UpdateInCooldown {
             version: "99.99.99".into(),
-            reason: CooldownReason::Backoff,
+            reason: Suppression::InCooldown {
+                consecutive_failures: 1,
+            },
         };
         let err2 = UpdaterError::UpdateInCooldown {
             version: "99.99.99".into(),
-            reason: CooldownReason::Backoff,
+            reason: Suppression::InCooldown {
+                consecutive_failures: 3,
+            },
         };
         assert_eq!(err1.to_string(), err2.to_string());
     }

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -6,6 +6,33 @@ use thiserror::Error;
 pub enum UpdaterError {
     #[error("update failed: {0}")]
     UpdateFailed(String),
+    /// The previous attempt to upgrade to this version failed; we are deliberately not hitting
+    /// the registry again until the cooldown elapses (or the version changes). The error message
+    /// is intentionally **stable across polls** so OpAMP `ConfigState::Failed` does not churn.
+    #[error("upgrade to {version} suppressed: {reason}")]
+    UpdateInCooldown {
+        version: String,
+        reason: CooldownReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CooldownReason {
+    /// Within the exponential-backoff cooldown window after a failed attempt.
+    Backoff,
+    /// Maximum consecutive failures reached; suppressed until the desired version changes.
+    CapReached,
+}
+
+impl std::fmt::Display for CooldownReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CooldownReason::Backoff => f.write_str("retrying after previous failure"),
+            CooldownReason::CapReached => {
+                f.write_str("max consecutive failures reached, waiting for new desired version")
+            }
+        }
+    }
 }
 
 /// A trait for updating the agent control version using a dynamic configuration.

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -43,9 +43,12 @@ pub trait VersionUpdater {
     /// to the external controller, or an `UpdaterError` if the update fails.
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError>;
 
-    /// Re-attempts the most recently requested upgrade, if one is still pending. Driven by a
-    /// periodic heartbeat so a transient registry outage recovers without a new desired version
-    /// being pushed. Defaults to a no-op for updaters without a retry concept.
+    /// Re-attempts a previously-requested upgrade that has not yet succeeded, without waiting for a
+    /// new desired version to be pushed. Driven by a periodic heartbeat so a transient registry
+    /// outage can recover on its own.
+    ///
+    /// Whether an upgrade is "still pending" is implementation-defined and evaluated by the
+    /// implementer, the default below is the noop fallback
     fn retry(&self) -> Result<(), UpdaterError> {
         Ok(())
     }

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -25,7 +25,7 @@ fn cooldown_reason(reason: &Suppression) -> &'static str {
     match reason {
         Suppression::InCooldown { .. } => "retrying after previous failure",
         Suppression::CapReached { .. } => {
-            "max consecutive failures reached, waiting for new desired version"
+            "max consecutive failures reached, retrying at the maximum backoff interval"
         }
     }
 }
@@ -42,6 +42,13 @@ pub trait VersionUpdater {
     /// Returns `Ok(())` if the desired version has been successfully communicated
     /// to the external controller, or an `UpdaterError` if the update fails.
     fn update(&self, config: &AgentControlDynamicConfig) -> Result<(), UpdaterError>;
+
+    /// Re-attempts the most recently requested upgrade, if one is still pending. Driven by a
+    /// periodic heartbeat so a transient registry outage recovers without a new desired version
+    /// being pushed. Defaults to a no-op for updaters without a retry concept.
+    fn retry(&self) -> Result<(), UpdaterError> {
+        Ok(())
+    }
 }
 
 pub struct NoOpUpdater;

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -1,4 +1,5 @@
 use crate::agent_control::config::AgentControlDynamicConfig;
+use crate::utils::backoff_gate::Suppression;
 use thiserror::Error;
 
 /// Represents errors that can occur during the update process of the agent control version.
@@ -7,30 +8,24 @@ pub enum UpdaterError {
     #[error("update failed: {0}")]
     UpdateFailed(String),
     /// The previous attempt to upgrade to this version failed; we are deliberately not hitting
-    /// the registry again until the cooldown elapses (or the version changes). The error message
-    /// is intentionally **stable across polls** so OpAMP `ConfigState::Failed` does not churn.
-    #[error("upgrade to {version} suppressed: {reason}")]
+    /// the registry again until the cooldown elapses (or the version changes). The message is
+    /// derived from the [`Suppression`] *variant* only (not its failure count), so it is
+    /// intentionally **stable across polls** and OpAMP `ConfigState::Failed` does not churn.
+    #[error("upgrade to {version} suppressed: {}", cooldown_reason(reason))]
     UpdateInCooldown {
         version: String,
-        reason: CooldownReason,
+        reason: Suppression,
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CooldownReason {
-    /// Within the exponential-backoff cooldown window after a failed attempt.
-    Backoff,
-    /// Maximum consecutive failures reached; suppressed until the desired version changes.
-    CapReached,
-}
-
-impl std::fmt::Display for CooldownReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CooldownReason::Backoff => f.write_str("retrying after previous failure"),
-            CooldownReason::CapReached => {
-                f.write_str("max consecutive failures reached, waiting for new desired version")
-            }
+/// Domain wording for a suppressed upgrade. Lives here (not in the agnostic gate) because the
+/// phrasing — "desired version" — is agent-control/OpAMP vocabulary. Deliberately ignores the
+/// failure count so the rendered message stays stable across polls.
+fn cooldown_reason(reason: &Suppression) -> &'static str {
+    match reason {
+        Suppression::InCooldown { .. } => "retrying after previous failure",
+        Suppression::CapReached { .. } => {
+            "max consecutive failures reached, waiting for new desired version"
         }
     }
 }

--- a/agent-control/src/agent_control/version_updater/updater.rs
+++ b/agent-control/src/agent_control/version_updater/updater.rs
@@ -1,5 +1,5 @@
 use crate::agent_control::config::AgentControlDynamicConfig;
-use crate::utils::backoff_gate::Suppression;
+use crate::utils::backoff_gate::SuppressionReason;
 use thiserror::Error;
 
 /// Represents errors that can occur during the update process of the agent control version.
@@ -9,22 +9,22 @@ pub enum UpdaterError {
     UpdateFailed(String),
     /// The previous attempt to upgrade to this version failed; we are deliberately not hitting
     /// the registry again until the cooldown elapses (or the version changes). The message is
-    /// derived from the [`Suppression`] *variant* only (not its failure count), so it is
+    /// derived from the [`SuppressionReason`] *variant* only (not its failure count), so it is
     /// intentionally **stable across polls** and OpAMP `ConfigState::Failed` does not churn.
     #[error("upgrade to {version} suppressed: {}", cooldown_reason(reason))]
     UpdateInCooldown {
         version: String,
-        reason: Suppression,
+        reason: SuppressionReason,
     },
 }
 
 /// Domain wording for a suppressed upgrade. Lives here (not in the agnostic gate) because the
 /// phrasing — "desired version" — is agent-control/OpAMP vocabulary. Deliberately ignores the
 /// failure count so the rendered message stays stable across polls.
-fn cooldown_reason(reason: &Suppression) -> &'static str {
+fn cooldown_reason(reason: &SuppressionReason) -> &'static str {
     match reason {
-        Suppression::InCooldown { .. } => "retrying after previous failure",
-        Suppression::CapReached { .. } => {
+        SuppressionReason::InCooldown { .. } => "retrying after previous failure",
+        SuppressionReason::CapReached { .. } => {
             "max consecutive failures reached, retrying at the maximum backoff interval"
         }
     }

--- a/agent-control/src/agent_type/oci/downloader.rs
+++ b/agent-control/src/agent_type/oci/downloader.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use oci_client::Reference;
 use oci_client::secrets::RegistryAuth;
 use tracing::{debug, warn};
@@ -91,10 +89,10 @@ impl OCIAgentTypeArtifactDownloader {
         }
     }
 
-    /// Returns a new downloader with the provided retry configuration.
-    pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
+    /// Returns a new downloader with the provided retry policy.
+    pub fn with_retry_policy(self, policy: crate::utils::retry::BackoffPolicy) -> Self {
         Self {
-            fetcher: self.fetcher.with_retries(retries, retry_interval),
+            fetcher: self.fetcher.with_retry_policy(policy),
             ..self
         }
     }

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -27,14 +27,12 @@ mod signature_verification;
 pub use error::OciClientError;
 
 /// Default no-retry policy: a single attempt, no backoff.
-fn default_no_retry_policy() -> BackoffPolicy {
-    BackoffPolicy {
-        max_attempts: NonZeroUsize::MIN,
-        base_delay: Duration::ZERO,
-        max_delay: Duration::ZERO,
-        jitter: false,
-    }
-}
+const DEFAULT_NO_RETRY_POLICY: BackoffPolicy = BackoffPolicy {
+    max_attempts: NonZeroUsize::MIN,
+    base_delay: Duration::ZERO,
+    max_delay: Duration::ZERO,
+    jitter: false,
+};
 
 /// [oci_client::Client] wrapper with extended functionality.
 /// It also wraps all _async_ operations using the underlying runtime, all functions will
@@ -205,7 +203,7 @@ impl OciArtifactFetcher {
                 .as_ref()
                 .map(RegistryAuth::from)
                 .unwrap_or(RegistryAuth::Anonymous),
-            policy: default_no_retry_policy(),
+            policy: DEFAULT_NO_RETRY_POLICY,
         }
     }
 

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -1,5 +1,6 @@
 //! This module provides an [oci_client] wrapper.
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 use std::{path::Path, sync::Arc};
 
@@ -28,7 +29,7 @@ pub use error::OciClientError;
 /// Default no-retry policy: a single attempt, no backoff.
 fn default_no_retry_policy() -> BackoffPolicy {
     BackoffPolicy {
-        max_attempts: 1,
+        max_attempts: NonZeroUsize::MIN,
         base_delay: Duration::ZERO,
         max_delay: Duration::ZERO,
         jitter: false,

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::{path::Path, sync::Arc};
 
 use crate::agent_control::config::OciAuth;
-use crate::utils::retry::retry;
+use crate::utils::retry::{BackoffPolicy, retry_with_backoff};
 use crate::{http::config::ProxyConfig, signature::public_key_fetcher::PublicKeyFetcher};
 
 use futures::TryStreamExt;
@@ -25,7 +25,15 @@ mod signature_verification;
 
 pub use error::OciClientError;
 
-const DEFAULT_RETRIES: usize = 0;
+/// Default no-retry policy: a single attempt, no backoff.
+fn default_no_retry_policy() -> BackoffPolicy {
+    BackoffPolicy {
+        max_attempts: 1,
+        base_delay: Duration::ZERO,
+        max_delay: Duration::ZERO,
+        jitter: false,
+    }
+}
 
 /// [oci_client::Client] wrapper with extended functionality.
 /// It also wraps all _async_ operations using the underlying runtime, all functions will
@@ -184,8 +192,7 @@ impl Client {
 pub struct OciArtifactFetcher {
     client: Client,
     auth: RegistryAuth,
-    max_retries: usize,
-    retry_interval: Duration,
+    policy: BackoffPolicy,
 }
 
 impl OciArtifactFetcher {
@@ -197,18 +204,14 @@ impl OciArtifactFetcher {
                 .as_ref()
                 .map(RegistryAuth::from)
                 .unwrap_or(RegistryAuth::Anonymous),
-            max_retries: DEFAULT_RETRIES,
-            retry_interval: Duration::default(),
+            policy: default_no_retry_policy(),
         }
     }
 
-    /// Returns a new fetcher with the provided retry configuration.
-    pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
-        Self {
-            max_retries: retries,
-            retry_interval,
-            ..self
-        }
+    /// Returns a new fetcher with the provided retry policy. For a fixed-interval policy, set
+    /// `base_delay == max_delay` and `jitter == false` on the [BackoffPolicy].
+    pub fn with_retry_policy(self, policy: BackoffPolicy) -> Self {
+        Self { policy, ..self }
     }
 
     /// Resolves the reference (verifying its signature when `public_key_url` is `Some`) and fetches
@@ -223,7 +226,7 @@ impl OciArtifactFetcher {
         public_key_url: Option<&Url>,
         fetch_artifact: impl Fn(&Client, &Reference, &RegistryAuth) -> Result<T, OciClientError>,
     ) -> Result<T, OciClientError> {
-        retry(self.max_retries, self.retry_interval, || {
+        retry_with_backoff(&self.policy, || {
             let reference = self.verified_reference(base_reference, public_key_url)?;
 
             fetch_artifact(&self.client, &reference, &self.auth)

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -3,10 +3,10 @@ use crate::agent_control::config::Registry;
 use crate::oci::artifact_definitions::LocalAgentPackage;
 use crate::oci::{Client, OciArtifactFetcher, OciClientError};
 use crate::package::manager::PackageData;
+use crate::utils::retry::BackoffPolicy;
 use oci_client::Reference;
 use oci_client::secrets::RegistryAuth;
 use std::path::Path;
-use std::time::Duration;
 use tracing::{debug, warn};
 use url::Url;
 
@@ -77,10 +77,10 @@ impl OCIPackageArtifactDownloader {
         }
     }
 
-    /// Returns a new downloader with the provided retry configuration.
-    pub fn with_retries(self, retries: usize, retry_interval: Duration) -> Self {
+    /// Returns a new downloader with the provided retry policy.
+    pub fn with_retry_policy(self, policy: BackoffPolicy) -> Self {
         Self {
-            fetcher: self.fetcher.with_retries(retries, retry_interval),
+            fetcher: self.fetcher.with_retry_policy(policy),
             ..self
         }
     }

--- a/agent-control/src/utils.rs
+++ b/agent-control/src/utils.rs
@@ -1,3 +1,4 @@
+pub mod backoff_gate;
 pub mod binary_metadata;
 pub mod env_var;
 pub mod extract;

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -66,25 +66,21 @@ where
 
         // Within the current backoff window → suppress, escalating the reported reason once the
         // consecutive-failure threshold has been crossed.
-        if let Some(t) = state.next_attempt_at
-            && self.clock.now() < t
-        {
-            let consecutive_failures = state.consecutive_failures;
-            return Some(
-                if (consecutive_failures as usize) >= self.policy.max_attempts {
-                    SuppressionReason::CapReached {
-                        consecutive_failures,
-                    }
-                } else {
-                    SuppressionReason::InCooldown {
-                        consecutive_failures,
-                    }
-                },
-            );
+        match state.next_attempt_at {
+            Some(t)
+                if self.clock.now() < t
+                    && (state.consecutive_failures as usize) >= self.policy.max_attempts =>
+            {
+                Some(SuppressionReason::CapReached {
+                    consecutive_failures: state.consecutive_failures,
+                })
+            }
+            Some(t) if self.clock.now() < t => Some(SuppressionReason::InCooldown {
+                consecutive_failures: state.consecutive_failures,
+            }),
+            // Outside the backoff window (or no attempt scheduled): proceed with the operation.
+            _ => None,
         }
-
-        // Proceed with the operation (download).
-        None
     }
 
     /// Records a failed attempt for `key`, incrementing the consecutive-failure count and

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -1,6 +1,6 @@
 use crate::utils::retry::BackoffPolicy;
 use crate::utils::time::{Clock, SystemClock};
-use std::sync::Mutex;
+use std::cell::RefCell;
 use std::time::Instant;
 
 /// Why the gate withheld an attempt. This is the suppressed outcome of [`BackoffGate::check`]
@@ -39,7 +39,7 @@ impl<K> Default for GateState<K> {
 pub struct BackoffGate<K, C = SystemClock> {
     policy: BackoffPolicy,
     clock: C,
-    state: Mutex<GateState<K>>,
+    state: RefCell<GateState<K>>,
 }
 
 impl<K, C> BackoffGate<K, C>
@@ -51,7 +51,7 @@ where
         Self {
             policy,
             clock,
-            state: Mutex::new(GateState::default()),
+            state: RefCell::new(GateState::default()),
         }
     }
 
@@ -61,7 +61,7 @@ where
     /// If `key` differs from the last-seen key the gate resets first, so switching targets
     /// always permits an immediate attempt.
     pub fn check(&self, key: &K) -> Option<SuppressionReason> {
-        let mut state = self.state.lock().expect("backoff-gate lock poisoned");
+        let mut state = self.state.borrow_mut();
         Self::reset_if_key_changed(&mut state, key);
 
         // Within the current backoff window → suppress, escalating the reported reason once the
@@ -86,7 +86,7 @@ where
     /// Records a failed attempt for `key`, incrementing the consecutive-failure count and
     /// scheduling the next permitted attempt per the backoff schedule.
     pub fn record_failure(&self, key: &K) {
-        let mut state = self.state.lock().expect("backoff-gate lock poisoned");
+        let mut state = self.state.borrow_mut();
         // The key may have changed between `check` and now if another caller ran; only count
         // failures against the key we were actually told failed.
         Self::reset_if_key_changed(&mut state, key);
@@ -97,17 +97,13 @@ where
 
     /// Clears all failure state (e.g. after a successful attempt).
     pub fn reset(&self) {
-        *self.state.lock().expect("backoff-gate lock poisoned") = GateState::default();
+        *self.state.borrow_mut() = GateState::default();
     }
 
     /// The key the gate is currently tracking (the last key seen via [`check`](Self::check) or
     /// [`record_failure`](Self::record_failure)), or `None` if the gate is unused or was reset.
     pub fn current_key(&self) -> Option<K> {
-        self.state
-            .lock()
-            .expect("backoff-gate lock poisoned")
-            .key
-            .clone()
+        self.state.borrow().key.clone()
     }
 
     /// Runs `op` for `key` through the gate.
@@ -149,7 +145,7 @@ where
 mod tests {
     use super::*;
     use std::num::NonZeroUsize;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     /// Test clock backed by `Arc<Mutex<Instant>>` so a test can advance time deterministically

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -3,27 +3,16 @@ use crate::utils::time::{Clock, SystemClock};
 use std::sync::Mutex;
 use std::time::Instant;
 
-/// The gate's verdict for a given key: attempt the operation now, or suppress it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GateDecision {
-    /// No active cooldown — the caller should attempt the operation.
-    Proceed,
-    /// Suppressed: the backoff cooldown window after the last failure has not elapsed yet.
-    InCooldown { consecutive_failures: u32 },
-    /// Suppressed: `max_attempts` consecutive failures reached; stays suppressed until the key
-    /// changes (or [`BackoffGate::reset`] is called).
-    CapReached { consecutive_failures: u32 },
-}
-
-/// Why the gate withheld an attempt. Mirrors the suppressed variants of [`GateDecision`] without
-/// the `Proceed` case, so it can never appear on the "ran the operation" path. Returned as the
-/// error of [`BackoffGate::guarded`].
+/// Why the gate withheld an attempt. This is the suppressed outcome of [`BackoffGate::check`]
+/// (which returns `None` to mean "proceed") and the error type of [`BackoffGate::guarded`], so a
+/// "proceed" case can never appear on the "ran the operation" path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Suppression {
     /// The backoff cooldown window after the last failure has not elapsed yet.
     InCooldown { consecutive_failures: u32 },
-    /// `max_attempts` consecutive failures reached; stays suppressed until the key changes
-    /// (or [`BackoffGate::reset`] is called).
+    /// Suppressed within the current backoff window, with the `max_attempts` consecutive-failure
+    /// threshold crossed. The gate keeps probing once the window elapses; this variant only
+    /// escalates how the suppression is reported.
     CapReached { consecutive_failures: u32 },
 }
 
@@ -45,15 +34,8 @@ impl<K> Default for GateState<K> {
     }
 }
 
-/// A thread-safe gate that throttles repeated attempts at a fallible operation keyed by `K`.
-///
-/// The operation is identified by a key (e.g. a target version). When an attempt for a key
-/// fails, [`BackoffGate::record_failure`] schedules the next permitted attempt using the
-/// exponential-backoff-plus-jitter schedule of the configured [`BackoffPolicy`]. Until that
-/// instant passes, [`BackoffGate::check`] returns [`GateDecision::InCooldown`]. After
-/// `policy.max_attempts` consecutive failures the gate returns [`GateDecision::CapReached`]
-/// and stays there until the key changes (a new key implicitly resets the gate) or
-/// [`BackoffGate::reset`] is called.
+/// A thread-safe gate that throttles repeated attempts at a fallible operation
+/// keyed by `K` (e.g. a target version
 pub struct BackoffGate<K, C = SystemClock> {
     policy: BackoffPolicy,
     clock: C,
@@ -73,29 +55,34 @@ where
         }
     }
 
-    /// Inspects the gate for `key`, returning whether the caller should proceed or suppress.
+    /// Inspects the gate for `key`: returns `None` when the caller should proceed, or
+    /// `Some(reason)` when the attempt should be suppressed.
     ///
     /// If `key` differs from the last-seen key the gate resets first, so switching targets
     /// always permits an immediate attempt.
-    pub fn check(&self, key: &K) -> GateDecision {
+    pub fn check(&self, key: &K) -> Option<Suppression> {
         let mut state = self.state.lock().expect("backoff-gate lock poisoned");
         Self::reset_if_key_changed(&mut state, key);
 
-        if (state.consecutive_failures as usize) >= self.policy.max_attempts {
-            return GateDecision::CapReached {
-                consecutive_failures: state.consecutive_failures,
-            };
-        }
-
+        // Within the current backoff window → suppress, escalating the reported reason once the
+        // consecutive-failure threshold has been crossed.
         if let Some(t) = state.next_attempt_at
             && self.clock.now() < t
         {
-            return GateDecision::InCooldown {
-                consecutive_failures: state.consecutive_failures,
-            };
+            let consecutive_failures = state.consecutive_failures;
+            return Some(if (consecutive_failures as usize) >= self.policy.max_attempts {
+                Suppression::CapReached {
+                    consecutive_failures,
+                }
+            } else {
+                Suppression::InCooldown {
+                    consecutive_failures,
+                }
+            });
         }
 
-        GateDecision::Proceed
+        // Proceed with the operation (download).
+        None
     }
 
     /// Records a failed attempt for `key`, incrementing the consecutive-failure count and
@@ -115,6 +102,16 @@ where
         *self.state.lock().expect("backoff-gate lock poisoned") = GateState::default();
     }
 
+    /// The key the gate is currently tracking (the last key seen via [`check`](Self::check) or
+    /// [`record_failure`](Self::record_failure)), or `None` if the gate is unused or was reset.
+    pub fn current_key(&self) -> Option<K> {
+        self.state
+            .lock()
+            .expect("backoff-gate lock poisoned")
+            .key
+            .clone()
+    }
+
     /// Runs `op` for `key` through the gate.
     ///
     /// When the gate permits an attempt the operation runs: the gate is [reset](Self::reset) on
@@ -126,7 +123,7 @@ where
         F: FnOnce() -> Result<T, E>,
     {
         match self.check(key) {
-            GateDecision::Proceed => {
+            None => {
                 let result = op();
                 if result.is_ok() {
                     self.reset();
@@ -135,16 +132,7 @@ where
                 }
                 Ok(result)
             }
-            GateDecision::InCooldown {
-                consecutive_failures,
-            } => Err(Suppression::InCooldown {
-                consecutive_failures,
-            }),
-            GateDecision::CapReached {
-                consecutive_failures,
-            } => Err(Suppression::CapReached {
-                consecutive_failures,
-            }),
+            Some(suppression) => Err(suppression),
         }
     }
 
@@ -203,45 +191,66 @@ mod tests {
     #[test]
     fn proceeds_when_no_failures() {
         let (gate, _clock) = gate(Duration::from_secs(1), Duration::from_secs(10), 5);
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
     }
 
     #[test]
     fn suppresses_within_cooldown_window_then_re_attempts() {
         let (gate, clock) = gate(Duration::from_secs(30), Duration::from_secs(600), 5);
 
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
         gate.record_failure(&"v1");
 
         assert_eq!(
             gate.check(&"v1"),
-            GateDecision::InCooldown {
+            Some(Suppression::InCooldown {
                 consecutive_failures: 1
-            }
+            })
         );
 
         // base_delay is 30s with no jitter; advancing past it re-opens the gate.
         clock.advance(Duration::from_secs(31));
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
     }
 
     #[test]
-    fn cap_reached_suppresses_indefinitely() {
-        let (gate, clock) = gate(Duration::from_millis(1), Duration::from_millis(1), 2);
+    fn cap_is_reported_but_not_terminal() {
+        let (gate, clock) = gate(Duration::from_secs(30), Duration::from_secs(30), 2);
 
+        // One failure: below the cap, suppressed only within the window.
         gate.record_failure(&"v1");
-        clock.advance(Duration::from_secs(1));
-        gate.record_failure(&"v1");
-        clock.advance(Duration::from_secs(1));
+        assert_eq!(
+            gate.check(&"v1"),
+            Some(Suppression::InCooldown {
+                consecutive_failures: 1
+            })
+        );
+        clock.advance(Duration::from_secs(31));
+        assert_eq!(gate.check(&"v1"), None);
 
-        for _ in 0..5 {
-            assert_eq!(
-                gate.check(&"v1"),
-                GateDecision::CapReached {
-                    consecutive_failures: 2
-                }
-            );
-        }
+        // Second failure: cap reached — reported as CapReached *within* the window...
+        gate.record_failure(&"v1");
+        assert_eq!(
+            gate.check(&"v1"),
+            Some(Suppression::CapReached {
+                consecutive_failures: 2
+            })
+        );
+
+        // ...but the cap is not terminal: once the window elapses the gate probes again.
+        clock.advance(Duration::from_secs(31));
+        assert_eq!(gate.check(&"v1"), None);
+    }
+
+    #[test]
+    fn current_key_tracks_last_key_and_clears_on_reset() {
+        let (gate, _clock) = gate(Duration::from_secs(60), Duration::from_secs(600), 5);
+
+        assert_eq!(gate.current_key(), None);
+        gate.record_failure(&"v1");
+        assert_eq!(gate.current_key(), Some("v1"));
+        gate.reset();
+        assert_eq!(gate.current_key(), None);
     }
 
     #[test]
@@ -251,12 +260,12 @@ mod tests {
         gate.record_failure(&"v1");
         assert_eq!(
             gate.check(&"v1"),
-            GateDecision::InCooldown {
+            Some(Suppression::InCooldown {
                 consecutive_failures: 1
-            }
+            })
         );
         // A different key clears the cooldown without advancing the clock.
-        assert_eq!(gate.check(&"v2"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v2"), None);
     }
 
     #[test]
@@ -265,7 +274,7 @@ mod tests {
 
         gate.record_failure(&"v1");
         gate.reset();
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
     }
 
     #[test]
@@ -275,18 +284,18 @@ mod tests {
         // First failure: 10s window.
         gate.record_failure(&"v1");
         clock.advance(Duration::from_secs(10));
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
 
         // Second failure: 20s window — still suppressed after only 10s.
         gate.record_failure(&"v1");
         clock.advance(Duration::from_secs(10));
         assert_eq!(
             gate.check(&"v1"),
-            GateDecision::InCooldown {
+            Some(Suppression::InCooldown {
                 consecutive_failures: 2
-            }
+            })
         );
         clock.advance(Duration::from_secs(11));
-        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        assert_eq!(gate.check(&"v1"), None);
     }
 }

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 /// (which returns `None` to mean "proceed") and the error type of [`BackoffGate::guarded`], so a
 /// "proceed" case can never appear on the "ran the operation" path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Suppression {
+pub enum SuppressionReason {
     /// The backoff cooldown window after the last failure has not elapsed yet.
     InCooldown { consecutive_failures: u32 },
     /// Suppressed within the current backoff window, with the `max_attempts` consecutive-failure
@@ -60,7 +60,7 @@ where
     ///
     /// If `key` differs from the last-seen key the gate resets first, so switching targets
     /// always permits an immediate attempt.
-    pub fn check(&self, key: &K) -> Option<Suppression> {
+    pub fn check(&self, key: &K) -> Option<SuppressionReason> {
         let mut state = self.state.lock().expect("backoff-gate lock poisoned");
         Self::reset_if_key_changed(&mut state, key);
 
@@ -72,11 +72,11 @@ where
             let consecutive_failures = state.consecutive_failures;
             return Some(
                 if (consecutive_failures as usize) >= self.policy.max_attempts {
-                    Suppression::CapReached {
+                    SuppressionReason::CapReached {
                         consecutive_failures,
                     }
                 } else {
-                    Suppression::InCooldown {
+                    SuppressionReason::InCooldown {
                         consecutive_failures,
                     }
                 },
@@ -119,8 +119,8 @@ where
     /// When the gate permits an attempt the operation runs: the gate is [reset](Self::reset) on
     /// `Ok` and a failure is [recorded](Self::record_failure) on `Err`, and the operation's own
     /// result is returned wrapped in `Ok`. When the gate is in cooldown or has reached its cap,
-    /// `op` is not run and the [`Suppression`] verdict is returned as `Err`.
-    pub fn guarded<T, E, F>(&self, key: &K, op: F) -> Result<Result<T, E>, Suppression>
+    /// `op` is not run and the [`SuppressionReason`] verdict is returned as `Err`.
+    pub fn guarded<T, E, F>(&self, key: &K, op: F) -> Result<Result<T, E>, SuppressionReason>
     where
         F: FnOnce() -> Result<T, E>,
     {
@@ -209,7 +209,7 @@ mod tests {
 
         assert_eq!(
             gate.check(&"v1"),
-            Some(Suppression::InCooldown {
+            Some(SuppressionReason::InCooldown {
                 consecutive_failures: 1
             })
         );
@@ -227,7 +227,7 @@ mod tests {
         gate.record_failure(&"v1");
         assert_eq!(
             gate.check(&"v1"),
-            Some(Suppression::InCooldown {
+            Some(SuppressionReason::InCooldown {
                 consecutive_failures: 1
             })
         );
@@ -238,7 +238,7 @@ mod tests {
         gate.record_failure(&"v1");
         assert_eq!(
             gate.check(&"v1"),
-            Some(Suppression::CapReached {
+            Some(SuppressionReason::CapReached {
                 consecutive_failures: 2
             })
         );
@@ -266,7 +266,7 @@ mod tests {
         gate.record_failure(&"v1");
         assert_eq!(
             gate.check(&"v1"),
-            Some(Suppression::InCooldown {
+            Some(SuppressionReason::InCooldown {
                 consecutive_failures: 1
             })
         );
@@ -297,7 +297,7 @@ mod tests {
         clock.advance(Duration::from_secs(10));
         assert_eq!(
             gate.check(&"v1"),
-            Some(Suppression::InCooldown {
+            Some(SuppressionReason::InCooldown {
                 consecutive_failures: 2
             })
         );

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -15,6 +15,18 @@ pub enum GateDecision {
     CapReached { consecutive_failures: u32 },
 }
 
+/// Why the gate withheld an attempt. Mirrors the suppressed variants of [`GateDecision`] without
+/// the `Proceed` case, so it can never appear on the "ran the operation" path. Returned as the
+/// error of [`BackoffGate::guarded`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Suppression {
+    /// The backoff cooldown window after the last failure has not elapsed yet.
+    InCooldown { consecutive_failures: u32 },
+    /// `max_attempts` consecutive failures reached; stays suppressed until the key changes
+    /// (or [`BackoffGate::reset`] is called).
+    CapReached { consecutive_failures: u32 },
+}
+
 #[derive(Debug)]
 struct GateState<K> {
     key: Option<K>,
@@ -101,6 +113,39 @@ where
     /// Clears all failure state (e.g. after a successful attempt).
     pub fn reset(&self) {
         *self.state.lock().expect("backoff-gate lock poisoned") = GateState::default();
+    }
+
+    /// Runs `op` for `key` through the gate.
+    ///
+    /// When the gate permits an attempt the operation runs: the gate is [reset](Self::reset) on
+    /// `Ok` and a failure is [recorded](Self::record_failure) on `Err`, and the operation's own
+    /// result is returned wrapped in `Ok`. When the gate is in cooldown or has reached its cap,
+    /// `op` is not run and the [`Suppression`] verdict is returned as `Err`.
+    pub fn guarded<T, E, F>(&self, key: &K, op: F) -> Result<Result<T, E>, Suppression>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        match self.check(key) {
+            GateDecision::Proceed => {
+                let result = op();
+                if result.is_ok() {
+                    self.reset();
+                } else {
+                    self.record_failure(key);
+                }
+                Ok(result)
+            }
+            GateDecision::InCooldown {
+                consecutive_failures,
+            } => Err(Suppression::InCooldown {
+                consecutive_failures,
+            }),
+            GateDecision::CapReached {
+                consecutive_failures,
+            } => Err(Suppression::CapReached {
+                consecutive_failures,
+            }),
+        }
     }
 
     fn reset_if_key_changed(state: &mut GateState<K>, key: &K) {

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -34,7 +34,7 @@ impl<K> Default for GateState<K> {
     }
 }
 
-/// A thread-safe gate that throttles repeated attempts at a fallible operation
+/// A gate that throttles repeated attempts at a fallible operation
 /// keyed by `K` (e.g. a target version
 pub struct BackoffGate<K, C = SystemClock> {
     policy: BackoffPolicy,

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -69,7 +69,7 @@ where
         match state.next_attempt_at {
             Some(t)
                 if self.clock.now() < t
-                    && (state.consecutive_failures as usize) >= self.policy.max_attempts =>
+                    && (state.consecutive_failures as usize) >= self.policy.max_attempts.get() =>
             {
                 Some(SuppressionReason::CapReached {
                     consecutive_failures: state.consecutive_failures,
@@ -148,6 +148,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -173,7 +174,8 @@ mod tests {
 
     fn policy(base: Duration, max: Duration, max_attempts: usize) -> BackoffPolicy {
         BackoffPolicy {
-            max_attempts,
+            max_attempts: NonZeroUsize::new(max_attempts)
+                .expect("test policy max_attempts non-zero"),
             base_delay: base,
             max_delay: max,
             jitter: false,

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -70,15 +70,17 @@ where
             && self.clock.now() < t
         {
             let consecutive_failures = state.consecutive_failures;
-            return Some(if (consecutive_failures as usize) >= self.policy.max_attempts {
-                Suppression::CapReached {
-                    consecutive_failures,
-                }
-            } else {
-                Suppression::InCooldown {
-                    consecutive_failures,
-                }
-            });
+            return Some(
+                if (consecutive_failures as usize) >= self.policy.max_attempts {
+                    Suppression::CapReached {
+                        consecutive_failures,
+                    }
+                } else {
+                    Suppression::InCooldown {
+                        consecutive_failures,
+                    }
+                },
+            );
         }
 
         // Proceed with the operation (download).
@@ -182,7 +184,11 @@ mod tests {
         }
     }
 
-    fn gate(base: Duration, max: Duration, max_attempts: usize) -> (BackoffGate<&'static str, FakeClock>, FakeClock) {
+    fn gate(
+        base: Duration,
+        max: Duration,
+        max_attempts: usize,
+    ) -> (BackoffGate<&'static str, FakeClock>, FakeClock) {
         let clock = FakeClock::new(Instant::now());
         let gate = BackoffGate::new(policy(base, max, max_attempts), clock.clone());
         (gate, clock)

--- a/agent-control/src/utils/backoff_gate.rs
+++ b/agent-control/src/utils/backoff_gate.rs
@@ -1,0 +1,247 @@
+use crate::utils::retry::BackoffPolicy;
+use crate::utils::time::{Clock, SystemClock};
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// The gate's verdict for a given key: attempt the operation now, or suppress it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDecision {
+    /// No active cooldown — the caller should attempt the operation.
+    Proceed,
+    /// Suppressed: the backoff cooldown window after the last failure has not elapsed yet.
+    InCooldown { consecutive_failures: u32 },
+    /// Suppressed: `max_attempts` consecutive failures reached; stays suppressed until the key
+    /// changes (or [`BackoffGate::reset`] is called).
+    CapReached { consecutive_failures: u32 },
+}
+
+#[derive(Debug)]
+struct GateState<K> {
+    key: Option<K>,
+    consecutive_failures: u32,
+    next_attempt_at: Option<Instant>,
+}
+
+// Manual impl (rather than `#[derive(Default)]`) so `K` need not be `Default`.
+impl<K> Default for GateState<K> {
+    fn default() -> Self {
+        Self {
+            key: None,
+            consecutive_failures: 0,
+            next_attempt_at: None,
+        }
+    }
+}
+
+/// A thread-safe gate that throttles repeated attempts at a fallible operation keyed by `K`.
+///
+/// The operation is identified by a key (e.g. a target version). When an attempt for a key
+/// fails, [`BackoffGate::record_failure`] schedules the next permitted attempt using the
+/// exponential-backoff-plus-jitter schedule of the configured [`BackoffPolicy`]. Until that
+/// instant passes, [`BackoffGate::check`] returns [`GateDecision::InCooldown`]. After
+/// `policy.max_attempts` consecutive failures the gate returns [`GateDecision::CapReached`]
+/// and stays there until the key changes (a new key implicitly resets the gate) or
+/// [`BackoffGate::reset`] is called.
+pub struct BackoffGate<K, C = SystemClock> {
+    policy: BackoffPolicy,
+    clock: C,
+    state: Mutex<GateState<K>>,
+}
+
+impl<K, C> BackoffGate<K, C>
+where
+    K: PartialEq + Clone,
+    C: Clock,
+{
+    pub fn new(policy: BackoffPolicy, clock: C) -> Self {
+        Self {
+            policy,
+            clock,
+            state: Mutex::new(GateState::default()),
+        }
+    }
+
+    /// Inspects the gate for `key`, returning whether the caller should proceed or suppress.
+    ///
+    /// If `key` differs from the last-seen key the gate resets first, so switching targets
+    /// always permits an immediate attempt.
+    pub fn check(&self, key: &K) -> GateDecision {
+        let mut state = self.state.lock().expect("backoff-gate lock poisoned");
+        Self::reset_if_key_changed(&mut state, key);
+
+        if (state.consecutive_failures as usize) >= self.policy.max_attempts {
+            return GateDecision::CapReached {
+                consecutive_failures: state.consecutive_failures,
+            };
+        }
+
+        if let Some(t) = state.next_attempt_at
+            && self.clock.now() < t
+        {
+            return GateDecision::InCooldown {
+                consecutive_failures: state.consecutive_failures,
+            };
+        }
+
+        GateDecision::Proceed
+    }
+
+    /// Records a failed attempt for `key`, incrementing the consecutive-failure count and
+    /// scheduling the next permitted attempt per the backoff schedule.
+    pub fn record_failure(&self, key: &K) {
+        let mut state = self.state.lock().expect("backoff-gate lock poisoned");
+        // The key may have changed between `check` and now if another caller ran; only count
+        // failures against the key we were actually told failed.
+        Self::reset_if_key_changed(&mut state, key);
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+        let delay = self.policy.delay_with_jitter(state.consecutive_failures);
+        state.next_attempt_at = Some(self.clock.now() + delay);
+    }
+
+    /// Clears all failure state (e.g. after a successful attempt).
+    pub fn reset(&self) {
+        *self.state.lock().expect("backoff-gate lock poisoned") = GateState::default();
+    }
+
+    fn reset_if_key_changed(state: &mut GateState<K>, key: &K) {
+        if state.key.as_ref() != Some(key) {
+            *state = GateState {
+                key: Some(key.clone()),
+                consecutive_failures: 0,
+                next_attempt_at: None,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Test clock backed by `Arc<Mutex<Instant>>` so a test can advance time deterministically
+    /// while the gate holds the clock by value.
+    #[derive(Clone)]
+    struct FakeClock(Arc<Mutex<Instant>>);
+
+    impl FakeClock {
+        fn new(initial: Instant) -> Self {
+            Self(Arc::new(Mutex::new(initial)))
+        }
+        fn advance(&self, by: Duration) {
+            *self.0.lock().unwrap() += by;
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> Instant {
+            *self.0.lock().unwrap()
+        }
+    }
+
+    fn policy(base: Duration, max: Duration, max_attempts: usize) -> BackoffPolicy {
+        BackoffPolicy {
+            max_attempts,
+            base_delay: base,
+            max_delay: max,
+            jitter: false,
+        }
+    }
+
+    fn gate(base: Duration, max: Duration, max_attempts: usize) -> (BackoffGate<&'static str, FakeClock>, FakeClock) {
+        let clock = FakeClock::new(Instant::now());
+        let gate = BackoffGate::new(policy(base, max, max_attempts), clock.clone());
+        (gate, clock)
+    }
+
+    #[test]
+    fn proceeds_when_no_failures() {
+        let (gate, _clock) = gate(Duration::from_secs(1), Duration::from_secs(10), 5);
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+    }
+
+    #[test]
+    fn suppresses_within_cooldown_window_then_re_attempts() {
+        let (gate, clock) = gate(Duration::from_secs(30), Duration::from_secs(600), 5);
+
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+        gate.record_failure(&"v1");
+
+        assert_eq!(
+            gate.check(&"v1"),
+            GateDecision::InCooldown {
+                consecutive_failures: 1
+            }
+        );
+
+        // base_delay is 30s with no jitter; advancing past it re-opens the gate.
+        clock.advance(Duration::from_secs(31));
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+    }
+
+    #[test]
+    fn cap_reached_suppresses_indefinitely() {
+        let (gate, clock) = gate(Duration::from_millis(1), Duration::from_millis(1), 2);
+
+        gate.record_failure(&"v1");
+        clock.advance(Duration::from_secs(1));
+        gate.record_failure(&"v1");
+        clock.advance(Duration::from_secs(1));
+
+        for _ in 0..5 {
+            assert_eq!(
+                gate.check(&"v1"),
+                GateDecision::CapReached {
+                    consecutive_failures: 2
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn key_change_resets_and_allows_immediate_attempt() {
+        let (gate, _clock) = gate(Duration::from_secs(60), Duration::from_secs(600), 5);
+
+        gate.record_failure(&"v1");
+        assert_eq!(
+            gate.check(&"v1"),
+            GateDecision::InCooldown {
+                consecutive_failures: 1
+            }
+        );
+        // A different key clears the cooldown without advancing the clock.
+        assert_eq!(gate.check(&"v2"), GateDecision::Proceed);
+    }
+
+    #[test]
+    fn reset_clears_failure_state() {
+        let (gate, _clock) = gate(Duration::from_secs(60), Duration::from_secs(600), 5);
+
+        gate.record_failure(&"v1");
+        gate.reset();
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+    }
+
+    #[test]
+    fn exponential_growth_lengthens_window() {
+        let (gate, clock) = gate(Duration::from_secs(10), Duration::from_secs(600), 10);
+
+        // First failure: 10s window.
+        gate.record_failure(&"v1");
+        clock.advance(Duration::from_secs(10));
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+
+        // Second failure: 20s window — still suppressed after only 10s.
+        gate.record_failure(&"v1");
+        clock.advance(Duration::from_secs(10));
+        assert_eq!(
+            gate.check(&"v1"),
+            GateDecision::InCooldown {
+                consecutive_failures: 2
+            }
+        );
+        clock.advance(Duration::from_secs(11));
+        assert_eq!(gate.check(&"v1"), GateDecision::Proceed);
+    }
+}

--- a/agent-control/src/utils/retry.rs
+++ b/agent-control/src/utils/retry.rs
@@ -1,5 +1,5 @@
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 /// Retries the execution of `f` after the `interval` has elapsed, until `max_attempts` is reached.
 /// Returns the result of the last successful execution of `f` or the latest error if all attempts fail.
@@ -27,9 +27,100 @@ where
     Err(last_err.expect("some error must exist at this point"))
 }
 
+/// Configuration for retrying an operation that may fail with transient errors.
+///
+/// When an attempt fails, we wait before retrying with exponential delay —
+/// `base_delay`, then `2× base_delay`, then `4×`, etc. — capped at `max_delay`.
+///
+/// `jitter = true` randomizes each wait somewhere between zero and the computed value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BackoffPolicy {
+    // `0` is treated as `1`.
+    pub max_attempts: usize,
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+    pub jitter: bool,
+}
+
+impl BackoffPolicy {
+    /// Returns the wait time before the `attempt`-th retry, ignoring jitter.
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        if attempt == 0 {
+            return Duration::ZERO;
+        }
+
+        // 2^(attempt - 1), guarded against unsigned underflow (saturating_sub) and
+        // u32 overflow (checked_pow → u32::MAX). The max_delay cap below clamps the
+        // resulting Duration regardless.
+        let multiplier = 2u32
+            .checked_pow(attempt.saturating_sub(1))
+            .unwrap_or(u32::MAX);
+        let candidate = self
+            .base_delay
+            .checked_mul(multiplier)
+            .unwrap_or(self.max_delay);
+        candidate.min(self.max_delay)
+    }
+
+    /// Returns the wait time before the `attempt`-th retry, applying [full_jitter] when
+    /// `self.jitter` is set. This is the agnostic building block for any backoff schedule —
+    /// callers that sleep between attempts and callers that store a "next attempt at" instant
+    /// (cooldown windows across polls) share the exact same exponential-capped-plus-jitter math.
+    pub fn delay_with_jitter(&self, attempt: u32) -> Duration {
+        let delay = self.delay_for_attempt(attempt);
+        if self.jitter {
+            full_jitter(delay)
+        } else {
+            delay
+        }
+    }
+}
+
+/// Calls `f`, retrying with exponential backoff (and optional jitter) when it fails.
+pub fn retry_with_backoff<F, T, E>(policy: &BackoffPolicy, mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    let attempts = policy.max_attempts.max(1);
+    let mut last_err = None;
+    for attempt in 1..=attempts {
+        match f() {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last_err = Some(e);
+                // Don't sleep after the final attempt — there's nothing left to wait for.
+                if attempt < attempts {
+                    sleep(policy.delay_with_jitter(attempt as u32));
+                }
+            }
+        }
+    }
+    Err(last_err.expect("at least one attempt must have produced an error"))
+}
+
+/// Returns a random duration somewhere in `[0, d]`.
+///
+/// Each call to produces a different value so retries on different machines
+/// (and different attempts on the same machine) don't all happen at the same instant.
+/// current system time in nanoseconds is always advancing, and it differs across machine.
+pub fn full_jitter(d: Duration) -> Duration {
+    let cap_nanos = d.as_nanos() as u64;
+    if cap_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let now_nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos() as u64)
+        .unwrap_or(0);
+    // `+ 1` so the upper bound `d` is reachable (we want the inclusive range `[0, d]`).
+    Duration::from_nanos(now_nanos % (cap_nanos + 1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::time::Instant;
 
     #[test]
     fn test_retry_success() {
@@ -55,5 +146,112 @@ mod tests {
             }
         });
         assert_eq!(result, Ok("finally succeeded"));
+    }
+
+    #[test]
+    fn delay_schedule_exponential_capped() {
+        let p = BackoffPolicy {
+            max_attempts: 5,
+            base_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(4),
+            jitter: false,
+        };
+        assert_eq!(p.delay_for_attempt(0), Duration::ZERO);
+        assert_eq!(p.delay_for_attempt(1), Duration::from_secs(1));
+        assert_eq!(p.delay_for_attempt(2), Duration::from_secs(2));
+        assert_eq!(p.delay_for_attempt(3), Duration::from_secs(4));
+        // Capped at max_delay.
+        assert_eq!(p.delay_for_attempt(4), Duration::from_secs(4));
+        assert_eq!(p.delay_for_attempt(10), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn retry_with_backoff_succeeds_after_transient_failures() {
+        let attempts = Cell::new(0u32);
+        let policy = BackoffPolicy {
+            max_attempts: 4,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+            jitter: false,
+        };
+        let result: Result<&str, &str> = retry_with_backoff(&policy, || {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() < 3 {
+                Err("nope")
+            } else {
+                Ok("ok")
+            }
+        });
+        assert_eq!(result, Ok("ok"));
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn retry_with_backoff_gives_up_after_max_attempts() {
+        let attempts = Cell::new(0u32);
+        let policy = BackoffPolicy {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+            jitter: false,
+        };
+        let result: Result<(), &str> = retry_with_backoff(&policy, || {
+            attempts.set(attempts.get() + 1);
+            Err("permanent")
+        });
+        assert_eq!(result, Err("permanent"));
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn retry_with_backoff_zero_attempts_runs_once() {
+        let attempts = Cell::new(0u32);
+        let policy = BackoffPolicy {
+            max_attempts: 0,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+            jitter: false,
+        };
+        let _: Result<(), &str> = retry_with_backoff(&policy, || {
+            attempts.set(attempts.get() + 1);
+            Err("e")
+        });
+        assert_eq!(attempts.get(), 1);
+    }
+
+    #[test]
+    fn retry_with_backoff_no_sleep_after_final_attempt() {
+        // Three attempts with 50ms base — without the "skip sleep on last attempt" guard,
+        // a permanently-failing call would sleep ~150ms. With it, ~50+100=150ms is the upper
+        // bound for the 1st+2nd inter-attempt sleeps; we just assert it's well under 4× base.
+        let policy = BackoffPolicy {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(20),
+            max_delay: Duration::from_millis(40),
+            jitter: false,
+        };
+        let start = Instant::now();
+        let _: Result<(), &str> = retry_with_backoff(&policy, || Err("e"));
+        let elapsed = start.elapsed();
+        // 20ms after attempt 1 + 40ms after attempt 2 = 60ms; nothing after attempt 3.
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "elapsed {:?} suggests we slept after the final attempt",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn jitter_stays_within_bound() {
+        let d = Duration::from_millis(100);
+        for _ in 0..200 {
+            let j = full_jitter(d);
+            assert!(j <= d, "{:?} exceeded {:?}", j, d);
+        }
+    }
+
+    #[test]
+    fn jitter_zero_returns_zero() {
+        assert_eq!(full_jitter(Duration::ZERO), Duration::ZERO);
     }
 }

--- a/agent-control/src/utils/retry.rs
+++ b/agent-control/src/utils/retry.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
 
@@ -35,8 +36,7 @@ where
 /// `jitter = true` randomizes each wait somewhere between zero and the computed value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BackoffPolicy {
-    // `0` is treated as `1`.
-    pub max_attempts: usize,
+    pub max_attempts: NonZeroUsize,
     pub base_delay: Duration,
     pub max_delay: Duration,
     pub jitter: bool,
@@ -81,7 +81,7 @@ pub fn retry_with_backoff<F, T, E>(policy: &BackoffPolicy, mut f: F) -> Result<T
 where
     F: FnMut() -> Result<T, E>,
 {
-    let attempts = policy.max_attempts.max(1);
+    let attempts = policy.max_attempts.get();
     let mut last_err = None;
     for attempt in 1..=attempts {
         match f() {
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn delay_schedule_exponential_capped() {
         let p = BackoffPolicy {
-            max_attempts: 5,
+            max_attempts: NonZeroUsize::new(5).unwrap(),
             base_delay: Duration::from_secs(1),
             max_delay: Duration::from_secs(4),
             jitter: false,
@@ -169,7 +169,7 @@ mod tests {
     fn retry_with_backoff_succeeds_after_transient_failures() {
         let attempts = Cell::new(0u32);
         let policy = BackoffPolicy {
-            max_attempts: 4,
+            max_attempts: NonZeroUsize::new(4).unwrap(),
             base_delay: Duration::from_millis(1),
             max_delay: Duration::from_millis(5),
             jitter: false,
@@ -190,7 +190,7 @@ mod tests {
     fn retry_with_backoff_gives_up_after_max_attempts() {
         let attempts = Cell::new(0u32);
         let policy = BackoffPolicy {
-            max_attempts: 3,
+            max_attempts: NonZeroUsize::new(3).unwrap(),
             base_delay: Duration::from_millis(1),
             max_delay: Duration::from_millis(5),
             jitter: false,
@@ -204,28 +204,12 @@ mod tests {
     }
 
     #[test]
-    fn retry_with_backoff_zero_attempts_runs_once() {
-        let attempts = Cell::new(0u32);
-        let policy = BackoffPolicy {
-            max_attempts: 0,
-            base_delay: Duration::from_millis(1),
-            max_delay: Duration::from_millis(1),
-            jitter: false,
-        };
-        let _: Result<(), &str> = retry_with_backoff(&policy, || {
-            attempts.set(attempts.get() + 1);
-            Err("e")
-        });
-        assert_eq!(attempts.get(), 1);
-    }
-
-    #[test]
     fn retry_with_backoff_no_sleep_after_final_attempt() {
         // Three attempts with 50ms base — without the "skip sleep on last attempt" guard,
         // a permanently-failing call would sleep ~150ms. With it, ~50+100=150ms is the upper
         // bound for the 1st+2nd inter-attempt sleeps; we just assert it's well under 4× base.
         let policy = BackoffPolicy {
-            max_attempts: 3,
+            max_attempts: NonZeroUsize::new(3).unwrap(),
             base_delay: Duration::from_millis(20),
             max_delay: Duration::from_millis(40),
             jitter: false,

--- a/agent-control/src/utils/time.rs
+++ b/agent-control/src/utils/time.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 /// Converts a unix epoch timestamp in nanoseconds to a `SystemTime`.
 ///
@@ -15,4 +15,18 @@ pub fn unix_timestamp_from_sys_time(time: SystemTime) -> u64 {
     time.duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as u64
+}
+
+/// Monotonic time source — abstracted from [Instant::now] so tests can substitute a fake clock.
+pub trait Clock: Send + Sync {
+    fn now(&self) -> Instant;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
 }

--- a/agent-control/tests/on_host/oci_artifact_downloader.rs
+++ b/agent-control/tests/on_host/oci_artifact_downloader.rs
@@ -12,6 +12,7 @@ use newrelic_agent_control::package::manager::PackageData;
 use newrelic_agent_control::package::oci::downloader::{
     OCIPackageArtifactDownloader, OCIPackageDownloader,
 };
+use newrelic_agent_control::utils::retry::BackoffPolicy;
 use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_test_utils::{PackageMediaType, PackagePublisher, blob_digest};
 use std::str::FromStr;
@@ -131,7 +132,12 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
         Default::default(),
         false,
     )
-    .with_retries(4, Duration::from_millis(100));
+    .with_retry_policy(BackoffPolicy {
+        max_attempts: 4,
+        base_delay: Duration::from_millis(100),
+        max_delay: Duration::from_millis(100),
+        jitter: true,
+    });
 
     let package_data = PackageData {
         id: "test-package".to_string(),

--- a/agent-control/tests/on_host/oci_artifact_downloader.rs
+++ b/agent-control/tests/on_host/oci_artifact_downloader.rs
@@ -133,7 +133,7 @@ fn test_download_artifact_from_local_registry_using_proxy_with_retries_with_oci_
         false,
     )
     .with_retry_policy(BackoffPolicy {
-        max_attempts: 4,
+        max_attempts: std::num::NonZeroUsize::new(4).unwrap(),
         base_delay: Duration::from_millis(100),
         max_delay: Duration::from_millis(100),
         jitter: true,

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -294,6 +294,124 @@ agents: {{}}
     });
 }
 
+/// Local config for the recovery scenario: self-update enabled with a deliberately fast,
+/// jitter-free backoff so the test reaches the failure cap and the periodic retry within seconds.
+/// The download retry is set to a single attempt so each failing probe returns quickly.
+fn create_self_update_recovery_config(
+    opamp_server: &FakeServer,
+    signer: &OCISigner,
+    local_dir: &Path,
+) {
+    let config = format!(
+        r#"
+host_id: integration-test
+fleet_control:
+  endpoint: {}
+  poll_interval: 1s
+  signature_validation:
+    public_key_server_url: {}
+agents: {{}}
+oci:
+  registry: {OCI_TEST_REGISTRY_URL}
+self_update:
+  enabled: true
+  signature_verification_enabled: false
+  download_retry:
+    max_attempts: 1
+  upgrade_backoff:
+    base_delay: 1s
+    max_delay: 1s
+    max_consecutive_failures: 2
+    jitter: false
+  package:
+    download:
+      oci:
+        registry: {OCI_TEST_REGISTRY_URL}
+        repository: test
+        public_key_url: {}
+"#,
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        signer.jwks_url()
+    );
+    create_local_config(AGENT_CONTROL_ID, config, local_dir.to_path_buf());
+}
+
+#[test]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+/// Exercises self-update *recovery* from a transient registry outage.
+fn test_ac_self_update_recovers_after_registry_outage_with_oci_registry() {
+    const RECOVERY_VERSION_TAG: &str = "recovery-after-outage";
+
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+
+    let local_dir = tempdir().expect("failed to create local temp dir");
+    let remote_dir = tempdir().expect("failed to create remote temp dir");
+
+    create_self_update_recovery_config(&opamp_server, &signer, local_dir.path());
+
+    let current_exe_path = std::env::current_exe()
+        .expect("failed to get current exe path")
+        .canonicalize()
+        .expect("failed to canonicalize current exe path");
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.path().to_path_buf(),
+        remote_dir: remote_dir.path().to_path_buf(),
+        log_dir: local_dir.path().to_path_buf(),
+    };
+
+    let mut agent_control =
+        start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+    let ac_instance_id = get_instance_id(&AgentID::AgentControl, base_paths.clone());
+
+    // Request a version whose package is not in the registry yet — downloads will fail.
+    let update_config = format!(
+        r#"
+version: "{}"
+agents: {{}}
+"#,
+        RECOVERY_VERSION_TAG
+    );
+    opamp_server.set_config_response(ac_instance_id.clone(), update_config);
+
+    // The download fails (version absent) and AC reports a Failed config status. Reporting that
+    // status acks the hash, after which the fake server stops re-sending the config — so from here
+    // on, only the periodic self-update retry can drive another attempt.
+    retry(60, Duration::from_secs(5), || {
+        check_latest_remote_config_status(&opamp_server, &ac_instance_id, |status| {
+            if status.status != RemoteConfigStatuses::Failed as i32 {
+                return Err(format!("expected Failed status, got: {}", status.status).into());
+            }
+            Ok(())
+        })
+    });
+
+    // Nothing to download yet, so AC must still be running (retrying), not stopped.
+    assert!(
+        !agent_control.has_gracefully_stopped(),
+        "Agent Control should keep running and retrying while the package is unavailable"
+    );
+
+    // The registry "comes back": publish the package under the requested tag. With base_delay=1s
+    // and the non-terminal cap, the next retry probe (~1s later) picks it up.
+    let _ = push_ac_package(build_fake_ac_binary, None, Some(RECOVERY_VERSION_TAG));
+
+    // A retry downloads the now-available package, self-replaces, and AC gracefully stops —
+    // without any new remote config from OpAMP.
+    retry(60, Duration::from_secs(5), || {
+        if agent_control.has_gracefully_stopped() {
+            Ok(())
+        } else {
+            Err("Agent Control should have self-updated once the package became available".into())
+        }
+    });
+
+    assert_is_fake_binary(&current_exe_path);
+}
+
 fn create_self_update_local_config(
     opamp_server: &FakeServer,
     signer: &OCISigner,
@@ -313,20 +431,27 @@ fn create_self_update_local_config(
 /// Pushes an invalid fake agent-control binary package to the OCI registry and signs it.
 /// The binary will fail verification (`verify` exits 1 with a structured message).
 fn push_signed_invalid_fake_ac_package(signer: &OCISigner) -> String {
-    push_ac_package(build_invalid_fake_ac_binary, Some(signer))
+    push_ac_package(build_invalid_fake_ac_binary, Some(signer), None)
 }
 
 /// Pushes a fake agent-control binary package to the OCI registry and signs it.
 fn push_signed_fake_ac_package(signer: &OCISigner) -> String {
-    push_ac_package(build_fake_ac_binary, Some(signer))
+    push_ac_package(build_fake_ac_binary, Some(signer), None)
 }
 
 /// Pushes a fake agent-control binary package to the OCI registry without signing it.
 fn push_unsigned_fake_ac_package() -> String {
-    push_ac_package(build_fake_ac_binary, None)
+    push_ac_package(build_fake_ac_binary, None, None)
 }
 
-fn push_ac_package(build: fn() -> (TempDir, PathBuf), signer: Option<&OCISigner>) -> String {
+/// Pushes a package, returning the resulting tag. When `tag` is `Some`, the package is published
+/// under that exact tag (so a test can request a version *before* its package exists, then make it
+/// available); otherwise a unique tag is generated.
+fn push_ac_package(
+    build: fn() -> (TempDir, PathBuf),
+    signer: Option<&OCISigner>,
+    tag: Option<&str>,
+) -> String {
     let dir = tempdir().unwrap();
     let (_binary_dir, binary_path) = build();
 
@@ -344,8 +469,11 @@ fn push_ac_package(build: fn() -> (TempDir, PathBuf), signer: Option<&OCISigner>
         (path, PackageMediaType::Zip)
     };
 
-    let reference = PackagePublisher::new(tokio_runtime().handle().clone(), OCI_TEST_REGISTRY_URL)
-        .push(&path, media_type);
+    let publisher = PackagePublisher::new(tokio_runtime().handle().clone(), OCI_TEST_REGISTRY_URL);
+    let reference = match tag {
+        Some(tag) => publisher.push_with_tag(&path, media_type, tag),
+        None => publisher.push(&path, media_type),
+    };
     if let Some(signer) = signer {
         signer.sign_artifact(&reference);
     }

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -6,6 +6,7 @@ use crate::common::retry::retry;
 use crate::common::retry::retry_never;
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::config::AgentControlConfigBuilder;
+use crate::on_host::tools::config::create_local_config;
 use crate::on_host::tools::fake_binary::assert_is_fake_binary;
 use crate::on_host::tools::fake_binary::build_fake_ac_binary;
 use crate::on_host::tools::fake_binary::build_invalid_fake_ac_binary;
@@ -13,9 +14,13 @@ use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
+use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_VERSION;
+use newrelic_agent_control::agent_control::defaults::PACKAGES_FOLDER_NAME;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
+use newrelic_agent_control::agent_control::version_updater::on_host::AGENT_CONTROL_BIN;
+use newrelic_agent_control::agent_control::version_updater::on_host::AGENT_CONTROL_BIN_PACKAGE_ID;
 use oci_test_utils::OCISigner;
 use oci_test_utils::{PackageMediaType, PackagePublisher};
 use opamp_client::opamp::proto::RemoteConfigStatuses;
@@ -339,33 +344,27 @@ self_update:
 
 #[test]
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
-/// Exercises self-update *recovery* from a transient registry outage.
+/// Exercises self-update *recovery* from a transient registry outage: while the package is absent
+/// AC keeps retrying instead of giving up, and once it reappears the periodic retry (with no new
+/// OpAMP config) picks it up and downloads it.
+///
+/// Recovery is asserted on the package landing on disk, *not* on a completed self-replace.
 fn test_ac_self_update_recovers_after_registry_outage_with_oci_registry() {
     const RECOVERY_VERSION_TAG: &str = "recovery-after-outage";
 
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let signer = OCISigner::start(tokio_runtime().handle().clone());
 
-    let local_dir = tempdir().expect("failed to create local temp dir");
-    let remote_dir = tempdir().expect("failed to create remote temp dir");
+    let dirs = TempBasePaths::default();
 
-    create_self_update_recovery_config(&opamp_server, &signer, local_dir.path());
+    create_self_update_recovery_config(&opamp_server, &signer, &dirs.local_dir());
 
-    let current_exe_path = std::env::current_exe()
-        .expect("failed to get current exe path")
-        .canonicalize()
-        .expect("failed to canonicalize current exe path");
+    let mut agent_control = start_agent_control_with_custom_config(
+        dirs.base_paths().clone(),
+        AGENT_CONTROL_MODE_ON_HOST,
+    );
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.path().to_path_buf(),
-        remote_dir: remote_dir.path().to_path_buf(),
-        log_dir: local_dir.path().to_path_buf(),
-    };
-
-    let mut agent_control =
-        start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
-
-    let ac_instance_id = get_instance_id(&AgentID::AgentControl, base_paths.clone());
+    let ac_instance_id = get_instance_id(&AgentID::AgentControl, dirs.base_paths());
 
     // Request a version whose package is not in the registry yet — downloads will fail.
     let update_config = format!(
@@ -399,17 +398,39 @@ agents: {{}}
     // and the non-terminal cap, the next retry probe (~1s later) picks it up.
     let _ = push_ac_package(build_fake_ac_binary, None, Some(RECOVERY_VERSION_TAG));
 
-    // A retry downloads the now-available package, self-replaces, and AC gracefully stops —
-    // without any new remote config from OpAMP.
+    // The periodic self-update retry (no new OpAMP config) downloads and extracts the now-available
+    // package, leaving the AC binary under the installed-packages directory. We assert recovery on
+    // that install, which happens just before the (out-of-scope) self-replace step.
+    let installed_packages_dir = dirs
+        .remote_dir()
+        .join(PACKAGES_FOLDER_NAME)
+        .join(AGENT_CONTROL_ID)
+        .join("stored_packages")
+        .join(AGENT_CONTROL_BIN_PACKAGE_ID);
     retry(60, Duration::from_secs(5), || {
-        if agent_control.has_gracefully_stopped() {
+        if dir_contains_file(&installed_packages_dir, AGENT_CONTROL_BIN) {
             Ok(())
         } else {
-            Err("Agent Control should have self-updated once the package became available".into())
+            Err(
+                "the periodic retry should have downloaded the package once it became available"
+                    .into(),
+            )
         }
     });
+}
 
-    assert_is_fake_binary(&current_exe_path);
+fn dir_contains_file(dir: &Path, name: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        if path.is_dir() {
+            dir_contains_file(&path, name)
+        } else {
+            path.file_name().is_some_and(|f| f == name)
+        }
+    })
 }
 
 fn create_self_update_local_config(

--- a/docs/ac-remote-update/how-it-works.md
+++ b/docs/ac-remote-update/how-it-works.md
@@ -133,3 +133,45 @@ If there's any error, Agent Control will send `Failed` status. If everything wen
 The rolling update is an [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) implemented by kubernetes that incrementally replaces old pods with new ones. It's done in such a way, that old pods will be kept alive if new ones can't be started. Kubernetes assures it with [Liveness and Startup probes](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/).
 
 ![](./images/rolling-update.png)
+
+## Onhost Remote Update resilience: retry and backoff
+
+The on-host self-update is driven by the desired version in the OpAMP remote config and is re-evaluated on every poll. To not re-attempt a failing upgrade on every poll, hammering the OCI registry, the updater uses exponential backoff with jitter.
+
+- **Download retry**: within a single attempt the OCI download is retried up to `max_attempts`, *sleeping* between tries, to absorb transient blips.
+- **Upgrade backoff**: when a whole attempt fails, a non-sleeping cooldown gate keyed by target version suppresses re-attempts across polls; after `max_consecutive_failures` it only escalates logging (not terminal) and keeps probing every `max_delay`, and a new desired version resets it.
+
+Config — `self_update.download_retry`:
+
+| Field          | Default | Meaning |
+|----------------|---------|---------|
+| `max_attempts` | `3`     | Total download attempts (validated `>= 1`). |
+| `base_delay`   | `1s`    | First backoff delay; doubles each retry. |
+| `max_delay`    | `30s`   | Cap on the per-retry delay. |
+| `jitter`       | `true`  | Randomize each delay within `[0, computed]`. |
+
+Config — `self_update.upgrade_backoff`:
+
+| Field                      | Default | Meaning |
+|----------------------------|---------|---------|
+| `max_consecutive_failures` | `5`     | Consecutive failures before suppression is reported as "capped" (validated `>= 1`). Not a hard stop. |
+| `base_delay`               | `30s`   | First cooldown window; doubles each consecutive failure. |
+| `max_delay`                | `600s`  | Cap on the cooldown window (the steady-state retry cadence during a sustained outage). |
+| `jitter`                   | `true`  | Randomize each cooldown within `[0, computed]`. |
+
+Example configuration (values shown are the defaults):
+
+```yaml
+self_update:
+  enabled: true
+  download_retry:
+    max_attempts: 3
+    base_delay: 1s
+    max_delay: 30s
+    jitter: true
+  upgrade_backoff:
+    max_consecutive_failures: 5
+    base_delay: 30s
+    max_delay: 600s
+    jitter: true
+```


### PR DESCRIPTION
Adds exponential-backoff + jitter retries to self-update OCI downloads via a configurable BackoffPolicy (self_update.download_retry). A new BackoffGate throttles upgrade attempts per target version up to a max-delay cap; once capped, Agent Control keeps retrying rather than giving up. This lets it recover automatically from transient registry outages, and reset when a new version arrives. Covered by a new integration test for outage recovery.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
