### PR TITLE
chore(health): allow no health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Remember that the keywords that you can use are the following:
 - Hardens service restart policies on Linux and Windows (systemd rate limiting: 5 restarts max in 60s) to prevent crash-looping from saturating CPU.
 - Added support for remote agent type definition retrieval from OCI registries.
 - Agent type definitions now tolerate unknown fields for forward compatibility.
+- On-host agents: now it is possible to avoid specifying a health check in the agent type definition, in which case the agent health will be not reported.
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
@@ -206,6 +206,10 @@ variables:
     required: false
     default: false
 deployment:
+  health:
+    interval: 60s
+    initial_delay: 0s
+    timeout: 15s
   enable_file_logging: ${nr-var:enable_file_logging}
   executables:
     - id: nr-ebpf-agent-client

--- a/agent-control/src/agent_type/runtime_config/health_config/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config/rendered.rs
@@ -7,7 +7,7 @@ use crate::agent_type::runtime_config::health_config::{
 use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
 
 /// Rendered on-host health-check configuration.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OnHostHealthConfig {
     /// The duration to wait between health checks.
     pub(crate) interval: HealthCheckInterval,

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -143,7 +143,7 @@ impl Templateable for K8sHealthCheckDefinition {
 }
 
 /// Health-check configuration for a Kubernetes deployment.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct K8sHealthConfig {
     /// The duration to wait between health checks.
     #[serde(default)]

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -28,7 +28,7 @@ pub struct OnHost {
     enable_file_logging: TemplateableValue<bool>,
     /// Enables and define health checks configuration.
     #[serde(default)]
-    health: OnHostHealthConfig,
+    health: Option<OnHostHealthConfig>,
     #[serde(default)]
     filesystem: FileSystem,
     #[serde(default)]
@@ -79,7 +79,10 @@ impl Templateable for OnHost {
                 .map(|e| e.template_with(&extended_vars))
                 .collect::<Result<Vec<_>, _>>()?,
             enable_file_logging: self.enable_file_logging.template_with(&extended_vars)?,
-            health: self.health.template_with(&extended_vars)?,
+            health: self
+                .health
+                .map(|health| health.template_with(&extended_vars))
+                .transpose()?,
             filesystem: self.filesystem.template_with(&extended_vars)?,
             packages: rendered_packages,
         })
@@ -91,7 +94,6 @@ mod tests {
     use super::*;
 
     use crate::agent_type::agent_attributes::AgentAttributes;
-    use crate::agent_type::runtime_config::health_config::HealthCheckTimeout;
     use crate::agent_type::runtime_config::on_host::executable::{Args, Env};
     use crate::agent_type::runtime_config::on_host::package::{Download, Oci};
     use crate::agent_type::runtime_config::restart_policy::{
@@ -100,7 +102,6 @@ mod tests {
     };
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
-    use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
     use serde_json::Number;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -633,15 +634,8 @@ executables:
 
         let on_host: OnHost = serde_saphyr::from_str(yaml_without_health).unwrap();
 
-        // If no health is specified the default should be ExecHealth with default values
-        let default_health_config = OnHostHealthConfig {
-            interval: HealthCheckInterval::default(),
-            initial_delay: InitialDelay::default(),
-            timeout: HealthCheckTimeout::default(),
-            check: None,
-        };
-
-        // Create a default OnHost instance to compare
+        // When `health:` is omitted, the parsed value should be `None` (no health checker
+        // will be spawned by the supervisor).
         let default_on_host = OnHost {
             executables: vec![Executable {
                 id: "otelcol".to_string(),
@@ -661,7 +655,7 @@ executables:
                 env: Env::default(),
             }],
             enable_file_logging: TemplateableValue::default(),
-            health: default_health_config,
+            health: None,
             filesystem: FileSystem::default(),
             packages: Default::default(),
         };

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -15,7 +15,7 @@ pub struct OnHost {
     /// Whether file logging is enabled.
     pub enable_file_logging: bool,
     /// Enables and define health checks configuration.
-    pub health: OnHostHealthConfig,
+    pub health: Option<OnHostHealthConfig>,
     /// Files and directories to materialize on disk.
     pub filesystem: FileSystem,
     /// Packages to download for this agent.

--- a/agent-control/src/sub_agent/k8s/supervisor.rs
+++ b/agent-control/src/sub_agent/k8s/supervisor.rs
@@ -364,9 +364,14 @@ pub mod tests {
     use super::*;
     use crate::agent_control::agent_id::AgentID;
     use crate::agent_type::agent_type_id::AgentTypeID;
-    use crate::agent_type::runtime_config::k8s::K8sObjectMeta;
     use crate::agent_type::runtime_config::k8s::{K8s, K8sObject};
+    use crate::agent_type::runtime_config::k8s::{
+        K8sHealthCheckDefinition, K8sHealthConfig, K8sHealthResourceKind, K8sObjectMeta,
+    };
     use crate::agent_type::runtime_config::rendered::{Deployment, Runtime};
+    use crate::checkers::health::health_checker::{
+        HEALTH_CHECKER_THREAD_NAME, HealthCheckInterval, InitialDelay,
+    };
     use crate::event::channel::pub_sub;
     use crate::k8s::annotations::Annotations;
     use crate::k8s::client::tests::MockK8sClient;
@@ -376,6 +381,7 @@ pub mod tests {
     use crate::sub_agent::identity::AgentIdentity;
     use crate::sub_agent::supervisor::Supervisor;
     use crate::sub_agent::supervisor::SupervisorStarter;
+    use crate::utils::retry::retry;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
     use kube::api::DynamicObject;
     use kube::core::TypeMeta;
@@ -478,7 +484,6 @@ pub mod tests {
 
         let config = K8s {
             objects: HashMap::from([("obj".to_string(), k8s_object())]),
-            health: Some(Default::default()),
             ..K8s::default()
         };
 
@@ -513,12 +518,66 @@ pub mod tests {
     }
 
     #[test]
+    fn test_health_checker_thread_publishes_periodically_when_health_config_set() {
+        let (sub_agent_internal_publisher, sub_agent_internal_consumer) = pub_sub();
+
+        let config = K8s {
+            health: Some(K8sHealthConfig {
+                interval: HealthCheckInterval::from(Duration::from_millis(50)),
+                initial_delay: InitialDelay::from(Duration::ZERO),
+                checks: vec![K8sHealthCheckDefinition {
+                    name: "test".to_string(),
+                    namespace: "test".to_string(),
+                    kind: K8sHealthResourceKind::Deployment,
+                    target_namespace: None,
+                }],
+            }),
+            ..K8s::default()
+        };
+
+        // The Deployment health checker calls list_deployment; return an empty list so each
+        // health tick produces a healthy result.
+        let not_started = not_started_supervisor(
+            config,
+            Some(|c: &mut MockK8sClient| {
+                c.expect_list_deployment().returning(|_| Ok(Vec::new()));
+            }),
+        );
+
+        let started = not_started
+            .start(sub_agent_internal_publisher)
+            .expect("supervisor should start");
+
+        // A health-checker thread must have been spawned.
+        assert!(
+            started
+                .thread_contexts
+                .iter()
+                .any(|ctx| ctx.thread_name() == HEALTH_CHECKER_THREAD_NAME),
+            "expected a '{HEALTH_CHECKER_THREAD_NAME}' thread"
+        );
+
+        // That thread must publish AgentHealthInfo events periodically.
+        let mut received = 0;
+        retry(30, Duration::from_millis(100), || {
+            while let Ok(event) = sub_agent_internal_consumer.as_ref().try_recv() {
+                if matches!(event, SubAgentInternalEvent::AgentHealthInfo(_)) {
+                    received += 1;
+                }
+            }
+            if received >= 2 { Ok(()) } else { Err(()) }
+        })
+        .expect("expected at least 2 AgentHealthInfo events from the health thread");
+
+        started.stop().expect("supervisor should stop");
+    }
+
+    #[test]
     fn test_supervisor_apply() {
         let (sub_agent_internal_publisher, _) = pub_sub();
 
         let config = K8s {
             objects: HashMap::from([("obj".to_string(), k8s_object())]),
-            health: Some(Default::default()),
             ..K8s::default()
         };
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -102,7 +102,7 @@ where
     executables: Vec<ExecutableData>,
     file_logging_enable: bool,
     file_logging_path: PathBuf,
-    health_config: OnHostHealthConfig,
+    health_config: Option<OnHostHealthConfig>,
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
     filesystem: FileSystem,
@@ -222,7 +222,7 @@ where
     pub fn new(
         agent_identity: AgentIdentity,
         executables: Vec<ExecutableData>,
-        health_config: OnHostHealthConfig,
+        health_config: Option<OnHostHealthConfig>,
         packages_config: RenderedPackages,
         package_manager: Arc<PM>,
         file_logging_enable: bool,
@@ -245,9 +245,10 @@ where
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
         health_consumer: EventConsumer<(String, HealthWithStartTime)>,
-    ) -> Result<Option<StartedThreadContext>, SupervisorError> {
+        health_config: &OnHostHealthConfig,
+    ) -> Result<StartedThreadContext, SupervisorError> {
         let start_time = StartTime::now();
-        let client_timeout = Duration::from(self.health_config.clone().timeout);
+        let client_timeout = Duration::from(health_config.clone().timeout);
         let http_config = HttpConfig::new(client_timeout, client_timeout, ProxyConfig::default());
         let http_client = HttpClient::new(http_config).map_err(|err| {
             HealthCheckerError::Generic(format!("could not build the http client: {err}"))
@@ -256,7 +257,7 @@ where
         let health_checker = OnHostHealthCheckers::try_new(
             health_consumer,
             http_client,
-            self.health_config.check.clone(),
+            health_config.check.clone(),
             start_time,
         )?;
 
@@ -264,11 +265,11 @@ where
             self.agent_identity.id.clone(),
             health_checker,
             sub_agent_internal_publisher,
-            self.health_config.interval,
-            self.health_config.initial_delay,
+            health_config.interval,
+            health_config.initial_delay,
             start_time,
         );
-        Ok(Some(started_thread_context))
+        Ok(started_thread_context)
     }
 
     /// Runs the agent version check (if configured), publishing detected attributes as events.
@@ -333,22 +334,21 @@ where
             .write(&LocalFile, &DirectoryManagerFs)
             .map_err(SupervisorError::FileSystem)?;
 
-        let executable_thread_contexts = self
+        let mut thread_contexts: Vec<StartedThreadContext> = self
             .executables
             .iter()
-            .map(|e| self.start_process_thread(e, health_publisher.clone()));
+            .map(|e| self.start_process_thread(e, health_publisher.clone()))
+            .collect();
 
         self.check_subagent_version(sub_agent_internal_publisher.clone());
 
-        let thread_contexts =
-            [self.start_health_check(sub_agent_internal_publisher.clone(), health_consumer)?]
-                .into_iter()
-                .flatten();
-
-        let thread_contexts = executable_thread_contexts
-            .into_iter()
-            .chain(thread_contexts)
-            .collect();
+        if let Some(ref health_config) = self.health_config {
+            thread_contexts.push(self.start_health_check(
+                sub_agent_internal_publisher.clone(),
+                health_consumer,
+                health_config,
+            )?);
+        }
 
         Ok(StartedSupervisorOnHost {
             thread_contexts,
@@ -739,7 +739,7 @@ pub mod tests {
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             executable_data,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -784,7 +784,7 @@ pub mod tests {
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -835,7 +835,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             vec![],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -904,7 +904,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             vec![],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -947,7 +947,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -996,7 +996,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1045,7 +1045,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1089,7 +1089,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1152,7 +1152,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1332,7 +1332,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             true,
@@ -1370,7 +1370,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: true,
-            health: OnHostHealthConfig::default(),
+            health: Some(OnHostHealthConfig::default()),
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1458,7 +1458,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             false,
@@ -1496,7 +1496,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: true,
-            health: OnHostHealthConfig::default(),
+            health: Some(OnHostHealthConfig::default()),
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1582,7 +1582,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             true,
@@ -1620,7 +1620,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: false,
-            health: OnHostHealthConfig::default(),
+            health: Some(OnHostHealthConfig::default()),
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1707,7 +1707,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            OnHostHealthConfig::default(),
+            Some(OnHostHealthConfig::default()),
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             false,
@@ -1745,7 +1745,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: false,
-            health: OnHostHealthConfig::default(),
+            health: Some(OnHostHealthConfig::default()),
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -647,6 +647,7 @@ pub mod tests {
     use crate::agent_type::agent_attributes::AgentAttributes;
     use crate::agent_type::agent_type_id::AgentTypeID;
     use crate::agent_type::definition::Variables;
+    use crate::agent_type::runtime_config::health_config::HealthCheckTimeout;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
     use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
     use crate::agent_type::runtime_config::on_host::rendered::OnHost;
@@ -655,13 +656,16 @@ pub mod tests {
     use crate::agent_type::templates::Templateable;
     use crate::agent_type::variable::Variable;
     use crate::agent_type::variable::namespace::Namespace;
-    use crate::checkers::health::health_checker::HEALTH_CHECKER_THREAD_NAME;
+    use crate::checkers::health::health_checker::{
+        HEALTH_CHECKER_THREAD_NAME, HealthCheckInterval, InitialDelay,
+    };
     use crate::event::channel::pub_sub;
     use crate::package::manager::tests::MockPackageManager;
     use crate::sub_agent::effective_agents_assembler::EffectiveAgent;
     use crate::sub_agent::on_host::command::restart_policy::BackoffStrategy;
     use crate::sub_agent::on_host::command::restart_policy::{Backoff, RestartPolicy};
     use crate::sub_agent::supervisor::Supervisor;
+    use crate::utils::retry::retry;
     use serde::Deserialize;
     use std::collections::HashMap;
     use std::{
@@ -739,7 +743,7 @@ pub mod tests {
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             executable_data,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -784,7 +788,7 @@ pub mod tests {
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -835,7 +839,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             vec![],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -904,7 +908,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity,
             vec![],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -947,7 +951,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -996,7 +1000,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1045,7 +1049,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1089,7 +1093,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1152,7 +1156,7 @@ persistent.txt:
         let agent = NotStartedSupervisorOnHost::new(
             agent_identity,
             executables,
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             MockPackageManager::new_arc(),
             false,
@@ -1332,7 +1336,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             true,
@@ -1370,7 +1374,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: true,
-            health: Some(OnHostHealthConfig::default()),
+            health: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1458,7 +1462,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             false,
@@ -1496,7 +1500,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: true,
-            health: Some(OnHostHealthConfig::default()),
+            health: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1582,7 +1586,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             true,
@@ -1620,7 +1624,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: false,
-            health: Some(OnHostHealthConfig::default()),
+            health: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };
@@ -1673,6 +1677,60 @@ persistent.txt:
     }
 
     #[test]
+    fn test_health_checker_thread_publishes_periodically_when_health_config_set() {
+        let health_config = OnHostHealthConfig {
+            interval: HealthCheckInterval::from(Duration::from_millis(50)),
+            initial_delay: InitialDelay::from(Duration::ZERO),
+            timeout: HealthCheckTimeout::from(Duration::from_secs(1)),
+            check: None,
+        };
+
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("health-agent").unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity,
+            vec![],
+            Some(health_config),
+            get_empty_packages(),
+            MockPackageManager::new_arc(),
+            false,
+            PathBuf::default(),
+            FileSystem::test_empty(),
+        );
+
+        let (sub_agent_internal_publisher, sub_agent_internal_consumer) = pub_sub();
+        let started = supervisor
+            .start(sub_agent_internal_publisher)
+            .expect("supervisor should start");
+
+        // A health-checker thread must have been spawned.
+        assert!(
+            started
+                .thread_contexts
+                .iter()
+                .any(|ctx| ctx.thread_name() == HEALTH_CHECKER_THREAD_NAME),
+            "expected a '{HEALTH_CHECKER_THREAD_NAME}' thread"
+        );
+
+        // The health-checker thread must publish AgentHealthInfo events periodically.
+        let mut received = 0;
+        retry(30, Duration::from_millis(100), || {
+            while let Ok(event) = sub_agent_internal_consumer.as_ref().try_recv() {
+                if matches!(event, SubAgentInternalEvent::AgentHealthInfo(_)) {
+                    received += 1;
+                }
+            }
+            if received >= 2 { Ok(()) } else { Err(()) }
+        })
+        .expect("expected at least 2 AgentHealthInfo events from the health thread");
+
+        started.stop().expect("supervisor should stop");
+    }
+
+    #[test]
     fn test_supervisor_reloading_keeps_file_logging_disabled() {
         let dir = tempfile::tempdir().unwrap();
         let logging_path = dir.path().to_path_buf();
@@ -1707,7 +1765,7 @@ persistent.txt:
         let supervisor = NotStartedSupervisorOnHost::new(
             agent_identity.clone(),
             vec![exec_data_1],
-            Some(OnHostHealthConfig::default()),
+            None,
             get_empty_packages(),
             Arc::new(MockPackageManager::new()),
             false,
@@ -1745,7 +1803,7 @@ persistent.txt:
         let on_host_config = OnHost {
             executables: vec![executable_rendered],
             enable_file_logging: false,
-            health: Some(OnHostHealthConfig::default()),
+            health: None,
             filesystem: FileSystem::test_empty(),
             packages: get_empty_packages(),
         };

--- a/agent-control/tests/on_host/scenarios.rs
+++ b/agent-control/tests/on_host/scenarios.rs
@@ -11,6 +11,7 @@ mod invalid_remote_config;
 mod memory_benchmark;
 mod multiple_executables;
 mod multiple_remote_config;
+mod no_health_config;
 mod no_orphan_processes;
 mod oci_auth;
 mod opamp;

--- a/agent-control/tests/on_host/scenarios/no_health_config.rs
+++ b/agent-control/tests/on_host/scenarios/no_health_config.rs
@@ -1,0 +1,73 @@
+use crate::common::agent_control::start_agent_control_with_custom_config;
+use crate::common::base_paths::TempBasePaths;
+use crate::common::effective_config::check_latest_effective_config_is_expected;
+use crate::common::retry::{retry, retry_never};
+use crate::common::runtime::tokio_runtime;
+use crate::on_host::consts::NO_CONFIG;
+use crate::on_host::tools::config::OnHostAgentControlConfigBuilder;
+use crate::on_host::tools::config::create_local_config;
+use crate::on_host::tools::custom_agent_type::CustomAgentType;
+use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
+use newrelic_agent_control::agent_control::agent_id::AgentID;
+use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
+use std::time::Duration;
+
+/// When an on-host sub-agent uses an agent type that does NOT define a `health:` block, no
+/// `ComponentHealth` should be recorded for the sub-agent.
+///
+/// We check for the sub-agent's effective configuration to be reported, so that the no-health
+/// assertion cannot pass for the wrong reason (i.e. the sub-agent never connecting to OpAMP).
+#[test]
+fn test_on_host_no_health_in_agent_type_reports_no_health_via_opamp() {
+    let opamp_server = FakeServer::start(tokio_runtime().handle());
+
+    let dirs = TempBasePaths::default();
+    let sub_agent_id = AgentID::try_from("test-agent-no-health").unwrap();
+
+    let agent_type = CustomAgentType::default()
+        .with_health(None)
+        .build(dirs.local_dir());
+
+    let agents = format!(
+        r#"
+  {sub_agent_id}:
+    agent_type: "{agent_type}"
+"#
+    );
+
+    create_local_config(
+        sub_agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
+    OnHostAgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(agents.to_string())
+        .write(dirs.local_dir());
+
+    let _agent_control =
+        start_agent_control_with_custom_config(dirs.base_paths(), AGENT_CONTROL_MODE_ON_HOST);
+
+    let sub_agent_instance_id = get_instance_id(&sub_agent_id, dirs.base_paths());
+
+    // Cross-check: the sub-agent must actually be talking to OpAMP. Wait until
+    // its (empty) effective configuration shows up on the server.
+    retry(60, Duration::from_secs(1), || {
+        check_latest_effective_config_is_expected(
+            &opamp_server,
+            &sub_agent_instance_id,
+            "".to_string(),
+        )
+    });
+
+    // No health status is expected
+    retry_never(10, Duration::from_secs(1), || {
+        match opamp_server.get_health_status(sub_agent_instance_id.clone()) {
+            None => Ok(()),
+            Some(health) => Err(format!(
+                "Expected no ComponentHealth for sub-agent without `health:` in agent type, got: {health:?}"
+            )
+            .into()),
+        }
+    });
+}

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -1,11 +1,11 @@
-use std::fmt::Display;
-use std::path::PathBuf;
-
 use fs::file::LocalFile;
 use fs::file::writer::FileWriter;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
 use newrelic_agent_control::agent_type::definition::AgentTypeDefinition;
+use std::fmt::Display;
+use std::path::PathBuf;
+
 pub const DYNAMIC_AGENT_TYPE_FILENAME: &str = "dynamic-agent-types/type.yaml";
 
 /// Helper to build a Custom Agent type with defaults ready to use in integration tests
@@ -37,7 +37,16 @@ fake_variable:
             executables: Some(Self::default_executables()),
             filesystem: None,
             packages: None,
-            health: None,
+            health: Some(
+                serde_saphyr::from_str(
+                    r#"
+interval: 60s
+initial_delay: 0s
+timeout: 15s
+"#,
+                )
+                .unwrap(),
+            ),
         }
     }
 }

--- a/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
+++ b/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
@@ -225,6 +225,10 @@ variables:
     required: false
     default: latest
 deployment:
+  health:
+    interval: 60s
+    initial_delay: 0s
+    timeout: 15s
   packages:
     test-package:
       type: tar


### PR DESCRIPTION
The health component should be Optional for onHost since not all Ohai will have a way to report their health.
Notice that such field was optional already for K8s agentTypes