### PR TITLE
fix: publish agent.version before package download and reset OCI test registry

### DIFF
--- a/agent-control/Makefile
+++ b/agent-control/Makefile
@@ -30,6 +30,7 @@ test/onhost/root/integration:
 test/onhost/oci-registry/integration:
 	@echo "testing-machine-id" > /tmp/machine-id
 	@../tools/oci-registry.sh install
+	@../tools/oci-registry.sh clean
 	@../tools/oci-registry.sh run > /dev/null 2>&1 &
 	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests _with_oci_registry -- --ignored --skip no_root --skip k8s
 	@../tools/oci-registry.sh killall
@@ -38,6 +39,7 @@ test/onhost/oci-registry/integration:
 test/onhost/oci-auth-registry/integration:
 	@echo "testing-machine-id" > /tmp/machine-id
 	@../tools/oci-registry.sh install --basic-auth
+	@../tools/oci-registry.sh clean
 	@../tools/oci-registry.sh run --basic-auth > /dev/null 2>&1 &
 	$(TEST_FIXTURES) cargo $(CARGO_CMD) $(PACKAGE_SA) --features=multiple-instances --test integration_tests _with_auth_oci_registry -- --ignored --skip no_root --skip k8s
 	@../tools/oci-registry.sh killall

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -119,6 +119,11 @@ where
         self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) -> Result<Self::Supervisor, Self::Error> {
+        // `agent.version` is derived from the package *config* (`download.oci.version`).
+        // Publish it before the (potentially slow / registry-contended)
+        // package download so version reporting does not depend on the download finishing.
+        self.check_subagent_version(sub_agent_internal_publisher.clone());
+
         install_packages(
             &self.package_manager,
             &self.agent_identity.id,

--- a/tools/oci-registry.sh
+++ b/tools/oci-registry.sh
@@ -56,9 +56,10 @@ fi
 
 # ----- HELPER FUNCTIONS -----
 function print_usage() {
-  echo "Usage: $0 [install|run|uninstall|killall|help] [--basic-auth]"
+  echo "Usage: $0 [install|run|clean|uninstall|killall|help] [--basic-auth]"
   echo "  install    - Download and install zot registry"
   echo "  run        - Run zot registry"
+  echo "  clean      - Remove the registry storage (start each run from an empty registry)"
   echo "  uninstall  - Remove zot registry and all associated files"
   echo "  killall    - Kill all running zot processes"
   echo "  help       - Display this help message"
@@ -166,12 +167,20 @@ function run() {
 
 
 # ----- MAIN -----
-if [[ $OPTION != "help" && $OPTION != "install" && $OPTION != "uninstall" && $OPTION != "run" && $OPTION != "killall" ]]; then
+if [[ $OPTION != "help" && $OPTION != "install" && $OPTION != "uninstall" && $OPTION != "run" && $OPTION != "killall" && $OPTION != "clean" ]]; then
     echo "Invalid option: $OPTION"
     print_usage
     exit 1
 elif [[ $OPTION == "help" || $OPTION == "empty" ]]; then
     print_usage
+    exit 0
+elif [[ $OPTION == "clean" ]]; then
+    # Wipe persisted registry storage so each test run starts from an empty registry. zot keeps its
+    # data under STORAGE_PATH across runs; leftover tags break tests that assume a version is absent
+    # (e.g. the self-update recovery test) and bloat the registry, slowing concurrent pulls.
+    echo "Cleaning zot registry storage at $STORAGE_PATH..."
+    rm -rf "$STORAGE_PATH"
+    echo "Registry storage cleaned"
     exit 0
 elif [[ $OPTION == "uninstall" ]]; then
     echo "Uninstalling zot registry..."

--- a/tools/oci-registry.sh
+++ b/tools/oci-registry.sh
@@ -175,9 +175,6 @@ elif [[ $OPTION == "help" || $OPTION == "empty" ]]; then
     print_usage
     exit 0
 elif [[ $OPTION == "clean" ]]; then
-    # Wipe persisted registry storage so each test run starts from an empty registry. zot keeps its
-    # data under STORAGE_PATH across runs; leftover tags break tests that assume a version is absent
-    # (e.g. the self-update recovery test) and bloat the registry, slowing concurrent pulls.
     echo "Cleaning zot registry storage at $STORAGE_PATH..."
     rm -rf "$STORAGE_PATH"
     echo "Registry storage cleaned"


### PR DESCRIPTION
Fix two flaky OCI integration tests at their root: publish agent.version from config before the (slow, contended) package download so it no longer races the download window, and wipe the persisted zot registry storage before each run so tests that assume a version is absent start hermetic.                                                                                                                                                                 
Also clears accumulated registry bloat that was slowing concurrent pulls.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
