### PR TITLE
feat(fs): introduce copy operation [NR-579370]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Remember that the keywords that you can use are the following:
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
+- Extend internal `fs` crate with a copy operation.
 
 ## v1.17.0 - 2026-06-16
 

--- a/fs/src/file.rs
+++ b/fs/src/file.rs
@@ -1,3 +1,5 @@
+/// Copying files on disk.
+pub mod copier;
 /// Deleting files from disk.
 pub mod deleter;
 /// Reading files and directory entries from disk.
@@ -9,6 +11,7 @@ pub mod writer;
 
 /// Filesystem-backed implementation of the file operation traits
 /// ([`FileReader`](reader::FileReader), [`FileWriter`](writer::FileWriter),
-/// [`FileRenamer`](renamer::FileRenamer), [`FileDeleter`](deleter::FileDeleter)).
+/// [`FileRenamer`](renamer::FileRenamer), [`FileDeleter`](deleter::FileDeleter),
+/// [`FileCopier`](copier::FileCopier)).
 #[derive(Debug)]
 pub struct LocalFile;

--- a/fs/src/file.rs
+++ b/fs/src/file.rs
@@ -10,8 +10,5 @@ pub mod renamer;
 pub mod writer;
 
 /// Filesystem-backed implementation of the file operation traits
-/// ([`FileReader`](reader::FileReader), [`FileWriter`](writer::FileWriter),
-/// [`FileRenamer`](renamer::FileRenamer), [`FileDeleter`](deleter::FileDeleter),
-/// [`FileCopier`](copier::FileCopier)).
 #[derive(Debug)]
 pub struct LocalFile;

--- a/fs/src/file/copier.rs
+++ b/fs/src/file/copier.rs
@@ -4,48 +4,32 @@ use std::path::Path;
 use std::{fs, io};
 use tracing::instrument;
 
