### PR TITLE
fix: add uninstall script into ac folder and delete .key to prevent r…

### DIFF
--- a/build/package/windows/install.ps1
+++ b/build/package/windows/install.ps1
@@ -127,6 +127,12 @@ Set-RestrictedAcl -Path $acDataDir
 Write-Host "Copying New Relic Agent Control program files..."
 Copy-Item -Path ".\newrelic-agent-control.exe" -Destination "$acProgramFilesDir"
 
+# Copy uninstall script if it exists
+if (Test-Path ".\uninstall.ps1") {
+    Copy-Item -Path ".\uninstall.ps1" -Destination "$acProgramFilesDir\uninstall.ps1"
+    Write-Host "Uninstall script copied to $acProgramFilesDir"
+}
+
 # Generate configuration based on inputs
 $localConfigPath = Join-Path $acLocalConfigDir 'local_config.yaml'
 

--- a/build/package/windows/uninstall.ps1
+++ b/build/package/windows/uninstall.ps1
@@ -11,6 +11,7 @@ if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Adm
 $serviceName = "newrelic-agent-control"
 $acDir = [IO.Path]::Combine($env:ProgramFiles, 'New Relic\newrelic-agent-control')
 $acExecPath = [IO.Path]::Combine($acDir, 'newrelic-agent-control.exe')
+$acKeysDir = [IO.Path]::Combine($acDir, 'keys')
 
 $markerPath = [IO.Path]::Combine($acDir, '.nr-ac-install')
 
@@ -31,6 +32,12 @@ if ($existingService) {
 if (Test-Path $acExecPath) {
     Write-Host "Deleting $acExecPath..."
     Remove-Item -Path $acExecPath -Force
+}
+
+# Remove the keys directory if exists
+if (Test-Path $acKeysDir) {
+    Write-Host "Removing keys directory..."
+    Remove-Item -Path $acKeysDir -Recurse -Force
 }
 
 if (Test-Path $markerPath) {


### PR DESCRIPTION
After uninstalling Agent Control on Windows, the `keys/agent-control-identity.key` file remains on disk. When reinstalling, the configuration generation fails with: ERROR could not generate System Identity's key-pair; invalid path: local key path already exists

### Changes
  1. **install.ps1**: Copy `uninstall.ps1` to the installation directory
  2. **uninstall.ps1**: Remove `keys/` directory during uninstallation to prevent conflicts on reinstalls
