### PR TITLE
fix(self-update): treat empty version string as absent (no-op)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Remember that the keywords that you can use are the following:
 
 ## Unreleased
 
+### bugfix
+- On-host self-update: an empty `version: ""` pushed from Fleet Control now behaves the same as an absent `version` field (no-op, no update attempted). Previously it silently triggered a pull of the `:latest` OCI tag.
+
 ### enhancement
 - Hardens service restart policies on Linux and Windows (systemd rate limiting: 5 restarts max in 60s) to prevent
   crash-looping from saturating CPU.

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -277,10 +277,18 @@ pub struct AgentControlDynamicConfig {
     )]
     pub version: Option<Version>,
     /// chart_version represent the AC chart version that needs to be executed.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_chart_version"
+    )]
     pub chart_version: Option<String>,
     /// cd_chart_version represent the agent control cd chart version that needs to be executed.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_chart_version"
+    )]
     pub cd_chart_version: Option<String>,
 }
 
@@ -394,6 +402,17 @@ where
         Some(v) => Version::from_str(v)
             .map(Some)
             .map_err(|e| de::Error::custom(e.to_string())),
+    }
+}
+
+fn deserialize_chart_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    match s.as_deref() {
+        None | Some("") => Ok(None),
+        Some(v) => Ok(Some(v.to_string())),
     }
 }
 

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -22,7 +22,7 @@ use crate::{
 use http::HeaderMap;
 use kube::api::TypeMeta;
 use oci_client::secrets::RegistryAuth;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -270,7 +270,11 @@ const AGENTS_KEY: &str = "agents";
 pub struct AgentControlDynamicConfig {
     pub agents: SubAgentsMap,
     /// version represent the AC version that needs to be executed.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_version"
+    )]
     pub version: Option<Version>,
     /// chart_version represent the AC chart version that needs to be executed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -377,6 +381,19 @@ impl TryFrom<YAMLConfig> for AgentControlDynamicConfig {
             .map_err(|e| AgentControlConfigError(format!("deserializing: {e}")))?;
         serde_saphyr::from_str(&value_string)
             .map_err(|e| AgentControlConfigError(format!("serializing: {e}")))
+    }
+}
+
+fn deserialize_version<'de, D>(deserializer: D) -> Result<Option<Version>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    match s.as_deref() {
+        None | Some("") => Ok(None),
+        Some(v) => Version::from_str(v)
+            .map(Some)
+            .map_err(|e| de::Error::custom(e.to_string())),
     }
 }
 
@@ -878,8 +895,16 @@ agents: {}
     }
 
     #[test]
+    fn dynamic_config_empty_version_deserializes_as_none() {
+        let config =
+            serde_saphyr::from_str::<AgentControlDynamicConfig>("agents: {}\nversion: \"\"\n")
+                .expect("empty version should deserialize successfully");
+        assert_eq!(config.version, None);
+    }
+
+    #[test]
     fn dynamic_config_invalid_version_fails_to_deserialize() {
-        let yaml = "agents: {}\nversion: invalid-version; rm -rf /\n";
+        let yaml = "agents: {}\nversion: \"invalid-version; rm -rf /\"\n";
         assert!(serde_saphyr::from_str::<AgentControlDynamicConfig>(yaml).is_err());
     }
 

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -56,6 +56,12 @@ impl Oci {
             (None, Some(digest)) => {
                 Ok(Reference::with_digest(registry_str, repository_str, digest))
             }
+
+            // We should never reach this case.
+            // For sub-agents, the version is always required. If the version is empty, it should be caught during validation.
+            // For Agent Control, the version is optional. If the version isn't configured, or it's an empty string,
+            // we don't update and this function is never called.
+            // This error is here as a defensive programming measure to catch any unexpected cases where the version is empty.
             (None, None) => Err(InvalidVersion("version cannot be empty".to_string())),
         }
     }

--- a/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package/rendered.rs
@@ -40,22 +40,23 @@ pub struct PostDownloadHook {
     pub env: Env,
 }
 
-const DEFAULT_TAG: &str = "latest";
-
 impl Oci {
-    pub fn to_reference(&self, registry: &Registry) -> Reference {
+    pub fn to_reference(&self, registry: &Registry) -> Result<Reference, InvalidVersion> {
         let registry_str = registry.to_string();
         let repository_str = self.repository.to_string();
 
         match self.version.tag_and_digest() {
-            (Some(tag), Some(digest)) => {
-                Reference::with_tag_and_digest(registry_str, repository_str, tag, digest)
+            (Some(tag), Some(digest)) => Ok(Reference::with_tag_and_digest(
+                registry_str,
+                repository_str,
+                tag,
+                digest,
+            )),
+            (Some(tag), None) => Ok(Reference::with_tag(registry_str, repository_str, tag)),
+            (None, Some(digest)) => {
+                Ok(Reference::with_digest(registry_str, repository_str, digest))
             }
-            (Some(tag), None) => Reference::with_tag(registry_str, repository_str, tag),
-            (None, Some(digest)) => Reference::with_digest(registry_str, repository_str, digest),
-            (None, None) => {
-                Reference::with_tag(registry_str, repository_str, DEFAULT_TAG.to_owned())
-            }
+            (None, None) => Err(InvalidVersion("version cannot be empty".to_string())),
         }
     }
 }
@@ -147,6 +148,10 @@ impl FromStr for Version {
     type Err = InvalidVersion;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(InvalidVersion("version cannot be empty".to_string()));
+        }
+
         if s.ends_with('@') {
             return Err(InvalidVersion("version cannot end with '@'".to_string()));
         }
@@ -235,6 +240,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case("")]
     #[case("v1.0.0@")]
     #[case("v1.0.0@sha256:123")]
     #[case("v1.0.0@invaliddigest")]
@@ -277,7 +283,6 @@ mod tests {
             "v1.0.0@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             "docker.io/nr/test:v1.0.0@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         )]
