### PR TITLE
Feat/filesystem persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ coverage/
 
 # zig compiler
 .zig-cache/
+
+# Sidecar manifest written by Agent Control's filesystem rendering.
+.ac-managed-paths.json

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ coverage/
 # zig compiler
 .zig-cache/
 
-# Sidecar manifest written by Agent Control's filesystem rendering.
+# manifest written by Agent Control's filesystem rendering.
 .ac-managed-paths.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Remember that the keywords that you can use are the following:
 - Agent type definitions now tolerate unknown fields for forward compatibility.
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
+- Add new persistence behavior for filesystems in the agent type allowing to set a folder or file as persistent to have different behaviors on stop/start/restart of an agent, it also adds resource cleaning after an agent is removed.
 
 ## v1.17.0 - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Remember that the keywords that you can use are the following:
 - Agent type definitions now tolerate unknown fields for forward compatibility.
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
-- On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a sidecar `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
+- On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 
 ## v1.17.0 - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Remember that the keywords that you can use are the following:
 - Agent type definitions now tolerate unknown fields for forward compatibility.
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
-- Add new persistence behavior for filesystems in the agent type allowing to set a folder or file as persistent to have different behaviors on stop/start/restart of an agent, it also adds resource cleaning after an agent is removed.
+- On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a sidecar `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 
 ## v1.17.0 - 2026-06-16
 

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -78,6 +78,15 @@ deployment:
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
+    # Agent data root (NRIA_AGENT_DIR). Persistent so the agent's stored data survives restarts
+    newrelic-infra:
+      kind: dir
+      persistent: true
+      entries:
+        # NRIA_AGENT_TEMP_DIR: fluent-bit scratch that the agent does not clean up. Declared
+        # ephemeral so AC reclaims it on every (re)start instead of letting it grow unbounded.
+        tmp:
+          kind: dir
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
@@ -90,12 +99,6 @@ deployment:
         # Otherwise, a user could write data to a folder with lower permissions and potentially escalate privileges.
         # For the same reason we are also changing the location of the integration binaries.
         NRIA_AGENT_DIR: "${nr-sub:filesystem_agent_dir}/newrelic-infra"
-        # TODO
-        # This is a non public infra-agent config variable that allows us to change the location of the agent temporary files, which is used currently
-        # for storing fluent-bit generated configuration files. Currently infra-agent does not clean-up on start this directory if
-        # not on the default location, making this configs to potentially grow indefinitely with fluent-bit generated files.
-        # In the future this clean up process should be handled by the infra-agent itself or by AC file system clean up policies (same as the ones
-        # that are going to remove integration configs whenever variables are removed)
         NRIA_AGENT_TEMP_DIR: "${nr-sub:filesystem_agent_dir}/newrelic-infra/tmp"
         NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"
         NRIA_SAFE_BIN_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -74,15 +74,24 @@ deployment:
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
-    # this is needed in order to create the logging integration directory expected by fluentBit
+    # Agent data root (NRIA_AGENT_DIR). Persistent so the agent's stored data survives restarts
     newrelic-infra:
       kind: dir
+      persistent: true
       entries:
+        # NRIA_AGENT_TEMP_DIR: fluent-bit scratch that the agent does not clean up. Declared
+        # ephemeral so AC reclaims it on every (re)start instead of letting it grow unbounded.
+        tmp:
+          kind: dir
+        # Logging integration directory expected by fluentBit; persistent (like its parent) so any
+        # state it holds survives restarts.
         newrelic-integrations:
           kind: dir
+          persistent: true
           entries:
             logging:
               kind: dir
+              persistent: true
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
@@ -96,12 +105,6 @@ deployment:
         # For the same reason we are also changing the location of the integration binaries.
         NRIA_APP_DATA_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra"
         NRIA_AGENT_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra"
-        # TODO
-        # This is a non public infra-agent config variable that allows us to change the location of the agent temporary files, which is used currently
-        # for storing fluent-bit generated configuration files. Currently infra-agent does not clean-up on start this directory if
-        # not on the default location, making this configs to potentially grow indefinitely with fluent-bit generated files.
-        # In the future this clean up process should be handled by the infra-agent itself or by AC file system clean up policies (same as the ones
-        # that are going to remove integration configs whenever variables are removed)
         NRIA_AGENT_TEMP_DIR: "${nr-sub:filesystem_agent_dir}\\newrelic-infra\\tmp"
         # On windows, logs are written to 'NRIA_APP_DATA_DIR/newrelic-infra.log' and this cannot be disabled.
         # To avoid disks exhaustion issues, a default log rotation policy is applied to this log file.

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -2,13 +2,14 @@
 
 use fs::directory_manager::DirectoryManager;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use thiserror::Error;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::agent_control::agent_id::AgentID;
+use crate::agent_control::defaults::RESERVED_AGENT_IDS;
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::opamp::instance_id::storer::{InstanceIDStorer, StorerError};
 use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
@@ -19,6 +20,8 @@ use super::{ResourceCleaner, ResourceCleanerError};
 /// delegating to the same storers that wrote it, also recursively deletes the sub-agent's
 /// dedicated filesystem directory, the `persistent` flag is bypassed here because the agent
 /// has been removed from the fleet.
+/// The same removal logic is reused at startup by [`Self::purge_stale_agents`] to reclaim the
+/// resources of agents removed from the fleet config while Agent Control was stopped.
 pub struct OnHostCleaner<S, C, D>
 where
     S: InstanceIDStorer,
@@ -28,6 +31,7 @@ where
     instance_id_storer: Arc<S>,
     config_repo: Arc<C>,
     agent_filesystem_base: PathBuf,
+    fleet_data_base: PathBuf,
     dir_manager: Arc<D>,
 }
 
@@ -42,13 +46,80 @@ where
         instance_id_storer: Arc<S>,
         config_repo: Arc<C>,
         agent_filesystem_base: PathBuf,
+        fleet_data_base: PathBuf,
         dir_manager: Arc<D>,
     ) -> Self {
         Self {
             instance_id_storer,
             config_repo,
             agent_filesystem_base,
+            fleet_data_base,
             dir_manager,
+        }
+    }
+
+    /// Deletes all on-disk resources Agent Control owns for `agent_id`: its stored remote config,
+    /// its OpAMP instance id, and its dedicated filesystem directory.
+    fn remove_agent_resources(&self, agent_id: &AgentID) -> Result<(), OnHostCleanerError> {
+        debug!(%agent_id, "Cleaning remote config data");
+        self.config_repo
+            .delete_remote(agent_id)
+            .map_err(OnHostCleanerError::RemoteConfig)?;
+
+        debug!(%agent_id, "Cleaning opamp identifier data");
+        self.instance_id_storer
+            .delete(agent_id)
+            .map_err(OnHostCleanerError::InstanceId)?;
+
+        let fs_dir = self.agent_filesystem_base.join(agent_id);
+        debug!(%agent_id, path = ?fs_dir, "Cleaning agent filesystem directory");
+        self.dir_manager
+            .delete(&fs_dir)
+            .map_err(|err| OnHostCleanerError::Filesystem {
+                path: fs_dir,
+                source: err,
+            })
+    }
+
+    /// At startup, reclaims the resources of any agent that is no longer in the agents config.
+    pub fn purge_stale_agents<'a>(&self, configured_agent_ids: impl IntoIterator<Item = &'a str>) {
+        let mut skip: HashSet<String> = configured_agent_ids.into_iter().map(String::from).collect();
+        skip.extend(RESERVED_AGENT_IDS.iter().map(|id| id.to_string()));
+
+        let mut names: HashSet<String> = HashSet::new();
+        names.extend(self.agent_dir_names(&self.agent_filesystem_base));
+        names.extend(self.agent_dir_names(&self.fleet_data_base));
+
+        for name in names {
+            if skip.contains(&name) {
+                continue;
+            }
+            let agent_id = match AgentID::try_from(name.as_str()) {
+                Ok(id) => id,
+                Err(err) => {
+                    warn!(?err, name, "skipping stale directory with invalid agent id");
+                    continue;
+                }
+            };
+            tracing::info!(%agent_id, "reclaiming resources of agent no longer in fleet config");
+            if let Err(err) = self.remove_agent_resources(&agent_id) {
+                warn!(?err, %agent_id, "failed to reclaim stale agent resources");
+            }
+        }
+    }
+
+    /// Lists the immediate child directory names under `base` (the per-agent subdirectories).
+    /// A missing `base` yields no names; a listing error is logged and treated as empty.
+    fn agent_dir_names(&self, base: &Path) -> Vec<String> {
+        match self.dir_manager.list(base) {
+            Ok(entries) => entries
+                .iter()
+                .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+                .collect(),
+            Err(err) => {
+                warn!(?err, ?base, "cannot list agent directory for stale cleanup");
+                Vec::new()
+            }
         }
     }
 }
@@ -68,26 +139,7 @@ where
         if agent_id == &AgentID::AgentControl {
             return Err(OnHostCleanerError::AgentControlId.into());
         }
-
-        debug!(%agent_id, "Cleaning remote config data");
-        self.config_repo
-            .delete_remote(agent_id)
-            .map_err(OnHostCleanerError::RemoteConfig)?;
-
-        debug!(%agent_id, "Cleaning opamp identifier data");
-        self.instance_id_storer
-            .delete(agent_id)
-            .map_err(OnHostCleanerError::InstanceId)?;
-
-        let fs_dir = self.agent_filesystem_base.join(agent_id);
-        debug!(%agent_id, path = ?fs_dir, "Cleaning agent filesystem directory");
-        self.dir_manager
-            .delete(&fs_dir)
-            .map_err(|err| OnHostCleanerError::Filesystem {
-                path: fs_dir,
-                source: err,
-            })?;
-
+        self.remove_agent_resources(agent_id)?;
         Ok(())
     }
 }
@@ -118,48 +170,10 @@ impl From<OnHostCleanerError> for ResourceCleanerError {
     }
 }
 
