### PR TITLE
feat: new explicit filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Remember that the keywords that you can use are the following:
   crash-looping from saturating CPU.
 - Added support for remote agent type retrieval.
 - add post-download script support for OCI packages.
+- Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 
 ## v1.17.0 - 2026-06-16
 

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -71,10 +71,18 @@ deployment:
     regex: \d+\.\d+\.\d+
   filesystem:
     config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+      kind: dir
+      entries:
+        newrelic-infra.yaml:
+          kind: file
+          text: |
+            ${nr-var:config_agent}
+    integrations.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    logging.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_logging}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -64,8 +64,12 @@ deployment:
     regex: \d+\.\d+\.\d+
   filesystem:
     otel-config:
-      config.yaml: |
-        ${nr-var:config}
+      kind: dir
+      entries:
+        config.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
@@ -44,8 +44,12 @@ deployment:
     regex: \d+\.\d+\.\d+
   filesystem:
     otel-config:
-      config.yaml: |
-        ${nr-var:config}
+      kind: dir
+      entries:
+        config.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -67,12 +67,21 @@ deployment:
     regex: \d+\.\d+\.\d+
   filesystem:
     config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+      kind: dir
+      entries:
+        newrelic-infra.yaml:
+          kind: file
+          text: |
+            ${nr-var:config_agent}
+    integrations.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    logging.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_logging}
     # this is needed in order to create the logging integration directory expected by fluentBit
-    newrelic-infra/newrelic-integrations/logging: { }
+    newrelic-infra/newrelic-integrations/logging:
+      kind: dir
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -80,8 +80,14 @@ deployment:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
     # this is needed in order to create the logging integration directory expected by fluentBit
-    newrelic-infra/newrelic-integrations/logging:
+    newrelic-infra:
       kind: dir
+      entries:
+        newrelic-integrations:
+          kind: dir
+          entries:
+            logging:
+              kind: dir
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -70,8 +70,12 @@ deployment:
     regex: \d+\.\d+\.\d+
   filesystem:
     otel-config:
-      config.yaml: |
-        ${nr-var:config}
+      kind: dir
+      entries:
+        config.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
   executables:
     - # Important to note the binary name is nrdot-collector matching the new nrdot binary
       id: nrdot-collector

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -319,7 +319,6 @@ mod tests {
     // Multi-segment keys are rejected: nested dirs must be declared with `kind: dir` + `entries:`.
     #[case::multi_segment("agent/data", false)]
     #[case::dot_segment("agent/./data", false)]
-    #[case::windows_style_path(r"some\\windows\\style\\path", true)]
     #[case::absolute("/etc", false)]
     #[case::dotdot("agent/../escape", false)]
     fn safe_path_parsing(#[case] path: &str, #[case] should_parse: bool) {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -129,12 +129,12 @@ impl Templateable for FilesystemEntry {
             }
             FilesystemEntry::DirContentFromMap { source } => {
                 let map = source.template_with(variables)?;
-                let children = map
+                let files = map
                     .0
                     .into_iter()
-                    .map(|(k, content)| (PathBuf::from(k), rendered::RenderedEntry::File(content)))
+                    .map(|(k, content)| (PathBuf::from(k), content))
                     .collect();
-                Ok(rendered::RenderedEntry::Dir(children))
+                Ok(rendered::RenderedEntry::DirContentFromMap(files))
             }
         }
     }
@@ -210,23 +210,20 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     }
 }
 
-/// Rejects multi-segment keys (e.g. `newrelic-infra/newrelic-integrations/logging`) so a nested
-/// tree must be spelled out with explicit `kind: dir` + `entries:` levels. Only the `Normal`
-/// components are counted; `.` (`CurDir`) is ignored. Escaping components (`..`, root, Windows
-/// prefixes) are handled by [`check_basedir_escape_safety`].
+/// A key must be exactly one `Normal` path segment (a leaf). This rejects multi-segment keys
+/// (e.g. `newrelic-infra/newrelic-integrations/logging` — declare nested trees explicitly with
+/// `kind: dir` + `entries:`) and also non-canonical single-segment spellings such as `./config`. 
+/// Escaping components (`..`, root, Windows prefixes) are handled by `check_basedir_escape_safety`.
 fn check_single_segment(path: &Path) -> Result<(), String> {
-    let normal_segments = path
-        .components()
-        .filter(|c| matches!(c, Component::Normal(_)))
-        .count();
-    if normal_segments > 1 {
-        return Err(format!(
-            "path `{}` must be a single path segment (a leaf); declare nested directories \
-             explicitly with `kind: dir` and `entries:`",
-            path.display()
-        ));
+    let mut components = path.components();
+    if let (Some(Component::Normal(_)), None) = (components.next(), components.next()) {
+        return Ok(());
     }
-    Ok(())
+    Err(format!(
+        "path `{}` must be a single path segment (a leaf); declare nested directories \
+         explicitly with `kind: dir` and `entries:`",
+        path.display()
+    ))
 }
 
 /// Rejects paths that traverse outside their base directory (e.g. `./../../some_path`) so that
@@ -315,7 +312,8 @@ mod tests {
 
     #[rstest]
     #[case::single_segment("config", true)]
-    #[case::single_segment_curdir("./config", true)]
+    // `./config` is a non-canonical spelling of `config` (distinct map key, same on-disk path).
+    #[case::leading_curdir("./config", false)]
     // Multi-segment keys are rejected: nested dirs must be declared with `kind: dir` + `entries:`.
     #[case::multi_segment("agent/data", false)]
     #[case::dot_segment("agent/./data", false)]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -1,11 +1,13 @@
 //! Module defining the file system configuration for sub-agents.
 //!
-//! This includes files and directories that should be created for the sub-agent at runtime,
-//! based on templated content and paths. The paths are always relative to the sub-agent's
-//! dedicated directory created by agent-control
-//! (usually something like `/var/lib/newrelic-agent-control/filesystem/<SUB_AGENT_ID>`).
-//! The files are created in a dedicated `files/` subdirectory, while directories are created in
-//! a dedicated `directories/` subdirectory, to avoid name clashes.
+//! Every entry under `filesystem:` is declared with an explicit `kind:` (`file`, `dir`, or
+//! `dir_content_from_map`). Directory trees are built recursively via the `entries:` field on
+//! `kind: dir`. A directory's contents may also be projected from a `map[string]yaml` variable
+//! using `kind: dir_content_from_map`, where map keys become filenames and values become file
+//! bodies.
+//!
+//! Top-level keys are interpreted relative to the sub-agent's dedicated filesystem directory
+//! (`${nr-sub:filesystem_agent_dir}`).
 
 use std::{
     collections::HashMap,
@@ -27,46 +29,44 @@ use serde::de::Error;
 
 pub mod rendered;
 
-/// Represents the file system configuration for the deployment of a host agent. Consisting of
-/// a set of directories (map keys) which in turn contain a set of files (nested map keys) with
-/// their respective content (map values).
+/// Filesystem configuration for an on-host sub-agent: a tree of files, directories, and
+/// directories whose contents are projected from `map[string]yaml` variables.
 ///
-/// It would be equivalent to a YAML mapping of this format:
-/// ```yaml
-/// filesystem:
-///   "path/to/my-dir":
-///      # YAML content, expected to be a mapping string -> yaml
-///      filepath1: "file1 content"
-///      filepath2: | # multi-line string content
-///        key: value
-///   # fully templated content, expected to render to a valid YAML mapping string -> string
-///   "another/path/to/my-dir": ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-/// ```
-///
-/// The files can be hardcoded, with the contents possibly containing templates, or the whole set of
-/// files can be templated so a directory contains an arbitrary number of files (a place to use a
-/// `map[string]yaml` variable type). **The paths cannot be templated.**
-///
-/// See [`AgentDirectoryEntry`] and [`DirEntriesType`] for more details.
+/// Every entry is tagged with a `kind:`. `dir` entries may contain further entries under
+/// `entries:`, recursively.
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
-pub struct FileSystem(HashMap<SafePath, DirEntriesType>);
+pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 
-/// A path to a file or directory that has been validated to be "safe",
-/// i.e. relative and not escaping its base directory (e.g. with parent dir specifiers like `..`).
+/// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FilesystemEntry {
+    /// A single file with literal or templated content.
+    File { text: TemplateableValue<String> },
+    /// An explicitly declared directory. Children, if any, live under `entries:`.
+    Dir {
+        #[serde(default)]
+        entries: HashMap<SafePath, FilesystemEntry>,
+    },
+    /// A directory whose set of files is computed at deploy time from a `map[string]yaml`
+    /// variable. Map keys become filenames; values become file contents.
+    DirContentFromMap {
+        source: TemplateableValue<DirEntriesMap>,
+    },
+}
+
+/// A path validated to be relative and not escaping its base directory (no `..`, no absolute
+/// roots, no Windows prefixes).
 #[derive(Debug, Default, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(try_from = "PathBuf")]
 pub struct SafePath(PathBuf);
 
-/// Allow borrowing the inner [`Path`] from a [`SafePath`].
 impl AsRef<Path> for SafePath {
     fn as_ref(&self) -> &Path {
         &self.0
     }
 }
 
-/// Try to create a [`SafePath`] from a [`PathBuf`], validating that the path is relative
-/// and does not escape its base directory. If the path is invalid, an error string is returned
-/// containing a comma-separated list of the issues found.
 impl TryFrom<PathBuf> for SafePath {
     type Error = IOError;
 
@@ -83,43 +83,8 @@ impl From<SafePath> for PathBuf {
     }
 }
 
-/// The type of items present in a directory entry.
-///
-/// There are two supported modes:
-///   1. A fixed set of entries, where each entry's content can be templated.
-///      This implies the number and names of the entries are known at parse time.
-///   2. A fully templated set of entries, where it's expected that a full template is provided as
-///      a placeholder for later rendering.
-#[derive(Debug, Deserialize, PartialEq, Clone)]
-#[serde(untagged)]
-enum DirEntriesType {
-    /// A directory with a fixed set of entries (i.e. files). Each entry's content can be templated.
-    /// E.g.
-    /// ```yaml
-    /// "my/dir":
-    ///   filepath1: "file1 content with ${nr-var:some_var}"
-    ///   filepath2: "file2 content"
-    /// ```
-    FixedWithTemplatedContent(HashMap<SafePath, TemplateableValue<String>>),
-
-    /// A directory with a fully templated set of entries, where it's expected that a full template
-    /// is provided that renders to a valid YAML mapping of a safe [`PathBuf`] to [`String`].
-    /// E.g.
-    /// ```yaml
-    /// "my/templated/dir":
-    ///   ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-    /// ```
-    FullyTemplated(TemplateableValue<DirEntriesMap>),
-}
-
-impl Default for DirEntriesType {
-    fn default() -> Self {
-        DirEntriesType::FixedWithTemplatedContent(HashMap::default())
-    }
-}
-
-/// A helper newtype to allow implementing `Templateable` for `TemplateableValue<HashMap<PathBuf, String>>`
-/// without running into orphan rule issues.
+/// Helper carrying the rendered output of a `${nr-var:map[string]yaml}` source — exists
+/// to satisfy the orphan rule when implementing `Templateable` for `TemplateableValue<_>`.
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct DirEntriesMap(HashMap<SafePath, String>);
 
@@ -127,82 +92,68 @@ impl Templateable for FileSystem {
     type Output = rendered::FileSystem;
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        if let Some(TrivialValue::String(filesystem_dir)) = variables
-            .get(
-                &Namespace::SubAgent
-                    .namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            )
-            .and_then(Variable::get_final_value)
-        {
-            let filesystem = self
-                .0
-                .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        // The only place where we construct a `SafePath` directly, prepending the
-                        // sub-agent's filesystem directory to the user-provided relative path.
-                        // FIXME: when we fix the templating and make the agent type definitions
-                        // type-safe, we will make sure to always build correct "final paths" here.
-                        SafePath(PathBuf::from(filesystem_dir.clone()).join(k)),
-                        v.template_with(variables)?,
-                    ))
-                })
-                .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-            Ok(rendered::FileSystem(filesystem))
-        } else {
-            Err(AgentTypeError::MissingValue(
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            ))
-        }
+        let base_dir = filesystem_agent_dir(variables)?;
+
+        let entries = self
+            .0
+            .into_iter()
+            .map(|(key, entry)| {
+                // The only place we construct a final-on-disk path: prepend the sub-agent's
+                // dedicated filesystem dir to the user-provided relative top-level key.
+                let path = PathBuf::from(&base_dir).join(&key);
+                Ok((path, entry.template_with(variables)?))
+            })
+            .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
+
+        Ok(rendered::FileSystem(entries))
     }
 }
 
