### PR TITLE
fix: only one thread for oci_registry tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Remember that the keywords that you can use are the following:
 - Added support for remote agent type definition retrieval from OCI registries.
 - Agent type definitions now tolerate unknown fields for forward compatibility.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
+- Added support to set a different self-update binary target.
 
 ## v1.17.0 - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Remember that the keywords that you can use are the following:
 - Added support for remote agent type definition retrieval from OCI registries.
 - Agent type definitions now tolerate unknown fields for forward compatibility.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
-- Added support to set a different self-update binary target.
 
 ## v1.17.0 - 2026-06-16
 

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -90,6 +90,7 @@ pub struct AgentControlRunner {
     base_paths: BasePaths,
     runtime: Arc<Runtime>,
     http_server_runner: Option<Runner>,
+    self_replace_target: Option<PathBuf>,
 }
 
 impl AgentControlRunner {
@@ -157,6 +158,7 @@ impl AgentControlRunner {
             sub_agent_publisher,
             base_paths: context.base_paths,
             signature_validator,
+            self_replace_target: context.self_replace_target,
         })
     }
 }

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -55,6 +55,7 @@ use fs::file::LocalFile;
 use opamp_client::http::StartedHttpClient;
 use opamp_client::http::client::OpAMPHttpClient;
 use opamp_client::operation::settings::{AgentDescription, DescriptionValueType, StartSettings};
+use self_replacer::BinarySelfReplacer;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -236,11 +237,18 @@ impl AgentControlRunner {
             remote_dir.clone(),
         );
 