-/// Removes filesystem directories under `agent_filesystem_base` whose name does not match a
-/// currently-configured agent ID. This handles "agent removed from fleet config while Agent
-/// Control was stopped": on next start, the orphaned directory is reclaimed.
-pub fn purge_stale_agent_filesystems<'a>(
-    dir_manager: &impl DirectoryManager,
-    agent_filesystem_base: &std::path::Path,
-    configured_agent_ids: impl IntoIterator<Item = &'a str>,
-) {
-    let configured: HashSet<&str> = configured_agent_ids.into_iter().collect();
-
-    let entries = match dir_manager.list(agent_filesystem_base) {
-        Ok(entries) => entries,
-        Err(err) => {
-            tracing::warn!(
-                ?err,
-                path = ?agent_filesystem_base,
-                "skipping stale-agent filesystem cleanup: cannot read base dir"
-            );
-            return;
-        }
-    };
-
-    for path in entries {
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        if configured.contains(name) {
-            continue;
-        }
-        tracing::info!(
-            path = ?path,
-            "purging filesystem directory of agent no longer in fleet config"
-        );
-        if let Err(err) = dir_manager.delete(&path) {
-            tracing::warn!(?err, ?path, "failed to purge stale agent filesystem dir");
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_control::defaults::AGENT_CONTROL_ID;
     use crate::opamp::instance_id::storer::tests::MockInstanceIDStorer;
     use crate::values::config_repository::tests::MockConfigRepository;
     use ::fs::directory_manager::mock::MockDirectoryManager;
@@ -176,6 +190,10 @@ mod tests {
 
     fn fs_base() -> PathBuf {
         PathBuf::from("/var/lib/newrelic-agent-control/filesystem")
+    }
+
+    fn fleet_base() -> PathBuf {
+        PathBuf::from("/var/lib/newrelic-agent-control/fleet-data")
     }
 
     #[test]
@@ -204,6 +222,7 @@ mod tests {
             Arc::new(instance_id_storer),
             Arc::new(config_repo),
             fs_base(),
+            fleet_base(),
             Arc::new(dir_manager),
         );
 
@@ -231,6 +250,7 @@ mod tests {
             Arc::new(instance_id_storer),
             Arc::new(config_repo),
             fs_base(),
+            fleet_base(),
             Arc::new(dir_manager),
         );
 
@@ -251,6 +271,7 @@ mod tests {
             Arc::new(instance_id_storer),
             Arc::new(config_repo),
             PathBuf::new(),
+            PathBuf::new(),
             Arc::new(dir_manager),
         );
 
@@ -259,41 +280,136 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Subdirs under the filesystem base whose names are not in the configured-agents set are
-    /// removed; configured ones survive.
-    #[test]
-    fn purge_stale_agent_filesystems_removes_only_orphans() {
-        let kept_path = fs_base().join("kept");
-        let orphan_path = fs_base().join("orphan");
-
-        let mut dir_manager = MockDirectoryManager::new();
-        dir_manager.should_list(&fs_base(), vec![kept_path.clone(), orphan_path.clone()]);
-        dir_manager.should_delete(&orphan_path);
-        // `kept` is in the configured set → no `delete` call expected for it.
-
-        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["kept"]);
+    fn cleaner(
+        instance_id_storer: MockInstanceIDStorer,
+        config_repo: MockConfigRepository,
+        dir_manager: MockDirectoryManager,
+    ) -> OnHostCleaner<MockInstanceIDStorer, MockConfigRepository, MockDirectoryManager> {
+        OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            fs_base(),
+            fleet_base(),
+            Arc::new(dir_manager),
+        )
     }
 
+    /// Orphans (agents no longer configured) are fully reclaimed — remote config, instance id and
+    /// filesystem dir — and discovered from BOTH the filesystem and fleet-data bases. Configured
+    /// agents survive.
     #[test]
-    fn purge_stale_agent_filesystems_is_noop_on_empty_base() {
+    fn purge_reclaims_orphans_from_filesystem_and_fleet_data() {
+        let orphan_fs = agent_id("orphan-fs");
+        let orphan_fleet = agent_id("orphan-fleet");
+
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_list(
+            &fs_base(),
+            vec![fs_base().join("kept"), fs_base().join("orphan-fs")],
+        );
+        dir_manager.should_list(&fleet_base(), vec![fleet_base().join("orphan-fleet")]);
+        // `remove_agent_resources` always deletes the agent's filesystem dir (idempotent).
+        dir_manager.should_delete(&fs_base().join("orphan-fs"));
+        dir_manager.should_delete(&fs_base().join("orphan-fleet"));
+
+        let mut config_repo = MockConfigRepository::new();
+        config_repo
+            .expect_delete_remote()
+            .with(predicate::eq(orphan_fs.clone()))
+            .once()
+            .returning(|_| Ok(()));
+        config_repo
+            .expect_delete_remote()
+            .with(predicate::eq(orphan_fleet.clone()))
+            .once()
+            .returning(|_| Ok(()));
+
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer
+            .expect_delete()
+            .with(predicate::eq(orphan_fs))
+            .once()
+            .returning(|_| Ok(()));
+        instance_id_storer
+            .expect_delete()
+            .with(predicate::eq(orphan_fleet))
+            .once()
+            .returning(|_| Ok(()));
+
+        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents(["kept"]);
+    }
+
+    /// Agent Control's own directory (a reserved ID) is never reclaimed.
+    #[test]
+    fn purge_skips_agent_control_dir() {
+        let orphan = agent_id("orphan");
+
         let mut dir_manager = MockDirectoryManager::new();
         dir_manager.should_list(&fs_base(), vec![]);
-        dir_manager.expect_delete().never();
+        dir_manager.should_list(
+            &fleet_base(),
+            vec![fleet_base().join(AGENT_CONTROL_ID), fleet_base().join("orphan")],
+        );
+        dir_manager.should_delete(&fs_base().join("orphan"));
 
-        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["any"]);
+        let mut config_repo = MockConfigRepository::new();
+        config_repo
+            .expect_delete_remote()
+            .with(predicate::eq(orphan.clone()))
+            .once()
+            .returning(|_| Ok(()));
+
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer
+            .expect_delete()
+            .with(predicate::eq(orphan))
+            .once()
+            .returning(|_| Ok(()));
+
+        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents([]);
     }
 
-    /// If listing the base dir fails, the helper logs and returns without attempting any
-    /// deletes. Stale dirs survive until the next AC start.
     #[test]
-    fn purge_stale_agent_filesystems_skips_when_list_fails() {
+    fn purge_is_noop_when_there_are_no_orphans() {
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_list(&fs_base(), vec![]);
+        dir_manager.should_list(&fleet_base(), vec![]);
+        dir_manager.expect_delete().never();
+
+        let mut config_repo = MockConfigRepository::new();
+        config_repo.expect_delete_remote().never();
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer.expect_delete().never();
+
+        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents(["any"]);
+    }
+
+    /// If listing one base fails, the helper logs and still reclaims orphans found in the other.
+    #[test]
+    fn purge_continues_when_one_base_listing_fails() {
+        let orphan = agent_id("orphan");
+
         let mut dir_manager = MockDirectoryManager::new();
         dir_manager
             .expect_list()
             .with(predicate::eq(fs_base()))
             .return_once(|_: &Path| Err(std::io::Error::other("boom")));
-        dir_manager.expect_delete().never();
+        dir_manager.should_list(&fleet_base(), vec![fleet_base().join("orphan")]);
+        dir_manager.should_delete(&fs_base().join("orphan"));
 
-        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["any"]);
+        let mut config_repo = MockConfigRepository::new();
+        config_repo
+            .expect_delete_remote()
+            .with(predicate::eq(orphan.clone()))
+            .once()
+            .returning(|_| Ok(()));
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer
+            .expect_delete()
+            .with(predicate::eq(orphan))
+            .once()
+            .returning(|_| Ok(()));
+
+        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents([]);
     }
 }

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -155,9 +155,12 @@ pub enum OnHostCleanerError {
     /// Failed to delete the stored remote configuration.
     #[error("failed to delete stored remote config: {0}")]
     RemoteConfig(#[source] ConfigRepositoryError),
+    /// Failed to delete agent filesystem directory.
     #[error("failed to delete agent filesystem directory {path:?}: {source}")]
     Filesystem {
+        /// The path in the filesystem that couldn't be deleted.
         path: PathBuf,
+        /// The io error.
         #[source]
         source: std::io::Error,
     },

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -210,8 +210,8 @@ mod tests {
         assert!(cleaner.clean(&id, &any_type_id()).is_ok());
     }
 
-    /// `delete` on a missing dir is a no-op per the trait contract — `OnHostCleaner` doesn't
-    /// pre-check existence; it just delegates.
+    /// When the directory manager's `delete` fails, `clean` propagates the error rather than
+    /// swallowing it, annotating it with `agent filesystem directory` for context.
     #[test]
     fn clean_propagates_directory_manager_delete_error() {
         let id = agent_id("foo-agent");

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -250,7 +250,7 @@ mod tests {
         let cleaner = OnHostCleaner::new(
             Arc::new(instance_id_storer),
             Arc::new(config_repo),
-            fs_base(),
+            PathBuf::new(),
             Arc::new(dir_manager),
         );
 

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -83,7 +83,8 @@ where
 
     /// At startup, reclaims the resources of any agent that is no longer in the agents config.
     pub fn purge_stale_agents<'a>(&self, configured_agent_ids: impl IntoIterator<Item = &'a str>) {
-        let mut skip: HashSet<String> = configured_agent_ids.into_iter().map(String::from).collect();
+        let mut skip: HashSet<String> =
+            configured_agent_ids.into_iter().map(String::from).collect();
         skip.extend(RESERVED_AGENT_IDS.iter().map(|id| id.to_string()));
 
         let mut names: HashSet<String> = HashSet::new();
@@ -348,7 +349,10 @@ mod tests {
         dir_manager.should_list(&fs_base(), vec![]);
         dir_manager.should_list(
             &fleet_base(),
-            vec![fleet_base().join(AGENT_CONTROL_ID), fleet_base().join("orphan")],
+            vec![
+                fleet_base().join(AGENT_CONTROL_ID),
+                fleet_base().join("orphan"),
+            ],
         );
         dir_manager.should_delete(&fs_base().join("orphan"));
 

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -83,9 +83,11 @@ where
 
     /// At startup, reclaims the resources of any agent that is no longer in the agents config.
     pub fn purge_stale_agents<'a>(&self, configured_agent_ids: impl IntoIterator<Item = &'a str>) {
-        let mut skip: HashSet<String> =
-            configured_agent_ids.into_iter().map(String::from).collect();
-        skip.extend(RESERVED_AGENT_IDS.iter().map(|id| id.to_string()));
+        let skip: HashSet<String> = configured_agent_ids
+            .into_iter()
+            .map(String::from)
+            .chain(RESERVED_AGENT_IDS.iter().map(|id| id.to_string()))
+            .collect();
 
         let mut names: HashSet<String> = HashSet::new();
         names.extend(self.agent_dir_names(&self.agent_filesystem_base));
@@ -111,17 +113,13 @@ where
 
     /// Lists the immediate child directory names under `base` (the per-agent subdirectories).
     /// A missing `base` yields no names; a listing error is logged and treated as empty.
-    fn agent_dir_names(&self, base: &Path) -> Vec<String> {
-        match self.dir_manager.list(base) {
-            Ok(entries) => entries
-                .iter()
-                .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
-                .collect(),
-            Err(err) => {
-                warn!(?err, ?base, "cannot list agent directory for stale cleanup");
-                Vec::new()
-            }
-        }
+    fn agent_dir_names(&self, base: &Path) -> impl Iterator<Item = String> {
+        self.dir_manager
+            .list(base)
+            .inspect_err(|err| warn!(?err, ?base, "cannot list agent directory for stale cleanup"))
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
     }
 }
 

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -17,8 +17,8 @@ use super::{ResourceCleaner, ResourceCleanerError};
 
 /// On-host implementation of [`ResourceCleaner`] that wipes a sub-agent's fleet data by
 /// delegating to the same storers that wrote it, also recursively deletes the sub-agent's
-/// dedicated filesystem directory, the `persistent` flag is bypassed here because fleet removal
-/// is final.
+/// dedicated filesystem directory, the `persistent` flag is bypassed here because the agent
+/// has been removed from the fleet.
 pub struct OnHostCleaner<S, C, D>
 where
     S: InstanceIDStorer,

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -1,5 +1,8 @@
 //! On-host resource cleaner that wipes a removed sub-agent's fleet data and OpAMP instance id.
 
+use fs::directory_manager::DirectoryManager;
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -13,34 +16,48 @@ use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
 use super::{ResourceCleaner, ResourceCleanerError};
 
 /// On-host implementation of [`ResourceCleaner`] that wipes a sub-agent's fleet data by
-/// delegating to the same storers that wrote it.
-pub struct OnHostCleaner<S, C>
+/// delegating to the same storers that wrote it, also recursively deletes the sub-agent's
+/// dedicated filesystem directory, the `persistent` flag is bypassed here because fleet removal
+/// is final.
+pub struct OnHostCleaner<S, C, D>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
+    D: DirectoryManager,
 {
     instance_id_storer: Arc<S>,
     config_repo: Arc<C>,
+    agent_filesystem_base: PathBuf,
+    dir_manager: Arc<D>,
 }
 
-impl<S, C> OnHostCleaner<S, C>
+impl<S, C, D> OnHostCleaner<S, C, D>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
+    D: DirectoryManager,
 {
     /// Builds a cleaner delegating to the given instance-id storer and config repository.
-    pub fn new(instance_id_storer: Arc<S>, config_repo: Arc<C>) -> Self {
+    pub fn new(
+        instance_id_storer: Arc<S>,
+        config_repo: Arc<C>,
+        agent_filesystem_base: PathBuf,
+        dir_manager: Arc<D>,
+    ) -> Self {
         Self {
             instance_id_storer,
             config_repo,
+            agent_filesystem_base,
+            dir_manager,
         }
     }
 }
 
-impl<S, C> ResourceCleaner for OnHostCleaner<S, C>
+impl<S, C, D> ResourceCleaner for OnHostCleaner<S, C, D>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
+    D: DirectoryManager,
 {
     #[instrument(skip_all, name = "agent_resource_clean", fields(%agent_id))]
     fn clean(
@@ -62,6 +79,15 @@ where
             .delete(agent_id)
             .map_err(OnHostCleanerError::InstanceId)?;
 
+        let fs_dir = self.agent_filesystem_base.join(agent_id);
+        debug!(%agent_id, path = ?fs_dir, "Cleaning agent filesystem directory");
+        self.dir_manager
+            .delete(&fs_dir)
+            .map_err(|err| OnHostCleanerError::Filesystem {
+                path: fs_dir,
+                source: err,
+            })?;
+
         Ok(())
     }
 }
@@ -78,6 +104,12 @@ pub enum OnHostCleanerError {
     /// Failed to delete the stored remote configuration.
     #[error("failed to delete stored remote config: {0}")]
     RemoteConfig(#[source] ConfigRepositoryError),
+    #[error("failed to delete agent filesystem directory {path:?}: {source}")]
+    Filesystem {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 impl From<OnHostCleanerError> for ResourceCleanerError {
@@ -86,12 +118,53 @@ impl From<OnHostCleanerError> for ResourceCleanerError {
     }
 }
 
+/// Removes filesystem directories under `agent_filesystem_base` whose name does not match a
+/// currently-configured agent ID. This handles "agent removed from fleet config while Agent
+/// Control was stopped": on next start, the orphaned directory is reclaimed.
+pub fn purge_stale_agent_filesystems<'a>(
+    dir_manager: &impl DirectoryManager,
+    agent_filesystem_base: &std::path::Path,
+    configured_agent_ids: impl IntoIterator<Item = &'a str>,
+) {
+    let configured: HashSet<&str> = configured_agent_ids.into_iter().collect();
+
+    let entries = match dir_manager.list(agent_filesystem_base) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                path = ?agent_filesystem_base,
+                "skipping stale-agent filesystem cleanup: cannot read base dir"
+            );
+            return;
+        }
+    };
+
+    for path in entries {
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if configured.contains(name) {
+            continue;
+        }
+        tracing::info!(
+            path = ?path,
+            "purging filesystem directory of agent no longer in fleet config"
+        );
+        if let Err(err) = dir_manager.delete(&path) {
+            tracing::warn!(?err, ?path, "failed to purge stale agent filesystem dir");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::opamp::instance_id::storer::tests::MockInstanceIDStorer;
     use crate::values::config_repository::tests::MockConfigRepository;
+    use ::fs::directory_manager::mock::MockDirectoryManager;
     use mockall::predicate;
+    use std::path::Path;
 
     fn agent_id(s: &str) -> AgentID {
         AgentID::try_from(s).unwrap()
@@ -101,9 +174,15 @@ mod tests {
         AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap()
     }
 
+    fn fs_base() -> PathBuf {
+        PathBuf::from("/var/lib/newrelic-agent-control/filesystem")
+    }
+
     #[test]
-    fn clean_deletes_instance_id_and_remote_config() {
+    fn clean_deletes_instance_id_remote_config_and_agent_filesystem_dir() {
         let id = agent_id("foo-agent");
+        let expected_fs_dir = fs_base().join(id.as_str());
+
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer
             .expect_delete()
@@ -118,23 +197,103 @@ mod tests {
             .with(predicate::eq(id.clone()))
             .returning(|_| Ok(()));
 
-        let cleaner = OnHostCleaner::new(Arc::new(instance_id_storer), Arc::new(config_repo));
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_delete(&expected_fs_dir);
+
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            fs_base(),
+            Arc::new(dir_manager),
+        );
 
         assert!(cleaner.clean(&id, &any_type_id()).is_ok());
+    }
+
+    /// `delete` on a missing dir is a no-op per the trait contract — `OnHostCleaner` doesn't
+    /// pre-check existence; it just delegates.
+    #[test]
+    fn clean_propagates_directory_manager_delete_error() {
+        let id = agent_id("foo-agent");
+        let expected_fs_dir = fs_base().join(id.as_str());
+
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer.expect_delete().returning(|_| Ok(()));
+        let mut config_repo = MockConfigRepository::new();
+        config_repo.expect_delete_remote().returning(|_| Ok(()));
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_not_delete(
+            &expected_fs_dir,
+            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+        );
+
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            fs_base(),
+            Arc::new(dir_manager),
+        );
+
+        let err = cleaner.clean(&id, &any_type_id()).unwrap_err();
+        assert!(err.0.contains("agent filesystem directory"));
     }
 
     #[test]
     fn clean_refuses_agent_control_id() {
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer.expect_delete().never();
-
         let mut config_repo = MockConfigRepository::new();
         config_repo.expect_delete_remote().never();
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.expect_delete().never();
 
-        let cleaner = OnHostCleaner::new(Arc::new(instance_id_storer), Arc::new(config_repo));
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            fs_base(),
+            Arc::new(dir_manager),
+        );
 
         let result = cleaner.clean(&AgentID::AgentControl, &any_type_id());
 
         assert!(result.is_err());
+    }
+
+    /// Subdirs under the filesystem base whose names are not in the configured-agents set are
+    /// removed; configured ones survive.
+    #[test]
+    fn purge_stale_agent_filesystems_removes_only_orphans() {
+        let kept_path = fs_base().join("kept");
+        let orphan_path = fs_base().join("orphan");
+
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_list(&fs_base(), vec![kept_path.clone(), orphan_path.clone()]);
+        dir_manager.should_delete(&orphan_path);
+        // `kept` is in the configured set → no `delete` call expected for it.
+
+        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["kept"]);
+    }
+
+    #[test]
+    fn purge_stale_agent_filesystems_is_noop_on_empty_base() {
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_list(&fs_base(), vec![]);
+        dir_manager.expect_delete().never();
+
+        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["any"]);
+    }
+
+    /// If listing the base dir fails, the helper logs and returns without attempting any
+    /// deletes. Stale dirs survive until the next AC start.
+    #[test]
+    fn purge_stale_agent_filesystems_skips_when_list_fails() {
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager
+            .expect_list()
+            .with(predicate::eq(fs_base()))
+            .return_once(|_: &Path| Err(std::io::Error::other("boom")));
+        dir_manager.expect_delete().never();
+
+        purge_stale_agent_filesystems(&dir_manager, &fs_base(), ["any"]);
     }
 }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -61,7 +61,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::info;
+use tracing::{debug, info};
 
 /// Agent Control variable name carrying the host id.
 pub const HOST_ID_VARIABLE_NAME: &str = "host_id";
@@ -127,6 +127,7 @@ impl AgentControlRunner {
             fleet_data_base,
             dir_manager,
         );
+        debug!("Removing stale agents from the filesystem");
         resource_cleaner.purge_stale_agents(
             agent_control_config
                 .dynamic

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -5,12 +5,15 @@ use crate::agent_control::config::{AgentControlConfig, OpAMPClientConfig};
 use crate::agent_control::config_repository::repository::AgentControlConfigLoader;
 use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
-    AGENT_CONTROL_VERSION, EXECUTION_MODE_ATTRIBUTE_KEY, FLEET_ID_ATTRIBUTE_KEY,
-    HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
-    OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE, default_capabilities, default_custom_capabilities,
+    AGENT_CONTROL_VERSION, AGENT_FILESYSTEM_FOLDER_NAME, EXECUTION_MODE_ATTRIBUTE_KEY,
+    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE, default_capabilities,
+    default_custom_capabilities,
 };
 use crate::agent_control::http_server::runner::Runner;
-use crate::agent_control::resource_cleaner::on_host::OnHostCleaner;
+use crate::agent_control::resource_cleaner::on_host::{
+    OnHostCleaner, purge_stale_agent_filesystems,
+};
 use crate::agent_control::run::{
     AgentControlRunner, GracefulShutdownReason, RunError, RunningMode,
     setup_config_repository_and_store,
@@ -116,8 +119,23 @@ impl AgentControlRunner {
         let instance_id_getter =
             InstanceIDWithIdentifiersGetter::new(instance_id_storer.clone(), identifiers.clone());
 
-        let resource_cleaner =
-            OnHostCleaner::new(instance_id_storer, yaml_config_repository.clone());
+        let agent_filesystem_base = remote_dir.join(AGENT_FILESYSTEM_FOLDER_NAME);
+        let dir_manager = Arc::new(DirectoryManagerFs);
+        purge_stale_agent_filesystems(
+            dir_manager.as_ref(),
+            &agent_filesystem_base,
+            agent_control_config
+                .dynamic
+                .agents
+                .keys()
+                .map(|id| id.as_str()),
+        );
+        let resource_cleaner = OnHostCleaner::new(
+            instance_id_storer,
+            yaml_config_repository.clone(),
+            agent_filesystem_base.clone(),
+            dir_manager,
+        );
 
         let opamp_client_builder = maybe_opamp.map(|config| {
             opamp_client_builder(

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -6,14 +6,12 @@ use crate::agent_control::config_repository::repository::AgentControlConfigLoade
 use crate::agent_control::config_validator::RegistryDynamicConfigValidator;
 use crate::agent_control::defaults::{
     AGENT_CONTROL_VERSION, AGENT_FILESYSTEM_FOLDER_NAME, EXECUTION_MODE_ATTRIBUTE_KEY,
-    FLEET_ID_ATTRIBUTE_KEY, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
+    FLEET_ID_ATTRIBUTE_KEY, FOLDER_NAME_FLEET_DATA, HOST_ID_ATTRIBUTE_KEY, HOST_NAME_ATTRIBUTE_KEY,
     OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE, default_capabilities,
     default_custom_capabilities,
 };
 use crate::agent_control::http_server::runner::Runner;
-use crate::agent_control::resource_cleaner::on_host::{
-    OnHostCleaner, purge_stale_agent_filesystems,
-};
+use crate::agent_control::resource_cleaner::on_host::OnHostCleaner;
 use crate::agent_control::run::{
     AgentControlRunner, GracefulShutdownReason, RunError, RunningMode,
     setup_config_repository_and_store,
@@ -120,21 +118,21 @@ impl AgentControlRunner {
             InstanceIDWithIdentifiersGetter::new(instance_id_storer.clone(), identifiers.clone());
 
         let agent_filesystem_base = remote_dir.join(AGENT_FILESYSTEM_FOLDER_NAME);
+        let fleet_data_base = remote_dir.join(FOLDER_NAME_FLEET_DATA);
         let dir_manager = Arc::new(DirectoryManagerFs);
-        purge_stale_agent_filesystems(
-            dir_manager.as_ref(),
-            &agent_filesystem_base,
+        let resource_cleaner = OnHostCleaner::new(
+            instance_id_storer,
+            yaml_config_repository.clone(),
+            agent_filesystem_base,
+            fleet_data_base,
+            dir_manager,
+        );
+        resource_cleaner.purge_stale_agents(
             agent_control_config
                 .dynamic
                 .agents
                 .keys()
                 .map(|id| id.as_str()),
-        );
-        let resource_cleaner = OnHostCleaner::new(
-            instance_id_storer,
-            yaml_config_repository.clone(),
-            agent_filesystem_base.clone(),
-            dir_manager,
         );
 
         let opamp_client_builder = maybe_opamp.map(|config| {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -700,6 +700,11 @@ projected:
             .write(&LocalFile, &DirectoryManagerFs)
             .unwrap();
 
+        assert!(tmp_dir.path().join("A.txt").exists());
+        assert!(tmp_dir.path().join("persistent-dir/old.txt").exists());
+        assert!(tmp_dir.path().join("projected/a.yaml").exists());
+        assert!(tmp_dir.path().join("projected/b.yaml").exists());
+
         // Sub-agent process writes runtime files. None of these are in any manifest, so the
         // sidecar diff must leave them alone on the next reconciliation.
         let runtime_top = tmp_dir.path().join("agent-runtime.log");

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -38,11 +38,14 @@ pub mod rendered;
 pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 
 /// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
-/// Every variant carries a `persistent` flag (default `false`):
+/// The `file` and `dir` variants carry a `persistent` flag (default `false`):
 ///
 /// - `persistent: false` (ephemeral): the entry's on-disk tree is deleted on sub-agent stop.
 /// - `persistent: true`: the entry survives sub-agent stop and restart; it is only deleted when
 ///   the agent is removed from the fleet.
+///
+/// `dir_content_from_map` has no `persistent` flag: its projected files are re-rendered on every
+/// write, so it is always ephemeral.
 ///
 /// Independently of the flag, every write event reconciles the on-disk state against the current
 /// declared set, anything no longer declared in the agent type is deleted.
@@ -69,8 +72,6 @@ pub enum FilesystemEntry {
     DirContentFromMap {
         /// The (templated) `map[string]yaml` source whose keys/values become files.
         source: TemplateableValue<DirEntriesMap>,
-        #[serde(default)]
-        persistent: TemplateableValue<bool>,
     },
 }
 
@@ -153,17 +154,14 @@ impl Templateable for FilesystemEntry {
                     persistent: persistent.template_with(variables)?,
                 })
             }
-            FilesystemEntry::DirContentFromMap { source, persistent } => {
+            FilesystemEntry::DirContentFromMap { source } => {
                 let map = source.template_with(variables)?;
                 let files = map
                     .0
                     .into_iter()
                     .map(|(k, content)| (PathBuf::from(k), content))
                     .collect();
-                Ok(rendered::RenderedEntry::DirContentFromMap {
-                    files,
-                    persistent: persistent.template_with(variables)?,
-                })
+                Ok(rendered::RenderedEntry::DirContentFromMap { files })
             }
         }
     }
@@ -627,7 +625,7 @@ persistent-file:
 persistent-dir:
   kind: dir
   persistent: true
-persistent-map:
+map-with-ignored-persistent:
   kind: dir_content_from_map
   source: ${nr-var:m}
   persistent: true
@@ -649,10 +647,8 @@ persistent-map:
             FilesystemEntry::Dir { persistent, .. } => assert_eq!(persistent.template, "true"),
             other => panic!("unexpected variant: {other:?}"),
         }
-        match parsed.0.get(&key("persistent-map")).unwrap() {
-            FilesystemEntry::DirContentFromMap { persistent, .. } => {
-                assert_eq!(persistent.template, "true");
-            }
+        match parsed.0.get(&key("map-with-ignored-persistent")).unwrap() {
+            FilesystemEntry::DirContentFromMap { .. } => {}
             other => panic!("unexpected variant: {other:?}"),
         }
     }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -231,7 +231,7 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     if let Err(e) = check_single_segment(path) {
         errors.push(e);
     }
-    // Keys must not collide with AC's reserved sidecar-manifest filename.
+    // Keys must not collide with AC's reserved manifest filename.
     if let Err(e) = check_not_reserved(path) {
         errors.push(e);
     }
@@ -259,7 +259,7 @@ fn check_single_segment(path: &Path) -> Result<(), String> {
     ))
 }
 
-/// Rejects the reserved sidecar-manifest filename at any level. Agent Control writes its
+/// Rejects the reserved manifest filename at any level. Agent Control writes its
 /// managed-paths manifest at `<base_dir>/.ac-managed-paths.json`; an entry declaring that name
 /// would collide with (and corrupt) AC's own reconciliation bookkeeping.
 fn check_not_reserved(path: &Path) -> Result<(), String> {
@@ -657,7 +657,7 @@ persistent-map:
         }
     }
 
-    /// Reconciliation diffs the sidecar manifest against the current declared set.
+    /// Reconciliation diffs the manifest against the current declared set.
     #[test]
     fn reconciles_against_current_declared_set() {
         let tmp_dir = TempDir::new().unwrap();
@@ -706,7 +706,7 @@ projected:
         assert!(tmp_dir.path().join("projected/b.yaml").exists());
 
         // Sub-agent process writes runtime files. None of these are in any manifest, so the
-        // sidecar diff must leave them alone on the next reconciliation.
+        // manifest diff must leave them alone on the next reconciliation.
         let runtime_top = tmp_dir.path().join("agent-runtime.log");
         let runtime_in_dir = tmp_dir.path().join("persistent-dir/cache.db");
         let runtime_in_projected = tmp_dir.path().join("projected/agent-state.log");

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -231,6 +231,10 @@ fn validate_file_entry_path(path: &Path) -> Result<(), String> {
     if let Err(e) = check_single_segment(path) {
         errors.push(e);
     }
+    // Keys must not collide with AC's reserved sidecar-manifest filename.
+    if let Err(e) = check_not_reserved(path) {
+        errors.push(e);
+    }
 
     if errors.is_empty() {
         Ok(())
@@ -253,6 +257,24 @@ fn check_single_segment(path: &Path) -> Result<(), String> {
          explicitly with `kind: dir` and `entries:`",
         path.display()
     ))
+}
+
+/// Rejects the reserved sidecar-manifest filename at any level. Agent Control writes its
+/// managed-paths manifest at `<base_dir>/.ac-managed-paths.json`; an entry declaring that name
+/// would collide with (and corrupt) AC's own reconciliation bookkeeping.
+fn check_not_reserved(path: &Path) -> Result<(), String> {
+    let collides = path.components().any(|c| {
+        matches!(c, Component::Normal(name)
+            if name.to_str() == Some(rendered::MANAGED_PATHS_MANIFEST_FILENAME))
+    });
+    if collides {
+        return Err(format!(
+            "path `{}` uses the reserved filename `{}`",
+            path.display(),
+            rendered::MANAGED_PATHS_MANIFEST_FILENAME
+        ));
+    }
+    Ok(())
 }
 
 /// Rejects paths that traverse outside their base directory (e.g. `./../../some_path`) so that
@@ -368,6 +390,40 @@ mod tests {
             parsed.is_ok(),
             should_parse,
             "input: {yaml}, parsed: {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_manifest_filename() {
+        let reserved = rendered::MANAGED_PATHS_MANIFEST_FILENAME;
+
+        // Top-level key.
+        let top_level = format!(
+            r#"
+"{reserved}":
+  kind: file
+  text: x
+"#
+        );
+        assert!(
+            serde_saphyr::from_str::<FileSystem>(&top_level).is_err(),
+            "reserved filename must be rejected at the top level"
+        );
+
+        // Nested under a dir's `entries:` — rejected at any level.
+        let nested = format!(
+            r#"
+somedir:
+  kind: dir
+  entries:
+    "{reserved}":
+      kind: file
+      text: x
+"#
+        );
+        assert!(
+            serde_saphyr::from_str::<FileSystem>(&nested).is_err(),
+            "reserved filename must be rejected at nested levels"
         );
     }
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -38,6 +38,14 @@ pub mod rendered;
 pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 
 /// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
+/// Every variant carries a `persistent` flag (default `false`):
+///
+/// - `persistent: false` (ephemeral): the entry's on-disk tree is deleted on sub-agent stop.
+/// - `persistent: true`: the entry survives sub-agent stop and restart; it is only deleted when
+///   the agent is removed from the fleet.
+///
+/// Independently of the flag, every write event reconciles the on-disk state against the current
+/// declared set, anything no longer declared in the agent type is deleted.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FilesystemEntry {
@@ -45,18 +53,24 @@ pub enum FilesystemEntry {
     File {
         /// The file's (possibly templated) content.
         text: TemplateableValue<String>,
+        #[serde(default)]
+        persistent: TemplateableValue<bool>,
     },
     /// An explicitly declared directory. Children, if any, live under `entries:`.
     Dir {
         /// The directory's child entries.
         #[serde(default)]
         entries: HashMap<SafePath, FilesystemEntry>,
+        #[serde(default)]
+        persistent: TemplateableValue<bool>,
     },
     /// A directory whose set of files is computed at deploy time from a `map[string]yaml`
     /// variable. Map keys become filenames; values become file contents.
     DirContentFromMap {
         /// The (templated) `map[string]yaml` source whose keys/values become files.
         source: TemplateableValue<DirEntriesMap>,
+        #[serde(default)]
+        persistent: TemplateableValue<bool>,
     },
 }
 
@@ -97,7 +111,7 @@ impl Templateable for FileSystem {
     type Output = rendered::FileSystem;
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        let base_dir = filesystem_agent_dir(variables)?;
+        let base_dir = PathBuf::from(filesystem_agent_dir(variables)?);
 
         let entries = self
             .0
@@ -105,12 +119,12 @@ impl Templateable for FileSystem {
             .map(|(key, entry)| {
                 // The only place we construct a final-on-disk path: prepend the sub-agent's
                 // dedicated filesystem dir to the user-provided relative top-level key.
-                let path = PathBuf::from(&base_dir).join(&key);
+                let path = base_dir.join(&key);
                 Ok((path, entry.template_with(variables)?))
             })
             .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
 
-        Ok(rendered::FileSystem(entries))
+        Ok(rendered::FileSystem::new(base_dir, entries))
     }
 }
 
@@ -122,24 +136,34 @@ impl Templateable for FilesystemEntry {
     /// the top level by [`FileSystem::template_with`].
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         match self {
-            FilesystemEntry::File { text } => Ok(rendered::RenderedEntry::File(
-                text.template_with(variables)?,
-            )),
-            FilesystemEntry::Dir { entries } => {
+            FilesystemEntry::File { text, persistent } => Ok(rendered::RenderedEntry::File {
+                content: text.template_with(variables)?,
+                persistent: persistent.template_with(variables)?,
+            }),
+            FilesystemEntry::Dir {
+                entries,
+                persistent,
+            } => {
                 let children = entries
                     .into_iter()
                     .map(|(k, v)| Ok((PathBuf::from(k), v.template_with(variables)?)))
                     .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-                Ok(rendered::RenderedEntry::Dir(children))
+                Ok(rendered::RenderedEntry::Dir {
+                    children,
+                    persistent: persistent.template_with(variables)?,
+                })
             }
-            FilesystemEntry::DirContentFromMap { source } => {
+            FilesystemEntry::DirContentFromMap { source, persistent } => {
                 let map = source.template_with(variables)?;
                 let files = map
                     .0
                     .into_iter()
                     .map(|(k, content)| (PathBuf::from(k), content))
                     .collect();
-                Ok(rendered::RenderedEntry::DirContentFromMap(files))
+                Ok(rendered::RenderedEntry::DirContentFromMap {
+                    files,
+                    persistent: persistent.template_with(variables)?,
+                })
             }
         }
     }
@@ -282,15 +306,22 @@ mod tests {
             PathBuf::from("newrelic.yaml").try_into().unwrap(),
             FilesystemEntry::File {
                 text: TemplateableValue::from_template("hello".to_string()),
+                persistent: TemplateableValue::default(),
             },
         )]));
 
         let rendered = fs_input.template_with(&variables).unwrap();
 
-        let expected = rendered::FileSystem(HashMap::from([(
-            PathBuf::from("/base/dir/newrelic.yaml"),
-            RenderedEntry::File("hello".to_string()),
-        )]));
+        let expected = rendered::FileSystem::new(
+            PathBuf::from("/base/dir"),
+            HashMap::from([(
+                PathBuf::from("/base/dir/newrelic.yaml"),
+                RenderedEntry::File {
+                    content: "hello".to_string(),
+                    persistent: false,
+                },
+            )]),
+        );
         assert_eq!(rendered, expected);
     }
 
@@ -301,6 +332,7 @@ mod tests {
             PathBuf::from("any").try_into().unwrap(),
             FilesystemEntry::Dir {
                 entries: HashMap::new(),
+                persistent: TemplateableValue::default(),
             },
         )]));
 
@@ -435,7 +467,7 @@ agent:
         assert!(matches!(file_entry, FilesystemEntry::File { .. }));
 
         let empty_dir = parsed.0.get(&SafePath(PathBuf::from("config"))).unwrap();
-        assert!(matches!(empty_dir, FilesystemEntry::Dir { entries } if entries.is_empty()));
+        assert!(matches!(empty_dir, FilesystemEntry::Dir { entries, .. } if entries.is_empty()));
 
         let dir_from_map = parsed.0.get(&SafePath(PathBuf::from("logging.d"))).unwrap();
         assert!(matches!(
@@ -444,7 +476,7 @@ agent:
         ));
 
         let nested_dir = parsed.0.get(&SafePath(PathBuf::from("agent"))).unwrap();
-        let FilesystemEntry::Dir { entries } = nested_dir else {
+        let FilesystemEntry::Dir { entries, .. } = nested_dir else {
             panic!("expected agent to be a Dir, got {nested_dir:?}");
         };
         assert_eq!(entries.len(), 3);
@@ -521,6 +553,369 @@ foo:
         assert!(
             nested_empty_dir.is_dir(),
             "nested empty dir not created at {nested_empty_dir:?}"
+        );
+    }
+
+    /// Persistent flag defaults to false; explicit `persistent: true` and templated values both
+    /// parse correctly. Independent per variant.
+    #[test]
+    fn persistent_field_parses_per_variant() {
+        let yaml = r#"
+default-file:
+  kind: file
+  text: hi
+persistent-file:
+  kind: file
+  text: hi
+  persistent: true
+persistent-dir:
+  kind: dir
+  persistent: true
+persistent-map:
+  kind: dir_content_from_map
+  source: ${nr-var:m}
+  persistent: true
+"#;
+        let parsed = serde_saphyr::from_str::<FileSystem>(yaml).unwrap();
+        let key = |k: &str| SafePath(PathBuf::from(k));
+
+        match parsed.0.get(&key("default-file")).unwrap() {
+            FilesystemEntry::File { persistent, .. } => {
+                assert_eq!(persistent.template, "");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+        match parsed.0.get(&key("persistent-file")).unwrap() {
+            FilesystemEntry::File { persistent, .. } => assert_eq!(persistent.template, "true"),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+        match parsed.0.get(&key("persistent-dir")).unwrap() {
+            FilesystemEntry::Dir { persistent, .. } => assert_eq!(persistent.template, "true"),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+        match parsed.0.get(&key("persistent-map")).unwrap() {
+            FilesystemEntry::DirContentFromMap { persistent, .. } => {
+                assert_eq!(persistent.template, "true");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// Reconciliation diffs the sidecar manifest against the current declared set.
+    #[test]
+    fn reconciles_against_current_declared_set() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        // First write: A (top-level file), persistent-dir with declared `old.txt`, projected map.
+        let first_yaml = r#"
+A.txt:
+  kind: file
+  text: hello
+persistent-dir:
+  kind: dir
+  persistent: true
+  entries:
+    old.txt:
+      kind: file
+      text: from-config-1
+projected:
+  kind: dir_content_from_map
+  source: ${nr-var:proj}
+"#;
+        let proj_first = HashMap::from([
+            ("a.yaml".to_string(), Value::String("a-content".to_string())),
+            ("b.yaml".to_string(), Value::String("b-content".to_string())),
+        ]);
+        let variables_first = Variables::from_iter(vec![
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+            ),
+            (
+                Namespace::Variable.namespaced_name("proj"),
+                Variable::new(String::default(), false, None, Some(proj_first)),
+            ),
+        ]);
+
+        serde_saphyr::from_str::<FileSystem>(first_yaml)
+            .unwrap()
+            .template_with(&variables_first)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // Sub-agent process writes runtime files. None of these are in any manifest, so the
+        // sidecar diff must leave them alone on the next reconciliation.
+        let runtime_top = tmp_dir.path().join("agent-runtime.log");
+        let runtime_in_dir = tmp_dir.path().join("persistent-dir/cache.db");
+        let runtime_in_projected = tmp_dir.path().join("projected/agent-state.log");
+        std::fs::write(&runtime_top, "top-level runtime data").unwrap();
+        std::fs::write(&runtime_in_dir, "cache").unwrap();
+        std::fs::write(&runtime_in_projected, "state").unwrap();
+
+        // Second write: A.txt removed; `old.txt` removed from persistent-dir's entries; `b.yaml`
+        // dropped from the projected map.
+        let second_yaml = r#"
+persistent-dir:
+  kind: dir
+  persistent: true
+projected:
+  kind: dir_content_from_map
+  source: ${nr-var:proj}
+"#;
+        let proj_second = HashMap::from([(
+            "a.yaml".to_string(),
+            Value::String("a-content-v2".to_string()),
+        )]);
+        let variables_second = Variables::from_iter(vec![
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+            ),
+            (
+                Namespace::Variable.namespaced_name("proj"),
+                Variable::new(String::default(), false, None, Some(proj_second)),
+            ),
+        ]);
+
+        serde_saphyr::from_str::<FileSystem>(second_yaml)
+            .unwrap()
+            .template_with(&variables_second)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // Previously-declared, no-longer-declared paths are deleted by the manifest diff.
+        assert!(
+            !tmp_dir.path().join("A.txt").exists(),
+            "A.txt should have been deleted"
+        );
+        assert!(
+            !tmp_dir.path().join("persistent-dir/old.txt").exists(),
+            "old.txt inside persistent-dir should have been deleted (was in prev manifest)"
+        );
+        assert!(
+            !tmp_dir.path().join("projected/b.yaml").exists(),
+            "projected/b.yaml should have been deleted"
+        );
+        // Currently-declared paths are present and updated.
+        assert_eq!(
+            std::fs::read_to_string(tmp_dir.path().join("projected/a.yaml")).unwrap(),
+            "a-content-v2"
+        );
+        assert!(tmp_dir.path().join("persistent-dir").is_dir());
+        // Agent-process-created files survive everywhere, they were never in the manifest.
+        assert!(
+            runtime_top.exists(),
+            "top-level runtime file should survive"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&runtime_top).unwrap(),
+            "top-level runtime data"
+        );
+        assert!(
+            runtime_in_dir.exists(),
+            "agent-created file inside persistent dir should survive"
+        );
+        assert_eq!(std::fs::read_to_string(&runtime_in_dir).unwrap(), "cache");
+        assert!(
+            runtime_in_projected.exists(),
+            "agent-created file inside dir_content_from_map should survive"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&runtime_in_projected).unwrap(),
+            "state"
+        );
+    }
+
+    /// `delete_ephemeral` removes ephemeral entries' on-disk paths but leaves persistent ones
+    /// alone. A persistent child of an ephemeral parent is wiped along with the parent.
+    #[test]
+    fn delete_ephemeral_clears_only_non_persistent() {
+        let tmp_dir = TempDir::new().unwrap();
+        let yaml = r#"
+ephemeral.txt:
+  kind: file
+  text: e
+persistent.txt:
+  kind: file
+  text: p
+  persistent: true
+ephemeral-dir:
+  kind: dir
+  entries:
+    inner.txt:
+      kind: file
+      text: e
+persistent-dir:
+  kind: dir
+  persistent: true
+"#;
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+        )]);
+        let templated = serde_saphyr::from_str::<FileSystem>(yaml)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap();
+        templated.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert!(tmp_dir.path().join("ephemeral.txt").exists());
+        assert!(tmp_dir.path().join("persistent.txt").exists());
+        assert!(tmp_dir.path().join("ephemeral-dir/inner.txt").exists());
+        assert!(tmp_dir.path().join("persistent-dir").is_dir());
+
+        templated.delete_ephemeral().unwrap();
+
+        assert!(!tmp_dir.path().join("ephemeral.txt").exists());
+        assert!(!tmp_dir.path().join("ephemeral-dir").exists());
+        assert!(tmp_dir.path().join("persistent.txt").exists());
+        assert!(tmp_dir.path().join("persistent-dir").is_dir());
+    }
+
+    #[test]
+    fn removed_parent_dir_takes_agent_created_descendants_with_it() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        // Config A: declares `agent/data` as a persistent dir.
+        let config_a = r#"
+agent:
+  kind: dir
+  persistent: true
+  entries:
+    data:
+      kind: dir
+      persistent: true
+"#;
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+        )]);
+
+        serde_saphyr::from_str::<FileSystem>(config_a)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // Sub-agent process writes a runtime file inside `agent/data`.
+        let runtime_file = tmp_dir.path().join("agent/data/runtime.log");
+        std::fs::create_dir_all(runtime_file.parent().unwrap()).unwrap();
+        std::fs::write(&runtime_file, "agent runtime data").unwrap();
+        assert!(runtime_file.exists());
+
+        // Config B: agent type no longer declares `agent` at all.
+        let config_b = r#"
+unrelated.txt:
+  kind: file
+  text: hi
+"#;
+        serde_saphyr::from_str::<FileSystem>(config_b)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        // The previously-declared persistent dir tree is gone.
+        assert!(
+            !runtime_file.exists(),
+            "agent-created file under removed parent should be deleted"
+        );
+        assert!(
+            !tmp_dir.path().join("agent/data").exists(),
+            "formerly-declared persistent dir should be deleted"
+        );
+        assert!(
+            !tmp_dir.path().join("agent").exists(),
+            "ancestor dir of removed entry should be deleted"
+        );
+        // The new entry from config B is in place.
+        assert_eq!(
+            std::fs::read_to_string(tmp_dir.path().join("unrelated.txt")).unwrap(),
+            "hi"
+        );
+    }
+
+    #[rstest]
+    #[case::manifest_missing(true, None)]
+    #[case::manifest_truncated(false, Some(""))]
+    #[case::manifest_invalid_json(false, Some("{ not valid json"))]
+    #[case::manifest_wrong_schema(false, Some("{\"different_field\":[]}"))]
+    fn write_does_not_delete_when_manifest_is_unreadable(
+        #[case] delete_manifest: bool,
+        #[case] overwrite_with: Option<&str>,
+    ) {
+        let tmp_dir = TempDir::new().unwrap();
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+        )]);
+
+        let first_yaml = r#"
+keep.txt:
+  kind: file
+  text: keep me
+also-keep.txt:
+  kind: file
+  text: also keep me
+"#;
+        serde_saphyr::from_str::<FileSystem>(first_yaml)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        let manifest_path = tmp_dir
+            .path()
+            .join(rendered::MANAGED_PATHS_MANIFEST_FILENAME);
+        assert!(manifest_path.exists(), "first write should create manifest");
+
+        if delete_manifest {
+            std::fs::remove_file(&manifest_path).unwrap();
+        }
+        if let Some(garbage) = overwrite_with {
+            std::fs::write(&manifest_path, garbage).unwrap();
+        }
+
+        // Manifest unreadable, the diff is empty → nothing deleted.
+        let second_yaml = r#"
+new.txt:
+  kind: file
+  text: new
+"#;
+        serde_saphyr::from_str::<FileSystem>(second_yaml)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert!(
+            tmp_dir.path().join("keep.txt").exists(),
+            "keep.txt should NOT have been deleted (manifest was unreadable)"
+        );
+        assert!(
+            tmp_dir.path().join("also-keep.txt").exists(),
+            "also-keep.txt should NOT have been deleted (manifest was unreadable)"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp_dir.path().join("new.txt")).unwrap(),
+            "new"
+        );
+        // The second write rewrote a fresh, valid manifest, so subsequent writes will reconcile
+        // normally going forward.
+        assert!(
+            manifest_path.exists(),
+            "second write should have written a fresh manifest"
+        );
+        let manifest_content = std::fs::read_to_string(&manifest_path).unwrap();
+        assert!(
+            manifest_content.contains("new.txt"),
+            "fresh manifest should track the new entry: {manifest_content}"
         );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -56,6 +56,7 @@ pub enum FilesystemEntry {
     File {
         /// The file's (possibly templated) content.
         text: TemplateableValue<String>,
+        /// The persistency attribute marking it's lifecicle.
         #[serde(default)]
         persistent: TemplateableValue<bool>,
     },
@@ -64,6 +65,7 @@ pub enum FilesystemEntry {
         /// The directory's child entries.
         #[serde(default)]
         entries: HashMap<SafePath, FilesystemEntry>,
+        /// The persistency attribute marking it's lifecicle.
         #[serde(default)]
         persistent: TemplateableValue<bool>,
     },

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -789,8 +789,8 @@ projected:
         );
     }
 