-/// Copies a file on disk, setting permissions on the destination.
+/// Copies a file on disk, preserving the source's permissions on Unix.
 pub trait FileCopier {
     /// Copies the file at `from` to the file at `to`, creating or truncating `to`.
     ///
-    /// The copy is byte-for-byte, so non-UTF-8 binaries are preserved exactly. On Unix the
-    /// destination's permissions are set to `mode` (for example `0o755` for an executable),
-    /// overriding whatever the source carried. On Windows `mode` is ignored and the destination
-    /// is restricted to administrators, matching [`FileWriter::write`](super::writer::FileWriter).
+    /// The copy is byte-for-byte, so non-UTF-8 binaries are preserved exactly. On Unix it
+    /// **preserves the source file's mode bits**.
     ///
-    /// `mode` is kept in the signature on every platform on purpose: it expresses the caller's
-    /// Unix permission intent (Linux is the primary on-host target), and a single cross-platform
-    /// signature lets callers state that intent uniformly. Windows uses an ACL-based model with no
-    /// Unix mode to honor, so the value is intentionally ignored there rather than dropped from the
-    /// API.
+    /// On Windows, permissions cannot be preserved this way (the copy does not carry the source's
+    /// ACL, and executability is determined by extension, not permissions), so the destination is
+    /// restricted to administrators, matching [super::writer::FileWriter].
     ///
     /// The destination's parent directory must already exist.
-    fn copy(&self, from: &Path, to: &Path, mode: u32) -> io::Result<()>;
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<()>;
 }
 
 impl FileCopier for LocalFile {
-    /// Copies `from` to `to` byte-for-byte and sets the destination's permissions.
-    /// On Unix the destination mode is set to `mode`; on Windows access is restricted to
-    /// administrators and `mode` is ignored.
+    /// Copies `from` to `to` byte-for-byte, preserving the source's mode on Unix and applying the
+    /// administrators-only ACL on Windows.
     #[instrument(skip_all, fields(from = %from.display(), to = %to.display()))]
-    fn copy(&self, from: &Path, to: &Path, mode: u32) -> io::Result<()> {
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<()> {
         validate_path(to)?;
 
         fs::copy(from, to)?;
 
-        #[cfg(target_family = "unix")]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            fs::set_permissions(to, fs::Permissions::from_mode(mode))?;
-        }
-
         #[cfg(target_family = "windows")]
         {
-            // Windows has no Unix mode to apply: file access is governed by ACLs, which we set the
-            // same way `FileWriter::write` does. `mode` is accepted for a uniform cross-platform
-            // signature but has no Windows equivalent, so it is intentionally unused here.
-            let _ = mode;
             crate::win_permissions::set_file_permissions_for_administrator(to)
                 .map_err(io::Error::other)?;
         }
@@ -59,33 +43,41 @@ impl FileCopier for LocalFile {
 pub mod tests {
     use super::*;
 
-    /// A byte-for-byte copy preserves non-UTF-8 content and sets the requested mode, regardless of
-    /// the source file's own (non-executable) permissions.
+    /// A byte-for-byte copy preserves non-UTF-8 content and the source file's mode (whatever it is,
+    /// executable or not) rather than forcing a fixed mode.
     #[cfg(unix)]
     #[test]
-    fn test_copy_preserves_non_utf8_bytes_and_overrides_mode() {
+    fn test_copy_preserves_non_utf8_bytes_and_source_mode() {
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("bin");
-        let dst = dir.path().join("copied-bin");
-
         let bytes = [0xFFu8, 0xFE, 0x00, 0x01, b'h', b'i'];
-        fs::write(&src, bytes).unwrap();
-        // Source is deliberately non-executable, to prove we don't inherit its mode.
-        fs::set_permissions(&src, fs::Permissions::from_mode(0o600)).unwrap();
 
-        LocalFile.copy(&src, &dst, 0o755).unwrap();
+        // The low 9 bits of a Unix mode (rwxrwxrwx); the rest of `st_mode` holds the file-type and
+        // setuid/setgid/sticky bits, which we don't compare here.
+        const PERMISSION_BITS: u32 = 0o777;
 
-        assert_eq!(fs::read(&dst).unwrap(), bytes, "content must be preserved");
-        assert_eq!(
-            fs::metadata(&dst).unwrap().permissions().mode() & 0o777,
-            0o755,
-            "destination mode must be the requested one, not the source's"
-        );
+        // Both an executable and a non-executable source mode must be reproduced on the copy.
+        let source_modes: [u32; 2] = [0o644, 0o755];
+        for mode in source_modes {
+            let dir = tempfile::tempdir().unwrap();
+            let src = dir.path().join("bin");
+            let dst = dir.path().join("copied-bin");
+
+            fs::write(&src, bytes).unwrap();
+            fs::set_permissions(&src, fs::Permissions::from_mode(mode)).unwrap();
+
+            LocalFile.copy(&src, &dst).unwrap();
+
+            let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & PERMISSION_BITS;
+            assert_eq!(fs::read(&dst).unwrap(), bytes, "content must be preserved");
+            assert_eq!(
+                dst_mode, mode,
+                "destination must preserve the source's mode {mode:#o}"
+            );
+        }
     }
 
-    /// Copying onto an existing file.
+    /// Copying onto an existing file replaces the existing
     #[cfg(unix)]
     #[test]
     fn test_copy_overwrites_existing_destination() {
@@ -95,7 +87,7 @@ pub mod tests {
         fs::write(&src, "new").unwrap();
         fs::write(&dst, "older content with greater len").unwrap();
 
-        LocalFile.copy(&src, &dst, 0o644).unwrap();
+        LocalFile.copy(&src, &dst).unwrap();
 
         assert_eq!(fs::read_to_string(&dst).unwrap(), "new");
     }
@@ -106,7 +98,7 @@ pub mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dst = dir.path().join("dst");
 
-        let result = LocalFile.copy(&dir.path().join("does-not-exist"), &dst, 0o755);
+        let result = LocalFile.copy(&dir.path().join("does-not-exist"), &dst);
 
         assert!(result.is_err());
         assert!(!dst.exists());
@@ -119,7 +111,7 @@ pub mod tests {
         let src = dir.path().join("src");
         fs::write(&src, "data").unwrap();
 
-        let result = LocalFile.copy(&src, Path::new("some/path/../../etc/passwd"), 0o755);
+        let result = LocalFile.copy(&src, Path::new("some/path/../../etc/passwd"));
 
         assert!(result.is_err());
         assert!(
@@ -141,7 +133,7 @@ pub mod tests {
         let dst = dir.path().join("dst");
         fs::write(&src, "data").unwrap();
 
-        LocalFile.copy(&src, &dst, 0o755).unwrap();
+        LocalFile.copy(&src, &dst).unwrap();
 
         assert_eq!(fs::read_to_string(&dst).unwrap(), "data");
         crate::win_permissions::tests::assert_windows_permissions(&dst);

--- a/fs/src/file/copier.rs
+++ b/fs/src/file/copier.rs
@@ -4,35 +4,26 @@ use std::path::Path;
 use std::{fs, io};
 use tracing::instrument;
 
-/// Copies a file on disk, preserving the source's permissions on Unix.
+/// Copies a file on disk, keeping the destination's permissions consistent with the source.
 pub trait FileCopier {
     /// Copies the file at `from` to the file at `to`, creating or truncating `to`.
     ///
-    /// The copy is byte-for-byte, so non-UTF-8 binaries are preserved exactly. On Unix it
-    /// **preserves the source file's mode bits**.
-    ///
-    /// On Windows, permissions cannot be preserved this way (the copy does not carry the source's
-    /// ACL, and executability is determined by extension, not permissions), so the destination is
-    /// restricted to administrators, matching [super::writer::FileWriter].
+    /// The copy is byte-for-byte, so non-UTF-8 binaries are preserved exactly, and the destination
+    /// keeps the permissions a plain copy yields: on Unix the source's mode bits are carried over
+    /// (e.g. the executable bit); on Windows the destination takes the default ACL for its location.
     ///
     /// The destination's parent directory must already exist.
     fn copy(&self, from: &Path, to: &Path) -> io::Result<()>;
 }
 
 impl FileCopier for LocalFile {
-    /// Copies `from` to `to` byte-for-byte, preserving the source's mode on Unix and applying the
-    /// administrators-only ACL on Windows.
+    /// Copies `from` to `to` byte-for-byte, leaving the destination with the permissions a plain
+    /// copy yields (the source's mode on Unix; the default ACL on Windows).
     #[instrument(skip_all, fields(from = %from.display(), to = %to.display()))]
     fn copy(&self, from: &Path, to: &Path) -> io::Result<()> {
         validate_path(to)?;
 
         fs::copy(from, to)?;
-
-        #[cfg(target_family = "windows")]
-        {
-            crate::win_permissions::set_file_permissions_for_administrator(to)
-                .map_err(io::Error::other)?;
-        }
 
         Ok(())
     }
@@ -77,8 +68,6 @@ pub mod tests {
         }
     }
 
-    /// Copying onto an existing file replaces the existing
-    #[cfg(unix)]
     #[test]
     fn test_copy_overwrites_existing_destination() {
         let dir = tempfile::tempdir().unwrap();
@@ -122,20 +111,31 @@ pub mod tests {
         );
     }
 
-    // Needs administrator rights on Windows (matches the writer tests). On GitHub Actions the
-    // Windows runner is elevated, so it passes there.
+    /// A copied executable must stay runnable: copy the running test binary and launch the copy.
+    /// The earlier implementation dropped `FILE_EXECUTE`, which this would have caught.
+    #[cfg(windows)]
     #[test]
-    #[ignore = "requires windows administrator"]
-    #[cfg(target_family = "windows")]
-    fn test_copy_sets_windows_admin_permissions() {
+    fn test_copied_executable_is_still_executable() {
+        use std::process::{Command, Stdio};
+
+        let source = std::env::current_exe().expect("path to the running test executable");
         let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("src");
-        let dst = dir.path().join("dst");
-        fs::write(&src, "data").unwrap();
+        let dst = dir.path().join("copied-test-bin.exe");
 
-        LocalFile.copy(&src, &dst).unwrap();
+        LocalFile.copy(&source, &dst).unwrap();
 
-        assert_eq!(fs::read_to_string(&dst).unwrap(), "data");
-        crate::win_permissions::tests::assert_windows_permissions(&dst);
+        // `--list` makes the test harness exit 0 without running any test; a successful launch
+        // proves the copy is executable (a missing `FILE_EXECUTE` would fail the spawn instead).
+        let status = Command::new(&dst)
+            .arg("--list")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("the copied executable should be launchable");
+
+        assert!(
+            status.success(),
+            "copied executable failed to run: {status:?}"
+        );
     }
 }

--- a/fs/src/file/copier.rs
+++ b/fs/src/file/copier.rs
@@ -1,0 +1,149 @@
+use super::super::utils::validate_path;
+use super::LocalFile;
+use std::path::Path;
+use std::{fs, io};
+use tracing::instrument;
+
+/// Copies a file on disk, setting permissions on the destination.
+pub trait FileCopier {
+    /// Copies the file at `from` to the file at `to`, creating or truncating `to`.
+    ///
+    /// The copy is byte-for-byte, so non-UTF-8 binaries are preserved exactly. On Unix the
+    /// destination's permissions are set to `mode` (for example `0o755` for an executable),
+    /// overriding whatever the source carried. On Windows `mode` is ignored and the destination
+    /// is restricted to administrators, matching [`FileWriter::write`](super::writer::FileWriter).
+    ///
+    /// `mode` is kept in the signature on every platform on purpose: it expresses the caller's
+    /// Unix permission intent (Linux is the primary on-host target), and a single cross-platform
+    /// signature lets callers state that intent uniformly. Windows uses an ACL-based model with no
+    /// Unix mode to honor, so the value is intentionally ignored there rather than dropped from the
+    /// API.
+    ///
+    /// The destination's parent directory must already exist.
+    fn copy(&self, from: &Path, to: &Path, mode: u32) -> io::Result<()>;
+}
+
+impl FileCopier for LocalFile {
+    /// Copies `from` to `to` byte-for-byte and sets the destination's permissions.
+    /// On Unix the destination mode is set to `mode`; on Windows access is restricted to
+    /// administrators and `mode` is ignored.
+    #[instrument(skip_all, fields(from = %from.display(), to = %to.display()))]
+    fn copy(&self, from: &Path, to: &Path, mode: u32) -> io::Result<()> {
+        validate_path(to)?;
+
+        fs::copy(from, to)?;
+
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::set_permissions(to, fs::Permissions::from_mode(mode))?;
+        }
+
+        #[cfg(target_family = "windows")]
+        {
+            // Windows has no Unix mode to apply: file access is governed by ACLs, which we set the
+            // same way `FileWriter::write` does. `mode` is accepted for a uniform cross-platform
+            // signature but has no Windows equivalent, so it is intentionally unused here.
+            let _ = mode;
+            crate::win_permissions::set_file_permissions_for_administrator(to)
+                .map_err(io::Error::other)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(missing_docs)] // test-support code
+pub mod tests {
+    use super::*;
+
+    /// A byte-for-byte copy preserves non-UTF-8 content and sets the requested mode, regardless of
+    /// the source file's own (non-executable) permissions.
+    #[cfg(unix)]
+    #[test]
+    fn test_copy_preserves_non_utf8_bytes_and_overrides_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("bin");
+        let dst = dir.path().join("copied-bin");
+
+        let bytes = [0xFFu8, 0xFE, 0x00, 0x01, b'h', b'i'];
+        fs::write(&src, bytes).unwrap();
+        // Source is deliberately non-executable, to prove we don't inherit its mode.
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o600)).unwrap();
+
+        LocalFile.copy(&src, &dst, 0o755).unwrap();
+
+        assert_eq!(fs::read(&dst).unwrap(), bytes, "content must be preserved");
+        assert_eq!(
+            fs::metadata(&dst).unwrap().permissions().mode() & 0o777,
+            0o755,
+            "destination mode must be the requested one, not the source's"
+        );
+    }
+
+    /// Copying onto an existing file.
+    #[cfg(unix)]
+    #[test]
+    fn test_copy_overwrites_existing_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        fs::write(&src, "new").unwrap();
+        fs::write(&dst, "older content with greater len").unwrap();
+
+        LocalFile.copy(&src, &dst, 0o644).unwrap();
+
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "new");
+    }
+
+    /// A missing source surfaces an error (and never creates the destination).
+    #[test]
+    fn test_copy_missing_source_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("dst");
+
+        let result = LocalFile.copy(&dir.path().join("does-not-exist"), &dst, 0o755);
+
+        assert!(result.is_err());
+        assert!(!dst.exists());
+    }
+
+    /// The destination path is validated before any I/O: `..` components are rejected.
+    #[test]
+    fn test_copy_rejects_parent_dir_in_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::write(&src, "data").unwrap();
+
+        let result = LocalFile.copy(&src, Path::new("some/path/../../etc/passwd"), 0o755);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("dots disallowed in path")
+        );
+    }
+
+    // Needs administrator rights on Windows (matches the writer tests). On GitHub Actions the
+    // Windows runner is elevated, so it passes there.
+    #[test]
+    #[ignore = "requires windows administrator"]
+    #[cfg(target_family = "windows")]
+    fn test_copy_sets_windows_admin_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        fs::write(&src, "data").unwrap();
+
+        LocalFile.copy(&src, &dst, 0o755).unwrap();
+
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "data");
+        crate::win_permissions::tests::assert_windows_permissions(&dst);
+    }
+}


### PR DESCRIPTION
## Context

This is the first step  support of shared filesystem for OHI agent types. 

To let an OHI agent type place an integration **binary** in a shared location the infra-agent can execute, Agent Control needs to *copy* a file from one path (e.g. an extracted OCI package) to another and guarantee it ends up **executable**.

This PR adds the missing primitive to copy files. It is the first, self-contained step of the shared-filesystem work and is **not wired into any runtime path yet**. Later PRs will consume it.

## Changes

- A new `FileCopier` trait (impl'd on `LocalFile`).
- A redundant comment regarding implementations is removed.

> [!NOTE]
> `std::fs::copy` copies the bytes of the binary, including the bits representing permissions on Linux, however on Windows permissions are handled differently and the corresponding ACL is set (same as write operations).




