### PR TITLE
fix: adapt notices template to tera v2

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+      - uses: newrelic/rust-licenses-noticer@aafd951d814aa31bbe4a5b463fd52ba208905562 # v1.0.4
         with:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
 

--- a/.github/workflows/shared_create_prerelease_pr.yml
+++ b/.github/workflows/shared_create_prerelease_pr.yml
@@ -86,7 +86,7 @@ jobs:
         # The action fails the step whenever it regenerates the file with new content; the
         # follow-up step distinguishes that expected case from a real error.
         continue-on-error: true
-        uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+        uses: newrelic/rust-licenses-noticer@aafd951d814aa31bbe4a5b463fd52ba208905562 # v1.0.4
         with:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
 

--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -12,18 +12,18 @@ or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 For any licenses that require the disclosure of source code, the source code
 can be found at <https://github.com/newrelic/newrelic-agent-control>.
 {% for dep, licenseObj in dependencies %}
-{%- if dep is matching("newrelic_agent_control") %}{% continue %}{% endif -%}
-{%- if dep is matching("resource-detection") %}{% continue %}{% endif -%}
-{%- if dep is matching("self-replacer") %}{% continue %}{% endif -%}
-{%- if dep is matching("fs") %}{% continue %}{% endif -%}
-{%- if dep is matching("config-migrate") %}{% continue %}{% endif -%}
-{%- if dep is matching("wrapper_with_default") %}{% continue %}{% endif -%}
-{%- if dep is matching("e2e-runner") %}{% continue %}{% endif -%}
-{%- if dep is matching("fake-opamp-server") %}{% continue %}{% endif -%}
-{%- if dep is matching("oci-test-utils") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="newrelic_agent_control") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="resource-detection") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="self-replacer") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="fs") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="config-migrate") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="wrapper_with_default") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="e2e-runner") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="fake-opamp-server") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="oci-test-utils") %}{% continue %}{% endif -%}
 {# The next two dependencies are NR projects that share the same license. So not "third parties" #}
-{%- if dep is matching("nr-auth") %}{% continue %}{% endif -%}
-{%- if dep is matching("opamp-rs") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="nr-auth") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="opamp-rs") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>
 
 Distributed under the following license(s):


### PR DESCRIPTION
## Summary

`rust-licenses-noticer` was upgraded to `tera` v2, which introduced two breaking changes affecting this template:

1. The **`matching` test was removed** in v2.
2. Test arguments must now be **named** rather than positional.

The skip-list entries used `dep is matching("…")`, which now fails. They are switched to the `containing` test with a `pat` kwarg:

```diff
-{%- if dep is matching("newrelic_agent_control") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="newrelic_agent_control") %}{% continue %}{% endif -%}
```

All the skip patterns are plain substrings (no regex metacharacters), so `containing` is behaviorally equivalent to the previous `matching` usage. Verified by rendering the updated template through the v2-based noticer: the internal/NR crates are correctly excluded and output ordering is preserved.

## Related

Upstream fix: newrelic/rust-licenses-noticer#84