### PR TITLE
refactor: config build

### DIFF
--- a/agent-control/tests/on_host/proxy.rs
+++ b/agent-control/tests/on_host/proxy.rs
@@ -1,11 +1,11 @@
 #![cfg(target_family = "unix")]
-use fake_opamp_server::FakeServer;
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::health::check_latest_health_status_was_healthy;
-use crate::common::{runtime::tokio_runtime, retry::retry};
-use crate::on_host::tools::config::create_agent_control_config_with_proxy;
+use crate::common::{retry::retry, runtime::tokio_runtime};
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -50,15 +50,11 @@ fn proxy_onhost_opamp_agent_control_local_effective_config() {
 
     let agents = "{}";
 
-    create_agent_control_config_with_proxy(
-        opamp_server_endpoint,
-        jwks_endpoint,
-        agents.to_string(),
-        local_dir.path().to_path_buf(),
-        Some(format!(
+    AgentControlConfigBuilder::new(opamp_server_endpoint, jwks_endpoint, agents)
+        .with_proxy(format!(
             "{{\"url\": \"{proxy_url}\", \"ca_bundle_dir\": \"{proxy_ca_dir}\"}}"
-        )),
-    );
+        ))
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/proxy.rs
+++ b/agent-control/tests/on_host/proxy.rs
@@ -48,9 +48,7 @@ fn proxy_onhost_opamp_agent_control_local_effective_config() {
         .jwks_endpoint()
         .replace("localhost", host_gateway.as_str());
 
-    let agents = "{}";
-
-    AgentControlConfigBuilder::new(opamp_server_endpoint, jwks_endpoint, agents)
+    AgentControlConfigBuilder::basic(opamp_server_endpoint, jwks_endpoint)
         .with_proxy(format!(
             "{{\"url\": \"{proxy_url}\", \"ca_bundle_dir\": \"{proxy_ca_dir}\"}}"
         ))

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -4,7 +4,7 @@ use crate::common::remote_config_status::check_latest_remote_config_status_is_ex
 use crate::common::retry::retry;
 use crate::common::retry::retry_never;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::create_local_config;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::fake_binary::assert_is_fake_binary;
 use crate::on_host::tools::fake_binary::build_fake_ac_binary;
 use crate::on_host::tools::fake_binary::build_invalid_fake_ac_binary;
@@ -12,7 +12,6 @@ use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
-use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_VERSION;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
@@ -326,32 +325,14 @@ fn create_self_update_local_config(
     local_dir: &Path,
     signature_verification_enabled: bool,
 ) {
-    let config = format!(
-        r#"
-host_id: integration-test
-fleet_control:
-  endpoint: {}
-  poll_interval: 5s
-  signature_validation:
-    public_key_server_url: {}
-agents: {{}}
-oci:
-  registry: {OCI_TEST_REGISTRY_URL}
-self_update:
-  enabled: true
-  signature_verification_enabled: {signature_verification_enabled}
-  package:
-    download:
-      oci:
-        registry: {OCI_TEST_REGISTRY_URL}
-        repository: test
-        public_key_url: {}
-"#,
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        signer.jwks_url()
-    );
-    create_local_config(AGENT_CONTROL_ID, config, local_dir.to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_oci_registry(OCI_TEST_REGISTRY_URL)
+        .with_self_update(
+            signature_verification_enabled,
+            "test",
+            signer.jwks_url().to_string(),
+        )
+        .write(local_dir.to_path_buf());
 }
 
 /// Pushes an invalid fake agent-control binary package to the OCI registry and signs it.

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -46,12 +46,9 @@ fn test_attributes_from_non_existing_agent_type() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -139,12 +136,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has empty config values
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -6,7 +6,7 @@ use crate::common::attributes::{
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
-use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -46,12 +46,12 @@ fn test_attributes_from_non_existing_agent_type() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -139,12 +139,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has empty config values
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -38,12 +38,9 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -116,12 +113,9 @@ fn onhost_opamp_sub_agent_with_no_local_config() {
     );
 
     let agent_id = "nr-sleep-agent";
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // There is no local configuration for the sub-agent
 

--- a/agent-control/tests/on_host/scenarios/empty_config.rs
+++ b/agent-control/tests/on_host/scenarios/empty_config.rs
@@ -6,7 +6,7 @@ use crate::{
         runtime::tokio_runtime,
     },
     on_host::tools::{
-        config::{create_agent_control_config, create_local_config},
+        config::{AgentControlConfigBuilder, create_local_config},
         custom_agent_type::CustomAgentType,
         instance_id::get_instance_id,
     },
@@ -38,12 +38,12 @@ fn onhost_opamp_sub_agent_set_empty_config_defaults_to_local() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -116,12 +116,12 @@ fn onhost_opamp_sub_agent_with_no_local_config() {
     );
 
     let agent_id = "nr-sleep-agent";
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // There is no local configuration for the sub-agent
 

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -5,7 +5,7 @@ use crate::{
         agent_control::start_agent_control_with_custom_config, retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
-        config::{create_agent_control_config, create_file, create_local_config},
+        config::{AgentControlConfigBuilder, create_file, create_local_config},
         custom_agent_type::DYNAMIC_AGENT_TYPE_FILENAME,
         instance_id::get_instance_id,
     },
@@ -145,12 +145,12 @@ fn run_file_logging_scenario(
     agent_type: "test/file_logging_agent:0.0.0"
 "#
     );
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.to_path_buf(),
-    );
+    )
+    .write(local_dir.to_path_buf());
 
     // Provide the initial local config for the sub-agent
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/file_logging.rs
+++ b/agent-control/tests/on_host/scenarios/file_logging.rs
@@ -145,12 +145,9 @@ fn run_file_logging_scenario(
     agent_type: "test/file_logging_agent:0.0.0"
 "#
     );
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.to_path_buf());
 
     // Provide the initial local config for the sub-agent
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -58,12 +58,9 @@ deployment:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.to_path_buf());
     create_local_config(
         agent_id.to_string(),
         NO_CONFIG.to_string(),
@@ -172,17 +169,14 @@ deployment:
     );
 
     // Create AC config
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        format!(
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
             r#"
   {agent_id}:
     agent_type: "test/test:0.0.0"
 "#
-        ),
-    )
-    .write(local_dir.to_path_buf());
+        ))
+        .write(local_dir.to_path_buf());
     // Values. Contains 3 variables: a YAML, a string, and a map[string]yaml (to create files in a directory)
     create_local_config(
         agent_id.to_string(),
@@ -337,12 +331,9 @@ deployment:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.to_path_buf());
 
     create_local_config(
         agent_id.to_string(),

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -6,7 +6,7 @@ use crate::{
         agent_control::start_agent_control_with_custom_config, retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
-        config::{create_agent_control_config, create_file, create_local_config},
+        config::{AgentControlConfigBuilder, create_file, create_local_config},
         custom_agent_type::DYNAMIC_AGENT_TYPE_FILENAME,
     },
 };
