### PR TITLE
feat: expose `${nr-sub:shared_filesystem_dir}` variable [NR-579370]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Remember that the keywords that you can use are the following:
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
+- Include new 'shared-filesystem-dir` variable for Agent Types.
 
 ## v1.17.0 - 2026-06-16
 

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -145,6 +145,9 @@ pub const DYNAMIC_AGENT_TYPES_DIR: &str = "dynamic-agent-types";
 pub const INSTANCE_ID_FILENAME: &str = "instance_id.yaml";
 /// Folder name for an agent's managed filesystem.
 pub const AGENT_FILESYSTEM_FOLDER_NAME: &str = "filesystem";
+/// Folder name for the filesystem shared across sub-agents. Unlike
+/// [`AGENT_FILESYSTEM_FOLDER_NAME`] it is not suffixed per agent.
+pub const SHARED_FILESYSTEM_FOLDER_NAME: &str = "shared-filesystem";
 /// Folder name holding downloaded packages.
 pub const PACKAGES_FOLDER_NAME: &str = "packages";
 /// File name of the Agent Control log file.

--- a/agent-control/src/agent_type/agent_attributes.rs
+++ b/agent-control/src/agent_type/agent_attributes.rs
@@ -81,6 +81,7 @@ impl AgentAttributes {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_control::defaults::AGENT_CONTROL_DATA_DIR;
     use crate::agent_type::trivial_value::TrivialValue;
 
     fn final_string(vars: &HashMap<String, Variable>, name: &str) -> String {
@@ -97,27 +98,37 @@ mod tests {
 
     #[test]
     fn filesystems_are_available() {
-        let remote_dir = PathBuf::from("/var/lib/newrelic-agent-control");
+        let remote_dir = PathBuf::from(AGENT_CONTROL_DATA_DIR);
         let agent_id = AgentID::try_from("my-agent").unwrap();
-        let attrs = AgentAttributes::try_new(agent_id, remote_dir).unwrap();
+        let attrs = AgentAttributes::try_new(agent_id, remote_dir.clone()).unwrap();
 
         let vars = attrs.sub_agent_variables();
 
+        // Build expected paths via `join` so separators match the platform (e.g. `\` on Windows).
         // Shared dir lives directly under the remote dir, with no agent-id suffix.
+        let expected_shared = remote_dir
+            .join("shared-filesystem")
+            .to_string_lossy()
+            .to_string();
         assert_eq!(
             final_string(&vars, AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR),
-            "/var/lib/newrelic-agent-control/shared-filesystem",
+            expected_shared,
         );
         // The per-agent dir, in contrast, is suffixed with the agent id.
+        let expected_agent = remote_dir
+            .join("filesystem")
+            .join("my-agent")
+            .to_string_lossy()
+            .to_string();
         assert_eq!(
             final_string(&vars, AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            "/var/lib/newrelic-agent-control/filesystem/my-agent",
+            expected_agent,
         );
     }
 
     #[test]
     fn shared_filesystem_dir_is_identical_across_agents() {
-        let remote_dir = PathBuf::from("/var/lib/newrelic-agent-control");
+        let remote_dir = PathBuf::from(AGENT_CONTROL_DATA_DIR);
         let a = AgentAttributes::try_new(AgentID::try_from("agent-a").unwrap(), remote_dir.clone())
             .unwrap();
         let b =

--- a/agent-control/src/agent_type/agent_attributes.rs
+++ b/agent-control/src/agent_type/agent_attributes.rs
@@ -1,7 +1,7 @@
 //! Sub-agent attributes used to build the reserved variables that template an agent type.
 use super::variable::{Variable, namespace::Namespace};
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::defaults::AGENT_FILESYSTEM_FOLDER_NAME;
+use crate::agent_control::defaults::{AGENT_FILESYSTEM_FOLDER_NAME, SHARED_FILESYSTEM_FOLDER_NAME};
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
 use tracing::debug;
@@ -12,6 +12,7 @@ pub struct AgentAttributes {
     /// sub-agent Agent ID
     agent_id: String,
     agent_filesystem_dir: PathBuf,
+    shared_filesystem_dir: PathBuf,
     remote_dir: PathBuf,
 }
 
@@ -25,6 +26,8 @@ impl AgentAttributes {
     pub const VARIABLE_SUB_AGENT_ID: &'static str = "agent_id";
     /// Variable name holding the sub-agent's dedicated filesystem directory.
     pub const VARIABLE_FILESYSTEM_AGENT_DIR: &'static str = "filesystem_agent_dir";
+    /// Variable name holding the filesystem directory shared across sub-agents.
+    pub const VARIABLE_SHARED_FILESYSTEM_DIR: &'static str = "shared_filesystem_dir";
     /// Variable name holding the sub-agent's remote directory.
     pub const VARIABLE_REMOTE_DIR: &'static str = "remote_dir";
 
@@ -38,10 +41,13 @@ impl AgentAttributes {
             let agent_filesystem_dir = remote_dir
                 .join(AGENT_FILESYSTEM_FOLDER_NAME)
                 .join(&agent_id);
+            // Shared across sub-agents, so it is not suffixed with the agent id.
+            let shared_filesystem_dir = remote_dir.join(SHARED_FILESYSTEM_FOLDER_NAME);
             debug!(id = %agent_id, "filesystem directory path set to {}", agent_filesystem_dir.display());
             Ok(Self {
                 agent_id: agent_id.to_string(),
                 agent_filesystem_dir,
+                shared_filesystem_dir,
                 remote_dir,
             })
         } else {
@@ -61,9 +67,66 @@ impl AgentAttributes {
                 Variable::new_final_string_variable(self.agent_filesystem_dir.to_string_lossy()),
             ),
             (
+                Namespace::SubAgent.namespaced_name(Self::VARIABLE_SHARED_FILESYSTEM_DIR),
+                Variable::new_final_string_variable(self.shared_filesystem_dir.to_string_lossy()),
+            ),
+            (
                 Namespace::SubAgent.namespaced_name(Self::VARIABLE_REMOTE_DIR),
                 Variable::new_final_string_variable(self.remote_dir.to_string_lossy()),
             ),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_type::trivial_value::TrivialValue;
+
+    fn final_string(vars: &HashMap<String, Variable>, name: &str) -> String {
+        let key = Namespace::SubAgent.namespaced_name(name);
+        match vars
+            .get(&key)
+            .and_then(Variable::get_final_value)
+            .unwrap_or_else(|| panic!("missing variable {key}"))
+        {
+            TrivialValue::String(s) => s,
+            other => panic!("expected string for {key}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn filesystems_are_available() {
+        let remote_dir = PathBuf::from("/var/lib/newrelic-agent-control");
+        let agent_id = AgentID::try_from("my-agent").unwrap();
+        let attrs = AgentAttributes::try_new(agent_id, remote_dir).unwrap();
+
+        let vars = attrs.sub_agent_variables();
+
+        // Shared dir lives directly under the remote dir, with no agent-id suffix.
+        assert_eq!(
+            final_string(&vars, AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR),
+            "/var/lib/newrelic-agent-control/shared-filesystem",
+        );
+        // The per-agent dir, in contrast, is suffixed with the agent id.
+        assert_eq!(
+            final_string(&vars, AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            "/var/lib/newrelic-agent-control/filesystem/my-agent",
+        );
+    }
+
+    #[test]
+    fn shared_filesystem_dir_is_identical_across_agents() {
+        let remote_dir = PathBuf::from("/var/lib/newrelic-agent-control");
+        let a = AgentAttributes::try_new(AgentID::try_from("agent-a").unwrap(), remote_dir.clone())
+            .unwrap();
+        let b =
+            AgentAttributes::try_new(AgentID::try_from("agent-b").unwrap(), remote_dir).unwrap();
+
+        let key = AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR;
+        assert_eq!(
+            final_string(&a.sub_agent_variables(), key),
+            final_string(&b.sub_agent_variables(), key),
+        );
     }
 }


### PR DESCRIPTION
## Summary

In order to add support to shared filesystem for OHI agent types. Sub-agents that need to share files (binaries, configs) with another agent require a **common, well-known location** to write them to, instead of each agent's isolated per-agent directory. This PR exposes such variable, but there are no operations to include content into it yet, those will come in the next PRs.

## Changes

- New variable added under `nr-sub` variables namespace.

