### PR TITLE
feat: allow backward-compatible protocol versions

### DIFF
--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -12,13 +12,12 @@ On top of those sections, every file declares a top-level [`protocol_version`](#
 
 It is a quoted `MAJOR.MINOR` string (e.g. `"1.0"`). The value **must be quoted**, otherwise YAML parses `0.1` as a float and the field is rejected.
 
-It is parsed and validated on its own, at the registry ingestion boundary, *before* the rest of the document is interpreted — so it can gate files whose metadata or other sections use a shape this Agent Control would not otherwise understand. Each Agent Control release understands a single maximum protocol version, and the compatibility rules are:
+It is parsed and validated on its own, at the registry ingestion boundary, *before* the rest of the document is interpreted — so it can gate files whose metadata or other sections use a shape this Agent Control would not otherwise understand. Each Agent Control release understands a single maximum protocol version, and the `protocol_version` is treated as a single ordered `MAJOR.MINOR` value. The compatibility rules are:
 
-* Different `major` (either direction): rejected — a major bump is a breaking schema change.
-* Same `major`, higher `minor`: rejected — the file is newer than this Agent Control understands.
-* Same `major`, equal or lower `minor`: accepted — minor bumps are additive and backward-compatible.
+* Newer than supported (higher `major`, or same `major` with a higher `minor`): rejected — the file is newer than this Agent Control understands.
+* Equal to or older than supported: accepted — Agent Control understands every protocol version up to and including the supported one.
 
-For example, an Agent Control supporting `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new), and rejects `0.9` and `2.0` (wrong major).
+For example, an Agent Control supporting `1.6` accepts everything up to `1.6` (including `0.9` and `1.0`..=`1.6`) and rejects anything newer (`1.7`, `2.0`, ...).
 
 ## Metadata
 

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -106,7 +106,7 @@ impl AgentTypeDefinition {
     /// `protocol_version` before the document is converted into the definition.
     pub fn from_slice(content: &[u8]) -> Result<Self, AgentTypeDefinitionParseError> {
         let document: serde_json::Value = serde_saphyr::from_slice(content)?;
-        protocol_version::check(&document)?;
+        protocol_version::validate(&document)?;
         let definition = serde_json::from_value::<RawAgentTypeDefinition>(document)?.0;
         Ok(definition)
     }
@@ -611,14 +611,14 @@ deployment: {{}}
     }
 
     #[test]
-    fn parse_rejects_incompatible_protocol_version() {
-        // Assumes the supported version is on major 0; a major-1 file is a breaking change.
+    fn parse_rejects_too_new_protocol_version() {
+        // A far-future version is newer than this Agent Control understands.
         let yaml = k8s_definition_yaml("protocol_version: \"99.0\"");
 
         assert_matches!(
             AgentTypeDefinition::from_slice(yaml.as_bytes()),
             Err(AgentTypeDefinitionParseError::ProtocolVersion(
-                ProtocolVersionError::IncompatibleMajor { .. }
+                ProtocolVersionError::Incompatible { .. }
             ))
         );
     }

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -6,13 +6,15 @@
 //! validated against the supported version at the registry ingestion boundary before the rest of
 //! the file is parsed.
 //!
-//! Compatibility rules for a file's version against the supported version:
-//! - different `major` (either direction) → rejected: a major bump is a breaking schema change.
-//! - same `major`, higher `minor` → rejected: the file is newer than this Agent Control understands.
-//! - same `major`, equal or lower `minor` → accepted: minor bumps are additive and backward-compatible.
+//! The `protocol_version` is treated as a single ordered `MAJOR.MINOR` value. Compatibility against
+//! the supported version is:
+//! - version newer than supported (higher `major`, or same `major` with higher `minor`) → rejected:
+//!   the file is newer than this Agent Control understands.
+//! - version equal to or older than supported → accepted: Agent Control understands every protocol
+//!   version up to and including the supported one.
 //!
-//! For example, an Agent Control supporting `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new),
-//! and rejects `0.9` and `2.0` (wrong major).
+//! For example, an Agent Control supporting `1.6` accepts everything up to `1.6` (including `0.9` and
+//! `1.0`..=`1.6`) and rejects anything newer (`1.7`, `2.0`, ...).
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -38,20 +40,10 @@ pub enum ProtocolVersionError {
     InvalidFormat(String),
     /// The major version differs from the supported one (a breaking schema change).
     #[error(
-        "unsupported protocol_version {target}: incompatible major version (this agent control supports {supported})"
-    )]
-    IncompatibleMajor {
-        /// The version declared by the file.
-        target: ProtocolVersion,
-        /// The version supported by this Agent Control.
-        supported: ProtocolVersion,
-    },
-    /// The minor version is newer than the supported one under the same major.
-    #[error(
         "unsupported protocol_version {target}: newer than supported (this agent control supports up to {supported})"
     )]