-impl FileSystem {
-    /// Returns the list of directory paths (keys) defined in this filesystem configuration.
-    pub fn dir_paths(&self) -> impl Iterator<Item = &SafePath> {
-        self.0.keys()
-    }
-}
+impl Templateable for FilesystemEntry {
+    type Output = rendered::RenderedEntry;
 
-impl Templateable for DirEntriesType {
-    type Output = DirEntriesMap;
-    /// Replaces placeholders in the content with values from the `Variables` map.
-    ///
-    /// Behaves differently depending on the variant:
-    /// - For `FixedWithTemplatedContent`, it templates each entry's content individually.
-    /// - For `FullyTemplated`, it templates the entire content as a single unit, expecting it to
-    ///   be a valid (YAML) mapping of safe `PathBuf` to `String`.
-    ///
-    /// See [`TemplateableValue<DirEntriesMap>::template_with`] for details.
+    /// Recursively templates this entry into a [`rendered::RenderedEntry`] tree. Sub-paths in the
+    /// resulting tree are kept relative to their parent; the absolute prefix is applied once at
+    /// the top level by [`FileSystem::template_with`].
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         match self {
-            DirEntriesType::FixedWithTemplatedContent(map) => {
-                let rendered_map = map
+            FilesystemEntry::File { text } => Ok(rendered::RenderedEntry::File(
+                text.template_with(variables)?,
+            )),
+            FilesystemEntry::Dir { entries } => {
+                let children = entries
                     .into_iter()
-                    .map(|(k, v)| Ok((k, v.template_with(variables)?)))
+                    .map(|(k, v)| Ok((PathBuf::from(k), v.template_with(variables)?)))
                     .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-                Ok(DirEntriesMap(rendered_map))
+                Ok(rendered::RenderedEntry::Dir(children))
             }
-            DirEntriesType::FullyTemplated(tv) => Ok(tv.template_with(variables)?),
+            FilesystemEntry::DirContentFromMap { source } => {
+                let map = source.template_with(variables)?;
+                let children = map
+                    .0
+                    .into_iter()
+                    .map(|(k, content)| (PathBuf::from(k), rendered::RenderedEntry::File(content)))
+                    .collect();
+                Ok(rendered::RenderedEntry::Dir(children))
+            }
         }
+    }
+}
+
+fn filesystem_agent_dir(variables: &Variables) -> Result<String, AgentTypeError> {
+    let key = Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR);
+    match variables.get(&key).and_then(Variable::get_final_value) {
+        Some(TrivialValue::String(s)) => Ok(s.clone()),
+        _ => Err(AgentTypeError::MissingValue(key)),
     }
 }
 
 impl Templateable for TemplateableValue<DirEntriesMap> {
     type Output = DirEntriesMap;
-    /// Performs the templating of the defined directory entries for this sub-agent in the case where
-    /// they were fully templated (see [`DirEntriesType::FullyTemplated`]).
-    ///
-    /// The paths present in the DirectoryEntry structures are always assumed to start from the
-    /// sub-agent's dedicated directory.
-    ///
-    /// Besides, we know the paths are relative and don't go above their base dir (e.g. `/../..`)
-    /// due to the parse-time validations of [`FileSystem`], so here we "safely" prepend the
-    /// provided base dir to them, as it must be defined in the variables passed to the sub-agent.
-    /// If the value of the sub-agent's dedicated directory is missing, the templating fails.
+
+    /// Templates the source string of a `dir_content_from_map` entry, then parses the result as a
+    /// YAML mapping `filename -> contents`. Empty templated string yields an empty map.
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        // Template content as a string first. Then parse as a YAML and attempt to convert to the
-        // expected HashMap<PathBuf, String> type.
         let templated_string = self.template.template_with(variables)?;
         let value: HashMap<SafePath, String> = if templated_string.is_empty() {
             HashMap::new()
@@ -214,7 +165,6 @@ impl Templateable for TemplateableValue<DirEntriesMap> {
                     ))
                 })?;
 
-            // Convert the serde_json::Value (i.e. the file contents) to String
             map_string_value
                 .into_iter()
                 .map(|(k, v)| Ok((k, output_string(v)?)))