+        let self_replacer = match self.self_replace_target {
+            Some(target) => BinarySelfReplacer::with_target(target),
+            None => BinarySelfReplacer::new()
+                .map_err(|e| RunError(format!("resolving self-replace target: {e}")))?,
+        };
+
         let self_updater = OnHostACUpdater::new(
             agent_control_config.self_update.enabled.into(),
             agent_control_internal_publisher.clone(),
             agent_control_package_manager,
             ProcessVerifyExecutor::default(),
+            self_replacer,
             agent_control_config.self_update.package.clone(),
             agent_control_config.self_update.upgrade_backoff.clone(),
             SystemClock,

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -55,7 +55,7 @@ use fs::file::LocalFile;
 use opamp_client::http::StartedHttpClient;
 use opamp_client::http::client::OpAMPHttpClient;
 use opamp_client::operation::settings::{AgentDescription, DescriptionValueType, StartSettings};
-use self_replacer::BinarySelfReplacer;
+use self_replacer::BinaryReplacer;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -238,8 +238,8 @@ impl AgentControlRunner {
         );
 
         let self_replacer = match self.self_replace_target {
-            Some(target) => BinarySelfReplacer::with_target(target),
-            None => BinarySelfReplacer::new()
+            Some(target) => BinaryReplacer::with_target(target),
+            None => BinaryReplacer::new()
                 .map_err(|e| RunError(format!("resolving self-replace target: {e}")))?,
         };
 

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -15,7 +15,7 @@ use crate::package::manager::{PackageData, PackageManager};
 use crate::utils::backoff_gate::{BackoffGate, SuppressionReason};
 use crate::utils::retry::BackoffPolicy;
 use crate::utils::time::Clock;
-use self_replacer::{BinarySelfReplacer, SelfReplacer};
+use self_replacer::SelfReplacer;
 use thiserror::Error;
 use tracing::{debug, debug_span, warn};
 use url::Url;
@@ -41,16 +41,18 @@ pub enum BuildError {
 
 /// On-host [`VersionUpdater`] that installs and self-replaces the Agent Control binary, with a
 /// backoff gate throttling re-attempts at a failing upgrade.
-pub struct OnHostACUpdater<P, V, C>
+pub struct OnHostACUpdater<P, V, C, R>
 where
     P: PackageManager,
     V: VerifyExecutor,
     C: Clock,
+    R: SelfReplacer,
 {
     ac_remote_update_enabled: bool,
     agent_control_internal_publisher: EventPublisher<AgentControlInternalEvent>,
     package_manager: P,
     verify_executor: V,
+    self_replacer: R,
     repository: Repository,
     pub_key_url: Url,
     /// Throttles re-attempts at a failing upgrade so we don't hammer the registry every
@@ -58,11 +60,12 @@ where
     upgrade_gate: BackoffGate<Version, C>,
 }
 
-impl<P, V, C> VersionUpdater for OnHostACUpdater<P, V, C>
+impl<P, V, C, R> VersionUpdater for OnHostACUpdater<P, V, C, R>
 where
     P: PackageManager,
     V: VerifyExecutor,
     C: Clock,
+    R: SelfReplacer,
 {
     /// Only `config.version` is consumed from the dynamic config. This contract is what
     /// lets [`retry`](Self::retry) reconstruct a config from just the gate's tracked version.
@@ -118,19 +121,22 @@ where
     }
 }
 
-impl<P, V, C> OnHostACUpdater<P, V, C>
+impl<P, V, C, R> OnHostACUpdater<P, V, C, R>
 where
     P: PackageManager,
     V: VerifyExecutor,
     C: Clock,
+    R: SelfReplacer,
 {
     /// Builds the updater from the self-update toggle, event publisher, collaborators, package
     /// source, backoff configuration and clock.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ac_remote_update_enabled: bool,
         agent_control_internal_publisher: EventPublisher<AgentControlInternalEvent>,
         package_manager: P,
         verify_executor: V,
+        self_replacer: R,
         package: AgentControlPackage,
         backoff: UpgradeBackoffConfig,
         clock: C,
@@ -140,6 +146,7 @@ where
             agent_control_internal_publisher,
             package_manager,
             verify_executor,
+            self_replacer,
             repository: package.download.oci.repository.clone(),
             pub_key_url: package.download.oci.public_key_url.clone(),
             // The gate owns the exponential-backoff-plus-jitter schedule (it never sleeps; it
@@ -203,9 +210,11 @@ where
 
         debug!("Attempting to self-replace with new binary",);
 
-        BinarySelfReplacer::self_replace(&new_binary_path).map_err(|e| {
-            UpdaterError::UpdateFailed(format!("self replacing Agent Control binary: {e}"))
-        })?;
+        self.self_replacer
+            .self_replace(&new_binary_path)
+            .map_err(|e| {
+                UpdaterError::UpdateFailed(format!("self replacing Agent Control binary: {e}"))
+            })?;
 
         debug!("Agent Control binary replaced, stopping to allow the new version to start");
         self.agent_control_internal_publisher
@@ -240,6 +249,7 @@ mod tests {
     use crate::package::oci::package_manager::OCIPackageManagerError;
     use crate::utils::time::SystemClock;
     use mockall::mock;
+    use self_replacer::BinarySelfReplacer;
     use std::path::Path;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
@@ -272,7 +282,14 @@ mod tests {
         }
     }
 
-    type TestUpdater<C> = OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock, C>;
+    type TestUpdater<C> =
+        OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock, C, BinarySelfReplacer>;
+
+    /// Replacer used by the unit tests. They all fail at `install` before reaching the
+    /// self-replace step, so it never actually runs; the target is a throwaway path.
+    fn unused_self_replacer() -> BinarySelfReplacer {
+        BinarySelfReplacer::with_target(std::path::PathBuf::from("unused"))
+    }
 
     fn no_jitter_backoff(base: Duration, max: Duration, max_failures: u32) -> UpgradeBackoffConfig {
         UpgradeBackoffConfig {
@@ -299,6 +316,7 @@ mod tests {
             publisher,
             MockPackageManager::new(),
             MockVerifyExecutorMock::new(),
+            unused_self_replacer(),
             AgentControlPackage::default(),
             backoff,
             clock,
@@ -320,6 +338,7 @@ mod tests {
             publisher,
             MockPackageManager::new(),
             MockVerifyExecutorMock::new(),
+            unused_self_replacer(),
             AgentControlPackage::default(),
             UpgradeBackoffConfig::default(),
             SystemClock,

--- a/agent-control/src/agent_control/version_updater/on_host.rs
+++ b/agent-control/src/agent_control/version_updater/on_host.rs
@@ -249,7 +249,7 @@ mod tests {
     use crate::package::oci::package_manager::OCIPackageManagerError;
     use crate::utils::time::SystemClock;
     use mockall::mock;
-    use self_replacer::BinarySelfReplacer;
+    use self_replacer::BinaryReplacer;
     use std::path::Path;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
@@ -283,12 +283,12 @@ mod tests {
     }
 
     type TestUpdater<C> =
-        OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock, C, BinarySelfReplacer>;
+        OnHostACUpdater<MockPackageManager, MockVerifyExecutorMock, C, BinaryReplacer>;
 
     /// Replacer used by the unit tests. They all fail at `install` before reaching the
     /// self-replace step, so it never actually runs; the target is a throwaway path.
-    fn unused_self_replacer() -> BinarySelfReplacer {
-        BinarySelfReplacer::with_target(std::path::PathBuf::from("unused"))
+    fn unused_self_replacer() -> BinaryReplacer {
+        BinaryReplacer::with_target(std::path::PathBuf::from("unused"))
     }
 
     fn no_jitter_backoff(base: Duration, max: Duration, max_failures: u32) -> UpgradeBackoffConfig {

--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -135,6 +135,8 @@ pub struct RunnerContext {
     pub running_mode: Environment,
     /// The consuming end of the internal application event bus.
     pub application_event_consumer: EventConsumer<ApplicationEvent>,
+    /// Overrides the binary that on-host self-update replaces. `None` means the current executable.
+    pub self_replace_target: Option<std::path::PathBuf>,
 }
 
 impl Command {
@@ -285,6 +287,8 @@ impl Command {
                 base_paths,
                 running_mode,
                 application_event_consumer,
+                // None uses the current running executable.
+                self_replace_target: None,
             },
             tracer,
             #[cfg(target_family = "windows")]

--- a/agent-control/tests/common/agent_control.rs
+++ b/agent-control/tests/common/agent_control.rs
@@ -20,6 +20,24 @@ pub fn start_agent_control_with_custom_config(
     base_paths: BasePaths,
     ac_running_mode: Environment,
 ) -> StartedAgentControl {
+    start_agent_control(base_paths, ac_running_mode, None)
+}
+
+/// Like [`start_agent_control_with_custom_config`] but makes on-host self-update replace the
+/// binary at `self_replace_target` instead of the running executable.
+pub fn start_agent_control_with_self_replace_target(
+    base_paths: BasePaths,
+    ac_running_mode: Environment,
+    self_replace_target: std::path::PathBuf,
+) -> StartedAgentControl {
+    start_agent_control(base_paths, ac_running_mode, Some(self_replace_target))
+}
+
+fn start_agent_control(
+    base_paths: BasePaths,
+    ac_running_mode: Environment,
+    self_replace_target: Option<std::path::PathBuf>,
+) -> StartedAgentControl {
     let (application_event_publisher, application_event_consumer) = pub_sub();
 
     let handle = std::thread::spawn(move || {
@@ -48,6 +66,7 @@ pub fn start_agent_control_with_custom_config(
             base_paths,
             running_mode: ac_running_mode,
             application_event_consumer,
+            self_replace_target,
         };
         let runner = AgentControlRunner::try_new(runner_context).unwrap();
         match ac_running_mode {

--- a/agent-control/tests/common/remote_config_status.rs
+++ b/agent-control/tests/common/remote_config_status.rs
@@ -27,8 +27,8 @@ pub fn check_latest_remote_config_status_is_expected(
     check_latest_remote_config_status(opamp_server, instance_id, |config_status| {
         if config_status.status != expected_config_status {
             Err(format!(
-                "Remote config status not as expected, Expected: {:?}, Found: {:?}",
-                expected_config_status, config_status.status,
+                "Remote config status not as expected, Expected: {:?}, Found: {:?}, error_message: {:?}",
+                expected_config_status, config_status.status, config_status.error_message,
             )
             .into())
         } else {

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -1,4 +1,5 @@
 use crate::common::agent_control::start_agent_control_with_custom_config;
+use crate::common::agent_control::start_agent_control_with_self_replace_target;
 use crate::common::base_paths::TempBasePaths;
 use crate::common::remote_config_status::check_latest_remote_config_status;
 use crate::common::remote_config_status::check_latest_remote_config_status_is_expected;
@@ -45,14 +46,15 @@ fn test_ac_self_update_with_oci_registry() {
 
     create_self_update_local_config(&opamp_server, &signer, &dirs.local_dir(), true);
 
-    let current_exe_path = std::env::current_exe()
-        .expect("failed to get current exe path")
-        .canonicalize()
-        .expect("failed to canonicalize current exe path");
+    // AC runs in-process here, so the running executable is the shared test-harness binary.
+    // Self-update replaces a disposable copy of it instead, so the replace can't race other
+    // in-process tests over the live runner (which fails with ERROR_ACCESS_DENIED on Windows).
+    let (_self_replace_target_dir, self_replace_target) = copy_current_exe();
 
-    let mut agent_control = start_agent_control_with_custom_config(
+    let mut agent_control = start_agent_control_with_self_replace_target(
         dirs.base_paths().clone(),
         AGENT_CONTROL_MODE_ON_HOST,
+        self_replace_target.clone(),
     );
 
     let ac_instance_id = get_instance_id(&AgentID::AgentControl, dirs.base_paths());
@@ -83,7 +85,20 @@ agents: {{}}
         }
     });
 
-    assert_is_fake_binary(&current_exe_path);
+    assert_is_fake_binary(&self_replace_target);
+}
+
+/// Copies the running test binary to a throwaway file inside a fresh temp dir, returning the
+/// dir (which must be kept alive) and the path to the copy.
+fn copy_current_exe() -> (TempDir, PathBuf) {
+    let current_exe = std::env::current_exe()
+        .expect("failed to get current exe path")
+        .canonicalize()
+        .expect("failed to canonicalize current exe path");
+    let dir = tempdir().expect("failed to create temp dir for self-replace target");
+    let copy = dir.path().join(AGENT_CONTROL_BIN);
+    std::fs::copy(&current_exe, &copy).expect("failed to copy current exe");
+    (dir, copy)
 }
 
 #[test]
@@ -359,9 +374,12 @@ fn test_ac_self_update_recovers_after_registry_outage_with_oci_registry() {
 
     create_self_update_recovery_config(&opamp_server, &signer, &dirs.local_dir());
 
-    let mut agent_control = start_agent_control_with_custom_config(
+    let (_self_replace_target_dir, self_replace_target) = copy_current_exe();
+
+    let mut agent_control = start_agent_control_with_self_replace_target(
         dirs.base_paths().clone(),
         AGENT_CONTROL_MODE_ON_HOST,
+        self_replace_target,
     );
 
     let ac_instance_id = get_instance_id(&AgentID::AgentControl, dirs.base_paths());

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -417,8 +417,9 @@ agents: {{}}
     let _ = push_ac_package(build_fake_ac_binary, None, Some(RECOVERY_VERSION_TAG));
 
     // The periodic self-update retry (no new OpAMP config) downloads and extracts the now-available
-    // package, leaving the AC binary under the installed-packages directory. We assert recovery on
-    // that install, which happens just before the (out-of-scope) self-replace step.
+    // package into its installed-package directory. We assert recovery on that install directory
+    // landing because the self-replace step moves the binary out of `stored_packages` onto the
+    // self-replace target.
     let installed_packages_dir = dirs
         .remote_dir()
         .join(PACKAGES_FOLDER_NAME)
@@ -426,7 +427,7 @@ agents: {{}}
         .join("stored_packages")
         .join(AGENT_CONTROL_BIN_PACKAGE_ID);
     retry(60, Duration::from_secs(5), || {
-        if dir_contains_file(&installed_packages_dir, AGENT_CONTROL_BIN) {
+        if dir_contains_subdir(&installed_packages_dir) {
             Ok(())
         } else {
             Err(
@@ -437,18 +438,12 @@ agents: {{}}
     });
 }
 
-fn dir_contains_file(dir: &Path, name: &str) -> bool {
+/// Whether `dir` exists and contains at least one subdirectory.
+fn dir_contains_subdir(dir: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
     };
-    entries.flatten().any(|entry| {
-        let path = entry.path();
-        if path.is_dir() {
-            dir_contains_file(&path, name)
-        } else {
-            path.file_name().is_some_and(|f| f == name)
-        }
-    })
+    entries.flatten().any(|entry| entry.path().is_dir())
 }
 
 fn create_self_update_local_config(

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -17,11 +17,9 @@ use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_ID;
 use newrelic_agent_control::agent_control::defaults::AGENT_CONTROL_VERSION;
-use newrelic_agent_control::agent_control::defaults::PACKAGES_FOLDER_NAME;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
 use newrelic_agent_control::agent_control::version_updater::on_host::AGENT_CONTROL_BIN;
-use newrelic_agent_control::agent_control::version_updater::on_host::AGENT_CONTROL_BIN_PACKAGE_ID;
 use oci_test_utils::OCISigner;
 use oci_test_utils::{PackageMediaType, PackagePublisher};
 use opamp_client::opamp::proto::RemoteConfigStatuses;
@@ -361,9 +359,10 @@ self_update:
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 /// Exercises self-update *recovery* from a transient registry outage: while the package is absent
 /// AC keeps retrying instead of giving up, and once it reappears the periodic retry (with no new
-/// OpAMP config) picks it up and downloads it.
+/// OpAMP config) picks it up, downloads it, and completes the self-replace.
 ///
-/// Recovery is asserted on the package landing on disk, *not* on a completed self-replace.
+/// Recovery is asserted end-to-end (as in the happy path): AC gracefully stops to hand off to the
+/// new version, and the self-replace target ends up being the fake AC binary built for this test.
 fn test_ac_self_update_recovers_after_registry_outage_with_oci_registry() {
     const RECOVERY_VERSION_TAG: &str = "recovery-after-outage";
 
@@ -379,7 +378,7 @@ fn test_ac_self_update_recovers_after_registry_outage_with_oci_registry() {
     let mut agent_control = start_agent_control_with_self_replace_target(
         dirs.base_paths().clone(),
         AGENT_CONTROL_MODE_ON_HOST,
-        self_replace_target,
+        self_replace_target.clone(),
     );
 
     let ac_instance_id = get_instance_id(&AgentID::AgentControl, dirs.base_paths());
@@ -416,34 +415,22 @@ agents: {{}}
     // and the non-terminal cap, the next retry probe (~1s later) picks it up.
     let _ = push_ac_package(build_fake_ac_binary, None, Some(RECOVERY_VERSION_TAG));
 
-    // The periodic self-update retry (no new OpAMP config) downloads and extracts the now-available
-    // package into its installed-package directory. We assert recovery on that install directory
-    // landing because the self-replace step moves the binary out of `stored_packages` onto the
-    // self-replace target.
-    let installed_packages_dir = dirs
-        .remote_dir()
-        .join(PACKAGES_FOLDER_NAME)
-        .join(AGENT_CONTROL_ID)
-        .join("stored_packages")
-        .join(AGENT_CONTROL_BIN_PACKAGE_ID);
+    // The periodic self-update retry (no new OpAMP config) now downloads, extracts, verifies and
+    // self-replaces with the recovered package. As in the happy path, that triggers a graceful stop
+    // so the new binary can take effect.
     retry(60, Duration::from_secs(5), || {
-        if dir_contains_subdir(&installed_packages_dir) {
+        if agent_control.has_gracefully_stopped() {
             Ok(())
         } else {
             Err(
-                "the periodic retry should have downloaded the package once it became available"
+                "Agent Control should have recovered and stopped for the new binary to take effect"
                     .into(),
             )
         }
     });
-}
 
-/// Whether `dir` exists and contains at least one subdirectory.
-fn dir_contains_subdir(dir: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return false;
-    };
-    entries.flatten().any(|entry| entry.path().is_dir())
+    // The self-replace moved the recovered fake binary onto the target.
+    assert_is_fake_binary(&self_replace_target);
 }
 
 fn create_self_update_local_config(

--- a/self-replacer/examples/self_replacing_binary.rs
+++ b/self-replacer/examples/self_replacing_binary.rs
@@ -14,7 +14,7 @@
 //!
 //! ```
 
-use self_replacer::{BinarySelfReplacer, SelfReplacer};
+use self_replacer::{BinaryReplacer, SelfReplacer};
 
 use std::collections::hash_map::DefaultHasher;
 use std::env;
@@ -29,7 +29,7 @@ fn main() {
         let new_binary_path = &args[2];
 
         let result =
-            BinarySelfReplacer::new().and_then(|replacer| replacer.self_replace(new_binary_path));
+            BinaryReplacer::new().and_then(|replacer| replacer.self_replace(new_binary_path));
 
         match result {
             Ok(()) => {

--- a/self-replacer/examples/self_replacing_binary.rs
+++ b/self-replacer/examples/self_replacing_binary.rs
@@ -28,7 +28,8 @@ fn main() {
         // Perform self-replacement
         let new_binary_path = &args[2];
 
-        let result = BinarySelfReplacer::self_replace(new_binary_path);
+        let result =
+            BinarySelfReplacer::new().and_then(|replacer| replacer.self_replace(new_binary_path));
 
         match result {
             Ok(()) => {

--- a/self-replacer/src/lib.rs
+++ b/self-replacer/src/lib.rs
@@ -17,6 +17,6 @@ pub trait SelfReplacer {
     /// Error type returned when a replacement attempt fails.
     type Error: std::error::Error;
 
-    /// Replaces the currently running binary with the binary at `new_bin`.
-    fn self_replace(new_bin: impl AsRef<Path>) -> Result<(), Self::Error>;
+    /// Replaces the replacer's configured target binary with the binary at `new_bin`.
+    fn self_replace(&self, new_bin: impl AsRef<Path>) -> Result<(), Self::Error>;
 }

--- a/self-replacer/src/lib.rs
+++ b/self-replacer/src/lib.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 mod replacer;
-pub use replacer::{BinarySelfReplacer, ReplaceError};
+pub use replacer::{BinaryReplacer, ReplaceError};
 
 /// File extension appended to the original binary's name when a backup copy is created
 /// (e.g. `agent-control.bak`). Backups are not removed automatically.

--- a/self-replacer/src/replacer.rs
+++ b/self-replacer/src/replacer.rs
@@ -62,17 +62,43 @@ pub enum ReplaceError {
 }
 
 /// Platform-agnostic self-replacer implementation.
+/// Holds the path of the binary to replace.
 #[derive(Debug)]
-pub struct BinarySelfReplacer;
+pub struct BinarySelfReplacer {
+    target: PathBuf,
+}
+
+impl BinarySelfReplacer {
+    /// Builds a replacer targeting the currently running executable.
+    /// Canonicalize resolves symlinks on both platforms.
+    pub fn new() -> Result<Self, ReplaceError> {
+        let target = std::env::current_exe()
+            .and_then(|p| p.canonicalize())
+            .map_err(ReplaceError::CurrentExeNotFound)?;
+
+        debug!(
+            target = %target.display(),
+            "Current executable path",
+        );
+
+        Ok(Self { target })
+    }
+
+    /// Builds a replacer targeting an explicit binary path instead of the running executable.
+    pub fn with_target(target: PathBuf) -> Self {
+        Self { target }
+    }
+}
 
 impl SelfReplacer for BinarySelfReplacer {
     type Error = ReplaceError;
 
-    fn self_replace(new_bin: impl AsRef<Path>) -> Result<(), Self::Error> {
+    fn self_replace(&self, new_bin: impl AsRef<Path>) -> Result<(), Self::Error> {
         let new_bin = new_bin.as_ref();
 
         debug!(
             new_bin = %new_bin.display(),
+            target = %self.target.display(),
             "Starting binary self-replacement",
         );
 
@@ -82,18 +108,7 @@ impl SelfReplacer for BinarySelfReplacer {
             ));
         }
 
-        // Get current executable path
-        // Canonicalize resolves symlinks on both platforms
-        let current_exe = std::env::current_exe()
-            .and_then(|p| p.canonicalize())
-            .map_err(ReplaceError::CurrentExeNotFound)?;
-
-        debug!(
-            current_exe = %current_exe.display(),
-            "Current executable path",
-        );
-
-        replace_binary(&current_exe, new_bin)
+        replace_binary(&self.target, new_bin)
     }
 }
 
@@ -300,7 +315,8 @@ mod tests {
         let new_bin = temp_dir.path().join("program-new");
 
         // Don't create new_bin - it should not exist
-        let result = BinarySelfReplacer::self_replace(&new_bin);
+        let result =
+            BinarySelfReplacer::with_target(temp_dir.path().join("program")).self_replace(&new_bin);
         // Should fail with NewBinaryNotFound at the early validation check
         assert_matches!(result, Err(ReplaceError::NewBinaryNotFound(_)));
     }

--- a/self-replacer/src/replacer.rs
+++ b/self-replacer/src/replacer.rs
@@ -64,11 +64,11 @@ pub enum ReplaceError {
 /// Platform-agnostic self-replacer implementation.
 /// Holds the path of the binary to replace.
 #[derive(Debug)]
-pub struct BinarySelfReplacer {
+pub struct BinaryReplacer {
     target: PathBuf,
 }
 
-impl BinarySelfReplacer {
+impl BinaryReplacer {
     /// Builds a replacer targeting the currently running executable.
     /// Canonicalize resolves symlinks on both platforms.
     pub fn new() -> Result<Self, ReplaceError> {
@@ -90,7 +90,7 @@ impl BinarySelfReplacer {
     }
 }
 
-impl SelfReplacer for BinarySelfReplacer {
+impl SelfReplacer for BinaryReplacer {
     type Error = ReplaceError;
 
     fn self_replace(&self, new_bin: impl AsRef<Path>) -> Result<(), Self::Error> {
@@ -316,7 +316,7 @@ mod tests {
 
         // Don't create new_bin - it should not exist
         let result =
-            BinarySelfReplacer::with_target(temp_dir.path().join("program")).self_replace(&new_bin);
+            BinaryReplacer::with_target(temp_dir.path().join("program")).self_replace(&new_bin);
         // Should fail with NewBinaryNotFound at the early validation check
         assert_matches!(result, Err(ReplaceError::NewBinaryNotFound(_)));
     }

--- a/self-replacer/tests/integration_tests.rs
+++ b/self-replacer/tests/integration_tests.rs
@@ -9,7 +9,7 @@ use std::fs;
 use tempfile::TempDir;
 
 mod test_helpers;
-use self_replacer::{BinarySelfReplacer, SelfReplacer};
+use self_replacer::{BinaryReplacer, SelfReplacer};
 use test_helpers::{copy_example_binary, create_modified_binary};
 
 use self_replacer::BACKUP_SUFFIX;
@@ -105,8 +105,7 @@ fn test_rollback_on_invalid_path() {
         test_dir.join("does_not_exist")
     };
 
-    let result =
-        BinarySelfReplacer::with_target(original_binary.clone()).self_replace(&non_existent);
+    let result = BinaryReplacer::with_target(original_binary.clone()).self_replace(&non_existent);
 
     assert!(result.is_err(), "Should fail when new binary doesn't exist");
 

--- a/self-replacer/tests/integration_tests.rs
+++ b/self-replacer/tests/integration_tests.rs
@@ -105,7 +105,8 @@ fn test_rollback_on_invalid_path() {
         test_dir.join("does_not_exist")
     };
 
-    let result = BinarySelfReplacer::self_replace(&non_existent);
+    let result =
+        BinarySelfReplacer::with_target(original_binary.clone()).self_replace(&non_existent);
 
     assert!(result.is_err(), "Should fail when new binary doesn't exist");
 


### PR DESCRIPTION
Fixes intermittent Windows CI failures in test_ac_self_update_with_oci_registry where self-update reported Failed instead of Applied (Access is denied). 
The integration tests run AC in-process, so self-replace was rewriting the shared test-harness binary; the self-replace target is now injectable so each test replaces its own disposable copy. Also surfaces the remote-config error_message on assertion mismatch for easier diagnosis.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