-    TooNew {
-        /// The version declared by the file.
+    Incompatible {
+        /// The version to be validated.
         target: ProtocolVersion,
         /// The version supported by this Agent Control.
         supported: ProtocolVersion,
@@ -59,7 +51,7 @@ pub enum ProtocolVersionError {
 }
 
 /// A two-part `MAJOR.MINOR` schema-language version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion {
     major: u64,
     minor: u64,
@@ -87,10 +79,8 @@ impl FromStr for ProtocolVersion {
 }
 
 impl ProtocolVersion {
-    /// Checks this version against [SUPPORTED_PROTOCOL_VERSION].
-    /// A different major is a breaking change in either direction; a higher minor under the same major
-    /// is too new for this Agent Control. Equal or lower minors under the same major are additive and
-    /// backward-compatible.
+    /// Checks this version against [SUPPORTED_PROTOCOL_VERSION]. Any version newer than the supported
+    /// one is rejected; every version up to and including it is accepted.
     pub fn is_supported(&self) -> Result<(), ProtocolVersionError> {
         check_compatibility(*self, SUPPORTED_PROTOCOL_VERSION)
     }
@@ -100,11 +90,8 @@ fn check_compatibility(
     target: ProtocolVersion,
     supported: ProtocolVersion,
 ) -> Result<(), ProtocolVersionError> {
-    if target.major != supported.major {
-        return Err(ProtocolVersionError::IncompatibleMajor { target, supported });
-    }
-    if target.minor > supported.minor {
-        return Err(ProtocolVersionError::TooNew { target, supported });
+    if target > supported {
+        return Err(ProtocolVersionError::Incompatible { target, supported });
     }
     Ok(())
 }
@@ -112,7 +99,7 @@ fn check_compatibility(
 /// Validates the `protocol_version` field of an already-parsed agent-type document. It reads only
 /// that field and ignores the rest, so it can run before the document is converted into a
 /// definition.
-pub fn check(document: &serde_json::Value) -> Result<(), ProtocolVersionError> {
+pub fn validate(document: &serde_json::Value) -> Result<(), ProtocolVersionError> {
     let version = match document.get("protocol_version") {
         None => return Err(ProtocolVersionError::Missing),
         Some(serde_json::Value::String(raw)) => ProtocolVersion::from_str(raw)?,
@@ -149,14 +136,14 @@ mod tests {
     }
 
     #[rstest]
-    // Same major, lower/equal minor is accepted; higher minor is too new.
+    // Equal or older than supported is accepted, including a lower major.
     #[case(pv(1, 5), pv(1, 6), Ok(()))]
     #[case(pv(1, 6), pv(1, 6), Ok(()))]
     #[case(pv(1, 0), pv(1, 6), Ok(()))]
-    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::TooNew { target: pv(1, 7), supported: pv(1, 6) }))]
-    // Any major mismatch is rejected in either direction.
-    #[case(pv(0, 9), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { target: pv(0, 9), supported: pv(1, 6) }))]
-    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::IncompatibleMajor { target: pv(2, 0), supported: pv(1, 6) }))]
+    #[case(pv(0, 9), pv(1, 6), Ok(()))]
+    // Anything newer than supported is too new, whether by minor or major.
+    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(1, 7), supported: pv(1, 6) }))]
+    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(2, 0), supported: pv(1, 6) }))]
     fn compatibility_matrix(
         #[case] target: ProtocolVersion,
         #[case] supported: ProtocolVersion,
@@ -168,7 +155,7 @@ mod tests {
     #[test]
     fn check_accepts_supported_version() {
         assert_eq!(
-            check(&yaml_value("protocol_version: \"1.0\"\nname: whatever")),
+            validate(&yaml_value("protocol_version: \"1.0\"\nname: whatever")),
             Ok(())
         );
     }
@@ -176,7 +163,7 @@ mod tests {
     #[test]
     fn check_reports_missing_field() {
         assert_eq!(
-            check(&yaml_value("name: whatever")),
+            validate(&yaml_value("name: whatever")),
             Err(ProtocolVersionError::Missing)
         );
     }
@@ -185,16 +172,16 @@ mod tests {
     fn check_rejects_unquoted_float() {
         // An unquoted `0.1` is a yaml float, not the required quoted MAJOR.MINOR string.
         assert_eq!(
-            check(&yaml_value("protocol_version: 0.1")),
+            validate(&yaml_value("protocol_version: 0.1")),
             Err(ProtocolVersionError::InvalidFormat("0.1".to_string()))
         );
     }
 
     #[test]
-    fn check_rejects_incompatible_version() {
+    fn check_rejects_too_new_version() {
         assert_eq!(
-            check(&yaml_value("protocol_version: \"99.0\"")),
-            Err(ProtocolVersionError::IncompatibleMajor {
+            validate(&yaml_value("protocol_version: \"99.0\"")),
+            Err(ProtocolVersionError::Incompatible {
                 target: pv(99, 0),
                 supported: SUPPORTED_PROTOCOL_VERSION,
             })

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -273,6 +273,27 @@ objects:
     }
 
     #[test]
+    fn test_k8s_object_meta_accepts_unknown_fields() {
+        let yaml = r#"
+objects:
+  cr1:
+    apiVersion: agent_control.version/v0beta1
+    kind: Foo
+    metadata:
+      name: test
+      namespace: test-namespace
+      unknown_field: ignore
+      another_unknown:
+        nested: value
+"#;
+        let k8s: K8s = serde_saphyr::from_str(yaml).unwrap();
+        let metadata = &k8s.objects["cr1"].metadata;
+        assert_eq!("test", &metadata.name);
+        assert_eq!("test-namespace", &metadata.namespace);
+        assert!(metadata.labels.is_empty());
+    }
+
+    #[test]
     fn test_template_k8s() {
         let untouched_val = "${nr-var:any} no templated";
         let test_agent_id = "id";

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -22,13 +22,12 @@ Agent Types are versioned to ensure compatibility with a given configuration val
 
 Separately from the agent type `version`, every definition must declare a top-level `protocol_version`. This is **not** a metadata field — it is parsed on its own and versions the **agent-type schema language itself**: the set of fields and their meaning that Agent Control knows how to parse, *including the shape of the metadata block described here*. It is decoupled from both the agent type `version` (semver) and the Agent Control release version. It is a quoted `MAJOR.MINOR` string (for example `"1.0"`); the value **must be quoted**, otherwise YAML interprets `0.1` as a float and the field is rejected.
 
-Because it gates the rest of the document, Agent Control reads and validates `protocol_version` first, at the registry ingestion boundary, *before* the metadata and the other sections are interpreted. Each Agent Control release understands a single maximum protocol version. The compatibility rules are:
+Because it gates the rest of the document, Agent Control reads and validates `protocol_version` first, at the registry ingestion boundary, *before* the metadata and the other sections are interpreted. Each Agent Control release understands a single maximum protocol version, and the `protocol_version` is treated as a single ordered `MAJOR.MINOR` value. The compatibility rules are:
 
-- Different `major` (in either direction): rejected. A major bump is a breaking schema change.
-- Same `major`, higher `minor`: rejected. The file is newer than this Agent Control understands.
-- Same `major`, equal or lower `minor`: accepted. Minor bumps are additive and backward-compatible.
+- Newer than supported (higher `major`, or same `major` with a higher `minor`): rejected. The file is newer than this Agent Control understands.
+- Equal to or older than supported: accepted. Agent Control understands every protocol version up to and including the supported one.
 
-For example, an Agent Control that supports protocol version `1.6` accepts `1.0`..=`1.6`, rejects `1.7` (too new), and rejects `0.9` and `2.0` (wrong major).
+For example, an Agent Control that supports protocol version `1.6` accepts everything up to `1.6` (including `0.9` and `1.0`..=`1.6`) and rejects anything newer (`1.7`, `2.0`, ...).
 
 The `platform` field is required, and `operating_system` is required when `platform: host`. The supported combinations are:
 


### PR DESCRIPTION
Agent Control previously accepted only agent-type files whose `protocol_version` shared the same major as the supported version, rejecting older majors outright. This loosens the check so any version up to and including the supported one is accepted, treating `protocol_version` as a single ordered `MAJOR.MINOR` value.