@@ -225,9 +175,8 @@ impl Templateable for TemplateableValue<DirEntriesMap> {
     }
 }
 
-/// Converts a serde_json::Value to a String.
-/// If the value is already a String, it is returned as-is.
-/// Otherwise, it is serialized to a YAML string using serde_saphyr.
+/// Converts a serde_json::Value to a String. Strings pass through; other variants are serialized
+/// as YAML.
 fn output_string(value: serde_json::Value) -> Result<String, serde_saphyr::Error> {
     match value {
         // Pass the string directly (serde_saphyr inserts literal syntax for multi-line strings)
@@ -258,17 +207,11 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     }
 }
 
-/// Makes sure the passed directory goes not traverse outside the directory where it's contained.
-/// E.g. via relative path specifiers like `./../../some_path`.
-///
-/// This would make files and directories "safe" to be created inside a sub-agent's dedicated
-/// directory, as they would not be able to write outside of it
-/// (tampering with other sub-agents or worse).
-/// Returns an error string if this property does not hold.
+/// Rejects paths that traverse outside their base directory (e.g. `./../../some_path`) so that
+/// no sub-agent can write outside its dedicated dir.
 fn check_basedir_escape_safety(path: &Path) -> Result<(), String> {
     path.components().try_for_each(|comp| match comp {
         Component::Normal(_) | Component::CurDir => Ok(()),
-        // Disallow other non-supported variants like roots or prefixes
         Component::ParentDir | Component::RootDir | Component::Prefix(_) => Err(format!(
             "path `{}` has an invalid component: `{}`",
             path.display(),
@@ -280,6 +223,7 @@ fn check_basedir_escape_safety(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_type::runtime_config::on_host::filesystem::rendered::RenderedEntry;
     use fs::directory_manager::DirectoryManagerFs;
     use fs::file::LocalFile;
     use rstest::rstest;
@@ -304,56 +248,42 @@ mod tests {
     }
 
     #[test]
-    fn valid_filepath_rendering() {
+    fn templates_top_level_file() {
         let variables = Variables::from_iter(vec![(
             Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
             Variable::new_final_string_variable("/base/dir"),
         )]);
 
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::from_template("some content".to_string()),
-            )])),
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("config/newrelic.yaml").try_into().unwrap(),
+            FilesystemEntry::File {
+                text: TemplateableValue::from_template("hello".to_string()),
+            },
         )]));
 
-        let rendered = filesystem_entry.template_with(&variables);
-        assert!(rendered.is_ok());
-        let rendered = rendered.unwrap();
-        assert!(rendered.0.len() == 1);
+        let rendered = fs_input.template_with(&variables).unwrap();
 
-        let expected_filesystem = rendered::FileSystem(HashMap::from([(
-            SafePath(PathBuf::from("/base/dir/my/path")),
-            DirEntriesMap(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                "some content".to_string(),
-            )])),
+        let expected = rendered::FileSystem(HashMap::from([(
+            PathBuf::from("/base/dir/config/newrelic.yaml"),
+            RenderedEntry::File("hello".to_string()),
         )]));
-
-        assert_eq!(rendered, expected_filesystem);
+        assert_eq!(rendered, expected);
     }
 
     #[test]