-        #[case::without_tag_or_digest("docker.io", "nr/test", "", "docker.io/nr/test:latest")]
         fn test_to_reference(
             #[case] registry: &str,
             #[case] repository: &str,
@@ -290,8 +295,19 @@ mod tests {
                 version: Version::from_str(version).unwrap(),
                 public_key_url: None,
             };
-            let reference = oci.to_reference(&registry);
+            let reference = oci.to_reference(&registry).unwrap();
             assert_eq!(expected_whole, reference.whole());
+        }
+
+        #[test]
+        fn test_to_reference_empty_version_returns_error() {
+            let registry = Registry::from_str("docker.io").unwrap();
+            let oci = Oci {
+                repository: Repository::from_str("nr/test").unwrap(),
+                version: Version(String::new()),
+                public_key_url: None,
+            };
+            assert!(oci.to_reference(&registry).is_err());
         }
     }
 }

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -47,7 +47,9 @@ impl OCIPackageDownloader for OCIPackageArtifactDownloader {
             "Downloading from repository '{}' with version '{}'",
             package_data.oci.repository, package_data.oci.version
         );
-        let base_reference = package_data.oci.to_reference(&self.registry);
+        let base_reference = package_data.oci.to_reference(&self.registry).map_err(|e| {
+            OciClientError::FetchArtifact(format!("building OCI reference: {e}"))
+        })?;
         let public_key_url = self.should_verify_signature(&package_data.oci.public_key_url);
         self.fetcher.fetch(
             &base_reference,

--- a/agent-control/src/package/oci/downloader.rs
+++ b/agent-control/src/package/oci/downloader.rs
@@ -47,9 +47,10 @@ impl OCIPackageDownloader for OCIPackageArtifactDownloader {
             "Downloading from repository '{}' with version '{}'",
             package_data.oci.repository, package_data.oci.version
         );
-        let base_reference = package_data.oci.to_reference(&self.registry).map_err(|e| {
-            OciClientError::FetchArtifact(format!("building OCI reference: {e}"))
-        })?;
+        let base_reference = package_data
+            .oci
+            .to_reference(&self.registry)
+            .map_err(|e| OciClientError::FetchArtifact(format!("building OCI reference: {e}")))?;
         let public_key_url = self.should_verify_signature(&package_data.oci.public_key_url);
         self.fetcher.fetch(
             &base_reference,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -211,6 +211,21 @@ secrets_providers:
         engine: kv2
 ```
 
+### self_update
+
+Configures the on-host self-update mechanism.
+
+```yaml
+self_update:
+  enabled: false # Defaults to false. When true, Agent Control will attempt to self-update when Fleet Control pushes a new version.
+  signature_verification_enabled: true # Defaults to true. When false, package signature verification is skipped (not recommended for production).
+  package:
+    download:
+      oci:
+        repository: "newrelic/agent-control-artifacts" # OCI repository for Agent Control packages.
+        public_key_url: "https://..." # JWKS endpoint used to verify package signatures.
+```
+
 ### agent_packages
 
 This field configures packages behaviour.

--- a/docs/ac-remote-update/how-it-works.md
+++ b/docs/ac-remote-update/how-it-works.md
@@ -6,7 +6,7 @@ Remote update is a capability of Agent Control that enable updating its version 
 
 | System     | Supported |
 |------------|-----------|
-| OnHost     | ❌        |
+| OnHost     | ✅        |
 | Kubernetes | ✅        |
 
 ### Kubernetes
@@ -28,6 +28,33 @@ Flux it's a project of the [CNCF](https://www.cncf.io/) with their own roadmap. 
 Flux is wrapped in the `agent-control-cd` chart, which is used internally. The client doesn't interact with it directly. The version of this chart is what we allow updating, instead of the Flux version. Hence, we control the versions of flux that can be installed. For now, we don't support flux version with breaking changes. **Migrations** are not automated.
 
 ## How it works
+
+### On-host
+
+Fleet Control pushes a remote config containing a `version` field. Agent Control downloads the specified OCI artifact, verifies its signature, self-replaces its binary, and restarts.
+
+#### `version` field (remote config)
+
+The `version` field controls which version Agent Control should upgrade to.
+
+An absent `version` and an empty `version: ""` are both treated as no-ops — neither will trigger an update. This prevents accidental fleet-wide upgrades caused by pushing an unset version field.
+
+Valid version formats follow OCI distribution-spec rules:
+- Tag only: `v1.2.3`, `latest`, `1.0.0-alpha`
+- Digest only: `@sha256:<64 hex chars>`
+- Tag + digest (pinned): `v1.2.3@sha256:<64 hex chars>`
+
+#### Happy path
+
+1. Fleet Control sends a remote config with a `version` field via OpAMP.
+2. Agent Control validates the version (absent or empty → no-op; invalid format → error).
+3. Agent Control downloads the OCI artifact for the specified version and verifies its signature.
+4. Agent Control self-replaces its binary and publishes a restart event.
+5. The process manager restarts Agent Control with the new binary.
+
+#### Configuration
+
+Self-update must be explicitly enabled. See the [`self_update` configuration](../CONFIG.md#self_update) for details.
 
 ### Kubernetes
 

--- a/docs/opamp-communication-flows/ac-remote-update.md
+++ b/docs/opamp-communication-flows/ac-remote-update.md
@@ -1,9 +1,32 @@
 # Agent Control remote update
 
-Agent Control installation will include the latest Agent Control version. In Kubernetes it will also include Flux 2.15.0.
-These can be updated remotely.
+Agent Control can be updated remotely via Fleet Control. The mechanism differs by environment.
 
-Example message updating Agent Control version:
+## On-host
+
+Fleet Control pushes a `version` field. Absent or empty means no update.
+
+Example message updating the on-host Agent Control binary:
+
+```yaml
+agents:
+  nr-infra: newrelic/com.newrelic.infrastructure:0.1.0
+version: "v1.2.3"
+```
+
+Example with a pinned digest:
+
+```yaml
+agents:
+  nr-infra: newrelic/com.newrelic.infrastructure:0.1.0
+version: "v1.2.3@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+```
+
+## Kubernetes
+
+Agent Control installation will include the latest Agent Control version. In Kubernetes it will also include Flux 2.15.0.
+
+Example message updating Agent Control chart version:
 
 ```yaml
 agents:
@@ -28,6 +51,6 @@ chart_version: "1.0.0"
 cd_chart_version: "1.0.0"
 ```
 
-The message send through OpAMP will get transformed into an `AgentControlDynamicConfig`.
+The message sent through OpAMP will get transformed into an `AgentControlDynamicConfig`.
 
 Agent Control then will update itself, if needed, to the received version. Check the [in-depth explanation](../ac-remote-update/how-it-works.md).


### PR DESCRIPTION
Pushing `version: ""` from Fleet Control caused Agent Control to silently pull `docker.io/.../manifests/latest`, risking an unversioned upgrade across the entire fleet.

## Context

Fleet Control can push a remote config with a `version` field to trigger an on-host self-update. The bug was that an empty string `""` and an absent field had different behaviors:

- Absent `version` → no update (correct)
- `version: ""` → pull `:latest` tag (wrong)

An absent field correctly short-circuits in `on_host.rs::update()` via `let Some(new_version) = &config.version`. But an empty string deserialized to `Some(Version(""))`, passed the guard, and `Oci::to_reference` fell into a `(None, None)` arm that silently defaulted to `:latest`.

## Technical details

**Fix is applied at two layers:**

**Layer 1 — `Version::from_str` (`rendered.rs`):** Empty strings are now rejected at the type level (`Err(InvalidVersion("version cannot be empty"))`). This enforces the invariant that a `Version` value always contains a non-empty string.

**Layer 2 — `deserialize_version` custom deserializer (`config.rs`):** A `deserialize_with` function on `AgentControlDynamicConfig::version` maps `""` → `None` _before_ calling `Version::from_str`. This means Fleet Control pushing `version: ""` is silently treated as absent — a no-op with no error logged and no config rejection.

The two layers are intentionally separate: `Version` enforces a type invariant (non-empty), while the config deserializer enforces a domain semantic (empty from Fleet Control = no intent to update).

**`#[serde(default)]` is required alongside `deserialize_with`:** Normally serde implicitly handles absent `Option<T>` fields as `None`. Adding `deserialize_with` opts out of that implicit behavior, so `default` must be declared explicitly to restore it for the absent-key case.

**`Oci::to_reference` now returns `Result<Reference, InvalidVersion>`:** The `(None, None)` arm — reachable only if a `Version("")` is constructed directly in code, bypassing `from_str` — now returns an explicit error instead of panicking. `tag_and_digest` routes an empty inner string to `(None, None)` to make this path explicit and testable.

**Documentation:** Updated `CONFIG.md`, `docs/ac-remote-update/how-it-works.md` (OnHost now ✅, added on-host section), and `docs/opamp-communication-flows/ac-remote-update.md` (added on-host `version` field examples).