-    /// `delete_ephemeral` removes ephemeral entries' on-disk paths but leaves persistent ones
-    /// alone. A persistent child of an ephemeral parent is wiped along with the parent.
+    /// `delete_ephemeral` removes ephemeral entries' on-disk paths (files and directories) but
+    /// leaves persistent ones alone.
     #[test]
     fn delete_ephemeral_clears_only_non_persistent() {
         let tmp_dir = TempDir::new().unwrap();

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 use tracing::{trace, warn};
 
-/// Filename of the sidecar manifest Agent Control writes inside each sub-agent's filesystem dir.
+/// Filename of the manifest Agent Control writes inside each sub-agent's filesystem dir.
 /// The manifest records the absolute paths AC wrote on the previous successful write event so
 /// the next write can compute "previously managed but no longer declared → delete".
 ///
@@ -53,14 +53,6 @@ struct ManagedPathsManifest {
 impl FileSystem {
     pub(super) fn new(base_dir: PathBuf, entries: HashMap<PathBuf, RenderedEntry>) -> Self {
         Self { base_dir, entries }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn test_empty() -> Self {
-        let base_dir = tempfile::tempdir()
-            .expect("create temp dir for test FileSystem")
-            .keep();
-        Self::new(base_dir, HashMap::new())
     }
 
     /// Reconciles the on-disk state under `base_dir` against the current declared tree, then
@@ -174,7 +166,7 @@ fn read_manifest(path: &Path, base_dir: &Path) -> HashSet<PathBuf> {
             }
             let within = is_within_base(p, base_dir);
             if !within {
-                warn!(?p, ?base_dir, "ignoring out-of-base managed-paths entry");
+                warn!(?p, ?base_dir, "An agent is not allowed to modify files outside it's isolated filesystem. Ignoring path.");
             }
             within
         })
@@ -296,6 +288,15 @@ pub struct FileSystemEntriesError(String);
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    impl FileSystem {
+        pub(crate) fn test_empty() -> Self {
+            let base_dir = tempfile::tempdir()
+                .expect("create temp dir for test FileSystem")
+                .keep();
+            Self::new(base_dir, HashMap::new())
+        }
+    }
 
     // `path_from_root` is joined onto an OS-appropriate absolute root when `absolute` is true.
     #[rstest]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -173,6 +173,10 @@ fn read_manifest(path: &Path, base_dir: &Path) -> HashSet<PathBuf> {
         .collect()
 }
 
+/// Returns `true` only when `path` is genuinely contained in `base_dir`: an absolute path, with no
+/// `..` traversal, that lies under `base_dir`. Used to vet manifest entries before acting on them,
+/// since the manifest is read from an agent-writable location and must not be trusted to point
+/// outside the agent's own directory.
 fn is_within_base(path: &Path, base_dir: &Path) -> bool {
     let has_escape = path.components().any(|c| matches!(c, Component::ParentDir));
     !has_escape && path.is_absolute() && path.starts_with(base_dir)

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -30,16 +30,21 @@ pub struct FileSystem {
 pub enum RenderedEntry {
     /// A file with the given content.
     File {
+        /// The rendered content from the file.
         content: String,
+        /// The persistency attribute marking it's lifecicle.
         persistent: bool,
     },
     /// A directory containing child entries keyed by their relative path.
     Dir {
+        /// The dictionary containing each children path and the entry.
         children: HashMap<PathBuf, RenderedEntry>,
+        /// The persistency attribute marking it's lifecicle.
         persistent: bool,
     },
     /// A directory whose files were projected from a map (filename to content).
     DirContentFromMap {
+        /// The dictionary containing all file paths and their content.
         files: HashMap<PathBuf, String>,
     },
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -2,7 +2,7 @@
 use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 use tracing::{trace, warn};
 
@@ -10,8 +10,8 @@ use tracing::{trace, warn};
 /// The manifest records the absolute paths AC wrote on the previous successful write event so
 /// the next write can compute "previously managed but no longer declared → delete".
 ///
-/// Reserved name: agent-type definitions cannot declare a path with this exact filename at any
-/// level. The filesystem parser validates this at parse time.
+/// Reserved name: agent-type definitions cannot declare an entry with this exact filename at any
+/// level.
 pub const MANAGED_PATHS_MANIFEST_FILENAME: &str = ".ac-managed-paths.json";
 
 /// Rendered filesystem tree, ready to be materialized on disk.
@@ -71,7 +71,7 @@ impl FileSystem {
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         let manifest_path = self.manifest_path();
-        let prev_declared = read_manifest(&manifest_path);
+        let prev_declared = read_manifest(&manifest_path, &self.base_dir);
         let curr_declared = self.collect_declared_paths();
 
         // Reconcile: delete paths AC owned previously but no longer declares.
@@ -143,7 +143,9 @@ fn collect_recursive(path: &Path, entry: &RenderedEntry, declared: &mut HashSet<
     }
 }
 
-fn read_manifest(path: &Path) -> HashSet<PathBuf> {
+/// Reads the managed-paths manifest at `path`, returning only entries that are safe to act on:
+/// paths genuinely contained in `base_dir`.
+fn read_manifest(path: &Path, base_dir: &Path) -> HashSet<PathBuf> {
     let raw = match std::fs::read(path) {
         Ok(b) => b,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return HashSet::new(),
@@ -156,13 +158,32 @@ fn read_manifest(path: &Path) -> HashSet<PathBuf> {
             return HashSet::new();
         }
     };
-    match serde_json::from_slice::<ManagedPathsManifest>(&raw) {
-        Ok(m) => m.managed_paths.into_iter().collect(),
+    let managed_paths = match serde_json::from_slice::<ManagedPathsManifest>(&raw) {
+        Ok(m) => m.managed_paths,
         Err(err) => {
             warn!(?err, ?path, "managed-paths manifest is malformed, ignoring");
-            HashSet::new()
+            return HashSet::new();
         }
-    }
+    };
+    managed_paths
+        .into_iter()
+        .filter(|p| {
+            // Never let the manifest mark itself for deletion.
+            if p == path {
+                return false;
+            }
+            let within = is_within_base(p, base_dir);
+            if !within {
+                warn!(?p, ?base_dir, "ignoring out-of-base managed-paths entry");
+            }
+            within
+        })
+        .collect()
+}
+
+fn is_within_base(path: &Path, base_dir: &Path) -> bool {
+    let has_escape = path.components().any(|c| matches!(c, Component::ParentDir));
+    !has_escape && path.is_absolute() && path.starts_with(base_dir)
 }
 
 fn write_manifest(path: &Path, declared: &HashSet<PathBuf>) -> Result<(), std::io::Error> {
@@ -290,3 +311,70 @@ fn delete_ephemeral_recursive(
 #[derive(Debug, Error)]
 #[error("file system entries error: {0}")]
 pub struct FileSystemEntriesError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    // In-base paths are accepted.
+    #[case::file_in_base("/base/dir/file.txt", true)]
+    #[case::nested_in_base("/base/dir/a/b/c.txt", true)]
+    #[case::base_itself("/base/dir", true)]
+    // Outside the base dir.
+    #[case::unrelated_absolute("/etc/passwd", false)]
+    #[case::parent_of_base("/base", false)]
+    // Lexical-prefix confusion: a sibling sharing a name prefix must not pass.
+    #[case::sibling_prefix("/base/dirsuffix/x.txt", false)]
+    // `..` traversal that resolves outside base but would pass a naive `starts_with`.
+    #[case::parent_traversal("/base/dir/../escape.txt", false)]
+    // Relative paths can't be reasoned about safely.
+    #[case::relative("relative/path.txt", false)]
+    fn is_within_base_only_accepts_contained_absolute_paths(
+        #[case] path: &str,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(
+            is_within_base(Path::new(path), Path::new("/base/dir")),
+            expected
+        );
+    }
+
+    #[test]
+    fn read_manifest_drops_untrusted_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let manifest_path = base_dir.join(MANAGED_PATHS_MANIFEST_FILENAME);
+
+        let keep_1 = base_dir.join("keep.txt");
+        let keep_2 = base_dir.join("sub").join("deep.txt");
+
+        let manifest = ManagedPathsManifest {
+            managed_paths: vec![
+                keep_1.clone(),
+                keep_2.clone(),
+                // Out of base: a tampered manifest must not turn these into deletions.
+                PathBuf::from("/etc/passwd"),
+                base_dir.join("..").join("..").join("escape.txt"),
+                PathBuf::from("relative.txt"),
+                // The manifest must never list (and thus delete) itself.
+                manifest_path.clone(),
+            ],
+        };
+        std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let result = read_manifest(&manifest_path, &base_dir);
+
+        assert_eq!(result, HashSet::from([keep_1, keep_2]));
+    }
+
+    #[test]
+    fn read_manifest_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let manifest_path = base_dir.join(MANAGED_PATHS_MANIFEST_FILENAME);
+
+        assert!(read_manifest(&manifest_path, &base_dir).is_empty());
+    }
+}

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -41,16 +41,16 @@ pub enum RenderedEntry {
     /// A directory whose files were projected from a map (filename to content).
     DirContentFromMap {
         files: HashMap<PathBuf, String>,
-        persistent: bool,
     },
 }
 
 impl RenderedEntry {
     fn persistent(&self) -> bool {
         match self {
-            Self::File { persistent, .. }
-            | Self::Dir { persistent, .. }
-            | Self::DirContentFromMap { persistent, .. } => *persistent,
+            Self::File { persistent, .. } | Self::Dir { persistent, .. } => *persistent,
+            // `dir_content_from_map` has no persistent flag: Agent Control re-renders its
+            // projected files on every write, so it is always treated as ephemeral.
+            Self::DirContentFromMap { .. } => false,
         }
     }
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -243,8 +243,8 @@ fn write_entry(
     entry: &RenderedEntry,
 ) -> Result<(), FileSystemEntriesError> {
     match entry {
-        RenderedEntry::File(content) => write_file(file_writer, dir_manager, path, content),
-        RenderedEntry::Dir(children) => {
+        RenderedEntry::File { content, .. } => write_file(file_writer, dir_manager, path, content),
+        RenderedEntry::Dir { children, .. } => {
             ensure_dir(dir_manager, path)?;
             for (sub_path, child) in children {
                 let child_path = path.join(sub_path);
@@ -253,30 +253,10 @@ fn write_entry(
             }
             Ok(())
         }
-        RenderedEntry::DirContentFromMap(files) => {
+        RenderedEntry::DirContentFromMap { files, .. } => {
             ensure_dir(dir_manager, path)?;
             for (file_name, content) in files {
                 write_file(file_writer, dir_manager, &path.join(file_name), content)?;
-            }
-            Ok(())
-        }
-        RenderedEntry::DirContentFromMap { files, .. } => {
-            dir_manager.create(path).map_err(|err| {
-                FileSystemEntriesError(format!("creating directory {path:?}: {err}"))
-            })?;
-            for (file_name, content) in files {
-                let file_path = path.join(file_name);
-                let parent = file_path.parent().ok_or_else(|| {
-                    FileSystemEntriesError(format!("{} has no parent dir", file_path.display()))
-                })?;
-                dir_manager.create(parent).map_err(|err| {
-                    FileSystemEntriesError(format!("creating directory {parent:?}: {err}"))
-                })?;
-                file_writer
-                    .write(&file_path, content.to_owned())
-                    .map_err(|err| {
-                        FileSystemEntriesError(format!("creating file {file_path:?}: {err}"))
-                    })?;
             }
             Ok(())
         }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -19,7 +19,7 @@ pub const MANAGED_PATHS_MANIFEST_FILENAME: &str = ".ac-managed-paths.json";
 /// Top-level keys (`entries`) are absolute paths under `base_dir`; children inside a `Dir` are
 /// kept relative to their parent — recursion in [`FileSystem::write`] joins them onto the parent
 /// path.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FileSystem {
     pub(super) base_dir: PathBuf,
     pub(super) entries: HashMap<PathBuf, RenderedEntry>,
@@ -55,6 +55,14 @@ impl FileSystem {
         Self { base_dir, entries }
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_empty() -> Self {
+        let base_dir = tempfile::tempdir()
+            .expect("create temp dir for test FileSystem")
+            .keep();
+        Self::new(base_dir, HashMap::new())
+    }
+
     /// Reconciles the on-disk state under `base_dir` against the current declared tree, then
     /// writes the declared tree, then updates the manifest.
     pub fn write(
@@ -62,10 +70,6 @@ impl FileSystem {
         file_writer: &impl FileWriter,
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
-        // `FileSystem::default()` produces an empty `base_dir` so we don't want to write a manifest
-        if self.base_dir.as_os_str().is_empty() {
-            return Ok(());
-        }
         let manifest_path = self.manifest_path();
         let prev_declared = read_manifest(&manifest_path);
         let curr_declared = self.collect_declared_paths();

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -297,28 +297,38 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    // `path_from_root` is joined onto an OS-appropriate absolute root when `absolute` is true.
     #[rstest]
     // In-base paths are accepted.
-    #[case::file_in_base("/base/dir/file.txt", true)]
-    #[case::nested_in_base("/base/dir/a/b/c.txt", true)]
-    #[case::base_itself("/base/dir", true)]
+    #[case::file_in_base("base/dir/file.txt", true, true)]
+    #[case::nested_in_base("base/dir/a/b/c.txt", true, true)]
+    #[case::base_itself("base/dir", true, true)]
     // Outside the base dir.
-    #[case::unrelated_absolute("/etc/passwd", false)]
-    #[case::parent_of_base("/base", false)]
+    #[case::unrelated_absolute("etc/passwd", true, false)]
+    #[case::parent_of_base("base", true, false)]
     // Lexical-prefix confusion: a sibling sharing a name prefix must not pass.
-    #[case::sibling_prefix("/base/dirsuffix/x.txt", false)]
+    #[case::sibling_prefix("base/dirsuffix/x.txt", true, false)]
     // `..` traversal that resolves outside base but would pass a naive `starts_with`.
-    #[case::parent_traversal("/base/dir/../escape.txt", false)]
+    #[case::parent_traversal("base/dir/../escape.txt", true, false)]
     // Relative paths can't be reasoned about safely.
-    #[case::relative("relative/path.txt", false)]
+    #[case::relative("relative/path.txt", false, false)]
     fn is_within_base_only_accepts_contained_absolute_paths(
-        #[case] path: &str,
+        #[case] path_from_root: &str,
+        #[case] absolute: bool,
         #[case] expected: bool,
     ) {
-        assert_eq!(
-            is_within_base(Path::new(path), Path::new("/base/dir")),
-            expected
-        );
+        #[cfg(windows)]
+        const ABS_ROOT: &str = "C:\\";
+        #[cfg(not(windows))]
+        const ABS_ROOT: &str = "/";
+
+        let base = Path::new(ABS_ROOT).join("base").join("dir");
+        let path = if absolute {
+            Path::new(ABS_ROOT).join(path_from_root)
+        } else {
+            PathBuf::from(path_from_root)
+        };
+        assert_eq!(is_within_base(&path, &base), expected);
     }
 
     #[test]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -1,40 +1,185 @@
 //! Rendered filesystem tree and the logic to materialize it on disk.
 use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use tracing::trace;
+use tracing::{trace, warn};
+
+/// Filename of the sidecar manifest Agent Control writes inside each sub-agent's filesystem dir.
+/// The manifest records the absolute paths AC wrote on the previous successful write event so
+/// the next write can compute "previously managed but no longer declared → delete".
+///
+/// Reserved name: agent-type definitions cannot declare a path with this exact filename at any
+/// level. The filesystem parser validates this at parse time.
+pub const MANAGED_PATHS_MANIFEST_FILENAME: &str = ".ac-managed-paths.json";
 
 /// Rendered filesystem tree, ready to be materialized on disk.
 ///
-/// Top-level keys are absolute paths but children inside [`RenderedEntry::Dir`] are kept relative
-/// to their parent — recursion in [`FileSystem::write`] joins them onto the parent path.
+/// Top-level keys (`entries`) are absolute paths under `base_dir`; children inside a `Dir` are
+/// kept relative to their parent — recursion in [`FileSystem::write`] joins them onto the parent
+/// path.
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct FileSystem(pub(super) HashMap<PathBuf, RenderedEntry>);
+pub struct FileSystem {
+    pub(super) base_dir: PathBuf,
+    pub(super) entries: HashMap<PathBuf, RenderedEntry>,
+}
 
 /// A single rendered filesystem entry.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RenderedEntry {
     /// A file with the given content.
-    File(String),
+    File {
+        content: String,
+        persistent: bool,
+    },
     /// A directory containing child entries keyed by their relative path.
-    Dir(HashMap<PathBuf, RenderedEntry>),
+    Dir {
+        children: HashMap<PathBuf, RenderedEntry>,
+        persistent: bool,
+    },
     /// A directory whose files were projected from a map (filename to content).
-    DirContentFromMap(HashMap<PathBuf, String>),
+    DirContentFromMap {
+        files: HashMap<PathBuf, String>,
+        persistent: bool,
+    },
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct ManagedPathsManifest {
+    managed_paths: Vec<PathBuf>,
 }
 
 impl FileSystem {
-    /// Writes the whole rendered tree to disk using the given file writer and directory manager.
+    pub(super) fn new(base_dir: PathBuf, entries: HashMap<PathBuf, RenderedEntry>) -> Self {
+        Self { base_dir, entries }
+    }
+
+    /// Reconciles the on-disk state under `base_dir` against the current declared tree, then
+    /// writes the declared tree, then updates the manifest.
     pub fn write(
         &self,
         file_writer: &impl FileWriter,
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
-        for (path, entry) in &self.0 {
+        // `FileSystem::default()` produces an empty `base_dir` so we don't want to write a manifest
+        if self.base_dir.as_os_str().is_empty() {
+            return Ok(());
+        }
+        let manifest_path = self.manifest_path();
+        let prev_declared = read_manifest(&manifest_path);
+        let curr_declared = self.collect_declared_paths();
+
+        // Reconcile: delete paths AC owned previously but no longer declares.
+        let mut stale: Vec<&PathBuf> = prev_declared
+            .iter()
+            .filter(|p| !curr_declared.contains(*p))
+            .collect();
+        // Sort by depth descending so we delete leaves first; saves directory-not-empty churn.
+        stale.sort_by_key(|p| std::cmp::Reverse(p.components().count()));
+        for path in stale {
+            if path.exists()
+                && let Err(err) = delete_path(path)
+            {
+                warn!(?err, ?path, "failed to delete stale managed path");
+            }
+        }
+
+        for (path, entry) in &self.entries {
             write_entry(file_writer, dir_manager, path, entry)?;
+        }
+
+        if let Err(err) = write_manifest(&manifest_path, &curr_declared) {
+            warn!(
+                ?err,
+                ?manifest_path,
+                "failed to persist managed-paths manifest"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Deletes the on-disk path of every ephemeral entry in the tree.
+    /// A persistent entry whose ancestor is ephemeral is wiped along with the ancestor
+    pub fn delete_ephemeral(&self) -> Result<(), FileSystemEntriesError> {
+        for (path, entry) in &self.entries {
+            delete_ephemeral_recursive(path, entry)?;
         }
         Ok(())
     }
+
+    fn manifest_path(&self) -> PathBuf {
+        self.base_dir.join(MANAGED_PATHS_MANIFEST_FILENAME)
+    }
+
+    fn collect_declared_paths(&self) -> HashSet<PathBuf> {
+        let mut declared = HashSet::new();
+        for (path, entry) in &self.entries {
+            collect_recursive(path, entry, &mut declared);
+        }
+        declared
+    }
+}
+
+fn collect_recursive(path: &Path, entry: &RenderedEntry, declared: &mut HashSet<PathBuf>) {
+    declared.insert(path.to_path_buf());
+    match entry {
+        RenderedEntry::File { .. } => {}
+        RenderedEntry::Dir { children, .. } => {
+            for (sub, child) in children {
+                collect_recursive(&path.join(sub), child, declared);
+            }
+        }
+        RenderedEntry::DirContentFromMap { files, .. } => {
+            for sub in files.keys() {
+                declared.insert(path.join(sub));
+            }
+        }
+    }
+}
+
+fn read_manifest(path: &Path) -> HashSet<PathBuf> {
+    let raw = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return HashSet::new(),
+        Err(err) => {
+            warn!(
+                ?err,
+                ?path,
+                "failed to read managed-paths manifest, ignoring"
+            );
+            return HashSet::new();
+        }
+    };
+    match serde_json::from_slice::<ManagedPathsManifest>(&raw) {
+        Ok(m) => m.managed_paths.into_iter().collect(),
+        Err(err) => {
+            warn!(?err, ?path, "managed-paths manifest is malformed, ignoring");
+            HashSet::new()
+        }
+    }
+}
+
+fn write_manifest(path: &Path, declared: &HashSet<PathBuf>) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut managed_paths: Vec<PathBuf> = declared.iter().cloned().collect();
+    managed_paths.sort();
+    let body = serde_json::to_vec(&ManagedPathsManifest { managed_paths })
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    std::fs::write(path, body)
+}
+
+fn delete_path(path: &Path) -> Result<(), FileSystemEntriesError> {
+    trace!("Deleting stale managed path {}", path.display());
+    let res = if path.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    };
+    res.map_err(|err| FileSystemEntriesError(format!("deleting {}: {err}", path.display())))
 }
 
 /// Creates `dir` (and any missing parents), with error context. Safe if it already exists.
@@ -90,7 +235,51 @@ fn write_entry(
             }
             Ok(())
         }
+        RenderedEntry::DirContentFromMap { files, .. } => {
+            dir_manager.create(path).map_err(|err| {
+                FileSystemEntriesError(format!("creating directory {path:?}: {err}"))
+            })?;
+            for (file_name, content) in files {
+                let file_path = path.join(file_name);
+                let parent = file_path.parent().ok_or_else(|| {
+                    FileSystemEntriesError(format!("{} has no parent dir", file_path.display()))
+                })?;
+                dir_manager.create(parent).map_err(|err| {
+                    FileSystemEntriesError(format!("creating directory {parent:?}: {err}"))
+                })?;
+                file_writer
+                    .write(&file_path, content.to_owned())
+                    .map_err(|err| {
+                        FileSystemEntriesError(format!("creating file {file_path:?}: {err}"))
+                    })?;
+            }
+            Ok(())
+        }
     }
+}
+
+fn delete_ephemeral_recursive(
+    path: &Path,
+    entry: &RenderedEntry,
+) -> Result<(), FileSystemEntriesError> {
+    let persistent = match entry {
+        RenderedEntry::File { persistent, .. }
+        | RenderedEntry::Dir { persistent, .. }
+        | RenderedEntry::DirContentFromMap { persistent, .. } => *persistent,
+    };
+    if !persistent {
+        if path.exists() {
+            delete_path(path).inspect_err(|err| warn!(?err, ?path, "delete_ephemeral failed"))?;
+        }
+        return Ok(());
+    }
+    // Children may still be ephemeral.
+    if let RenderedEntry::Dir { children, .. } = entry {
+        for (sub, child) in children {
+            delete_ephemeral_recursive(&path.join(sub), child)?;
+        }
+    }
+    Ok(())
 }
 
 /// Error produced while writing the rendered filesystem tree to disk.

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -45,9 +45,117 @@ pub enum RenderedEntry {
     },
 }
 
+impl RenderedEntry {
+    fn persistent(&self) -> bool {
+        match self {
+            Self::File { persistent, .. }
+            | Self::Dir { persistent, .. }
+            | Self::DirContentFromMap { persistent, .. } => *persistent,
+        }
+    }
+
+    /// Inserts this entry's path and all of its descendants' paths into `declared`.
+    fn collect_declared(&self, path: &Path, declared: &mut HashSet<PathBuf>) {
+        declared.insert(path.to_path_buf());
+        match self {
+            Self::File { .. } => {}
+            Self::Dir { children, .. } => {
+                for (sub, child) in children {
+                    child.collect_declared(&path.join(sub), declared);
+                }
+            }
+            Self::DirContentFromMap { files, .. } => {
+                for sub in files.keys() {
+                    declared.insert(path.join(sub));
+                }
+            }
+        }
+    }
+
+    /// Materializes this entry (and its subtree) on disk at `path`.
+    fn write(
+        &self,
+        path: &Path,
+        file_writer: &impl FileWriter,
+        dir_manager: &impl DirectoryManager,
+    ) -> Result<(), FileSystemEntriesError> {
+        match self {
+            Self::File { content, .. } => write_file(file_writer, dir_manager, path, content),
+            Self::Dir { children, .. } => {
+                ensure_dir(dir_manager, path)?;
+                for (sub_path, child) in children {
+                    let child_path = path.join(sub_path);
+                    trace!("Recursing into child entry {}", child_path.display());
+                    child.write(&child_path, file_writer, dir_manager)?;
+                }
+                Ok(())
+            }
+            Self::DirContentFromMap { files, .. } => {
+                ensure_dir(dir_manager, path)?;
+                for (file_name, content) in files {
+                    write_file(file_writer, dir_manager, &path.join(file_name), content)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Deletes this entry's on-disk path if it is ephemeral. A persistent directory is kept, but
+    /// the walk recurses so ephemeral descendants are still cleaned; an ephemeral ancestor is
+    /// removed recursively, taking any persistent descendants with it.
+    fn delete_ephemeral(&self, path: &Path) -> Result<(), FileSystemEntriesError> {
+        if !self.persistent() {
+            if path.exists() {
+                delete_path(path)
+                    .inspect_err(|err| warn!(?err, ?path, "delete_ephemeral failed"))?;
+            }
+            return Ok(());
+        }
+        // Persistent: keep this node, but its children may still be ephemeral.
+        if let Self::Dir { children, .. } = self {
+            for (sub, child) in children {
+                child.delete_ephemeral(&path.join(sub))?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct ManagedPathsManifest {
     managed_paths: Vec<PathBuf>,
+}
+
+impl ManagedPathsManifest {
+    /// Loads the manifest at `path`. A missing or malformed file creates an empty manifest (logged)
+    fn load(path: &Path) -> Self {
+        let raw = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(err) => {
+                warn!(
+                    ?err,
+                    ?path,
+                    "failed to read managed-paths manifest, ignoring"
+                );
+                return Self::default();
+            }
+        };
+        serde_json::from_slice(&raw).unwrap_or_else(|err| {
+            warn!(?err, ?path, "managed-paths manifest is malformed, ignoring");
+            Self::default()
+        })
+    }
+
+    /// Serializes the manifest to `path`, creating its parent directory if needed.
+    fn save(&self, path: &Path) -> Result<(), std::io::Error> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let body = serde_json::to_vec(self)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        std::fs::write(path, body)
+    }
 }
 
 impl FileSystem {
@@ -63,7 +171,7 @@ impl FileSystem {
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         let manifest_path = self.manifest_path();
-        let prev_declared = read_manifest(&manifest_path, &self.base_dir);
+        let prev_declared = self.read_manifest();
         let curr_declared = self.collect_declared_paths();
 
         // Reconcile: delete paths AC owned previously but no longer declares.
@@ -82,10 +190,13 @@ impl FileSystem {
         }
 
         for (path, entry) in &self.entries {
-            write_entry(file_writer, dir_manager, path, entry)?;
+            entry.write(path, file_writer, dir_manager)?;
         }
 
-        if let Err(err) = write_manifest(&manifest_path, &curr_declared) {
+        let mut managed_paths: Vec<PathBuf> = curr_declared.iter().cloned().collect();
+        managed_paths.sort();
+        let manifest = ManagedPathsManifest { managed_paths };
+        if let Err(err) = manifest.save(&manifest_path) {
             warn!(
                 ?err,
                 ?manifest_path,
@@ -100,7 +211,7 @@ impl FileSystem {
     /// A persistent entry whose ancestor is ephemeral is wiped along with the ancestor
     pub fn delete_ephemeral(&self) -> Result<(), FileSystemEntriesError> {
         for (path, entry) in &self.entries {
-            delete_ephemeral_recursive(path, entry)?;
+            entry.delete_ephemeral(path)?;
         }
         Ok(())
     }
@@ -112,65 +223,30 @@ impl FileSystem {
     fn collect_declared_paths(&self) -> HashSet<PathBuf> {
         let mut declared = HashSet::new();
         for (path, entry) in &self.entries {
-            collect_recursive(path, entry, &mut declared);
+            entry.collect_declared(path, &mut declared);
         }
         declared
     }
-}
 
-fn collect_recursive(path: &Path, entry: &RenderedEntry, declared: &mut HashSet<PathBuf>) {
-    declared.insert(path.to_path_buf());
-    match entry {
-        RenderedEntry::File { .. } => {}
-        RenderedEntry::Dir { children, .. } => {
-            for (sub, child) in children {
-                collect_recursive(&path.join(sub), child, declared);
-            }
-        }
-        RenderedEntry::DirContentFromMap { files, .. } => {
-            for sub in files.keys() {
-                declared.insert(path.join(sub));
-            }
-        }
+    /// Reads the managed-paths manifest, returning only entries that are contained in `base_dir`
+    fn read_manifest(&self) -> HashSet<PathBuf> {
+        let manifest_path = self.manifest_path();
+        ManagedPathsManifest::load(&manifest_path)
+            .managed_paths
+            .into_iter()
+            .filter(|p| {
+                // Never let the manifest mark itself for deletion.
+                if p == &manifest_path {
+                    return false;
+                }
+                let within = is_within_base(p, &self.base_dir);
+                if !within {
+                    warn!(?p, base_dir = ?self.base_dir, "An agent is not allowed to modify files outside its isolated filesystem. Ignoring path.");
+                }
+                within
+            })
+            .collect()
     }
-}
-
-/// Reads the managed-paths manifest at `path`, returning only entries that are safe to act on:
-/// paths genuinely contained in `base_dir`.
-fn read_manifest(path: &Path, base_dir: &Path) -> HashSet<PathBuf> {
-    let raw = match std::fs::read(path) {
-        Ok(b) => b,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return HashSet::new(),
-        Err(err) => {
-            warn!(
-                ?err,
-                ?path,
-                "failed to read managed-paths manifest, ignoring"
-            );
-            return HashSet::new();
-        }
-    };
-    let managed_paths = match serde_json::from_slice::<ManagedPathsManifest>(&raw) {
-        Ok(m) => m.managed_paths,
-        Err(err) => {
-            warn!(?err, ?path, "managed-paths manifest is malformed, ignoring");
-            return HashSet::new();
-        }
-    };
-    managed_paths
-        .into_iter()
-        .filter(|p| {
-            // Never let the manifest mark itself for deletion.
-            if p == path {
-                return false;
-            }
-            let within = is_within_base(p, base_dir);
-            if !within {
-                warn!(?p, ?base_dir, "An agent is not allowed to modify files outside it's isolated filesystem. Ignoring path.");
-            }
-            within
-        })
-        .collect()
 }
 
 /// Returns `true` only when `path` is genuinely contained in `base_dir`: an absolute path, with no
@@ -182,19 +258,8 @@ fn is_within_base(path: &Path, base_dir: &Path) -> bool {
     !has_escape && path.is_absolute() && path.starts_with(base_dir)
 }
 
-fn write_manifest(path: &Path, declared: &HashSet<PathBuf>) -> Result<(), std::io::Error> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut managed_paths: Vec<PathBuf> = declared.iter().cloned().collect();
-    managed_paths.sort();
-    let body = serde_json::to_vec(&ManagedPathsManifest { managed_paths })
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    std::fs::write(path, body)
-}
-
 fn delete_path(path: &Path) -> Result<(), FileSystemEntriesError> {
-    trace!("Deleting stale managed path {}", path.display());
+    trace!("Deleting path {}", path.display());
     let res = if path.is_dir() {
         std::fs::remove_dir_all(path)
     } else {
@@ -230,57 +295,6 @@ fn write_file(
     file_writer
         .write(path, content.to_owned())
         .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
-}
-
-fn write_entry(
-    file_writer: &impl FileWriter,
-    dir_manager: &impl DirectoryManager,
-    path: &Path,
-    entry: &RenderedEntry,
-) -> Result<(), FileSystemEntriesError> {
-    match entry {
-        RenderedEntry::File { content, .. } => write_file(file_writer, dir_manager, path, content),
-        RenderedEntry::Dir { children, .. } => {
-            ensure_dir(dir_manager, path)?;
-            for (sub_path, child) in children {
-                let child_path = path.join(sub_path);
-                trace!("Recursing into child entry {}", child_path.display());
-                write_entry(file_writer, dir_manager, &child_path, child)?;
-            }
-            Ok(())
-        }
-        RenderedEntry::DirContentFromMap { files, .. } => {
-            ensure_dir(dir_manager, path)?;
-            for (file_name, content) in files {
-                write_file(file_writer, dir_manager, &path.join(file_name), content)?;
-            }
-            Ok(())
-        }
-    }
-}
-
-fn delete_ephemeral_recursive(
-    path: &Path,
-    entry: &RenderedEntry,
-) -> Result<(), FileSystemEntriesError> {
-    let persistent = match entry {
-        RenderedEntry::File { persistent, .. }
-        | RenderedEntry::Dir { persistent, .. }
-        | RenderedEntry::DirContentFromMap { persistent, .. } => *persistent,
-    };
-    if !persistent {
-        if path.exists() {
-            delete_path(path).inspect_err(|err| warn!(?err, ?path, "delete_ephemeral failed"))?;
-        }
-        return Ok(());
-    }
-    // Children may still be ephemeral.
-    if let RenderedEntry::Dir { children, .. } = entry {
-        for (sub, child) in children {
-            delete_ephemeral_recursive(&path.join(sub), child)?;
-        }
-    }
-    Ok(())
 }
 
 /// Error produced while writing the rendered filesystem tree to disk.
@@ -359,7 +373,7 @@ mod tests {
         };
         std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
 
-        let result = read_manifest(&manifest_path, &base_dir);
+        let result = FileSystem::new(base_dir, HashMap::new()).read_manifest();
 
         assert_eq!(result, HashSet::from([keep_1, keep_2]));
     }
@@ -368,8 +382,11 @@ mod tests {
     fn read_manifest_missing_file_is_empty() {
         let dir = tempfile::tempdir().unwrap();
         let base_dir = dir.path().to_path_buf();
-        let manifest_path = base_dir.join(MANAGED_PATHS_MANIFEST_FILENAME);
 
-        assert!(read_manifest(&manifest_path, &base_dir).is_empty());
+        assert!(
+            FileSystem::new(base_dir, HashMap::new())
+                .read_manifest()
+                .is_empty()
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -79,7 +79,7 @@ impl FileSystem {
             .iter()
             .filter(|p| !curr_declared.contains(*p))
             .collect();
-        // Sort by depth descending so we delete leaves first; saves directory-not-empty churn.
+        // Deepest first, so a dir's stale children are gone before we remove the dir.
         stale.sort_by_key(|p| std::cmp::Reverse(p.components().count()));
         for path in stale {
             if path.exists()

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -8,7 +8,7 @@ use crate::agent_type::runtime_config::{
 use std::collections::HashMap;
 
 /// On-host deployment configuration after templating.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OnHost {
     /// The executables to supervise.
     pub executables: Vec<Executable>,

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -315,6 +315,11 @@ where
     ) -> Result<StartedSupervisorOnHost<PM>, SupervisorError> {
         let (health_publisher, health_consumer) = pub_sub();
 
+        // Ensure all ephemeral entries are removed before start in case it didn't work on stop.
+        if let Err(err) = self.filesystem.delete_ephemeral() {
+            warn!(?err, "filesystem ephemeral cleanup failed on start");
+        }
+
         self.filesystem
             .write(&LocalFile, &DirectoryManagerFs)
             .map_err(SupervisorError::FileSystem)?;
@@ -631,10 +636,16 @@ pub mod tests {
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_control::defaults::STDOUT_LOG_FILE_NAME_SUFFIX;
     use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::agent_type::agent_attributes::AgentAttributes;
+    use crate::agent_type::definition::Variables;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
+    use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
     use crate::agent_type::runtime_config::on_host::rendered::OnHost;
     use crate::agent_type::runtime_config::rendered::{Deployment, Runtime};
     use crate::agent_type::runtime_config::restart_policy::rendered::RestartPolicyConfig;
+    use crate::agent_type::templates::Templateable;
+    use crate::agent_type::variable::Variable;
+    use crate::agent_type::variable::namespace::Namespace;
     use crate::checkers::health::health_checker::HEALTH_CHECKER_THREAD_NAME;
     use crate::event::channel::pub_sub;
     use crate::package::manager::tests::MockPackageManager;
@@ -644,9 +655,7 @@ pub mod tests {
     use crate::sub_agent::supervisor::Supervisor;
     use serde::Deserialize;
     use std::collections::HashMap;
-    use std::fs;
-    use std::thread;
-    use std::time::{Duration, Instant};
+    use std::{fs, thread, time::{Duration, Instant}};
     use tracing_test::traced_test;
 
     fn get_empty_packages() -> RenderedPackages {
@@ -787,13 +796,6 @@ pub mod tests {
 
     #[test]
     fn test_stop_runs_filesystem_delete_ephemeral() {
-        use crate::agent_type::agent_attributes::AgentAttributes;
-        use crate::agent_type::definition::Variables;
-        use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
-        use crate::agent_type::templates::Templateable;
-        use crate::agent_type::variable::Variable;
-        use crate::agent_type::variable::namespace::Namespace;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let yaml = r#"
 ephemeral.txt:
@@ -855,6 +857,65 @@ persistent.txt:
             persistent_path.exists(),
             "stop should have left the persistent file alone"
         );
+    }
+
+    #[test]
+    fn test_start_resets_ephemeral_entries_before_write() {
+
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let yaml = r#"
+ephemeral-dir:
+  kind: dir
+persistent.txt:
+  kind: file
+  text: p
+  persistent: true
+"#;
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+        )]);
+        let filesystem = serde_saphyr::from_str::<ParsedFileSystem>(yaml)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap();
+
+        // Simulate leftover state from an ungraceful previous run (stop-time cleanup skipped):
+        // an agent-created file inside the ephemeral dir.
+        let stale_file = tmp_dir.path().join("ephemeral-dir").join("stale.txt");
+        fs::create_dir_all(stale_file.parent().unwrap()).unwrap();
+        fs::write(&stale_file, "stale").unwrap();
+        assert!(stale_file.exists());
+
+        let agent_identity = AgentIdentity::from((
+            "start-test-agent".to_owned().try_into().unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity,
+            vec![],
+            OnHostHealthConfig::default(),
+            None,
+            get_empty_packages(),
+            MockPackageManager::new_arc(),
+            false,
+            PathBuf::default(),
+            filesystem,
+        );
+
+        let (publisher, _consumer) = pub_sub();
+        let started = supervisor.start(publisher).expect("start");
+
+        // The ephemeral dir is wiped before the write, so leftover content is gone; the dir itself
+        // is re-created by the write, and the persistent entry is present.
+        assert!(
+            !stale_file.exists(),
+            "startup should have removed stale content from the ephemeral dir"
+        );
+        assert!(tmp_dir.path().join("ephemeral-dir").is_dir());
+        assert!(tmp_dir.path().join("persistent.txt").exists());
+
+        let _ = started.stop();
     }
 
     #[test]

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -89,6 +89,7 @@ where
     pub internal_publisher: EventPublisher<SubAgentInternalEvent>,
     /// Directory where executable output is logged when file logging is enabled.
     pub logging_path: PathBuf,
+    /// The agent's filesystem.
     pub filesystem: FileSystem,
 }
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -725,7 +725,7 @@ pub mod tests {
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -770,7 +770,7 @@ pub mod tests {
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -884,7 +884,7 @@ persistent.txt:
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -933,7 +933,7 @@ persistent.txt:
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -982,7 +982,7 @@ persistent.txt:
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1026,7 +1026,7 @@ persistent.txt:
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1089,7 +1089,7 @@ persistent.txt:
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (health_publisher, health_consumer) = pub_sub();
@@ -1269,7 +1269,7 @@ persistent.txt:
             Arc::new(MockPackageManager::new()),
             true,
             logging_path.clone(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1303,7 +1303,8 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: true,
             health: OnHostHealthConfig::default(),
-            filesystem: FileSystem::default(),
+            version: None,
+            filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1395,7 +1396,7 @@ persistent.txt:
             Arc::new(MockPackageManager::new()),
             false,
             logging_path.clone(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1429,7 +1430,8 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: true,
             health: OnHostHealthConfig::default(),
-            filesystem: FileSystem::default(),
+            version: None,
+            filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1519,7 +1521,7 @@ persistent.txt:
             Arc::new(MockPackageManager::new()),
             true,
             logging_path.clone(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1553,7 +1555,8 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: false,
             health: OnHostHealthConfig::default(),
-            filesystem: FileSystem::default(),
+            version: None,
+            filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1644,7 +1647,7 @@ persistent.txt:
             Arc::new(MockPackageManager::new()),
             false,
             logging_path.clone(),
-            FileSystem::default(),
+            FileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1678,7 +1681,8 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: false,
             health: OnHostHealthConfig::default(),
-            filesystem: FileSystem::default(),
+            version: None,
+            filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -189,6 +189,9 @@ where
             onhost_config.filesystem,
         );
 
+        // No explicit file deletion is needed on apply: spin_up reconciles the filesystem. Its
+        // `write` removes any path AC owned under the previous config but no longer declares, and
+        // its `delete_ephemeral` freshens ephemeral state before re-rendering.
         let new_started_supervisor = starter.spin_up(internal_publisher)?;
 
         Ok(new_started_supervisor)

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -149,9 +149,7 @@ where
             internal_publisher,
             thread_contexts,
             logging_path,
-            // Dropped on purpose; listed by name (not via `..`) so any future field
-            // added to the struct fails to compile here until it's explicitly threaded through.
-            filesystem: _,
+            ..
         } = self;
 
         let installation_result = install_packages(

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -831,7 +831,6 @@ persistent.txt:
             agent_identity,
             vec![],
             OnHostHealthConfig::default(),
-            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -901,7 +900,6 @@ persistent.txt:
             agent_identity,
             vec![],
             OnHostHealthConfig::default(),
-            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1368,7 +1366,6 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: true,
             health: OnHostHealthConfig::default(),
-            version: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1495,7 +1492,6 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: true,
             health: OnHostHealthConfig::default(),
-            version: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1620,7 +1616,6 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: false,
             health: OnHostHealthConfig::default(),
-            version: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1746,7 +1741,6 @@ persistent.txt:
             executables: vec![executable_rendered],
             enable_file_logging: false,
             health: OnHostHealthConfig::default(),
-            version: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -635,8 +635,8 @@ pub mod tests {
     use super::*;
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_control::defaults::STDOUT_LOG_FILE_NAME_SUFFIX;
-    use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::agent_type::agent_attributes::AgentAttributes;
+    use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::agent_type::definition::Variables;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
     use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
@@ -655,7 +655,10 @@ pub mod tests {
     use crate::sub_agent::supervisor::Supervisor;
     use serde::Deserialize;
     use std::collections::HashMap;
-    use std::{fs, thread, time::{Duration, Instant}};
+    use std::{
+        fs, thread,
+        time::{Duration, Instant},
+    };
     use tracing_test::traced_test;
 
     fn get_empty_packages() -> RenderedPackages {
@@ -861,7 +864,6 @@ persistent.txt:
 
     #[test]
     fn test_start_resets_ephemeral_entries_before_write() {
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let yaml = r#"
 ephemeral-dir:

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -89,6 +89,7 @@ where
     pub internal_publisher: EventPublisher<SubAgentInternalEvent>,
     /// Directory where executable output is logged when file logging is enabled.
     pub logging_path: PathBuf,
+    pub filesystem: FileSystem,
 }
 
 /// An on-host supervisor ready to be started.
@@ -142,13 +143,15 @@ where
             .map_err(SupervisorError::RuntimeConfig)?
             .clone();
 
-        // Reuse supervisor inner fields
         let Self {
             agent_identity,
             package_manager,
             internal_publisher,
             thread_contexts,
             logging_path,
+            // Dropped on purpose; listed by name (not via `..`) so any future field
+            // added to the struct fails to compile here until it's explicitly threaded through.
+            filesystem: _,
         } = self;
 
         let installation_result = install_packages(
@@ -194,7 +197,11 @@ where
     }
 
     fn stop(self) -> Result<(), ThreadContextStopperError> {
-        stop_supervisor_threads(self.thread_contexts)
+        let stop_result = stop_supervisor_threads(self.thread_contexts);
+        if let Err(err) = self.filesystem.delete_ephemeral() {
+            warn!(?err, "filesystem ephemeral cleanup failed on stop");
+        }
+        stop_result
     }
 }
 
@@ -337,6 +344,7 @@ where
             agent_identity: self.agent_identity,
             internal_publisher: sub_agent_internal_publisher,
             logging_path: self.file_logging_path,
+            filesystem: self.filesystem,
         })
     }
 
@@ -777,6 +785,78 @@ pub mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_stop_runs_filesystem_delete_ephemeral() {
+        use crate::agent_type::agent_attributes::AgentAttributes;
+        use crate::agent_type::definition::Variables;
+        use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
+        use crate::agent_type::templates::Templateable;
+        use crate::agent_type::variable::Variable;
+        use crate::agent_type::variable::namespace::Namespace;
+
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let yaml = r#"
+ephemeral.txt:
+  kind: file
+  text: e
+persistent.txt:
+  kind: file
+  text: p
+  persistent: true
+"#;
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+        )]);
+        let filesystem = serde_saphyr::from_str::<ParsedFileSystem>(yaml)
+            .unwrap()
+            .template_with(&variables)
+            .unwrap();
+
+        let agent_identity = AgentIdentity::from((
+            "stop-test-agent".to_owned().try_into().unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity,
+            vec![],
+            OnHostHealthConfig::default(),
+            None,
+            get_empty_packages(),
+            MockPackageManager::new_arc(),
+            false,
+            PathBuf::default(),
+            filesystem,
+        );
+
+        let (publisher, _consumer) = pub_sub();
+        let started = supervisor.start(publisher).expect("start");
+
+        let ephemeral_path = tmp_dir.path().join("ephemeral.txt");
+        let persistent_path = tmp_dir.path().join("persistent.txt");
+        assert!(
+            ephemeral_path.exists(),
+            "spin_up should have written ephemeral.txt"
+        );
+        assert!(
+            persistent_path.exists(),
+            "spin_up should have written persistent.txt"
+        );
+
+        let stop_result = started.stop();
+        assert!(stop_result.is_ok(), "stop should succeed: {stop_result:?}");
+
+        assert!(
+            !ephemeral_path.exists(),
+            "stop should have removed the ephemeral file"
+        );
+        assert!(
+            persistent_path.exists(),
+            "stop should have left the persistent file alone"
+        );
     }
 
     #[test]

--- a/agent-control/tests/on_host/scenarios.rs
+++ b/agent-control/tests/on_host/scenarios.rs
@@ -18,3 +18,4 @@ mod postdownload_hook;
 mod remote_agent_removal;
 mod restarting_processes;
 mod self_instrumentation_otel;
+mod stale_agent_filesystem_cleanup;

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -321,28 +321,35 @@ deployment:
   filesystem:
     config:
       kind: dir
+      persistent: true
       entries:
         newrelic-infra.yaml:
           kind: file
+          persistent: true
           text: |-
             ${{nr-var:config_agent}}
     integrations.d:
       kind: dir
+      persistent: true
       entries:
         integration.yaml:
           kind: file
+          persistent: true
           text: |-
             ${{nr-var:config_integrations}}
     logging.d:
       kind: dir
+      persistent: true
       entries:
         logging.yaml:
           kind: file
+          persistent: true
           text: |-
             ${{nr-var:config_logging}}
     # This directory needs to persist across restarts for the infra agent
     newrelic-infra:
       kind: dir
+      persistent: true
       entries:
         newrelic-integrations:
           kind: dir
@@ -496,5 +503,364 @@ fn read_file_and_expect_content(
             path.as_ref().display(),
             e
         )),
+    }
+}
+
+#[test]
+fn ephemeral_entries_wiped_on_stop() {
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let tempdir = tempdir().expect("failed to create temp dir");
+    let local_dir = tempdir.path().join("local");
+    let remote_dir = tempdir.path().join("remote");
+
+    let agent_id = "ephemeral-agent";
+
+    create_file(
+        format!(
+            r#"
+namespace: test
+name: ephemeral
+version: 0.0.0
+platform: host
+operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "1.0"
+variables: {{}}
+deployment:
+  filesystem:
+    ephemeral.txt:
+      kind: file
+      text: "ephemeral content"
+    persistent.txt:
+      kind: file
+      persistent: true
+      text: "persistent content"
+"#,
+        ),
+        local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
+    );
+
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        format!("\n  {agent_id}:\n    agent_type: \"test/ephemeral:0.0.0\"\n"),
+        local_dir.to_path_buf(),
+    );
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        local_dir.to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.to_path_buf(),
+        remote_dir: remote_dir.to_path_buf(),
+        log_dir: local_dir.to_path_buf(),
+    };
+
+    let ephemeral_path = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("ephemeral.txt");
+    let persistent_path = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("persistent.txt");
+
+    {
+        let _agent_control =
+            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+        retry(30, Duration::from_secs(1), || {
+            read_file_and_expect_content(&ephemeral_path, "ephemeral content")?;
+            read_file_and_expect_content(&persistent_path, "persistent content")?;
+            Ok(())
+        });
+    }
+    // After AC drops the supervisor calls delete_ephemeral.
+    retry(30, Duration::from_secs(1), || {
+        if ephemeral_path.exists() {
+            return Err(format!("ephemeral file still on disk: {ephemeral_path:?}").into());
+        }
+        if !persistent_path.exists() {
+            return Err(
+                format!("persistent file should still be present: {persistent_path:?}").into(),
+            );
+        }
+        Ok(())
+    });
+}
+
+/// Full stop/restart-with-different-agent-type flow:
+///   1. AC boots with agent type A declaring a persistent file and a persistent `Dir`.
+///   2. AC stops. Persistent entries (and any agent-process-created files inside) persist.
+///   3. The agent-type is rewritten as agent type B without any of those entries.
+///   4. AC starts again. The sidecar-manifest diff finds the previously-managed paths absent
+///      from the new declared set and deletes them. The persistent Dir is removed via
+///      `remove_dir_all`, taking the agent-created file inside it with it as collateral.
+#[test]
+fn previously_persistent_entries_deleted_on_restart_with_new_agent_type() {
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let tempdir = tempdir().expect("failed to create temp dir");
+    let local_dir = tempdir.path().join("local");
+    let remote_dir = tempdir.path().join("remote");
+
+    let agent_id = "swap-agent";
+    let agent_type_yaml_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+
+    create_file(
+        format!(
+            r#"
+namespace: test
+name: swap
+version: 0.0.0
+platform: host
+operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "1.0"
+variables: {{}}
+deployment:
+  filesystem:
+    persistent.txt:
+      kind: file
+      persistent: true
+      text: "p"
+    drop-zone:
+      kind: dir
+      persistent: true
+"#,
+        ),
+        agent_type_yaml_path.clone(),
+    );
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        format!("\n  {agent_id}:\n    agent_type: \"test/swap:0.0.0\"\n"),
+        local_dir.to_path_buf(),
+    );
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        local_dir.to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.to_path_buf(),
+        remote_dir: remote_dir.to_path_buf(),
+        log_dir: local_dir.to_path_buf(),
+    };
+
+    let persistent_path = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("persistent.txt");
+    let drop_zone_path = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("drop-zone");
+    let runtime_file_path = drop_zone_path.join("runtime.log");
+
+    // Write agent type A's filesystem, drop a runtime file in the drop zone.
+    {
+        let _agent_control =
+            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+        retry(30, Duration::from_secs(1), || {
+            read_file_and_expect_content(&persistent_path, "p")?;
+            if !drop_zone_path.is_dir() {
+                return Err(format!("drop zone missing: {drop_zone_path:?}").into());
+            }
+            Ok(())
+        });
+
+        std::fs::write(&runtime_file_path, "agent runtime data").unwrap();
+    }
+
+    // After AC stops, persistent entries (and the agent-created file in the drop zone) survive.
+    assert!(
+        persistent_path.exists(),
+        "persistent file should survive stop: {persistent_path:?}"
+    );
+    assert!(
+        runtime_file_path.exists(),
+        "agent-created file in drop zone should survive stop: {runtime_file_path:?}"
+    );
+
+    // Swap to agent type B: no filesystem entries at all.
+    create_file(
+        format!(
+            r#"
+namespace: test
+name: swap
+version: 0.0.0
+platform: host
+operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "1.0"
+variables: {{}}
+deployment:
+  filesystem: {{}}
+"#,
+        ),
+        agent_type_yaml_path,
+    );
+
+    // AC run: reconciliation against B's empty declared set wipes everything.
+    {
+        let _agent_control =
+            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+        retry(30, Duration::from_secs(1), || {
+            if persistent_path.exists() {
+                return Err(format!(
+                    "previously-persistent file should be deleted: {persistent_path:?}"
+                )
+                .into());
+            }
+            if drop_zone_path.exists() {
+                return Err(format!(
+                    "formerly-persistent drop zone should be deleted: {drop_zone_path:?}"
+                )
+                .into());
+            }
+            if runtime_file_path.exists() {
+                return Err(format!(
+                    "agent-created file in formerly-persistent drop zone should be deleted: \
+                     {runtime_file_path:?}"
+                )
+                .into());
+            }
+            Ok(())
+        });
+    }
+}
+
+/// Sidecar-manifest reconciliation: when the agent type's `Dir.entries:` set changes between
+/// two AC runs, only the previously-declared (now-undeclared) entries are removed. The
+/// directory itself stays, and any agent-process-created file inside survives because it was
+/// never tracked in the manifest.
+#[test]
+fn agent_created_files_inside_persistent_dir_survive_sibling_removal() {
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let tempdir = tempdir().expect("failed to create temp dir");
+    let local_dir = tempdir.path().join("local");
+    let remote_dir = tempdir.path().join("remote");
+
+    let agent_id = "sidecar-agent";
+    let agent_type_yaml_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+
+    create_file(
+        format!(
+            r#"
+namespace: test
+name: sidecar
+version: 0.0.0
+platform: host
+operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "1.0"
+variables: {{}}
+deployment:
+  filesystem:
+    data:
+      kind: dir
+      persistent: true
+      entries:
+        managed.txt:
+          kind: file
+          persistent: true
+          text: "managed by AC"
+"#,
+        ),
+        agent_type_yaml_path.clone(),
+    );
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        format!("\n  {agent_id}:\n    agent_type: \"test/sidecar:0.0.0\"\n"),
+        local_dir.to_path_buf(),
+    );
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        local_dir.to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.to_path_buf(),
+        remote_dir: remote_dir.to_path_buf(),
+        log_dir: local_dir.to_path_buf(),
+    };
+
+    let data_dir = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id)
+        .join("data");
+    let managed_file = data_dir.join("managed.txt");
+    let runtime_file = data_dir.join("runtime.log");
+
+    {
+        let _agent_control =
+            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+        retry(30, Duration::from_secs(1), || {
+            read_file_and_expect_content(&managed_file, "managed by AC")?;
+            Ok(())
+        });
+
+        std::fs::write(&runtime_file, "runtime").unwrap();
+    }
+
+    // Rewrite agent type to remove `managed.txt`; keep `data` declared.
+    create_file(
+        format!(
+            r#"
+namespace: test
+name: sidecar
+version: 0.0.0
+platform: host
+operating_system: {AGENT_CONTROL_MODE_ON_HOST}
+protocol_version: "1.0"
+variables: {{}}
+deployment:
+  filesystem:
+    data:
+      kind: dir
+      persistent: true
+"#,
+        ),
+        agent_type_yaml_path,
+    );
+
+    {
+        let _agent_control =
+            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+        retry(30, Duration::from_secs(1), || {
+            if managed_file.exists() {
+                return Err(format!(
+                    "managed.txt should have been deleted (no longer in agent type): \
+                     {managed_file:?}"
+                )
+                .into());
+            }
+            if !runtime_file.exists() {
+                return Err(format!(
+                    "agent-created runtime.log should survive (never tracked by AC): \
+                     {runtime_file:?}"
+                )
+                .into());
+            }
+            if !data_dir.is_dir() {
+                return Err(
+                    format!("data dir should still exist (still declared): {data_dir:?}").into(),
+                );
+            }
+            Ok(())
+        });
     }
 }

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -346,16 +346,19 @@ deployment:
           persistent: true
           text: |-
             ${{nr-var:config_logging}}
-    # This directory needs to persist across restarts for the infra agent
+    # This directory needs to persist across restarts for the infra agent. Every level down to
+    # the leaf must be persistent: an ephemeral ancestor is wiped (with its whole subtree) on stop.
     newrelic-infra:
       kind: dir
       persistent: true
       entries:
         newrelic-integrations:
           kind: dir
+          persistent: true
           entries:
             logging:
               kind: dir
+              persistent: true
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -543,7 +543,11 @@ deployment:
             "\n  {agent_id}:\n    agent_type: \"test/ephemeral:0.0.0\"\n"
         ))
         .write(dirs.local_dir());
-    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
 
     let base_paths = dirs.base_paths();
 
@@ -626,7 +630,11 @@ deployment:
             "\n  {agent_id}:\n    agent_type: \"test/swap:0.0.0\"\n"
         ))
         .write(dirs.local_dir());
-    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
 
     let base_paths = dirs.base_paths();
 
@@ -758,7 +766,11 @@ deployment:
             "\n  {agent_id}:\n    agent_type: \"test/sidecar:0.0.0\"\n"
         ))
         .write(dirs.local_dir());
-    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
 
     let base_paths = dirs.base_paths();
 

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -510,9 +510,7 @@ fn read_file_and_expect_content(
 fn ephemeral_entries_wiped_on_stop() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
 
-    let tempdir = tempdir().expect("failed to create temp dir");
-    let local_dir = tempdir.path().join("local");
-    let remote_dir = tempdir.path().join("remote");
+    let dirs = TempBasePaths::default();
 
     let agent_id = "ephemeral-agent";
 
@@ -537,26 +535,17 @@ deployment:
       text: "persistent content"
 "#,
         ),
-        local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME),
+        dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
     );
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        format!("\n  {agent_id}:\n    agent_type: \"test/ephemeral:0.0.0\"\n"),
-        local_dir.to_path_buf(),
-    );
-    create_local_config(
-        agent_id.to_string(),
-        NO_CONFIG.to_string(),
-        local_dir.to_path_buf(),
-    );
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
+            "\n  {agent_id}:\n    agent_type: \"test/ephemeral:0.0.0\"\n"
+        ))
+        .write(dirs.local_dir());
+    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.to_path_buf(),
-        remote_dir: remote_dir.to_path_buf(),
-        log_dir: local_dir.to_path_buf(),
-    };
+    let base_paths = dirs.base_paths();
 
     let ephemeral_path = base_paths
         .remote_dir
@@ -604,12 +593,10 @@ deployment:
 fn previously_persistent_entries_deleted_on_restart_with_new_agent_type() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
 
-    let tempdir = tempdir().expect("failed to create temp dir");
-    let local_dir = tempdir.path().join("local");
-    let remote_dir = tempdir.path().join("remote");
+    let dirs = TempBasePaths::default();
 
     let agent_id = "swap-agent";
-    let agent_type_yaml_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+    let agent_type_yaml_path = dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME);
 
     create_file(
         format!(
@@ -634,23 +621,14 @@ deployment:
         ),
         agent_type_yaml_path.clone(),
     );
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        format!("\n  {agent_id}:\n    agent_type: \"test/swap:0.0.0\"\n"),
-        local_dir.to_path_buf(),
-    );
-    create_local_config(
-        agent_id.to_string(),
-        NO_CONFIG.to_string(),
-        local_dir.to_path_buf(),
-    );
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
+            "\n  {agent_id}:\n    agent_type: \"test/swap:0.0.0\"\n"
+        ))
+        .write(dirs.local_dir());
+    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.to_path_buf(),
-        remote_dir: remote_dir.to_path_buf(),
-        log_dir: local_dir.to_path_buf(),
-    };
+    let base_paths = dirs.base_paths();
 
     let persistent_path = base_paths
         .remote_dir
@@ -746,12 +724,10 @@ deployment:
 fn agent_created_files_inside_persistent_dir_survive_sibling_removal() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
 
-    let tempdir = tempdir().expect("failed to create temp dir");
-    let local_dir = tempdir.path().join("local");
-    let remote_dir = tempdir.path().join("remote");
+    let dirs = TempBasePaths::default();
 
     let agent_id = "sidecar-agent";
-    let agent_type_yaml_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+    let agent_type_yaml_path = dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME);
 
     create_file(
         format!(
@@ -777,23 +753,14 @@ deployment:
         ),
         agent_type_yaml_path.clone(),
     );
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        format!("\n  {agent_id}:\n    agent_type: \"test/sidecar:0.0.0\"\n"),
-        local_dir.to_path_buf(),
-    );
-    create_local_config(
-        agent_id.to_string(),
-        NO_CONFIG.to_string(),
-        local_dir.to_path_buf(),
-    );
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
+            "\n  {agent_id}:\n    agent_type: \"test/sidecar:0.0.0\"\n"
+        ))
+        .write(dirs.local_dir());
+    create_local_config(agent_id.to_string(), NO_CONFIG.to_string(), dirs.local_dir());
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.to_path_buf(),
-        remote_dir: remote_dir.to_path_buf(),
-        log_dir: local_dir.to_path_buf(),
-    };
+    let base_paths = dirs.base_paths();
 
     let data_dir = base_paths
         .remote_dir

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -145,6 +145,21 @@ agents:
         )
     });
 