-    fn invalid_filepath_rendering_nonexisting_subagent_basepath() {
-        // If the sub-agent variable (nr-sub) containing the agent's filesystem dir is missing,
-        // templating must fail.
+    fn templating_fails_without_filesystem_agent_dir_variable() {
         let variables = Variables::default();
-
-        let filesystem_entry = FileSystem(HashMap::from([(
-            PathBuf::from("my/path").try_into().unwrap(),
-            DirEntriesType::FixedWithTemplatedContent(HashMap::from([(
-                PathBuf::from("my/file/path").try_into().unwrap(),
-                TemplateableValue::new("some content".to_string()),
-            )])),
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("any").try_into().unwrap(),
+            FilesystemEntry::Dir {
+                entries: HashMap::new(),
+            },
         )]));
 
-        let rendered = filesystem_entry.template_with(&variables);
-        assert!(rendered.is_err());
-        let rendered_err = rendered.unwrap_err();
-        assert!(matches!(rendered_err, AgentTypeError::MissingValue(_)));
+        let err = fs_input.template_with(&variables).unwrap_err();
+        assert!(matches!(err, AgentTypeError::MissingValue(_)));
         assert_eq!(
-            rendered_err.to_string(),
+            err.to_string(),
             format!(
                 "missing value for key: {}",
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR)
@@ -362,207 +292,209 @@ mod tests {
     }
 
     #[rstest]
-    #[case::valid_filesystem_parse("basic/path", |r: Result<_, _>| r.is_ok())]
-    #[case::windows_style_path(r"some\\windows\\style\\path", |r: Result<_, _>| r.is_ok())]
-    #[case::invalid_absolute_path("/absolute/path", |r: Result<_, serde_saphyr::Error>| r.is_err())]
-    #[case::invalid_reaches_parentdir("basedir/dir/../dir/../../../outdir/path", |r: Result<_, serde_saphyr::Error>| r.is_err())]
-    // #[case::invalid_windows_path_prefix(r"C:\\absolute\\windows\\path", |r: Result<_, serde_saphyr::Error>| r.is_err_and(|e| e.to_string().contains("invalid path component")))]
-    // #[case::invalid_windows_root_device("C:", |r: Result<_, serde_saphyr::Error>| r.is_err_and(|e| e.to_string().contains("invalid path component")))]
-    // #[case::invalid_windows_server_path(r"\\\\server\\share", |r: Result<_, serde_saphyr::Error>| r.is_err_and(|e| e.to_string().contains("invalid path component")))]
-    // TODO add windows paths to check that this handles the `Component::Prefix(_)` case correctly
-    fn file_entry_parsing(
-        #[case] path: &str,
-        #[case] validation: impl Fn(Result<DirEntriesType, serde_saphyr::Error>) -> bool,
-    ) {
-        let yaml = format!("\"{path}\": \"some random content\"");
-        let parsed = serde_saphyr::from_str::<DirEntriesType>(&yaml);
-        let parsed_display = format!("{parsed:?}");
-        assert!(validation(parsed), "input: {yaml}, parsed:{parsed_display}");
+    #[case::single_segment("config", true)]
+    #[case::multi_segment("agent/data", true)]
+    #[case::dot_segment("agent/./data", true)]
+    #[case::windows_style_path(r"some\\windows\\style\\path", true)]
+    #[case::absolute("/etc", false)]
+    #[case::dotdot("agent/../escape", false)]
+    fn safe_path_parsing(#[case] path: &str, #[case] should_parse: bool) {
+        let yaml = format!(
+            r#"
+"{path}":
+  kind: dir
+"#
+        );
+        let parsed = serde_saphyr::from_str::<FileSystem>(&yaml);
+        assert_eq!(
+            parsed.is_ok(),
+            should_parse,
+            "input: {yaml}, parsed: {parsed:?}"
+        );
     }
 
-    const EXAMPLE_FILESYSTEM: &str = r#"
-"path/to/my-dir":
-    filepath1: "file1 content"
-    filepath2: |
-        key: ${nr-var:some_var}
-"another/path/to/my-dir":
-    ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-"#;
-
-    #[test]
-    fn parse_valid_directories() {
-        let parsed: Result<FileSystem, _> = serde_saphyr::from_str(EXAMPLE_FILESYSTEM);
-        assert!(
-            parsed.as_ref().is_ok_and(|p| p.0.len() == 2),
-            "Parsed directories: {parsed:?}"
+    #[cfg(windows)]
+    #[rstest]
+    #[case::drive_with_path(r"C:\\absolute\\windows\\path")]
+    #[case::drive_root("C:")]
+    #[case::unc_server_share(r"\\\\server\\share")]
+    fn safe_path_parsing_rejects_windows_prefixes(#[case] path: &str) {
+        let yaml = format!(
+            r#"
+"{path}":
+  kind: dir
+"#
         );
-
-        let parsed = parsed.unwrap().0;
-        let my_dir = parsed
-            .get(&SafePath(PathBuf::from("path/to/my-dir")))
-            .unwrap();
-        assert!(matches!(
-            my_dir,
-            DirEntriesType::FixedWithTemplatedContent(_)
-        ));
-
-        let another_dir = parsed
-            .get(&SafePath(PathBuf::from("another/path/to/my-dir")))
-            .unwrap();
-        assert!(matches!(another_dir, DirEntriesType::FullyTemplated(_)));
+        let parsed = serde_saphyr::from_str::<FileSystem>(&yaml);
+        assert!(parsed.is_err(), "input: {yaml}, parsed: {parsed:?}");
     }
 
     const FILESYSTEM_EXAMPLE: &str = r#"
-"some/files":
-    "path/to/my-file": "something ${nr-var:some_file_var}"
-    "another/path/to/my-file": |
-        some
-        multi-line
-        content
-"path/to/my-dir":
-    filepath1: "file1 content"
-    filepath2: |
-        key: ${nr-var:some_dir_var}
-"another/path/to/my-dir":
-    ${nr-var:some_var_that_renders_to_a_yaml_mapping}
-"empty/dir": {}
+newrelic-infra.yaml:
+  kind: file
+  text: ${nr-var:config_agent}
+
+config:
+  kind: dir
+
+logging.d:
+  kind: dir_content_from_map
+  source: ${nr-var:config_logging}
+
+agent:
+  kind: dir
+  entries:
+    data:
+      kind: dir
+    integrations.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    newrelic-infra.yaml:
+      kind: file
+      text: ${nr-var:config_agent}
 "#;
 
-    #[test]
-    fn parse_and_template_filesystem() {
-        let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
-        assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
-            "Parsed filesystem: {parsed:?}"
-        );
-
-        let parsed = parsed.unwrap();
-        let variables = Variables::from_iter(vec![
+    fn example_variables(base_dir: &str) -> Variables {
+        Variables::from_iter(vec![
             (
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-                Variable::new_final_string_variable("/test/base/dir"),
+                Variable::new_final_string_variable(base_dir),
             ),
             (
-                Namespace::Variable.namespaced_name("some_file_var"),
-                Variable::new_final_string_variable("file_var_value"),
+                Namespace::Variable.namespaced_name("config_agent"),
+                Variable::new_final_string_variable("license_key: REDACTED\n"),
             ),
             (
-                Namespace::Variable.namespaced_name("some_dir_var"),
-                Variable::new_final_string_variable("dir_var_value"),
-            ),
-            (
-                Namespace::Variable.namespaced_name("some_var_that_renders_to_a_yaml_mapping"),
-                // a map[string]yaml
+                Namespace::Variable.namespaced_name("config_integrations"),
                 Variable::new(
                     String::default(),
                     false,
                     None,
                     Some(HashMap::from([
-                        ("fileA".to_string(), Value::String("contentA".to_string())),
                         (
-                            "fileB".to_string(),
-                            Value::String("multi-line\ncontentB".to_string()),
+                            "nri-mysql.yaml".to_string(),
+                            Value::String("integration: mysql".to_string()),
+                        ),
+                        (
+                            "nri-redis.yaml".to_string(),
+                            Value::String("integration: redis".to_string()),
                         ),
                     ])),
                 ),
             ),
-        ]);
-
-        let templated = parsed.template_with(&variables);
-        assert!(templated.is_ok(), "Templated filesystem: {templated:?}");
+            (
+                Namespace::Variable.namespaced_name("config_logging"),
+                Variable::new(
+                    String::default(),
+                    false,
+                    None,
+                    Some(HashMap::from([(
+                        "syslog.yaml".to_string(),
+                        Value::String("logs: []".to_string()),
+                    )])),
+                ),
+            ),
+        ])
     }
 
     #[test]
-    fn rendered_files() {
-        let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE);
-        assert!(
-            parsed.as_ref().is_ok_and(|fs| fs.0.len() == 4),
-            "Parsed filesystem: {parsed:?}"
-        );
+    fn parses_all_three_kinds() {
+        let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE).unwrap();
+        assert_eq!(parsed.0.len(), 4);
+
+        let file_entry = parsed
+            .0
+            .get(&SafePath(PathBuf::from("newrelic-infra.yaml")))
+            .unwrap();
+        assert!(matches!(file_entry, FilesystemEntry::File { .. }));
+
+        let empty_dir = parsed.0.get(&SafePath(PathBuf::from("config"))).unwrap();
+        assert!(matches!(empty_dir, FilesystemEntry::Dir { entries } if entries.is_empty()));
+
+        let dir_from_map = parsed.0.get(&SafePath(PathBuf::from("logging.d"))).unwrap();
+        assert!(matches!(
+            dir_from_map,
+            FilesystemEntry::DirContentFromMap { .. }
+        ));
+
+        let nested_dir = parsed.0.get(&SafePath(PathBuf::from("agent"))).unwrap();
+        let FilesystemEntry::Dir { entries } = nested_dir else {
+            panic!("expected agent to be a Dir, got {nested_dir:?}");
+        };
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(
+            entries.get(&SafePath(PathBuf::from("data"))).unwrap(),
+            FilesystemEntry::Dir { .. }
+        ));
+        assert!(matches!(
+            entries
+                .get(&SafePath(PathBuf::from("integrations.d")))
+                .unwrap(),
+            FilesystemEntry::DirContentFromMap { .. }
+        ));
+        assert!(matches!(
+            entries
+                .get(&SafePath(PathBuf::from("newrelic-infra.yaml")))
+                .unwrap(),
+            FilesystemEntry::File { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        let yaml = r#"
+foo:
+  kind: invented
+"#;
+        let parsed = serde_saphyr::from_str::<FileSystem>(yaml);
+        assert!(parsed.is_err(), "parsed: {parsed:?}");
+    }
+
+    /// Templating + writing the example to disk produces every expected file with the right
+    /// content, an empty directory for `kind: dir` with no entries, and `dir_content_from_map`
+    /// projects the map's keys as files.
+    #[test]
+    fn rendered_files_on_disk() {
+        let parsed = serde_saphyr::from_str::<FileSystem>(FILESYSTEM_EXAMPLE).unwrap();
         let tmp_dir = TempDir::new().unwrap();
+        let variables = example_variables(&tmp_dir.path().to_string_lossy());
 
-        let parsed = parsed.unwrap();
-        let variables = Variables::from_iter(vec![
-            (
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-                Variable::new_final_string_variable(tmp_dir.path().to_string_lossy().to_string()),
-            ),
-            (
-                Namespace::Variable.namespaced_name("some_file_var"),
-                Variable::new_final_string_variable("file_var_value"),
-            ),
-            (
-                Namespace::Variable.namespaced_name("some_dir_var"),
-                Variable::new_final_string_variable("dir_var_value"),
-            ),
-            (
-                Namespace::Variable.namespaced_name("some_var_that_renders_to_a_yaml_mapping"),
-                // a map[string]yaml
-                Variable::new(
-                    String::default(),
-                    false,
-                    None,
-                    Some(HashMap::from([
-                        ("fileA".to_string(), Value::String("contentA".to_string())),
-                        (
-                            "fileB".to_string(),
-                            Value::String("multi-line\ncontentB".to_string()),
-                        ),
-                    ])),
-                ),
-            ),
-        ]);
-
-        let templated = parsed.template_with(&variables);
-        assert!(templated.is_ok(), "Templated filesystem: {templated:?}");
-        let templated = templated.unwrap();
+        let templated = parsed.template_with(&variables).unwrap();
         templated.write(&LocalFile, &DirectoryManagerFs).unwrap();
 
-        // Expected rendered paths with contents.
-        // All paths must be prepended by the sub-agent's generated dir and the
-        // corresponding `files/` or `directories/` subdir, depending on where they came from.
-        // They also must have all variables rendered and have the correct content.
-        let expected_rendered = [
+        let expected_files = [
             (
-                tmp_dir.path().join("another/path/to/my-dir/fileA"),
-                String::from("contentA"),
+                tmp_dir.path().join("newrelic-infra.yaml"),
+                "license_key: REDACTED\n",
             ),
             (
-                tmp_dir.path().join("path/to/my-dir/filepath1"),
-                String::from("file1 content"),
+                tmp_dir.path().join("agent/newrelic-infra.yaml"),
+                "license_key: REDACTED\n",
             ),
             (
-                tmp_dir.path().join("path/to/my-dir/filepath2"),
-                String::from("key: dir_var_value\n"),
+                tmp_dir.path().join("agent/integrations.d/nri-mysql.yaml"),
+                "integration: mysql",
             ),
             (
-                tmp_dir.path().join("some/files/path/to/my-file"),
-                String::from("something file_var_value"),
+                tmp_dir.path().join("agent/integrations.d/nri-redis.yaml"),
+                "integration: redis",
             ),
-            (
-                tmp_dir.path().join("some/files/another/path/to/my-file"),
-                String::from("some\nmulti-line\ncontent\n"),
-            ),
-            (
-                tmp_dir.path().join("another/path/to/my-dir/fileB"),
-                String::from("multi-line\ncontentB"),
-            ),
+            (tmp_dir.path().join("logging.d/syslog.yaml"), "logs: []"),
         ];
-        let empty_dir = tmp_dir.path().join("empty/dir");
-        assert!(
-            empty_dir.exists() && empty_dir.is_dir(),
-            "Empty dir was not created"
-        );
 
-        for (r_path, r_content) in expected_rendered.iter() {
-            println!("Checking rendered file at path: {}", r_path.display());
-            let read_content = std::fs::read_to_string(r_path).unwrap();
-            assert_eq!(
-                &read_content,
-                r_content,
-                "File content mismatch for path: {}",
-                r_path.display()
-            );
+        for (path, expected) in expected_files.iter() {
+            let actual = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+            assert_eq!(&actual, expected, "content mismatch at {}", path.display());
         }
+
+        let empty_dir = tmp_dir.path().join("config");
+        assert!(empty_dir.is_dir(), "empty dir not created at {empty_dir:?}");
+
+        let nested_empty_dir = tmp_dir.path().join("agent/data");
+        assert!(
+            nested_empty_dir.is_dir(),
+            "nested empty dir not created at {nested_empty_dir:?}"
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -212,7 +212,7 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
 
 /// A key must be exactly one `Normal` path segment (a leaf). This rejects multi-segment keys
 /// (e.g. `newrelic-infra/newrelic-integrations/logging` — declare nested trees explicitly with
-/// `kind: dir` + `entries:`) and also non-canonical single-segment spellings such as `./config`. 
+/// `kind: dir` + `entries:`) and also non-canonical single-segment spellings such as `./config`.
 /// Escaping components (`..`, root, Windows prefixes) are handled by `check_basedir_escape_safety`.
 fn check_single_segment(path: &Path) -> Result<(), String> {
     let mut components = path.components();

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -186,8 +186,7 @@ fn output_string(value: serde_json::Value) -> Result<String, serde_saphyr::Error
     }
 }
 
-/// Validates that a file entry path is relative and does not escape its base directory.
-/// Returns a comma-separated list of error messages, if any.
+/// Validates that a file entry path is a single, relative, non-escaping leaf segment.
 fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     let mut errors = Vec::new();
 
@@ -199,12 +198,35 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     if let Err(e) = check_basedir_escape_safety(path) {
         errors.push(e);
     }
+    // Each key must be a single leaf segment, not a sub-path.
+    if let Err(e) = check_single_segment(path) {
+        errors.push(e);
+    }
 
     if errors.is_empty() {
         Ok(())
     } else {
         Err(errors.join(", "))
     }
+}
+
+/// Rejects multi-segment keys (e.g. `newrelic-infra/newrelic-integrations/logging`) so a nested
+/// tree must be spelled out with explicit `kind: dir` + `entries:` levels. Only the `Normal`
+/// components are counted; `.` (`CurDir`) is ignored. Escaping components (`..`, root, Windows
+/// prefixes) are handled by [`check_basedir_escape_safety`].
+fn check_single_segment(path: &Path) -> Result<(), String> {
+    let normal_segments = path
+        .components()
+        .filter(|c| matches!(c, Component::Normal(_)))
+        .count();
+    if normal_segments > 1 {
+        return Err(format!(
+            "path `{}` must be a single path segment (a leaf); declare nested directories \
+             explicitly with `kind: dir` and `entries:`",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 /// Rejects paths that traverse outside their base directory (e.g. `./../../some_path`) so that
@@ -255,7 +277,7 @@ mod tests {
         )]);
 
         let fs_input = FileSystem(HashMap::from([(
-            PathBuf::from("config/newrelic.yaml").try_into().unwrap(),
+            PathBuf::from("newrelic.yaml").try_into().unwrap(),
             FilesystemEntry::File {
                 text: TemplateableValue::from_template("hello".to_string()),
             },
@@ -264,7 +286,7 @@ mod tests {
         let rendered = fs_input.template_with(&variables).unwrap();
 
         let expected = rendered::FileSystem(HashMap::from([(
-            PathBuf::from("/base/dir/config/newrelic.yaml"),
+            PathBuf::from("/base/dir/newrelic.yaml"),
             RenderedEntry::File("hello".to_string()),
         )]));
         assert_eq!(rendered, expected);
@@ -293,8 +315,10 @@ mod tests {
 
     #[rstest]
     #[case::single_segment("config", true)]
-    #[case::multi_segment("agent/data", true)]
-    #[case::dot_segment("agent/./data", true)]
+    #[case::single_segment_curdir("./config", true)]
+    // Multi-segment keys are rejected: nested dirs must be declared with `kind: dir` + `entries:`.
+    #[case::multi_segment("agent/data", false)]
+    #[case::dot_segment("agent/./data", false)]
     #[case::windows_style_path(r"some\\windows\\style\\path", true)]
     #[case::absolute("/etc", false)]
     #[case::dotdot("agent/../escape", false)]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -1,12 +1,21 @@
-use crate::agent_type::runtime_config::on_host::filesystem::{DirEntriesMap, SafePath};
 use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::trace;
 
+/// Rendered filesystem tree, ready to be materialized on disk.
+///
+/// Top-level keys are absolute paths but children inside [`RenderedEntry::Dir`] are kept relative
+/// to their parent — recursion in [`FileSystem::write`] joins them onto the parent path.
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct FileSystem(pub(super) HashMap<SafePath, DirEntriesMap>);
+pub struct FileSystem(pub(super) HashMap<PathBuf, RenderedEntry>);
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RenderedEntry {
+    File(String),
+    Dir(HashMap<PathBuf, RenderedEntry>),
+}
 
 impl FileSystem {
     pub fn write(
@@ -14,39 +23,44 @@ impl FileSystem {
         file_writer: &impl FileWriter,
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
-        self.0.iter().try_for_each(|(dir_path, dir_entries)| {
-            // Create the base directory so that we support empty directories
-            dir_manager.create(dir_path.as_ref()).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {dir_path:?}: {err}"))
-            })?;
-            dir_entries
-                .0
-                .iter()
-                .try_for_each(|(sub_path, file_content)| {
-                    let file_path = dir_path.as_ref().join(sub_path);
-                    create_file(file_writer, dir_manager, &file_path, file_content)
-                })
-        })
+        for (path, entry) in &self.0 {
+            write_entry(file_writer, dir_manager, path, entry)?;
+        }
+        Ok(())
     }
 }
 
-fn create_file(
+fn write_entry(
     file_writer: &impl FileWriter,
     dir_manager: &impl DirectoryManager,
-    file_path: &PathBuf,
-    file_content: &String,
+    path: &Path,
+    entry: &RenderedEntry,
 ) -> Result<(), FileSystemEntriesError> {
-    trace!("Writing filesystem entry to {}", file_path.display());
-    let parent_dir = file_path.parent().ok_or_else(|| {
-        FileSystemEntriesError(format!("{} has no parent dir", file_path.display()))
-    })?;
-    dir_manager.create(parent_dir).map_err(|err| {
-        FileSystemEntriesError(format!("creating directory {parent_dir:?}: {err}"))
-    })?;
-    // Will overwrite files if they already exist!
-    file_writer
-        .write(file_path.as_path(), file_content.to_owned())
-        .map_err(|err| FileSystemEntriesError(format!("creating file {file_path:?}: {err}")))
+    match entry {
+        RenderedEntry::File(content) => {
+            trace!("Writing filesystem entry to {}", path.display());
+            let parent = path.parent().ok_or_else(|| {
+                FileSystemEntriesError(format!("{} has no parent dir", path.display()))
+            })?;
+            // safe even if the dir already exists.
+            dir_manager.create(parent).map_err(|err| {
+                FileSystemEntriesError(format!("creating directory {parent:?}: {err}"))
+            })?;
+            // Will overwrite the file if it already exists.
+            file_writer
+                .write(path, content.to_owned())
+                .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
+        }
+        RenderedEntry::Dir(children) => {
+            dir_manager.create(path).map_err(|err| {
+                FileSystemEntriesError(format!("creating directory {path:?}: {err}"))
+            })?;
+            for (sub_path, child) in children {
+                write_entry(file_writer, dir_manager, &path.join(sub_path), child)?;
+            }
+            Ok(())
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -15,6 +15,7 @@ pub struct FileSystem(pub(super) HashMap<PathBuf, RenderedEntry>);
 pub enum RenderedEntry {
     File(String),
     Dir(HashMap<PathBuf, RenderedEntry>),
+    DirContentFromMap(HashMap<PathBuf, String>),
 }
 
 impl FileSystem {
@@ -30,6 +31,35 @@ impl FileSystem {
     }
 }
 
+/// Creates `dir` (and any missing parents), with error context. Safe if it already exists.
+fn ensure_dir(
+    dir_manager: &impl DirectoryManager,
+    dir: &Path,
+) -> Result<(), FileSystemEntriesError> {
+    trace!("Creating directory {}", dir.display());
+    dir_manager
+        .create(dir)
+        .map_err(|err| FileSystemEntriesError(format!("creating directory {dir:?}: {err}")))
+}
+
+/// Writes `content` to `path`, creating its parent directory first. Overwrites an existing file.
+fn write_file(
+    file_writer: &impl FileWriter,
+    dir_manager: &impl DirectoryManager,
+    path: &Path,
+    content: &str,
+) -> Result<(), FileSystemEntriesError> {
+    trace!("Writing filesystem entry to {}", path.display());
+    // We ensure the parent exists even if the dir is declared independently.
+    let parent = path
+        .parent()
+        .ok_or_else(|| FileSystemEntriesError(format!("{} has no parent dir", path.display())))?;
+    ensure_dir(dir_manager, parent)?;
+    file_writer
+        .write(path, content.to_owned())
+        .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
+}
+
 fn write_entry(
     file_writer: &impl FileWriter,
     dir_manager: &impl DirectoryManager,
@@ -37,26 +67,20 @@ fn write_entry(
     entry: &RenderedEntry,
 ) -> Result<(), FileSystemEntriesError> {
     match entry {
-        RenderedEntry::File(content) => {
-            trace!("Writing filesystem entry to {}", path.display());
-            let parent = path.parent().ok_or_else(|| {
-                FileSystemEntriesError(format!("{} has no parent dir", path.display()))
-            })?;
-            // safe even if the dir already exists.
-            dir_manager.create(parent).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {parent:?}: {err}"))
-            })?;
-            // Will overwrite the file if it already exists.
-            file_writer
-                .write(path, content.to_owned())
-                .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
-        }
+        RenderedEntry::File(content) => write_file(file_writer, dir_manager, path, content),
         RenderedEntry::Dir(children) => {
-            dir_manager.create(path).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {path:?}: {err}"))
-            })?;
+            ensure_dir(dir_manager, path)?;
             for (sub_path, child) in children {
-                write_entry(file_writer, dir_manager, &path.join(sub_path), child)?;
+                let child_path = path.join(sub_path);
+                trace!("Recursing into child entry {}", child_path.display());
+                write_entry(file_writer, dir_manager, &child_path, child)?;
+            }
+            Ok(())
+        }
+        RenderedEntry::DirContentFromMap(files) => {
+            ensure_dir(dir_manager, path)?;
+            for (file_name, content) in files {
+                write_file(file_writer, dir_manager, &path.join(file_name), content)?;
             }
             Ok(())
         }

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -26,7 +26,8 @@ fn writes_filesystem_entries() {
     let expected_file_contents = "Hello, world!";
     let agent_id = "test-agent";
     let dir_entry = "example-filepath";
-    let file_path = "randomdir/randomfile.txt";
+    let nested_dir = "randomdir";
+    let file_name = "randomfile.txt";
 
     create_file(
         format!(
@@ -43,9 +44,12 @@ deployment:
     {dir_entry}:
       kind: dir
       entries:
-        {file_path}:
-          kind: file
-          text: "{expected_file_contents}"
+        {nested_dir}:
+          kind: dir
+          entries:
+            {file_name}:
+              kind: file
+              text: "{expected_file_contents}"
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -75,7 +79,8 @@ deployment:
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
         .join(agent_id)
         .join(dir_entry)
-        .join(file_path);
+        .join(nested_dir)
+        .join(file_name);
 
     retry(30, Duration::from_secs(1), || {
         read_file_and_expect_content(&search_path, expected_file_contents)?;
@@ -147,16 +152,22 @@ variables:
     required: true
 deployment:
   filesystem:
-    randomdir:
+    parent_randomdir:
       kind: dir
       entries:
-        "{yaml_file_path}":
-          kind: file
-          text: |-
-            ${{nr-var:yaml_file_contents}}
-        "{string_file_path}":
-          kind: file
-          text: "Some string contents with a rendered variable: ${{nr-var:some_string}}"
+        randomdir:
+          kind: dir
+          entries:
+            randomfile.yaml:
+              kind: file
+              text: |-
+                ${{nr-var:yaml_file_contents}}
+        randomdir-2:
+          kind: dir
+          entries:
+            some_string.txt:
+              kind: file
+              text: "Some string contents with a rendered variable: ${{nr-var:some_string}}"
     {dir_path}:
       kind: dir
       entries:
@@ -217,13 +228,13 @@ some_mapstringyaml:
         .remote_dir()
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
         .join(agent_id)
-        .join("randomdir")
+        .join("parent_randomdir")
         .join(yaml_file_path);
     let string_search_path = dirs
         .remote_dir()
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
         .join(agent_id)
-        .join("randomdir")
+        .join("parent_randomdir")
         .join(string_file_path);
     let dir_search_path = dirs
         .remote_dir()
@@ -330,8 +341,14 @@ deployment:
           text: |-
             ${{nr-var:config_logging}}
     # This directory needs to persist across restarts for the infra agent
-    newrelic-infra/newrelic-integrations/logging:
+    newrelic-infra:
       kind: dir
+      entries:
+        newrelic-integrations:
+          kind: dir
+          entries:
+            logging:
+              kind: dir
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -41,7 +41,11 @@ variables: {{}}
 deployment:
   filesystem:
     {dir_entry}:
-      {file_path}: "{expected_file_contents}"
+      kind: dir
+      entries:
+        {file_path}:
+          kind: file
+          text: "{expected_file_contents}"
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -144,14 +148,28 @@ variables:
 deployment:
   filesystem:
     randomdir:
-      "{yaml_file_path}": |-
-        ${{nr-var:yaml_file_contents}}
-      "{string_file_path}": "Some string contents with a rendered variable: ${{nr-var:some_string}}"
+      kind: dir
+      entries:
+        "{yaml_file_path}":
+          kind: file
+          text: |-
+            ${{nr-var:yaml_file_contents}}
+        "{string_file_path}":
+          kind: file
+          text: "Some string contents with a rendered variable: ${{nr-var:some_string}}"
     {dir_path}:
-      file1.txt: "File 1 contents"
-      file2.txt: |
-        File 2 contents with a variable: ${{nr-var:some_string}}
-    "{fully_templated_dir}": ${{nr-var:some_mapstringyaml}}
+      kind: dir
+      entries:
+        file1.txt:
+          kind: file
+          text: "File 1 contents"
+        file2.txt:
+          kind: file
+          text: |
+            File 2 contents with a variable: ${{nr-var:some_string}}
+    "{fully_templated_dir}":
+      kind: dir_content_from_map
+      source: ${{nr-var:some_mapstringyaml}}
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -291,16 +309,29 @@ variables:
 deployment:
   filesystem:
     config:
-      newrelic-infra.yaml: |-
-        ${{nr-var:config_agent}}
+      kind: dir
+      entries:
+        newrelic-infra.yaml:
+          kind: file
+          text: |-
+            ${{nr-var:config_agent}}
     integrations.d:
-      integration.yaml: |-
-        ${{nr-var:config_integrations}}
+      kind: dir
+      entries:
+        integration.yaml:
+          kind: file
+          text: |-
+            ${{nr-var:config_integrations}}
     logging.d:
-      logging.yaml: |-
-        ${{nr-var:config_logging}}
+      kind: dir
+      entries:
+        logging.yaml:
+          kind: file
+          text: |-
+            ${{nr-var:config_logging}}
     # This directory needs to persist across restarts for the infra agent
-    newrelic-infra/newrelic-integrations/logging: {{}}
+    newrelic-infra/newrelic-integrations/logging:
+      kind: dir
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -40,7 +40,11 @@ fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
         .with_filesystem(Some(&format!(
             r#"
 {dir_entry}:
-  {file_path}: "{content_template}"
+  kind: dir
+  entries:
+    {file_path}:
+      kind: file
+      text: "{content_template}"
 "#
         )))
         .with_variables(

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -366,6 +366,21 @@ files can be templated, so a directory contains an arbitrary number of files (a 
 
 Every directory and every file is declared with a `kind`, and directory trees are built recursively via an `entries:` field. A directory's contents can also be templated from a `map[string]yaml` variable using `kind: dir_content_from_map`, the map's keys become filenames and the values become file contents.
 
+Each key names a single entry at its own level — it must be a single path segment (a leaf), not a slash-separated sub-path. A nested directory has to be spelled out level by level with explicit `kind: dir` + `entries:` blocks; a key such as `newrelic-infra/newrelic-integrations/logging` is rejected. Declare it as:
+
+```yaml
+newrelic-infra:
+  kind: dir
+  entries:
+    newrelic-integrations:
+      kind: dir
+      entries:
+        logging:
+          kind: dir
+```
+
+This applies to projected filenames too: the keys of a `map[string]yaml` used by `dir_content_from_map` must also be single segments.
+
 The example below uses these variables:
 
 ```yaml
@@ -494,7 +509,7 @@ agent/integrations.d/
 | Field        | Required | Default | Description                                                  |
 |--------------|----------|---------|--------------------------------------------------------------|
 | `kind`       | yes      | —       | Must be `dir`.                                               |
-| `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive.                  |
+| `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive. Each key must be a single path segment, not a sub-path. |
 | `persistent` | no       | `false` | If `true`, this directory and its tree survive cleanup.      |
 
 **`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -507,24 +507,38 @@ agent/integrations.d/
 
 ##### Persistence in Filesystem
 
-Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persistent:` (default `false`) that controls how the runtime treats it across the agent's lifecycle — start, stop, restart, config update, and removal from the fleet.
+Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persistent:` (default `false`). Two independent mechanisms govern lifecycle:
 
-**Ephemeral (`persistent: false`, default).** On every write event (start, restart, config update) the directory is wiped and recreated, then only the entries declared by the current manifest are written; the directory is deleted on agent stop.
-**Persistent (`persistent: true`).** On every write event the directory is created if absent (`mkdir -p`) and existing contents are left in place. Config-managed files are written or overwritten in place; agent-created files are preserved untouched. 
+- **The `persistent` flag** controls whether the entry's on-disk path is wiped on sub-agent stop. Ephemeral entries are deleted on stop; persistent entries are kept.
+- **The sidecar manifest** drives reconciliation on every write event. Anything Agent Control wrote on the previous successful write is recorded in the manifest. On the next write, Agent Control diffs the manifest against the new declared set: paths it owned previously and no longer owns are deleted; paths it never owned are left alone.
 
-**Stale-agent cleanup on startup.** If a sub-agent that was deployed previously is no longer present in the fleet config when Agent Control starts (e.g., it was removed while Agent Control was stopped), its filesystem is deleted on start regardless of any `persistent` flags.
+The flag does **not** shield the entry from intentional removal: if you delete an entry from the agent type (or remove a key from a `dir_content_from_map` source map), the manifest diff catches it and the on-disk path is deleted on the next write event.
 
-| Event              | Ephemeral (`persistent: false`)        | Persistent (`persistent: true`)                        |
-|--------------------|----------------------------------------|--------------------------------------------------------|
-| Agent start        | Wipe + recreate + write managed files  | `mkdir -p` if absent; write managed files              |
-| Agent stop         | Directory deleted                      | Directory kept                                         |
-| Agent restart      | Wipe + recreate + write managed files  | Reconcile managed files; agent-created files preserved |
-| Config update      | Wipe + recreate + write managed files  | Overwrite managed files; agent-created files preserved |
-| Removed from fleet | Deleted by `ResourceCleaner` if exists | Deleted by `ResourceCleaner`                           |
+###### Sidecar manifest
+
+After every successful write, Agent Control writes `.ac-managed-paths.json` inside the sub-agent's filesystem directory listing the absolute paths it just wrote. This filename is **reserved** — agent types must not declare it.
+
+The manifest is the source of truth for "what Agent Control owns." Files the sub-agent process creates at runtime are never in the manifest, so they're invisible to reconciliation: they survive every write event, every sub-agent restart, and every config update. They're only removed if some declared ancestor directory is itself removed from the agent type (the `remove_dir_all` of the parent takes them as collateral) or if the agent is removed from the fleet.
+
+###### Lifecycle
+
+- **Ephemeral (`persistent: false`, default).** On sub-agent stop, the entry's on-disk path is deleted.
+- **Persistent (`persistent: true`).** On sub-agent stop, the entry's on-disk path is preserved.
+- **Removed from fleet.** When an agent is removed from the fleet config (via remote config or by being absent at AC startup after a previous deploy), its entire filesystem directory is deleted by `ResourceCleaner`. The `persistent` flag is bypassed.
+
+| Event              | Ephemeral (`persistent: false`)           | Persistent (`persistent: true`)                        |
+|--------------------|-------------------------------------------|--------------------------------------------------------|
+| Agent start        | Reconcile (manifest diff) + write         | Reconcile (manifest diff) + write                      |
+| Agent stop         | Path deleted                              | Path kept                                              |
+| Agent restart      | Reconcile + write                         | Reconcile + write                                      |
+| Config update      | Reconcile + write                         | Reconcile + write                                      |
+| Removed from fleet | Filesystem dir deleted by ResourceCleaner | Filesystem dir deleted by ResourceCleaner              |
+
+In all the "Reconcile + write" rows, agent-process-created files survive (not in the manifest, not declared, not deleted).
 
 ##### `packages`
 
-Defines OCI packages containing the executables and data to be downloaded and installed for the sub-agent. 
+Defines OCI packages containing the executables and data to be downloaded and installed for the sub-agent.
 This is a map where keys are package identifiers and values contain package metadata and download configuration.
 
 The value yaml look like:
@@ -538,9 +552,9 @@ The value yaml look like:
 ```
 
 Note that a Package version. Can be:
-  - A tag (`:v1.0.0`)
-  - A digest (`@sha256:...`)
-  - Both tag and digest (`:v1.0.0@sha256:...`), when both are specified the digest takes precedence.
+- A tag (`:v1.0.0`)
+- A digest (`@sha256:...`)
+- Both tag and digest (`:v1.0.0@sha256:...`), when both are specified the digest takes precedence.
 
 `public_key_url` is an optional field, when not configured signature verifications is skipped and logged with warn level.
 
@@ -793,7 +807,7 @@ Key-value pairs of the [Kubernetes Objects](https://kubernetes.io/docs/concepts/
   - `namespace`, a string.
   - `labels`: key-value pair of strings representing Kubernetes labels.
 - And a collection of arbitrary fields representing the actual data (e.g. the `spec`) of the object.
-  
+
 Most of Agent Control sub-agents currently deploy [Flux](https://fluxcd.io) CRs which end up in helm chart installation.
 
 You can check an [existing agent type with a Kubernetes deployment](../agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml) as an example. This file includes all necessary Flux CR configurations required for Agent Control to manage sub-agent deployments effectively. It serves as a comprehensive reference for understanding the integration and deployment process.
@@ -820,12 +834,12 @@ The first time it runs, whether it's using static configs or when already runnin
 2. Attempt to assemble the actual, effective config that the sub-agent will have.
 3. If the assembly is successful, attempt to deploy (spawn process or create Kubernetes resources) the sub-agent using the effective config.
 4. Once the sub-agent is deployed:
-    - Perform regular health checks.
-    - Restart it if it crashes, according to the configured restart policy (for on-host).
-    - Assure that the resources match the ones defined in the agent-type (for k8s).
+  - Perform regular health checks.
+  - Restart it if it crashes, according to the configured restart policy (for on-host).
+  - Assure that the resources match the ones defined in the agent-type (for k8s).
 5. If Fleet Control is enabled, the supervisor will listen for incoming remote configs different from the one currently in use:
-    - When receiving one, the supervisor will stop its workload and restart from step 1 again.
-    - If an empty config is passed it means that this agent should be retired, so the supervisor will just stop its workload and exit.
+  - When receiving one, the supervisor will stop its workload and restart from step 1 again.
+  - If an empty config is passed it means that this agent should be retired, so the supervisor will just stop its workload and exit.
 6. On failure of assembly or deployment, the supervisor will be kept alive, but will report itself as unhealthy. If FC is enabled, this offers the user the possibility of pushing a new remote config, in case the sub-agent was left in a bad state due to receiving an invalid one.
 
 Agent Control itself shares much of the behavior of a supervisor, that's how, if FC is enabled, it can receive remote configs (mainly the desired list of sub-agents) and apply them.

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -364,6 +364,164 @@ The files can be hardcoded, with the contents possibly containing templates, or 
 files can be templated, so a directory contains an arbitrary number of files (a place to use a
 `map[string]yaml` variable type). **The paths cannot be templated individually.**
 
+Every directory and every file is declared with a `kind`, and directory trees are built recursively via an `entries:` field. A directory's contents can also be templated from a `map[string]yaml` variable using `kind: dir_content_from_map`, the map's keys become filenames and the values become file contents.
+
+The example below uses these variables:
+
+```yaml
+variables:
+  config_agent:
+    description: "Newrelic infra configuration"
+    type: yaml
+    required: false
+    default: ""
+  config_integrations:
+    description: "map of YAML configs for the OHIs"
+    type: map[string]yaml
+    required: false
+    default: {}
+  config_logging:
+    description: "map of YAML config for logging"
+    type: map[string]yaml
+    required: false
+    default: {}
+```
+
+And this `filesystem` block:
+
+```yaml
+filesystem:
+  newrelic-infra.yaml:
+    kind: file
+    persistent: true
+    text: ${nr-var:config_agent}
+
+  config:
+    kind: dir
+    persistent: true
+
+  logging.d:
+    kind: dir_content_from_map
+    source: ${nr-var:config_logging}
+
+  agent:
+    kind: dir
+    entries:
+      data:
+        kind: dir
+        persistent: true
+      integrations.d:
+        kind: dir_content_from_map
+        source: ${nr-var:config_integrations}
+      newrelic-infra.yaml:
+        kind: file
+        text: ${nr-var:config_agent}
+```
+
+###### Worked examples
+
+Given these user-supplied values:
+
+```yaml
+config_agent: |
+  license_key: REDACTED
+  log:
+    level: info
+
+config_integrations:
+  nri-mysql.yaml: |
+    integrations:
+      - name: nri-mysql
+        env:
+          HOSTNAME: localhost
+  nri-redis.yaml: |
+    integrations:
+      - name: nri-redis
+        env:
+          HOSTNAME: localhost
+
+config_logging:
+  syslog.yaml: |
+    logs:
+      - name: syslog
+        file: /var/log/syslog
+```
+
+The runtime produces the following on disk under `${nr-sub:filesystem_agent_dir}`. Each kind is shown in isolation.
+
+**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` means it survives `ResourceCleaner` on teardown.
+
+```
+newrelic-infra.yaml      ← contents from ${nr-var:config_agent}
+```
+
+**`kind: dir`**: an explicitly declared directory. With no `entries:` it's just an (optionally persistent) empty directory; with `entries:` it builds a tree, where each child is itself any of the three kinds, including another `dir`, so recursion is uniform.
+
+```
+config/                  ← empty, persistent
+
+agent/
+├── data/                ← empty, persistent
+├── integrations.d/      ← projected from config_integrations (see below)
+│   ├── nri-mysql.yaml
+│   └── nri-redis.yaml
+└── newrelic-infra.yaml  ← contents from ${nr-var:config_agent}
+```
+
+**`kind: dir_content_from_map`**: a directory whose entries are projected from a `map[string]yaml` variable at deploy time. Map keys become filenames; map values become file bodies.
+
+```
+logging.d/
+└── syslog.yaml          ← contents from config_logging["syslog.yaml"]
+
+agent/integrations.d/
+├── nri-mysql.yaml       ← contents from config_integrations["nri-mysql.yaml"]
+└── nri-redis.yaml       ← contents from config_integrations["nri-redis.yaml"]
+```
+
+###### Entry kinds reference
+
+**`file`** — a single file with literal or templated content.
+
+| Field        | Required | Default | Description                                                  |
+|--------------|----------|---------|--------------------------------------------------------------|
+| `kind`       | yes      | —       | Must be `file`.                                              |
+| `text`       | yes      | —       | File body. May reference `${nr-var:…}` / `${nr-sub:…}`.      |
+| `persistent` | no       | `false` | If `true`, survives `ResourceCleaner`.                       |
+
+**`dir`** — an explicitly declared directory. Its children, if any, live under `entries:`.
+
+| Field        | Required | Default | Description                                                  |
+|--------------|----------|---------|--------------------------------------------------------------|
+| `kind`       | yes      | —       | Must be `dir`.                                               |
+| `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive.                  |
+| `persistent` | no       | `false` | If `true`, this directory and its tree survive cleanup.      |
+
+**`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.
+
+| Field        | Required | Default | Description                                                  |
+|--------------|----------|---------|--------------------------------------------------------------|
+| `kind`       | yes      | —       | Must be `dir_content_from_map`.                              |
+| `source`     | yes      | —       | Reference to a `map[string]yaml` variable (`${nr-var:…}`).   |
+| `persistent` | no       | `false` | If `true`, files projected here are not removed on cleanup.  |
+
+##### Persistence in Filesystem
+
+Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persistent:` (default `false`) that controls how the runtime treats it across the agent's lifecycle — start, stop, restart, config update, and removal from the fleet.
+
+**Ephemeral (`persistent: false`, default).** On every write event (start, restart, config update) the directory is wiped and recreated, then only the entries declared by the current manifest are written; the directory is deleted on agent stop.
+**Persistent (`persistent: true`).** On every write event the directory is created if absent (`mkdir -p`) and existing contents are left in place. Config-managed files are written or overwritten in place; agent-created files are preserved untouched. 
+
+**Stale-agent cleanup on startup.** If a sub-agent that was deployed previously is no longer present in the fleet config when Agent Control starts (e.g., it was removed while Agent Control was stopped), its filesystem is deleted on start regardless of any `persistent` flags.
+
+| Event              | Ephemeral (`persistent: false`)        | Persistent (`persistent: true`)                        |
+|--------------------|----------------------------------------|--------------------------------------------------------|
+| Agent start        | Wipe + recreate + write managed files  | `mkdir -p` if absent; write managed files              |
+| Agent stop         | Directory deleted                      | Directory kept                                         |
+| Agent restart      | Wipe + recreate + write managed files  | Reconcile managed files; agent-created files preserved |
+| Config update      | Wipe + recreate + write managed files  | Overwrite managed files; agent-created files preserved |
+| Removed from fleet | Deleted by `ResourceCleaner` if exists | Deleted by `ResourceCleaner`                           |
+
 ##### `packages`
 
 Defines OCI packages containing the executables and data to be downloaded and installed for the sub-agent. 

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -409,7 +409,8 @@ filesystem:
   newrelic-infra.yaml:
     kind: file
     persistent: true
-    text: ${nr-var:config_agent}
+    text: |
+      ${nr-var:config_agent}
 
   config:
     kind: dir
@@ -430,7 +431,8 @@ filesystem:
         source: ${nr-var:config_integrations}
       newrelic-infra.yaml:
         kind: file
-        text: ${nr-var:config_agent}
+        text: |
+          ${nr-var:config_agent}
 ```
 
 ###### Worked examples

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -221,10 +221,18 @@ deployment:
           version: ${nr-var:version}
   filesystem:
     config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+      kind: dir
+      entries:
+        newrelic-infra.yaml:
+          kind: file
+          text: |
+            ${nr-var:config_agent}
+    integrations.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    logging.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_logging}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
@@ -263,10 +271,18 @@ deployment:
           version: ${nr-var:version}
   filesystem:
     config:
-      newrelic-infra.yaml: |
-        ${nr-var:config_agent}
-    integrations.d: ${nr-var:config_integrations}
-    logging.d: ${nr-var:config_logging}
+      kind: dir
+      entries:
+        newrelic-infra.yaml:
+          kind: file
+          text: |
+            ${nr-var:config_agent}
+    integrations.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    logging.d:
+      kind: dir_content_from_map
+      source: ${nr-var:config_logging}
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe


### PR DESCRIPTION
Replaces the implicit map-of-maps `filesystem:` shape in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`. Migrates all 6 host registry YAMLs and existing test fixtures.                                                

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