@@ -58,12 +58,12 @@ deployment:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.to_path_buf(),
-    );
+    )
+    .write(local_dir.to_path_buf());
     create_local_config(
         agent_id.to_string(),
         NO_CONFIG.to_string(),
@@ -172,7 +172,7 @@ deployment:
     );
 
     // Create AC config
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         format!(
@@ -181,8 +181,8 @@ deployment:
     agent_type: "test/test:0.0.0"
 "#
         ),
-        local_dir.to_path_buf(),
-    );
+    )
+    .write(local_dir.to_path_buf());
     // Values. Contains 3 variables: a YAML, a string, and a map[string]yaml (to create files in a directory)
     create_local_config(
         agent_id.to_string(),
@@ -337,12 +337,12 @@ deployment:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.to_path_buf(),
-    );
+    )
+    .write(local_dir.to_path_buf());
 
     create_local_config(
         agent_id.to_string(),

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -2,9 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
-use crate::on_host::tools::config::{
-    create_agent_control_config, create_file, create_local_config,
-};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_file, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -54,12 +52,12 @@ file:
         NO_CONFIG.to_string(),
         local_dir.path().into(),
     );
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -162,12 +160,12 @@ http:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
     create_local_config(
         sub_agent_id.to_string(),
         NO_CONFIG.to_string(),

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -52,12 +52,9 @@ file:
         NO_CONFIG.to_string(),
         local_dir.path().into(),
     );
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -160,12 +157,9 @@ http:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
     create_local_config(
         sub_agent_id.to_string(),
         NO_CONFIG.to_string(),

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -3,9 +3,7 @@ use crate::common::http_port::{available_port, status_server_url};
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::consts::NO_CONFIG;
-use crate::on_host::tools::config::{
-    create_agent_control_config_with_status_server, create_local_config,
-};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::defaults::{
@@ -43,14 +41,13 @@ fn test_http_status_endpoint_response() {
     );
 
     let status_server_port = available_port();
-    create_agent_control_config_with_status_server(
-        HOST_ID,
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-        status_server_port,
-    );
+    )
+    .with_status_server(status_server_port)
+    .write(local_dir.path().to_path_buf());
 
     create_local_config(
         AGENT_ID.to_string(),

--- a/agent-control/tests/on_host/scenarios/http_status_server.rs
+++ b/agent-control/tests/on_host/scenarios/http_status_server.rs
@@ -41,13 +41,10 @@ fn test_http_status_endpoint_response() {
     );
 
     let status_server_port = available_port();
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .with_status_server(status_server_port)
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .with_status_server(status_server_port)
+        .write(local_dir.path().to_path_buf());
 
     create_local_config(
         AGENT_ID.to_string(),

--- a/agent-control/tests/on_host/scenarios/install_agent_type.rs
+++ b/agent-control/tests/on_host/scenarios/install_agent_type.rs
@@ -4,13 +4,13 @@ use crate::common::attributes::{
 };
 use crate::common::retry::{retry, retry_never};
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::create_local_config;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
-    AGENT_CONTROL_ID, DYNAMIC_AGENT_TYPES_DIR, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+    DYNAMIC_AGENT_TYPES_DIR, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::{
@@ -77,28 +77,10 @@ fn start_agent_control_for_test(
     signer: &OCISigner,
     base_paths: &BasePaths,
 ) -> StartedAgentControl {
-    let config = format!(
-        r#"
-host_id: integration-test
-fleet_control:
-  endpoint: {}
-  poll_interval: 5s
-  signature_validation:
-    public_key_server_url: {}
-oci:
-  registry: "{OCI_TEST_REGISTRY_URL}"
-agent_types:
-  default_remote:
-    repository: test
-    signature_verification_enabled: true
-    public_key_url: {}
-agents: {{}}
-"#,
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        signer.jwks_url(),
-    );
-    create_local_config(AGENT_CONTROL_ID, config, base_paths.local_dir.clone());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_oci_registry(OCI_TEST_REGISTRY_URL)
+        .with_agent_types(true, "test", signer.jwks_url().to_string())
+        .write(base_paths.local_dir.clone());
 
     start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST)
 }

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -75,7 +75,8 @@ fn test_install_and_update_agent_remote_package_with_oci_registry() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_oci_registry(OCI_TEST_REGISTRY_URL)
         .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
@@ -182,7 +183,8 @@ fn test_unsigned_artifact_makes_remote_config_fail_with_oci_registry() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_oci_registry(OCI_TEST_REGISTRY_URL)
         .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -6,7 +6,7 @@ use crate::common::health::check_latest_health_status_was_healthy;
 use crate::common::remote_config_status::check_latest_remote_config_status;
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
@@ -75,12 +75,8 @@ fn test_install_and_update_agent_remote_package_with_oci_registry() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -186,12 +182,8 @@ fn test_unsigned_artifact_makes_remote_config_fail_with_oci_registry() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
@@ -40,12 +40,9 @@ fn onhost_opamp_sub_agent_invalid_remote_config() {
 "#,
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
 
@@ -129,12 +126,9 @@ fn test_invalid_config_executable_less_supervisor() {
         local_dir.path().to_path_buf(),
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -204,12 +198,9 @@ fn onhost_opamp_sub_agent_invalid_remote_config_rollback_previous_remote() {
 "#,
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
 

--- a/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/invalid_remote_config.rs
@@ -3,7 +3,7 @@ use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::{retry::retry, runtime::tokio_runtime};
 use crate::on_host::tools::config::load_remote_config_content;
-use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -40,12 +40,12 @@ fn onhost_opamp_sub_agent_invalid_remote_config() {
 "#,
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
 
@@ -129,12 +129,12 @@ fn test_invalid_config_executable_less_supervisor() {
         local_dir.path().to_path_buf(),
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -204,12 +204,12 @@ fn onhost_opamp_sub_agent_invalid_remote_config_rollback_previous_remote() {
 "#,
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
 

--- a/agent-control/tests/on_host/scenarios/memory_benchmark.rs
+++ b/agent-control/tests/on_host/scenarios/memory_benchmark.rs
@@ -48,7 +48,7 @@ fn test_memory_on_agent_substitution_and_version_update() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
         .with_oci_registry("non-existent:5000")
         .write(local_dir.path().to_path_buf());
 

--- a/agent-control/tests/on_host/scenarios/memory_benchmark.rs
+++ b/agent-control/tests/on_host/scenarios/memory_benchmark.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::health::check_latest_health_status;
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::create_agent_control_config_with_oci_registry;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -48,13 +48,9 @@ fn test_memory_on_agent_substitution_and_version_update() {
     let mut opamp_server = FakeServer::start(tokio_runtime().handle());
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    create_agent_control_config_with_oci_registry(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "non-existent:5000".to_string(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+        .with_oci_registry("non-existent:5000")
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/multiple_executables.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_executables.rs
@@ -6,7 +6,7 @@ use crate::{
         retry::retry, runtime::tokio_runtime,
     },
     on_host::tools::{
-        config::create_agent_control_config, custom_agent_type::CustomAgentType,
+        config::AgentControlConfigBuilder, custom_agent_type::CustomAgentType,
         instance_id::get_instance_id,
     },
 };
@@ -43,12 +43,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -101,12 +101,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/multiple_executables.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_executables.rs
@@ -43,12 +43,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -101,12 +98,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::{retry::retry, runtime::tokio_runtime};
-use crate::on_host::tools::config::create_agent_control_config;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -24,12 +24,8 @@ fn onhost_ac_multiconfig_agents_append() {
 
     let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -100,12 +96,8 @@ fn onhost_ac_multiconfig_agents_append_fails() {
 
     let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -175,12 +167,12 @@ fn onhost_sub_agent_multiconfig() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_remote_config.rs
@@ -24,7 +24,7 @@ fn onhost_ac_multiconfig_agents_append() {
 
     let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
 
-    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
         .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
@@ -96,7 +96,7 @@ fn onhost_ac_multiconfig_agents_append_fails() {
 
     let sleep_agent_type = CustomAgentType::default().build(local_dir.path().to_path_buf());
 
-    AgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint(), "{}")
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
         .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
@@ -167,12 +167,9 @@ fn onhost_sub_agent_multiconfig() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
+++ b/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
@@ -49,12 +49,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.path().to_path_buf());
 
     // Create local config to trigger the executable launch
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
+++ b/agent-control/tests/on_host/scenarios/no_orphan_processes.rs
@@ -4,7 +4,7 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::process_finder::find_processes_by_pattern;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -49,12 +49,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // Create local config to trigger the executable launch
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/oci_auth.rs
+++ b/agent-control/tests/on_host/scenarios/oci_auth.rs
@@ -1,13 +1,12 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::create_local_config;
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
-use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::{
     AGENT_CONTROL_MODE_ON_HOST, OCI_TEST_REGISTRY_URL,
@@ -213,34 +212,13 @@ fn create_ac_local_config(
     local_dir: &Path,
     agents: impl Into<String>,
 ) {
-    let config = format!(
-        r#"
-agents: {}
-host_id: integration-test
-fleet_control:
-  endpoint: {}
-  poll_interval: 5s
-  signature_validation:
-    public_key_server_url: {}
-oci:
-  registry: "{OCI_TEST_REGISTRY_URL}"
-  auth:
-    basic:
-      username: {OCI_TEST_REGISTRY_BASIC_AUTH_USERNAME}
-      password: {OCI_TEST_REGISTRY_BASIC_AUTH_PASSWORD}
-self_update:
-  enabled: true
-  signature_verification_enabled: true
-  package:
-    download:
-      oci:
-        repository: test
-        public_key_url: {}
-"#,
-        agents.into(),
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        signer.jwks_url()
-    );
-    create_local_config(AGENT_CONTROL_ID, config, local_dir.to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .with_oci_registry(OCI_TEST_REGISTRY_URL)
+        .with_oci_basic_auth(
+            OCI_TEST_REGISTRY_BASIC_AUTH_USERNAME,
+            OCI_TEST_REGISTRY_BASIC_AUTH_PASSWORD,
+        )
+        .with_self_update(true, "test", signer.jwks_url().to_string())
+        .write(local_dir.to_path_buf());
 }

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -36,13 +36,8 @@ fn onhost_opamp_agent_control_local_effective_config() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let agents = "{}";
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -83,13 +78,8 @@ fn onhost_opamp_agent_control_remote_effective_config() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let agents = "{}";
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -175,13 +165,8 @@ fn onhost_opamp_agent_control_accepts_unknown_fields_on_remote_config() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let agents = "{}";
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -246,12 +231,9 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -318,12 +300,9 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -387,12 +366,9 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has empty config values
     let agent_id = "nr-sleep-agent";
@@ -472,12 +448,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents.to_string(),
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(local_dir.path().to_path_buf());
 
     let sub_agent_id = AgentID::try_from("no-executables").unwrap();
     let local_values_config = "fake_variable: valid local config\n";

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -4,9 +4,7 @@ use crate::common::health::check_latest_health_status_was_healthy;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::{retry::retry, runtime::tokio_runtime};
 use crate::on_host::consts::NO_CONFIG;
-use crate::on_host::tools::config::{
-    create_agent_control_config, create_file, create_local_config,
-};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_file, create_local_config};
 use crate::on_host::tools::config::{create_remote_config, load_remote_config_content};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
@@ -39,12 +37,12 @@ fn onhost_opamp_agent_control_local_effective_config() {
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     let agents = "{}";
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -86,12 +84,12 @@ fn onhost_opamp_agent_control_remote_effective_config() {
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     let agents = "{}";
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -178,12 +176,12 @@ fn onhost_opamp_agent_control_accepts_unknown_fields_on_remote_config() {
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     let agents = "{}";
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -248,12 +246,12 @@ fn onhost_opamp_sub_agent_local_effective_config_with_env_var() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -320,12 +318,12 @@ fn onhost_opamp_sub_agent_remote_effective_config() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has local config values
     let agent_id = "nr-sleep-agent";
@@ -389,12 +387,12 @@ fn onhost_opamp_sub_agent_empty_local_effective_config() {
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // And the custom-agent has empty config values
     let agent_id = "nr-sleep-agent";
@@ -474,12 +472,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let sub_agent_id = AgentID::try_from("no-executables").unwrap();
     let local_values_config = "fake_variable: valid local config\n";

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::effective_config::check_latest_effective_config_is_expected;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
 use crate::common::{retry::retry, runtime::tokio_runtime};
-use crate::on_host::tools::config::create_agent_control_config;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use crate::on_host::tools::instance_id::get_instance_id;
 use fake_opamp_server::FakeServer;
@@ -29,12 +29,12 @@ fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     let agents = "{}";
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
-        agents.to_string(),
-        local_dir.path().to_path_buf(),
-    );
+        agents,
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -28,13 +28,8 @@ fn onhost_opamp_agent_control_remote_config_add_remove_add_agent() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let agents = "{}";
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),

--- a/agent-control/tests/on_host/scenarios/restarting_processes.rs
+++ b/agent-control/tests/on_host/scenarios/restarting_processes.rs
@@ -109,12 +109,9 @@ agents:
 "#
     );
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents)
+        .write(local_dir.path().to_path_buf());
 
     // Create local config to trigger the executable launch
     create_local_config(

--- a/agent-control/tests/on_host/scenarios/restarting_processes.rs
+++ b/agent-control/tests/on_host/scenarios/restarting_processes.rs
@@ -2,7 +2,7 @@ use crate::common::agent_control::start_agent_control_with_custom_config;
 use crate::common::process_finder::find_processes_by_pattern;
 use crate::common::retry::retry;
 use crate::common::runtime::tokio_runtime;
-use crate::on_host::tools::config::{create_agent_control_config, create_local_config};
+use crate::on_host::tools::config::{AgentControlConfigBuilder, create_local_config};
 use crate::on_host::tools::custom_agent_type::CustomAgentType;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::run::BasePaths;
@@ -109,12 +109,12 @@ agents:
 "#
     );
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     // Create local config to trigger the executable launch
     create_local_config(

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -10,7 +10,6 @@ use newrelic_agent_control::agent_control::defaults::{
     STORE_KEY_OPAMP_DATA_CONFIG, default_capabilities,
 };
 use newrelic_agent_control::agent_control::run::BasePaths;
-use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
 use newrelic_agent_control::on_host::file_store::{FileStore, build_config_name};
 use newrelic_agent_control::values::ConfigRepo;
 use newrelic_agent_control::values::config_repository::ConfigRepository;
@@ -18,30 +17,31 @@ use newrelic_agent_control::values::config_repository::ConfigRepository;
 pub struct AgentControlConfigBuilder {
     opamp_endpoint: String,
     jwks_endpoint: String,
-    agents: String,
-    oci_registry: String,
+    agents: Option<String>,
+    oci_registry: Option<String>,
     status_server_port: Option<u16>,
     proxy: Option<String>,
 }
 
 impl AgentControlConfigBuilder {
-    pub fn new(
-        opamp_endpoint: impl Into<String>,
-        jwks_endpoint: impl Into<String>,
-        agents: impl Into<String>,
-    ) -> Self {
+    pub fn basic(opamp_endpoint: impl Into<String>, jwks_endpoint: impl Into<String>) -> Self {
         Self {
             opamp_endpoint: opamp_endpoint.into(),
             jwks_endpoint: jwks_endpoint.into(),
-            agents: agents.into(),
-            oci_registry: OCI_TEST_REGISTRY_URL.to_string(),
+            agents: None,
+            oci_registry: None,
             status_server_port: None,
             proxy: None,
         }
     }
 
+    pub fn with_agents(mut self, agents: impl Into<String>) -> Self {
+        self.agents = Some(agents.into());
+        self
+    }
+
     pub fn with_oci_registry(mut self, registry: impl Into<String>) -> Self {
-        self.oci_registry = registry.into();
+        self.oci_registry = Some(registry.into());
         self
     }
 
@@ -50,7 +50,7 @@ impl AgentControlConfigBuilder {
         self
     }
 
-    // This is used in `proxy.rs`, which isn't automatized.
+    // This is used in `proxy.rs`, which isn't automated.
     // Therefore, we need to allow dead code here.
     #[allow(dead_code)]
     pub fn with_proxy(mut self, proxy: impl Into<String>) -> Self {
@@ -64,6 +64,11 @@ impl AgentControlConfigBuilder {
             .map(|p| format!("proxy: {p}"))
             .unwrap_or_default();
 
+        let oci_config = self
+            .oci_registry
+            .map(|r| format!("oci:\n  registry: \"{r}\""))
+            .unwrap_or_default();
+
         let status_server_config = self
             .status_server_port
             .map(|port| {
@@ -75,6 +80,8 @@ impl AgentControlConfigBuilder {
             })
             .unwrap_or_default();
 
+        let agents = self.agents.as_deref().unwrap_or("{}");
+
         let agent_control_config = format!(
             r#"
 host_id: integration-test
@@ -83,16 +90,13 @@ fleet_control:
   poll_interval: 5s
   signature_validation:
     public_key_server_url: {jwks_endpoint}
-oci:
-  registry: "{oci_registry}"
 agents: {agents}
+{oci_config}
 {proxy_config}
 {status_server_config}
 "#,
             opamp_endpoint = self.opamp_endpoint,
             jwks_endpoint = self.jwks_endpoint,
-            oci_registry = self.oci_registry,
-            agents = self.agents,
         );
 
         create_file(

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -17,10 +17,26 @@ use newrelic_agent_control::values::config_repository::ConfigRepository;
 pub struct AgentControlConfigBuilder {
     opamp_endpoint: String,
     jwks_endpoint: String,
+
     agents: Option<String>,
     oci_registry: Option<String>,
+    oci_basic_auth: Option<(String, String)>,
     status_server_port: Option<u16>,
     proxy: Option<String>,
+    self_update: Option<SelfUpdateConfig>,
+    agent_types: Option<AgentTypes>,
+}
+
+struct SelfUpdateConfig {
+    signature_verification_enabled: bool,
+    repository: String,
+    public_key_url: String,
+}
+
+struct AgentTypes {
+    signature_verification_enabled: bool,
+    repository: String,
+    public_key_url: String,
 }
 
 impl AgentControlConfigBuilder {
@@ -30,8 +46,11 @@ impl AgentControlConfigBuilder {
             jwks_endpoint: jwks_endpoint.into(),
             agents: None,
             oci_registry: None,
+            oci_basic_auth: None,
             status_server_port: None,
             proxy: None,
+            self_update: None,
+            agent_types: None,
         }
     }
 
@@ -40,8 +59,17 @@ impl AgentControlConfigBuilder {
         self
     }
 
-    pub fn with_oci_registry(mut self, registry: impl Into<String>) -> Self {
-        self.oci_registry = Some(registry.into());
+    pub fn with_oci_registry(mut self, oci_registry: impl Into<String>) -> Self {
+        self.oci_registry = Some(oci_registry.into());
+        self
+    }
+
+    pub fn with_oci_basic_auth(
+        mut self,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        self.oci_basic_auth = Some((username.into(), password.into()));
         self
     }
 
@@ -52,6 +80,34 @@ impl AgentControlConfigBuilder {
 
     // This is used in `proxy.rs`, which isn't automated.
     // Therefore, we need to allow dead code here.
+    pub fn with_self_update(
+        mut self,
+        signature_verification_enabled: bool,
+        repository: impl Into<String>,
+        public_key_url: impl Into<String>,
+    ) -> Self {
+        self.self_update = Some(SelfUpdateConfig {
+            signature_verification_enabled,
+            repository: repository.into(),
+            public_key_url: public_key_url.into(),
+        });
+        self
+    }
+
+    pub fn with_agent_types(
+        mut self,
+        signature_verification_enabled: bool,
+        repository: impl Into<String>,
+        public_key_url: impl Into<String>,
+    ) -> Self {
+        self.agent_types = Some(AgentTypes {
+            signature_verification_enabled,
+            repository: repository.into(),
+            public_key_url: public_key_url.into(),
+        });
+        self
+    }
+
     #[allow(dead_code)]
     pub fn with_proxy(mut self, proxy: impl Into<String>) -> Self {
         self.proxy = Some(proxy.into());
@@ -59,6 +115,8 @@ impl AgentControlConfigBuilder {
     }
 
     pub fn write(self, local_dir: PathBuf) {
+        let agents = self.agents.as_deref().unwrap_or("{}");
+
         let proxy_config = self
             .proxy
             .map(|p| format!("proxy: {p}"))
@@ -66,7 +124,18 @@ impl AgentControlConfigBuilder {
 
         let oci_config = self
             .oci_registry
-            .map(|r| format!("oci:\n  registry: \"{r}\""))
+            .map(|r| {
+                let auth = self
+                    .oci_basic_auth
+                    .map(|(username, password)| {
+                        format!(
+                            "  auth:\n  basic:\n    username: {username}\n    password: {password}"
+                        )
+                    })
+                    .unwrap_or_default();
+
+                format!("oci:\n  registry: \"{}\"\n{}", r, auth)
+            })
             .unwrap_or_default();
 
         let status_server_config = self
@@ -80,23 +149,53 @@ impl AgentControlConfigBuilder {
             })
             .unwrap_or_default();
 
-        let agents = self.agents.as_deref().unwrap_or("{}");
+        let self_update_config = self
+            .self_update
+            .map(|su| {
+                format!(
+                    r#"self_update:
+  enabled: true
+  signature_verification_enabled: {}
+  package:
+    download:
+      oci:
+        repository: {}
+        public_key_url: {}"#,
+                    su.signature_verification_enabled, su.repository, su.public_key_url,
+                )
+            })
+            .unwrap_or_default();
+
+        let agent_types_config = self
+            .agent_types
+            .map(|at| {
+                format!(
+                    r#"agent_types:
+  default_remote:
+    repository: {}
+    signature_verification_enabled: {}
+    public_key_url: {}"#,
+                    at.repository, at.signature_verification_enabled, at.public_key_url,
+                )
+            })
+            .unwrap_or_default();
 
         let agent_control_config = format!(
             r#"
 host_id: integration-test
 fleet_control:
-  endpoint: {opamp_endpoint}
+  endpoint: {}
   poll_interval: 5s
   signature_validation:
-    public_key_server_url: {jwks_endpoint}
+    public_key_server_url: {}
 agents: {agents}
-{oci_config}
 {proxy_config}
+{oci_config}
 {status_server_config}
+{self_update_config}
+{agent_types_config}
 "#,
-            opamp_endpoint = self.opamp_endpoint,
-            jwks_endpoint = self.jwks_endpoint,
+            self.opamp_endpoint, self.jwks_endpoint,
         );
 
         create_file(

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -129,7 +129,7 @@ impl AgentControlConfigBuilder {
                     .oci_basic_auth
                     .map(|(username, password)| {
                         format!(
-                            "  auth:\n  basic:\n    username: {username}\n    password: {password}"
+                            "  auth:\n    basic:\n      username: {username}\n      password: {password}"
                         )
                     })
                     .unwrap_or_default();

--- a/agent-control/tests/on_host/tools/config.rs
+++ b/agent-control/tests/on_host/tools/config.rs
@@ -15,110 +15,94 @@ use newrelic_agent_control::on_host::file_store::{FileStore, build_config_name};
 use newrelic_agent_control::values::ConfigRepo;
 use newrelic_agent_control::values::config_repository::ConfigRepository;
 
-/// Creates the agent-control config given an opamp_server_endpoint
-/// and a list of agents on the specified local_dir.
-pub fn create_agent_control_config(
-    opamp_server_endpoint: String,
+pub struct AgentControlConfigBuilder {
+    opamp_endpoint: String,
     jwks_endpoint: String,
     agents: String,
-    local_dir: PathBuf,
-) {
-    create_agent_control_config_with_proxy(
-        opamp_server_endpoint,
-        jwks_endpoint,
-        OCI_TEST_REGISTRY_URL.to_string(),
-        agents,
-        local_dir,
-        None,
-    );
-}
-
-/// Creates the agent-control config given an opamp_server_endpoint
-/// and a list of agents on the specified local_dir.
-pub fn create_agent_control_config_with_oci_registry(
-    opamp_server_endpoint: String,
-    jwks_endpoint: String,
     oci_registry: String,
-    agents: String,
-    local_dir: PathBuf,
-) {
-    create_agent_control_config_with_proxy(
-        opamp_server_endpoint,
-        jwks_endpoint,
-        oci_registry,
-        agents,
-        local_dir,
-        None,
-    );
+    status_server_port: Option<u16>,
+    proxy: Option<String>,
 }
 
-/// Extends [create_agent_control_config] enabling the HTTP status server on the given port.
-pub fn create_agent_control_config_with_status_server(
-    host_id: &str,
-    opamp_server_endpoint: String,
-    jwks_endpoint: String,
-    agents: String,
-    local_dir: PathBuf,
-    status_server_port: u16,
-) {
-    let agent_control_config = format!(
-        r#"
-host_id: {host_id}
+impl AgentControlConfigBuilder {
+    pub fn new(
+        opamp_endpoint: impl Into<String>,
+        jwks_endpoint: impl Into<String>,
+        agents: impl Into<String>,
+    ) -> Self {
+        Self {
+            opamp_endpoint: opamp_endpoint.into(),
+            jwks_endpoint: jwks_endpoint.into(),
+            agents: agents.into(),
+            oci_registry: OCI_TEST_REGISTRY_URL.to_string(),
+            status_server_port: None,
+            proxy: None,
+        }
+    }
+
+    pub fn with_oci_registry(mut self, registry: impl Into<String>) -> Self {
+        self.oci_registry = registry.into();
+        self
+    }
+
+    pub fn with_status_server(mut self, port: u16) -> Self {
+        self.status_server_port = Some(port);
+        self
+    }
+
+    // This is used in `proxy.rs`, which isn't automatized.
+    // Therefore, we need to allow dead code here.
+    #[allow(dead_code)]
+    pub fn with_proxy(mut self, proxy: impl Into<String>) -> Self {
+        self.proxy = Some(proxy.into());
+        self
+    }
+
+    pub fn write(self, local_dir: PathBuf) {
+        let proxy_config = self
+            .proxy
+            .map(|p| format!("proxy: {p}"))
+            .unwrap_or_default();
+
+        let status_server_config = self
+            .status_server_port
+            .map(|port| {
+                format!(
+                    r#"server:
+  enabled: true
+  port: {port}"#
+                )
+            })
+            .unwrap_or_default();
+
+        let agent_control_config = format!(
+            r#"
+host_id: integration-test
 fleet_control:
-  endpoint: {opamp_server_endpoint}
+  endpoint: {opamp_endpoint}
   poll_interval: 5s
   signature_validation:
     public_key_server_url: {jwks_endpoint}
-agents: {agents}
-server:
-  enabled: true
-  port: {status_server_port}
-"#,
-    );
-    create_file(
-        agent_control_config,
-        local_dir
-            .join(FOLDER_NAME_LOCAL_DATA)
-            .join(AGENT_CONTROL_ID)
-            .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)),
-    );
-}
-
-/// Extends [create_agent_control_config] with a proxy configuration parameter.
-pub fn create_agent_control_config_with_proxy(
-    opamp_server_endpoint: String,
-    jwks_endpoint: String,
-    oci_registry: String,
-    agents: String,
-    local_dir: PathBuf,
-    proxy: Option<String>,
-) {
-    let proxy_config = proxy
-        .map(|config| format!("proxy: {config}"))
-        .unwrap_or_default();
-
-    let agent_control_config = format!(
-        r#"
-host_id: integration-test
-fleet_control:
-  endpoint: {}
-  poll_interval: 5s
-  signature_validation:
-    public_key_server_url: {}
 oci:
-  registry: "{}"
-agents: {}
-{}
+  registry: "{oci_registry}"
+agents: {agents}
+{proxy_config}
+{status_server_config}
 "#,
-        opamp_server_endpoint, jwks_endpoint, oci_registry, agents, proxy_config,
-    );
-    create_file(
-        agent_control_config,
-        local_dir
-            .join(FOLDER_NAME_LOCAL_DATA)
-            .join(AGENT_CONTROL_ID)
-            .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)),
-    );
+            opamp_endpoint = self.opamp_endpoint,
+            jwks_endpoint = self.jwks_endpoint,
+            oci_registry = self.oci_registry,
+            agents = self.agents,
+        );
+
+        create_file(
+            agent_control_config,
+            local_dir
+                .join(FOLDER_NAME_LOCAL_DATA)
+                .join(AGENT_CONTROL_ID)
+                .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG)),
+        );
+    }
 }
 
 pub fn create_file(content: impl Into<String>, path: PathBuf) {

--- a/agent-control/tests/on_host/verify_executor.rs
+++ b/agent-control/tests/on_host/verify_executor.rs
@@ -11,7 +11,7 @@ use opamp_client::opamp::proto::any_value::Value;
 use tempfile::tempdir;
 
 use crate::{
-    common::runtime::tokio_runtime, on_host::tools::config::create_agent_control_config,
+    common::runtime::tokio_runtime, on_host::tools::config::AgentControlConfigBuilder,
     on_host::tools::instance_id::get_instance_id,
 };
 use fake_opamp_server::FakeServer;
@@ -29,12 +29,12 @@ fn test_verify_executor() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
     let agents = "{}".to_string();
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         opamp_server.endpoint(),
         opamp_server.jwks_endpoint(),
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -112,12 +112,12 @@ fn test_verify_executor_opamp_connectivity_failure() {
     let unreachable_jwks_endpoint = "http://localhost:19999/jwks".to_string();
     let agents = "{}".to_string();
 
-    create_agent_control_config(
+    AgentControlConfigBuilder::new(
         unreachable_opamp_endpoint,
         unreachable_jwks_endpoint,
         agents,
-        local_dir.path().to_path_buf(),
-    );
+    )
+    .write(local_dir.path().to_path_buf());
 
     let result = ProcessVerifyExecutor::default().execute(
         binary_path(),

--- a/agent-control/tests/on_host/verify_executor.rs
+++ b/agent-control/tests/on_host/verify_executor.rs
@@ -27,14 +27,9 @@ fn test_verify_executor() {
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
     let opamp_server = FakeServer::start(tokio_runtime().handle());
-    let agents = "{}".to_string();
 
-    AgentControlConfigBuilder::new(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(local_dir.path().to_path_buf());
 
     let base_paths = BasePaths {
         local_dir: local_dir.path().to_path_buf(),
@@ -108,16 +103,11 @@ fn test_verify_executor_opamp_connectivity_failure() {
     let local_dir = tempdir().expect("failed to create local temp dir");
     let remote_dir = tempdir().expect("failed to create remote temp dir");
 
-    let unreachable_opamp_endpoint = "http://localhost:19999".to_string();
-    let unreachable_jwks_endpoint = "http://localhost:19999/jwks".to_string();
-    let agents = "{}".to_string();
+    let unreachable_opamp_endpoint = "http://localhost:19999";
+    let unreachable_jwks_endpoint = "http://localhost:19999/jwks";
 
-    AgentControlConfigBuilder::new(
-        unreachable_opamp_endpoint,
-        unreachable_jwks_endpoint,
-        agents,
-    )
-    .write(local_dir.path().to_path_buf());
+    AgentControlConfigBuilder::basic(unreachable_opamp_endpoint, unreachable_jwks_endpoint)
+        .write(local_dir.path().to_path_buf());
 
     let result = ProcessVerifyExecutor::default().execute(
         binary_path(),


### PR DESCRIPTION
Simplify agent control config creation in onhost integration tests.

Other details:

* `test_ac_log_to_file_as_root`, `onhost_ac_multiconfig_agents_append_fails` and `self_instrumentation_otel_exports_logs_and_metrics_as_root` don't use it because I judged these are not so common configs, and adding support for them would imply modifications in all other tests. So I preferred to keep a more opinionated struct instead of more general.