+    // The sub-agent's filesystem directory must be deleted by ResourceCleaner
+    let agent_fs_dir = base_paths
+        .remote_dir
+        .join(AGENT_FILESYSTEM_FOLDER_NAME)
+        .join(agent_id);
+    retry(60, Duration::from_secs(1), || {
+        if agent_fs_dir.exists() {
+            return Err(format!(
+                "agent filesystem dir still present at {agent_fs_dir:?} after removal"
+            )
+            .into());
+        }
+        Ok(())
+    });
+
     // 3. Add agent again
     opamp_server.set_config_response(ac_instance_id.clone(), agents_config_with_agent.as_str());
 

--- a/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
+++ b/agent-control/tests/on_host/scenarios/remote_agent_removal.rs
@@ -146,8 +146,8 @@ agents:
     });
 
     // The sub-agent's filesystem directory must be deleted by ResourceCleaner
-    let agent_fs_dir = base_paths
-        .remote_dir
+    let agent_fs_dir = dirs
+        .remote_dir()
         .join(AGENT_FILESYSTEM_FOLDER_NAME)
         .join(agent_id);
     retry(60, Duration::from_secs(1), || {

--- a/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
+++ b/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
@@ -1,0 +1,57 @@
+use crate::common::{
+    agent_control::start_agent_control_with_custom_config, runtime::tokio_runtime,
+};
+use crate::on_host::tools::config::create_agent_control_config;
+use fake_opamp_server::FakeServer;
+use newrelic_agent_control::agent_control::defaults::AGENT_FILESYSTEM_FOLDER_NAME;
+use newrelic_agent_control::agent_control::run::BasePaths;
+use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
+use std::time::Duration;
+use tempfile::tempdir;
+
+/// On startup, Agent Control reclaims the filesystem dirs of any sub-agent that is no longer in
+/// the configured agents map (e.g. an agent removed from fleet config while AC was stopped). The
+/// dir of any agent that *is* configured stays untouched.
+#[test]
+fn stale_agent_filesystem_cleanup_on_startup() {
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let tempdir = tempdir().expect("failed to create temp dir");
+    let local_dir = tempdir.path().join("local");
+    let remote_dir = tempdir.path().join("remote");
+
+    // Pre-populate the filesystem dir with two sub-agent directories.
+    let fs_base = remote_dir.join(AGENT_FILESYSTEM_FOLDER_NAME);
+    let orphan_dir = fs_base.join("orphan-agent");
+    let kept_dir = fs_base.join("configured-agent");
+    std::fs::create_dir_all(orphan_dir.join("nested")).unwrap();
+    std::fs::write(orphan_dir.join("nested/a.txt"), "stale").unwrap();
+    std::fs::create_dir_all(&kept_dir).unwrap();
+    std::fs::write(kept_dir.join("placeholder.txt"), "placeholder").unwrap();
+
+    create_agent_control_config(
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        "{}".to_string(),
+        local_dir.to_path_buf(),
+    );
+
+    let base_paths = BasePaths {
+        local_dir: local_dir.to_path_buf(),
+        remote_dir: remote_dir.to_path_buf(),
+        log_dir: local_dir.to_path_buf(),
+    };
+    let _agent_control =
+        start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+
+    // The orphan dir must be gone after AC startup. Use a small retry to allow the start-up
+    // tasks to land before asserting.
+    crate::common::retry::retry(30, Duration::from_secs(1), || {
+        if orphan_dir.exists() {
+            return Err(
+                format!("orphan dir still present after AC startup: {orphan_dir:?}").into(),
+            );
+        }
+        Ok(())
+    });
+}

--- a/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
+++ b/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
@@ -1,13 +1,12 @@
+use crate::common::base_paths::TempBasePaths;
 use crate::common::{
     agent_control::start_agent_control_with_custom_config, runtime::tokio_runtime,
 };
-use crate::on_host::tools::config::create_agent_control_config;
+use crate::on_host::tools::config::AgentControlConfigBuilder;
 use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::defaults::AGENT_FILESYSTEM_FOLDER_NAME;
-use newrelic_agent_control::agent_control::run::BasePaths;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use std::time::Duration;
-use tempfile::tempdir;
 
 /// On startup, Agent Control reclaims the filesystem dirs of any sub-agent that is no longer in
 /// the configured agents map (e.g. an agent removed from fleet config while AC was stopped). The
@@ -16,12 +15,10 @@ use tempfile::tempdir;
 fn stale_agent_filesystem_cleanup_on_startup() {
     let opamp_server = FakeServer::start(tokio_runtime().handle());
 
-    let tempdir = tempdir().expect("failed to create temp dir");
-    let local_dir = tempdir.path().join("local");
-    let remote_dir = tempdir.path().join("remote");
+    let dirs = TempBasePaths::default();
 
     // Pre-populate the filesystem dir with two sub-agent directories.
-    let fs_base = remote_dir.join(AGENT_FILESYSTEM_FOLDER_NAME);
+    let fs_base = dirs.remote_dir().join(AGENT_FILESYSTEM_FOLDER_NAME);
     let orphan_dir = fs_base.join("orphan-agent");
     let kept_dir = fs_base.join("configured-agent");
     std::fs::create_dir_all(orphan_dir.join("nested")).unwrap();
@@ -29,20 +26,11 @@ fn stale_agent_filesystem_cleanup_on_startup() {
     std::fs::create_dir_all(&kept_dir).unwrap();
     std::fs::write(kept_dir.join("placeholder.txt"), "placeholder").unwrap();
 
-    create_agent_control_config(
-        opamp_server.endpoint(),
-        opamp_server.jwks_endpoint(),
-        "{}".to_string(),
-        local_dir.to_path_buf(),
-    );
+    AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .write(dirs.local_dir());
 
-    let base_paths = BasePaths {
-        local_dir: local_dir.to_path_buf(),
-        remote_dir: remote_dir.to_path_buf(),
-        log_dir: local_dir.to_path_buf(),
-    };
     let _agent_control =
-        start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
+        start_agent_control_with_custom_config(dirs.base_paths(), AGENT_CONTROL_MODE_ON_HOST);
 
     // The orphan dir must be gone after AC startup. Use a small retry to allow the start-up
     // tasks to land before asserting.

--- a/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
+++ b/agent-control/tests/on_host/scenarios/stale_agent_filesystem_cleanup.rs
@@ -27,6 +27,13 @@ fn stale_agent_filesystem_cleanup_on_startup() {
     std::fs::write(kept_dir.join("placeholder.txt"), "placeholder").unwrap();
 
     AgentControlConfigBuilder::basic(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(
+            r#"
+  configured-agent:
+    agent_type: "test/test:0.0.0"
+"#
+            .to_string(),
+        )
         .write(dirs.local_dir());
 
     let _agent_control =
@@ -42,4 +49,9 @@ fn stale_agent_filesystem_cleanup_on_startup() {
         }
         Ok(())
     });
+
+    assert!(
+        kept_dir.exists(),
+        "configured agent's filesystem dir should be preserved: {kept_dir:?}"
+    );
 }

--- a/docs/AC_repositories_and_files.md
+++ b/docs/AC_repositories_and_files.md
@@ -23,8 +23,13 @@ The remote configurations and in general any files expected to dynamically chang
 
 - The remote configurations, the hash and its state of AC and each sub-agent are stored in their respective subfolder inside `fleet-data`, in a file named `remote_config.yaml`.
 - On the other hand, host identifiers and the agent ULID are store in `instance_id.yaml`.
- - Moreover, `filesystem` is the directory where Agent Control will render files for each sub-agent. Each agent could also create
-its own subdirectories inside it to store files that are not managed by AC but are expected to be persistent across restarts.
+ - Moreover, `filesystem` is the directory where Agent Control renders each sub-agent's declared files. An agent may also write
+its own files here; these survive restarts **unless they live inside a directory AC declared as ephemeral** (the default), which AC
+wipes on stop and before each re-render. To keep agent-created data across restarts, place it under a `persistent` directory or a path
+AC doesn't manage. See [Persistence in Filesystem](./INTEGRATING_AGENTS.md#persistence-in-filesystem).
+- Inside each sub-agent's `filesystem/<agent-id>` directory AC also writes a reserved manifest, `.ac-managed-paths.json`, listing
+the paths it rendered on the last successful write. It drives reconciliation (deleting paths AC previously owned but no longer declares).
+This filename is reserved, agent types must not declare an entry with it.
 
 #### Logs
 The directory inside `[...]/log/<agent-id>` will store the logs if file logging was configured, 
@@ -76,6 +81,7 @@ The following shows the directory structure used by Agent Control, assuming an e
     │       │         └── remote_config.yaml 
     │       └── filesystem
     │            └── nr-infra
+    │                ├── .ac-managed-paths.json
     │                ├── integrations.d
     │                │   └── nri-redis.yaml
     │                └── config
@@ -107,6 +113,7 @@ C:\Program Files\New Relic\newrelic-agent-control
 C:\ProgramData\New Relic\newrelic-agent-control
 ├───filesystem
 │   └───nr-infra
+│       │   .ac-managed-paths.json
 │       ├───newrelic-infra
 │       │    └─── [...] Data files created by the infra agent
 │       └── config

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -524,11 +524,11 @@ agent/integrations.d/
 
 **`dir`** — an explicitly declared directory. Its children, if any, live under `entries:`.
 
-| Field        | Required | Default | Description                                                  |
-|--------------|----------|---------|--------------------------------------------------------------|
-| `kind`       | yes      | —       | Must be `dir`.                                               |
-| `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive. Each key must be a single path segment, not a sub-path. |
-| `persistent` | no       | `false` | If `true`, this directory and its tree survive cleanup.      |
+| Field        | Required | Default | Description                                                                                                                                                |
+|--------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `kind`       | yes      | —       | Must be `dir`.                                                                                                                                             |
+| `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive. Each key must be a single path segment, not a sub-path.                                                        |
+| `persistent` | no       | `false` | If `true`, this directory survives stop. Not inherited, each child is judged by its own `persistent` flag (see [Persistence](#persistence-in-filesystem)). |
 
 **`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.
 
@@ -546,6 +546,8 @@ Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persist
 - **The sidecar manifest** drives reconciliation on every write event. Anything Agent Control wrote on the previous successful write is recorded in the manifest. On the next write, Agent Control diffs the manifest against the new declared set: paths it owned previously and no longer owns are deleted; paths it never owned are left alone.
 
 The flag does **not** shield the entry from intentional removal: if you delete an entry from the agent type (or remove a key from a `dir_content_from_map` source map), the manifest diff catches it and the on-disk path is deleted on the next write event.
+
+**`persistent` applies per entry and does not cascade to children.** On stop, cleanup walks the declared tree: a persistent entry is kept and the walk descends into its children, while an ephemeral entry is deleted together with its entire on-disk subtree (a recursive `remove_dir_all`, which stops the walk there). So a nested path survives stop only if **every declared node on the path is `persistent: true`**.
 
 ###### Sidecar manifest
 

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -482,7 +482,7 @@ config_logging:
 
 The runtime produces the following on disk under `${nr-sub:filesystem_agent_dir}`. Each kind is shown in isolation.
 
-**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` means it survives `ResourceCleaner` on teardown.
+**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` keeps it across sub-agent stop and restarts.
 
 ```
 newrelic-infra.yaml      ← contents from ${nr-var:config_agent}
@@ -520,7 +520,7 @@ agent/integrations.d/
 |--------------|----------|---------|--------------------------------------------------------------|
 | `kind`       | yes      | —       | Must be `file`.                                              |
 | `text`       | yes      | —       | File body. May reference `${nr-var:…}` / `${nr-sub:…}`.      |
-| `persistent` | no       | `false` | If `true`, survives `ResourceCleaner`.                       |
+| `persistent` | no       | `false` | If `true`, survives sub-agent stop/restart.                  |
 
 **`dir`** — an explicitly declared directory. Its children, if any, live under `entries:`.
 
@@ -528,7 +528,7 @@ agent/integrations.d/
 |--------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `kind`       | yes      | —       | Must be `dir`.                                                                                                                                             |
 | `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive. Each key must be a single path segment, not a sub-path.                                                        |
-| `persistent` | no       | `false` | If `true`, this directory survives stop. Not inherited, each child is judged by its own `persistent` flag (see [Persistence](#persistence-in-filesystem)). |
+| `persistent` | no       | `false` | If `true`, this directory survives stop/restart. Not inherited, each child is judged by its own `persistent` flag (see [Persistence](#persistence-in-filesystem)). |
 
 **`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.
 
@@ -542,14 +542,14 @@ agent/integrations.d/
 
 Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persistent:` (default `false`). Two independent mechanisms govern lifecycle:
 
-- **The `persistent` flag** controls whether the entry's on-disk path is wiped on sub-agent stop. Ephemeral entries are deleted on stop; persistent entries are kept.
-- **The sidecar manifest** drives reconciliation on every write event. Anything Agent Control wrote on the previous successful write is recorded in the manifest. On the next write, Agent Control diffs the manifest against the new declared set: paths it owned previously and no longer owns are deleted; paths it never owned are left alone.
+- **The `persistent` flag** controls whether the entry's on-disk path is wiped when the tree is cleaned: on sub-agent stop, and just before every (re)write of the tree (start, restart, and config apply). Ephemeral entries are wiped at those points; persistent entries are kept. Wiping before each write means leftover ephemeral content never carries across — even after an ungraceful shutdown (crash/SIGKILL) that skipped the stop-time cleanup.
+- **The manifest** drives reconciliation on every write event. Anything Agent Control wrote on the previous successful write is recorded in the manifest. On the next write, Agent Control diffs the manifest against the new declared set: paths it owned previously and no longer owns are deleted; paths it never owned are left alone.
 
 The flag does **not** shield the entry from intentional removal: if you delete an entry from the agent type (or remove a key from a `dir_content_from_map` source map), the manifest diff catches it and the on-disk path is deleted on the next write event.
 
-**`persistent` applies per entry and does not cascade to children.** On stop, cleanup walks the declared tree: a persistent entry is kept and the walk descends into its children, while an ephemeral entry is deleted together with its entire on-disk subtree (a recursive `remove_dir_all`, which stops the walk there). So a nested path survives stop only if **every declared node on the path is `persistent: true`**.
+**`persistent` applies per entry and does not cascade to children.** When cleaning (on stop, and before each (re)write), cleanup walks the declared tree: a persistent entry is kept and the walk descends into its children, while an ephemeral entry is deleted together with its entire on-disk subtree (a recursive `remove_dir_all`, which stops the walk there). So a nested path survives cleanup only if **every declared node on the path is `persistent: true`**.
 
-###### Sidecar manifest
+###### Manifest
 
 After every successful write, Agent Control writes `.ac-managed-paths.json` inside the sub-agent's filesystem directory listing the absolute paths it just wrote. This filename is **reserved** — agent types must not declare it.
 
@@ -557,19 +557,19 @@ The manifest is the source of truth for "what Agent Control owns." Files the sub
 
 ###### Lifecycle
 
-- **Ephemeral (`persistent: false`, default).** On sub-agent stop, the entry's on-disk path is deleted.
-- **Persistent (`persistent: true`).** On sub-agent stop, the entry's on-disk path is preserved.
+- **Ephemeral (`persistent: false`, default).** Wiped on sub-agent stop, and again just before every (re)write of the tree (start, restart, config apply); the declared entry itself is then re-created by the write. Leftover content (including files the agent created inside an ephemeral directory) never carries across a restart, even an ungraceful one.
+- **Persistent (`persistent: true`).** Kept on stop and across (re)writes; only `write` re-renders its declared content.
 - **Removed from fleet.** When an agent is removed from the fleet config (via remote config or by being absent at AC startup after a previous deploy), its entire filesystem directory is deleted by `ResourceCleaner`. The `persistent` flag is bypassed.
 
-| Event              | Ephemeral (`persistent: false`)           | Persistent (`persistent: true`)                        |
-|--------------------|-------------------------------------------|--------------------------------------------------------|
-| Agent start        | Reconcile (manifest diff) + write         | Reconcile (manifest diff) + write                      |
-| Agent stop         | Path deleted                              | Path kept                                              |
-| Agent restart      | Reconcile + write                         | Reconcile + write                                      |
-| Config update      | Reconcile + write                         | Reconcile + write                                      |
-| Removed from fleet | Filesystem dir deleted by ResourceCleaner | Filesystem dir deleted by ResourceCleaner              |
+| Event              | Ephemeral (`persistent: false`)                 | Persistent (`persistent: true`)           |
+|--------------------|-------------------------------------------------|-------------------------------------------|
+| Agent start        | Wiped, then reconcile (manifest diff) + write   | Kept; reconcile (manifest diff) + write   |
+| Agent stop         | Path deleted                                    | Path kept                                 |
+| Agent restart      | Wiped, then reconcile + write                   | Kept; reconcile + write                   |
+| Config update      | Wiped, then reconcile + write                   | Kept; reconcile + write                   |
+| Removed from fleet | Filesystem dir deleted by ResourceCleaner       | Filesystem dir deleted by ResourceCleaner |
 
-In all the "Reconcile + write" rows, agent-process-created files survive (not in the manifest, not declared, not deleted).
+Agent-process-created files survive a reconcile + write (they're not in the manifest and not declared) **except** files inside an *ephemeral* directory, which are wiped along with it on stop and before each (re)write. To keep agent-created content across restarts, place it under a `persistent` directory.
 
 ##### `packages`
 

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -482,7 +482,7 @@ config_logging:
 
 The runtime produces the following on disk under `${nr-sub:filesystem_agent_dir}`. Each kind is shown in isolation.
 
-**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` keeps it across sub-agent stop and restarts.
+**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` keeps it across agent-control stop and restarts.
 
 ```
 newrelic-infra.yaml      ← contents from ${nr-var:config_agent}
@@ -532,15 +532,14 @@ agent/integrations.d/
 
 **`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.
 
-| Field        | Required | Default | Description                                                  |
-|--------------|----------|---------|--------------------------------------------------------------|
-| `kind`       | yes      | —       | Must be `dir_content_from_map`.                              |
-| `source`     | yes      | —       | Reference to a `map[string]yaml` variable (`${nr-var:…}`).   |
-| `persistent` | no       | `false` | If `true`, files projected here are not removed on cleanup.  |
+| Field        | Required | Default | Description                                                                                                            |
+|--------------|----------|---------|------------------------------------------------------------------------------------------------------------------------|
+| `kind`       | yes      | —       | Must be `dir_content_from_map`.                                                                                        |
+| `source`     | yes      | —       | Reference to a `map[string]yaml` variable (`${nr-var:…}`).                                                             |
 
 ##### Persistence in Filesystem
 
-Every `file`, `dir`, and `dir_content_from_map` entry accepts a boolean `persistent:` (default `false`). Two independent mechanisms govern lifecycle:
+Every `file` and `dir` entry accepts a boolean `persistent:` (default `false`). Two independent mechanisms govern lifecycle:
 
 - **The `persistent` flag** controls whether the entry's on-disk path is wiped when the tree is cleaned: on sub-agent stop, and just before every (re)write of the tree (start, restart, and config apply). Ephemeral entries are wiped at those points; persistent entries are kept. Wiping before each write means leftover ephemeral content never carries across — even after an ungraceful shutdown (crash/SIGKILL) that skipped the stop-time cleanup.
 - **The manifest** drives reconciliation on every write event. Anything Agent Control wrote on the previous successful write is recorded in the manifest. On the next write, Agent Control diffs the manifest against the new declared set: paths it owned previously and no longer owns are deleted; paths it never owned are left alone.
@@ -549,11 +548,52 @@ The flag does **not** shield the entry from intentional removal: if you delete a
 
 **`persistent` applies per entry and does not cascade to children.** When cleaning (on stop, and before each (re)write), cleanup walks the declared tree: a persistent entry is kept and the walk descends into its children, while an ephemeral entry is deleted together with its entire on-disk subtree (a recursive `remove_dir_all`, which stops the walk there). So a nested path survives cleanup only if **every declared node on the path is `persistent: true`**.
 
+**`dir_content_from_map` has no `persistent` flag.** Agent Control owns and re-renders the projected files on every write, so it is always ephemeral. A `persistent:` key left in the YAML is silently ignored, so older configs still parse.
+
 ###### Manifest
 
 After every successful write, Agent Control writes `.ac-managed-paths.json` inside the sub-agent's filesystem directory listing the absolute paths it just wrote. This filename is **reserved** — agent types must not declare it.
 
 The manifest is the source of truth for "what Agent Control owns." Files the sub-agent process creates at runtime are never in the manifest, so they're invisible to reconciliation: they survive every write event, every sub-agent restart, and every config update. They're only removed if some declared ancestor directory is itself removed from the agent type (the `remove_dir_all` of the parent takes them as collateral) or if the agent is removed from the fleet.
+
+**The manifest stores rendered paths, not agent-type declarations.** Reconciliation runs on the tree *after* variable substitution, so the manifest records the concrete absolute paths Agent Control actually wrote. This matters most for `dir_content_from_map`: the agent type only names the directory and a `source:` variable, but at render time each map key is expanded into its own file path, and every one of those paths is recorded individually in the manifest.
+
+As a result, removing a key from the source map is reconciled exactly like deleting a literal entry from the agent type: the rendered path is in the previous manifest but absent from the new declared set, so it is deleted on the next write.
+
+**Example.** Agent type:
+
+```yaml
+filesystem:
+  integrations.d:
+    kind: dir_content_from_map
+    source: ${nr-var:config_integrations}
+```
+
+The `config_integrations` variable (a `map[string]yaml`) supplied at deploy time:
+
+```yaml
+config_integrations:
+  nri-mysql.yaml: |
+    integrations:
+      - name: nri-mysql
+  nri-redis.yaml: |
+    integrations:
+      - name: nri-redis
+```
+
+With `${nr-sub:filesystem_agent_dir}` resolving to `/var/lib/newrelic-agent-control/filesystem/nr-infra`, the write produces `integrations.d/nri-mysql.yaml` and `integrations.d/nri-redis.yaml`, and the resulting `.ac-managed-paths.json` is:
+
+```json
+{
+  "managed_paths": [
+    "/var/lib/newrelic-agent-control/filesystem/nr-infra/integrations.d",
+    "/var/lib/newrelic-agent-control/filesystem/nr-infra/integrations.d/nri-mysql.yaml",
+    "/var/lib/newrelic-agent-control/filesystem/nr-infra/integrations.d/nri-redis.yaml"
+  ]
+}
+```
+
+Note the directory plus one entry per rendered map key, it's the variable's *content* that lands in the manifest, not the `source:` reference. If the next deploy drops `nri-redis.yaml` from `config_integrations`, the new declared set no longer contains `…/integrations.d/nri-redis.yaml` while the previous manifest still does, so that file is deleted on the next write.
 
 ###### Lifecycle
 

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.44"
 windows-sys = { workspace = true, features = [
   "Win32_Security",
   "Win32_Security_Authorization",
+  "Win32_Storage_FileSystem",
 ] }
 encoding_rs = "0.8.35"
 

--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -232,6 +232,36 @@ pub mod tests {
     }
 
     #[test]
+    fn test_list_missing_path_returns_empty() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let missing = tempdir.path().join("does_not_exist");
+        let directory_manager = DirectoryManagerFs;
+
+        let result = directory_manager.list(&missing).unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_list_returns_immediate_children() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let directory_manager = DirectoryManagerFs;
+
+        let child_dir = tempdir.path().join("child_dir");
+        directory_manager.create(&child_dir).unwrap();
+        let child_file = tempdir.path().join("child_file");
+        std::fs::write(&child_file, b"contents").unwrap();
+        std::fs::write(child_dir.join("grandchild"), b"contents").unwrap();
+
+        let mut result = directory_manager.list(tempdir.path()).unwrap();
+        result.sort();
+
+        let mut expected = vec![child_dir, child_file];
+        expected.sort();
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     #[ignore = "requires windows administrator"]
     fn test_folder_deletion() {
         // Prepare temp path and folder name

--- a/fs/src/directory_manager.rs
+++ b/fs/src/directory_manager.rs
@@ -1,7 +1,7 @@
 use super::utils::validate_path;
 use std::fs::{DirBuilder, remove_dir_all};
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::instrument;
 
 /// Creates and removes directories on disk.
@@ -12,6 +12,10 @@ pub trait DirectoryManager: Send + Sync {
     /// Delete the folder and its contents. If the folder does not exist it
     /// will not return an error.
     fn delete(&self, path: &Path) -> io::Result<()>;
+
+    /// List the immediate children of `path`. Returns absolute paths. If `path` does not
+    /// exist, returns an empty list (not an error).
+    fn list(&self, path: &Path) -> io::Result<Vec<PathBuf>>;
 }
 
 /// [`DirectoryManager`] implementation backed by the real filesystem.
@@ -56,6 +60,18 @@ impl DirectoryManager for DirectoryManagerFs {
         }
         remove_dir_all(path)
     }
+
+    #[instrument(skip_all, fields(path = %path.display()))]
+    fn list(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+        validate_path(path)?;
+
+        let read = match std::fs::read_dir(path) {
+            Ok(r) => r,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(err),
+        };
+        read.map(|entry| entry.map(|e| e.path())).collect()
+    }
 }
 
 impl DirectoryManagerFs {
@@ -83,6 +99,7 @@ pub mod mock {
         impl DirectoryManager for DirectoryManager {
             fn create(&self, path: &Path) -> io::Result<()>;
             fn delete(&self, path: &Path) -> io::Result<()>;
+            fn list(&self, path: &Path) -> io::Result<Vec<PathBuf>>;
         }
     }
 
@@ -115,6 +132,14 @@ pub mod mock {
             self.expect_delete()
                 .with(predicate::eq(path_clone))
                 .return_once(|_| Err(err));
+        }
+
+        pub fn should_list(&mut self, path: &Path, children: Vec<PathBuf>) {
+            let path_clone = PathBuf::from(path.to_str().unwrap().to_string().as_str());
+            self.expect_list()
+                .with(predicate::eq(path_clone))
+                .once()
+                .return_once(|_| Ok(children));
         }
     }
 }

--- a/fs/src/win_permissions.rs
+++ b/fs/src/win_permissions.rs
@@ -10,6 +10,7 @@ use windows_sys::Win32::Security::{
     ACL, CreateWellKnownSid, DACL_SECURITY_INFORMATION, NO_INHERITANCE,
     PROTECTED_DACL_SECURITY_INFORMATION, SECURITY_MAX_SID_SIZE, WinBuiltinAdministratorsSid,
 };
+use windows_sys::Win32::Storage::FileSystem::DELETE;
 
 /// Error returned when setting Windows file permissions (ACLs) fails.
 #[derive(Debug, thiserror::Error)]
@@ -41,7 +42,8 @@ fn get_administrator_sid() -> Result<Vec<u8>, PermissionError> {
 }
 
 /// set_file_permissions_for_administrator removes any other ACL from a file only granting
-/// read and write to Administrators.
+/// read, write, and delete to Administrators. DELETE is needed so the same Administrator that
+/// wrote the file can later remove it during filesystem reconciliation.
 pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), PermissionError> {
     // Conversion to UTF-16 format (native string representation in Windows OS)
     let path_wstr: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
@@ -56,9 +58,9 @@ pub fn set_file_permissions_for_administrator(path: &Path) -> Result<(), Permiss
         ..Default::default()
     };
 
-    // Define the access entry to allow read and write for the trustee
+    // Define the access entry to allow read, write, and delete for the trustee.
     let access_entry = EXPLICIT_ACCESS_W {
-        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE,
+        grfAccessPermissions: GENERIC_READ | GENERIC_WRITE | DELETE,
         grfAccessMode: SET_ACCESS,
         grfInheritance: NO_INHERITANCE,
         Trustee: trustee,
@@ -109,7 +111,7 @@ pub mod tests {
             ACCESS_ALLOWED_ACE, ACL_SIZE_INFORMATION, AclSizeInformation,
             Authorization::GetNamedSecurityInfoW, EqualSid, GetAce, GetAclInformation,
         },
-        Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE},
+        Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE},
     };
 
     use super::*;
@@ -180,11 +182,12 @@ pub mod tests {
             let sids_equal = EqualSid(sid_in_ace, admin_sid.as_mut_ptr() as *mut _);
             assert_ne!(sids_equal, 0, "ACE SID should match Administrators SID");
 
-            // FILE_GENERIC_READ and FILE_GENERIC_WRITE are what GENERIC_READ/WRITE map to
-            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE;
+            // FILE_GENERIC_READ and FILE_GENERIC_WRITE are what GENERIC_READ/WRITE map to;
+            // DELETE is a specific right and stays as-is in the ACE mask.
+            let expected_mask = FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE;
             assert_eq!(
                 ace.Mask, expected_mask,
-                "ACE should have FILE_GENERIC_READ and FILE_GENERIC_WRITE permissions"
+                "ACE should have FILE_GENERIC_READ, FILE_GENERIC_WRITE, and DELETE permissions"
             );
         }
     }


### PR DESCRIPTION
Implements the `persistent:` filesystem feature, every `file`/`dir`/`dir_content_from_map` entry now accepts `persistent: TemplateableValue<bool>` (default `false`), and the  supervisor runs `delete_ephemeral` on sub-agent at startup (before writing the tree) and stop so ephemeral entries are wiped while persistent ones survive.                                                                                                               
Adds a sidecar manifest at `${base_dir}/.ac-managed-paths.json` that records the paths Agent Control wrote on each successful write; the next write diffs prev vs current declared set and deletes the difference, so removing an entry from the agent type (or a key from a `dir_content_from_map` source) cleans up its on-disk path while agent-process-created files survive because they were never in the manifest. Manifest read failures degrade safely to "delete nothing."                                                                                                                                                                                                               
Wires fleet-removal cleanup through `OnHostCleaner` (now extended with `agent_filesystem_base` + `Arc<DirectoryManager>`) and adds a `purge_stale_agent_filesystems` startup pass for agents removed while AC was stopped.       

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
