### PR TITLE
feat(host): remove agent packages on clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Remember that the keywords that you can use are the following:
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
+- Removing an agent from the fleet now also deletes its installed packages from disk.
 
 ## v1.17.0 - 2026-06-16
 

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -12,42 +12,50 @@ use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::RESERVED_AGENT_IDS;
 use crate::agent_type::agent_type_id::AgentTypeID;
 use crate::opamp::instance_id::storer::{InstanceIDStorer, StorerError};
+use crate::package::manager::AgentPackagesRemover;
+use crate::package::oci::package_manager::OCIPackageManagerError;
 use crate::values::config_repository::{ConfigRepository, ConfigRepositoryError};
 
 use super::{ResourceCleaner, ResourceCleanerError};
 
 /// On-host implementation of [`ResourceCleaner`] that wipes a sub-agent's fleet data by
 /// delegating to the same storers that wrote it, also recursively deletes the sub-agent's
-/// dedicated filesystem directory, the `persistent` flag is bypassed here because the agent
-/// has been removed from the fleet.
+/// dedicated filesystem directory and its installed packages (via the [`AgentPackagesRemover`],
+/// which owns the on-disk package layout), the `persistent` flag is bypassed here because the
+/// agent has been removed from the fleet.
 /// The same removal logic is reused at startup by [`Self::purge_stale_agents`] to reclaim the
 /// resources of agents removed from the fleet config while Agent Control was stopped.
-pub struct OnHostCleaner<S, C, D>
+pub struct OnHostCleaner<S, C, D, P>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
     D: DirectoryManager,
+    P: AgentPackagesRemover,
 {
     instance_id_storer: Arc<S>,
     config_repo: Arc<C>,
     agent_filesystem_base: PathBuf,
     fleet_data_base: PathBuf,
     dir_manager: Arc<D>,
+    package_remover: Arc<P>,
 }
 
-impl<S, C, D> OnHostCleaner<S, C, D>
+impl<S, C, D, P> OnHostCleaner<S, C, D, P>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
     D: DirectoryManager,
+    P: AgentPackagesRemover,
 {
-    /// Builds a cleaner delegating to the given instance-id storer and config repository.
+    /// Builds a cleaner delegating to the given instance-id storer, config repository and package
+    /// remover.
     pub fn new(
         instance_id_storer: Arc<S>,
         config_repo: Arc<C>,
         agent_filesystem_base: PathBuf,
         fleet_data_base: PathBuf,
         dir_manager: Arc<D>,
+        package_remover: Arc<P>,
     ) -> Self {
         Self {
             instance_id_storer,
@@ -55,11 +63,12 @@ where
             agent_filesystem_base,
             fleet_data_base,
             dir_manager,
+            package_remover,
         }
     }
 
     /// Deletes all on-disk resources Agent Control owns for `agent_id`: its stored remote config,
-    /// its OpAMP instance id, and its dedicated filesystem directory.
+    /// its OpAMP instance id, its dedicated filesystem directory and its installed packages.
     fn remove_agent_resources(&self, agent_id: &AgentID) -> Result<(), OnHostCleanerError> {
         debug!(%agent_id, "Cleaning remote config data");
         self.config_repo
@@ -78,7 +87,14 @@ where
             .map_err(|err| OnHostCleanerError::Filesystem {
                 path: fs_dir,
                 source: err,
-            })
+            })?;
+
+        debug!(%agent_id, "Cleaning agent packages");
+        self.package_remover
+            .remove_agent_packages(agent_id)
+            .map_err(OnHostCleanerError::Packages)?;
+
+        Ok(())
     }
 
     /// At startup, reclaims the resources of any agent that is no longer in the agents config.
@@ -123,11 +139,12 @@ where
     }
 }
 
-impl<S, C, D> ResourceCleaner for OnHostCleaner<S, C, D>
+impl<S, C, D, P> ResourceCleaner for OnHostCleaner<S, C, D, P>
 where
     S: InstanceIDStorer,
     C: ConfigRepository,
     D: DirectoryManager,
+    P: AgentPackagesRemover,
 {
     #[instrument(skip_all, name = "agent_resource_clean", fields(%agent_id))]
     fn clean(
@@ -164,6 +181,9 @@ pub enum OnHostCleanerError {
         #[source]
         source: std::io::Error,
     },
+    /// Failed to remove the agent's installed packages.
+    #[error("failed to remove agent packages: {0}")]
+    Packages(#[source] OCIPackageManagerError),
 }
 
 impl From<OnHostCleanerError> for ResourceCleanerError {
@@ -177,6 +197,7 @@ mod tests {
     use super::*;
     use crate::agent_control::defaults::AGENT_CONTROL_ID;
     use crate::opamp::instance_id::storer::tests::MockInstanceIDStorer;
+    use crate::package::manager::tests::MockAgentPackagesRemover;
     use crate::values::config_repository::tests::MockConfigRepository;
     use ::fs::directory_manager::mock::MockDirectoryManager;
     use mockall::predicate;
@@ -184,6 +205,27 @@ mod tests {
 
     fn agent_id(s: &str) -> AgentID {
         AgentID::try_from(s).unwrap()
+    }
+
+    /// Package remover that expects `remove_agent_packages` exactly once per given agent id.
+    fn remover_removing(agent_ids: &[&str]) -> MockAgentPackagesRemover {
+        let mut remover = MockAgentPackagesRemover::new();
+        for id in agent_ids {
+            let id = agent_id(id);
+            remover
+                .expect_remove_agent_packages()
+                .with(predicate::eq(id))
+                .once()
+                .returning(|_| Ok(()));
+        }
+        remover
+    }
+
+    fn packages_error() -> OCIPackageManagerError {
+        OCIPackageManagerError::RemoveAgentPackages {
+            path: "/var/lib/newrelic-agent-control/packages/foo-agent".to_string(),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+        }
     }
 
     fn any_type_id() -> AgentTypeID {
@@ -226,6 +268,7 @@ mod tests {
             fs_base(),
             fleet_base(),
             Arc::new(dir_manager),
+            Arc::new(remover_removing(&[id.as_str()])),
         );
 
         assert!(cleaner.clean(&id, &any_type_id()).is_ok());
@@ -254,10 +297,43 @@ mod tests {
             fs_base(),
             fleet_base(),
             Arc::new(dir_manager),
+            Arc::new(remover_removing(&[])),
         );
 
         let err = cleaner.clean(&id, &any_type_id()).unwrap_err();
         assert!(err.0.contains("agent filesystem directory"));
+    }
+
+    #[test]
+    fn clean_propagates_package_removal_error() {
+        let id = agent_id("foo-agent");
+        let expected_fs_dir = fs_base().join(id.as_str());
+
+        let mut instance_id_storer = MockInstanceIDStorer::new();
+        instance_id_storer.expect_delete().returning(|_| Ok(()));
+        let mut config_repo = MockConfigRepository::new();
+        config_repo.expect_delete_remote().returning(|_| Ok(()));
+        let mut dir_manager = MockDirectoryManager::new();
+        dir_manager.should_delete(&expected_fs_dir);
+
+        let mut package_remover = MockAgentPackagesRemover::new();
+        package_remover
+            .expect_remove_agent_packages()
+            .with(predicate::eq(id.clone()))
+            .once()
+            .returning(|_| Err(packages_error()));
+
+        let cleaner = OnHostCleaner::new(
+            Arc::new(instance_id_storer),
+            Arc::new(config_repo),
+            fs_base(),
+            fleet_base(),
+            Arc::new(dir_manager),
+            Arc::new(package_remover),
+        );
+
+        let err = cleaner.clean(&id, &any_type_id()).unwrap_err();
+        assert!(err.0.contains("failed to remove agent packages"));
     }
 
     #[test]
@@ -268,6 +344,8 @@ mod tests {
         config_repo.expect_delete_remote().never();
         let mut dir_manager = MockDirectoryManager::new();
         dir_manager.expect_delete().never();
+        let mut package_remover = MockAgentPackagesRemover::new();
+        package_remover.expect_remove_agent_packages().never();
 
         let cleaner = OnHostCleaner::new(
             Arc::new(instance_id_storer),
@@ -275,6 +353,7 @@ mod tests {
             PathBuf::new(),
             PathBuf::new(),
             Arc::new(dir_manager),
+            Arc::new(package_remover),
         );
 
         let result = cleaner.clean(&AgentID::AgentControl, &any_type_id());
@@ -286,19 +365,26 @@ mod tests {
         instance_id_storer: MockInstanceIDStorer,
         config_repo: MockConfigRepository,
         dir_manager: MockDirectoryManager,
-    ) -> OnHostCleaner<MockInstanceIDStorer, MockConfigRepository, MockDirectoryManager> {
+        package_remover: MockAgentPackagesRemover,
+    ) -> OnHostCleaner<
+        MockInstanceIDStorer,
+        MockConfigRepository,
+        MockDirectoryManager,
+        MockAgentPackagesRemover,
+    > {
         OnHostCleaner::new(
             Arc::new(instance_id_storer),
             Arc::new(config_repo),
             fs_base(),
             fleet_base(),
             Arc::new(dir_manager),
+            Arc::new(package_remover),
         )
     }
 
-    /// Orphans (agents no longer configured) are fully reclaimed — remote config, instance id and
-    /// filesystem dir — and discovered from BOTH the filesystem and fleet-data bases. Configured
-    /// agents survive.
+    /// Orphans (agents no longer configured) are fully reclaimed — remote config, instance id,
+    /// filesystem dir and packages — and discovered from BOTH the filesystem and fleet-data bases.
+    /// Configured agents survive.
     #[test]
     fn purge_reclaims_orphans_from_filesystem_and_fleet_data() {
         let orphan_fs = agent_id("orphan-fs");
@@ -310,35 +396,33 @@ mod tests {
             vec![fs_base().join("kept"), fs_base().join("orphan-fs")],
         );
         dir_manager.should_list(&fleet_base(), vec![fleet_base().join("orphan-fleet")]);
-        // `remove_agent_resources` always deletes the agent's filesystem dir (idempotent).
-        dir_manager.should_delete(&fs_base().join("orphan-fs"));
-        dir_manager.should_delete(&fs_base().join("orphan-fleet"));
-
         let mut config_repo = MockConfigRepository::new();
-        config_repo
-            .expect_delete_remote()
-            .with(predicate::eq(orphan_fs.clone()))
-            .once()
-            .returning(|_| Ok(()));
-        config_repo
-            .expect_delete_remote()
-            .with(predicate::eq(orphan_fleet.clone()))
-            .once()
-            .returning(|_| Ok(()));
-
         let mut instance_id_storer = MockInstanceIDStorer::new();
-        instance_id_storer
-            .expect_delete()
-            .with(predicate::eq(orphan_fs))
-            .once()
-            .returning(|_| Ok(()));
-        instance_id_storer
-            .expect_delete()
-            .with(predicate::eq(orphan_fleet))
-            .once()
-            .returning(|_| Ok(()));
+        // `remove_agent_resources` always deletes the agent's filesystem dir (idempotent),
+        // regardless of which base the orphan was discovered from.
+        for orphan in [&orphan_fs, &orphan_fleet] {
+            dir_manager.should_delete(&fs_base().join(orphan.as_str()));
+            config_repo
+                .expect_delete_remote()
+                .with(predicate::eq(orphan.clone()))
+                .once()
+                .returning(|_| Ok(()));
+            instance_id_storer
+                .expect_delete()
+                .with(predicate::eq(orphan.clone()))
+                .once()
+                .returning(|_| Ok(()));
+        }
 
-        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents(["kept"]);
+        let package_remover = remover_removing(&["orphan-fs", "orphan-fleet"]);
+
+        cleaner(
+            instance_id_storer,
+            config_repo,
+            dir_manager,
+            package_remover,
+        )
+        .purge_stale_agents(["kept"]);
     }
 
     /// Agent Control's own directory (a reserved ID) is never reclaimed.
@@ -367,11 +451,19 @@ mod tests {
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer
             .expect_delete()
-            .with(predicate::eq(orphan))
+            .with(predicate::eq(orphan.clone()))
             .once()
             .returning(|_| Ok(()));
 
-        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents([]);
+        let package_remover = remover_removing(&[orphan.as_str()]);
+
+        cleaner(
+            instance_id_storer,
+            config_repo,
+            dir_manager,
+            package_remover,
+        )
+        .purge_stale_agents([]);
     }
 
     #[test]
@@ -386,7 +478,15 @@ mod tests {
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer.expect_delete().never();
 
-        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents(["any"]);
+        let package_remover = remover_removing(&[]);
+
+        cleaner(
+            instance_id_storer,
+            config_repo,
+            dir_manager,
+            package_remover,
+        )
+        .purge_stale_agents(["any"]);
     }
 
     /// If listing one base fails, the helper logs and still reclaims orphans found in the other.
@@ -411,10 +511,18 @@ mod tests {
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer
             .expect_delete()
-            .with(predicate::eq(orphan))
+            .with(predicate::eq(orphan.clone()))
             .once()
             .returning(|_| Ok(()));
 
-        cleaner(instance_id_storer, config_repo, dir_manager).purge_stale_agents([]);
+        let package_remover = remover_removing(&[orphan.as_str()]);
+
+        cleaner(
+            instance_id_storer,
+            config_repo,
+            dir_manager,
+            package_remover,
+        )
+        .purge_stale_agents([]);
     }
 }

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -91,7 +91,7 @@ where
 
         debug!(%agent_id, "Cleaning agent packages");
         self.package_remover
-            .remove_agent_packages(agent_id)
+            .remove(agent_id)
             .map_err(OnHostCleanerError::Packages)?;
 
         Ok(())
@@ -207,20 +207,6 @@ mod tests {
         AgentID::try_from(s).unwrap()
     }
 
-    /// Package remover that expects `remove_agent_packages` exactly once per given agent id.
-    fn remover_removing(agent_ids: &[&str]) -> MockAgentPackagesRemover {
-        let mut remover = MockAgentPackagesRemover::new();
-        for id in agent_ids {
-            let id = agent_id(id);
-            remover
-                .expect_remove_agent_packages()
-                .with(predicate::eq(id))
-                .once()
-                .returning(|_| Ok(()));
-        }
-        remover
-    }
-
     fn packages_error() -> OCIPackageManagerError {
         OCIPackageManagerError::RemoveAgentPackages {
             path: "/var/lib/newrelic-agent-control/packages/foo-agent".to_string(),
@@ -268,7 +254,7 @@ mod tests {
             fs_base(),
             fleet_base(),
             Arc::new(dir_manager),
-            Arc::new(remover_removing(&[id.as_str()])),
+            Arc::new(MockAgentPackagesRemover::new().removing(&[id.as_str()])),
         );
 
         assert!(cleaner.clean(&id, &any_type_id()).is_ok());
@@ -297,7 +283,7 @@ mod tests {
             fs_base(),
             fleet_base(),
             Arc::new(dir_manager),
-            Arc::new(remover_removing(&[])),
+            Arc::new(MockAgentPackagesRemover::new().removing(&[])),
         );
 
         let err = cleaner.clean(&id, &any_type_id()).unwrap_err();
@@ -318,7 +304,7 @@ mod tests {
 
         let mut package_remover = MockAgentPackagesRemover::new();
         package_remover
-            .expect_remove_agent_packages()
+            .expect_remove()
             .with(predicate::eq(id.clone()))
             .once()
             .returning(|_| Err(packages_error()));
@@ -345,7 +331,7 @@ mod tests {
         let mut dir_manager = MockDirectoryManager::new();
         dir_manager.expect_delete().never();
         let mut package_remover = MockAgentPackagesRemover::new();
-        package_remover.expect_remove_agent_packages().never();
+        package_remover.expect_remove().never();
 
         let cleaner = OnHostCleaner::new(
             Arc::new(instance_id_storer),
@@ -414,7 +400,8 @@ mod tests {
                 .returning(|_| Ok(()));
         }
 
-        let package_remover = remover_removing(&["orphan-fs", "orphan-fleet"]);
+        let package_remover =
+            MockAgentPackagesRemover::new().removing(&["orphan-fs", "orphan-fleet"]);
 
         cleaner(
             instance_id_storer,
@@ -455,7 +442,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
 
-        let package_remover = remover_removing(&[orphan.as_str()]);
+        let package_remover = MockAgentPackagesRemover::new().removing(&[orphan.as_str()]);
 
         cleaner(
             instance_id_storer,
@@ -478,7 +465,7 @@ mod tests {
         let mut instance_id_storer = MockInstanceIDStorer::new();
         instance_id_storer.expect_delete().never();
 
-        let package_remover = remover_removing(&[]);
+        let package_remover = MockAgentPackagesRemover::new().removing(&[]);
 
         cleaner(
             instance_id_storer,
@@ -515,7 +502,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
 
-        let package_remover = remover_removing(&[orphan.as_str()]);
+        let package_remover = MockAgentPackagesRemover::new().removing(&[orphan.as_str()]);
 
         cleaner(
             instance_id_storer,

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -117,6 +117,20 @@ impl AgentControlRunner {
         let instance_id_getter =
             InstanceIDWithIdentifiersGetter::new(instance_id_storer.clone(), identifiers.clone());
 
+        let agents_package_manager = Arc::new(OCIPackageManager::new(
+            OCIPackageArtifactDownloader::new(
+                self.oci_client.clone(),
+                self.bootstrap_config.oci.registry.clone(),
+                self.bootstrap_config.oci.auth.clone(),
+                agent_control_config
+                    .agent_packages
+                    .signature_verification_enabled
+                    .into(),
+            ),
+            DirectoryManagerFs,
+            remote_dir.clone(),
+        ));
+
         let agent_filesystem_base = remote_dir.join(AGENT_FILESYSTEM_FOLDER_NAME);
         let fleet_data_base = remote_dir.join(FOLDER_NAME_FLEET_DATA);
         let dir_manager = Arc::new(DirectoryManagerFs);
@@ -126,6 +140,7 @@ impl AgentControlRunner {
             agent_filesystem_base,
             fleet_data_base,
             dir_manager,
+            agents_package_manager.clone(),
         );
         debug!("Removing stale agents from the filesystem");
         resource_cleaner.purge_stale_agents(
@@ -188,23 +203,9 @@ impl AgentControlRunner {
             &remote_dir,
         ));
 
-        let agents_package_manager = OCIPackageManager::new(
-            OCIPackageArtifactDownloader::new(
-                self.oci_client.clone(),
-                self.bootstrap_config.oci.registry.clone(),
-                self.bootstrap_config.oci.auth.clone(),
-                agent_control_config
-                    .agent_packages
-                    .signature_verification_enabled
-                    .into(),
-            ),
-            DirectoryManagerFs,
-            remote_dir.clone(),
-        );
-
         let supervisor_builder = SupervisorBuilderOnHost {
             logging_path: self.base_paths.log_dir,
-            package_manager: Arc::new(agents_package_manager),
+            package_manager: agents_package_manager,
         };
 
         let signature_validator = Arc::new(self.signature_validator);

--- a/agent-control/src/package/manager.rs
+++ b/agent-control/src/package/manager.rs
@@ -46,6 +46,13 @@ pub trait PackageManager: Send + Sync {
     ) -> Result<(), OCIPackageManagerError>;
 }
 
+/// Removes every package an agent owns on disk.
+pub trait AgentPackagesRemover: Send + Sync {
+    /// Removes every package installed on disk for the given agent. A missing directory is not an
+    /// error.
+    fn remove_agent_packages(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError>;
+}
+
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod tests {
@@ -72,6 +79,16 @@ pub mod tests {
     impl MockPackageManager {
         pub fn new_arc() -> Arc<Self> {
             Arc::new(MockPackageManager::new())
+        }
+    }
+
+    mock! {
+        pub AgentPackagesRemover {}
+        impl AgentPackagesRemover for AgentPackagesRemover {
+            fn remove_agent_packages(
+                &self,
+                agent_id: &AgentID,
+            ) -> Result<(), OCIPackageManagerError>;
         }
     }
 }

--- a/agent-control/src/package/manager.rs
+++ b/agent-control/src/package/manager.rs
@@ -50,14 +50,16 @@ pub trait PackageManager: Send + Sync {
 pub trait AgentPackagesRemover: Send + Sync {
     /// Removes every package installed on disk for the given agent. A missing directory is not an
     /// error.
-    fn remove_agent_packages(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError>;
+    fn remove(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError>;
 }
 
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod tests {
     use super::*;
+    use crate::agent_control::agent_id::AgentID;
     use mockall::mock;
+    use mockall::predicate;
     use std::sync::Arc;
 
     mock! {
@@ -85,10 +87,23 @@ pub mod tests {
     mock! {
         pub AgentPackagesRemover {}
         impl AgentPackagesRemover for AgentPackagesRemover {
-            fn remove_agent_packages(
+            fn remove(
                 &self,
                 agent_id: &AgentID,
             ) -> Result<(), OCIPackageManagerError>;
+        }
+    }
+    impl MockAgentPackagesRemover {
+        /// Package remover that expects `remove_agent_packages` exactly once per given agent id.
+        pub fn removing(mut self, agent_ids: &[&str]) -> MockAgentPackagesRemover {
+            for id in agent_ids {
+                let id = AgentID::try_from(*id).unwrap();
+                self.expect_remove()
+                    .with(predicate::eq(id))
+                    .once()
+                    .returning(|_| Ok(()));
+            }
+            self
         }
     }
 }

--- a/agent-control/src/package/oci/package_manager.rs
+++ b/agent-control/src/package/oci/package_manager.rs
@@ -4,7 +4,9 @@ use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::PACKAGES_FOLDER_NAME;
 use crate::oci::OciClientError;
 use crate::oci::artifact_definitions::LocalAgentPackage;
-use crate::package::manager::{InstalledPackageData, PackageData, PackageManager};
+use crate::package::manager::{
+    AgentPackagesRemover, InstalledPackageData, PackageData, PackageManager,
+};
 use crate::package::oci::downloader::OCIPackageArtifactDownloader;
 use crate::package::post_download_hook_executor::{
     PostDownloadHookExecutionError, PostDownloadHookExecutor,
@@ -49,6 +51,13 @@ pub enum OCIPackageManagerError {
     /// Uninstalling the OCI artifact failed (filesystem error).
     #[error("error attempting to uninstall OCI artifact: {0}")]
     Uninstall(io::Error),
+    /// Removing an agent's packages directory failed (filesystem error).
+    #[error("error attempting to remove agent packages directory {path}: {source}")]
+    RemoveAgentPackages {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
     /// Extracting the downloaded archive failed.
     #[error("error extracting archive while installing OCI artifact: {0}")]
     Extraction(String),
@@ -294,10 +303,11 @@ fn get_generic_package_location_path(
     agent_id: &AgentID,
     location: &str,
 ) -> PathBuf {
-    base_path
-        .join(PACKAGES_FOLDER_NAME)
-        .join(agent_id)
-        .join(location)
+    get_agent_packages_dir(base_path, agent_id).join(location)
+}
+
+fn get_agent_packages_dir(base_path: &Path, agent_id: &AgentID) -> PathBuf {
+    base_path.join(PACKAGES_FOLDER_NAME).join(agent_id)
 }
 
 /// Computes the download destination of a package [`PackageData`].
@@ -403,6 +413,29 @@ where
         self.directory_manager
             .delete(&package.installation_path)
             .map_err(OCIPackageManagerError::Uninstall)
+    }
+}
+
+impl<D, DM> AgentPackagesRemover for OCIPackageManager<D, DM>
+where
+    D: OCIPackageDownloader,
+    DM: DirectoryManager,
+{
+    fn remove_agent_packages(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError> {
+        let packages_dir = get_agent_packages_dir(&self.remote_dir, agent_id);
+        debug!(%agent_id, path = %packages_dir.display(), "Removing agent packages directory");
+        self.directory_manager
+            .delete(&packages_dir)
+            .map_err(|source| OCIPackageManagerError::RemoveAgentPackages {
+                path: packages_dir.display().to_string(),
+                source,
+            })?;
+
+        self.latest_installed_packages
+            .lock()
+            .expect("fail to acquire packages lock")
+            .remove(agent_id);
+        Ok(())
     }
 }
 
@@ -903,5 +936,44 @@ mod tests {
 
         assert_eq!(installed.installation_path, install_dir);
         assert_eq!(installed.id, TEST_PACKAGE_ID);
+    }
+
+    #[test]
+    fn test_remove_agent_packages_deletes_only_that_agent() {
+        let agent_id_to_remove = AgentID::try_from("agent-id").unwrap();
+        let other_agent_id = AgentID::try_from("other-agent-id").unwrap();
+        let root_dir = tempdir().unwrap();
+
+        let agent_package =
+            get_package_path(root_dir.path(), &agent_id_to_remove, &test_package_data()).unwrap();
+        let other_package =
+            get_package_path(root_dir.path(), &other_agent_id, &test_package_data()).unwrap();
+        DirectoryManagerFs.create(&agent_package).unwrap();
+        DirectoryManagerFs.create(&other_package).unwrap();
+
+        let pm = OCIPackageManager::new(
+            MockOCIDownloader::new(),
+            DirectoryManagerFs,
+            PathBuf::from(root_dir.path()),
+        );
+
+        pm.remove_agent_packages(&agent_id_to_remove).unwrap();
+
+        assert!(!get_agent_packages_dir(root_dir.path(), &agent_id_to_remove).exists());
+        assert!(other_package.exists());
+    }
+
+    #[test]
+    fn test_remove_agent_packages_is_ok_when_missing() {
+        let agent_id = AgentID::try_from("agent-id").unwrap();
+        let root_dir = tempdir().unwrap();
+
+        let pm = OCIPackageManager::new(
+            MockOCIDownloader::new(),
+            DirectoryManagerFs,
+            PathBuf::from(root_dir.path()),
+        );
+
+        assert!(pm.remove_agent_packages(&agent_id).is_ok());
     }
 }

--- a/agent-control/src/package/oci/package_manager.rs
+++ b/agent-control/src/package/oci/package_manager.rs
@@ -421,7 +421,7 @@ where
     D: OCIPackageDownloader,
     DM: DirectoryManager,
 {
-    fn remove_agent_packages(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError> {
+    fn remove(&self, agent_id: &AgentID) -> Result<(), OCIPackageManagerError> {
         let packages_dir = get_agent_packages_dir(&self.remote_dir, agent_id);
         debug!(%agent_id, path = %packages_dir.display(), "Removing agent packages directory");
         self.directory_manager
@@ -957,9 +957,16 @@ mod tests {
             PathBuf::from(root_dir.path()),
         );
 
-        pm.remove_agent_packages(&agent_id_to_remove).unwrap();
+        pm.remove(&agent_id_to_remove).unwrap();
 
         assert!(!get_agent_packages_dir(root_dir.path(), &agent_id_to_remove).exists());
+        assert!(
+            !pm.latest_installed_packages
+                .lock()
+                .unwrap()
+                .contains_key(&agent_id_to_remove)
+        );
+
         assert!(other_package.exists());
     }
 
@@ -974,6 +981,6 @@ mod tests {
             PathBuf::from(root_dir.path()),
         );
 
-        assert!(pm.remove_agent_packages(&agent_id).is_ok());
+        assert!(pm.remove(&agent_id).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
On-host resource cleanup now also deletes an agent's installed OCI packages, so removing an agent from the fleet fully reclaims its on-disk footprint. 

## Changes
- Add `AgentPackagesRemover` trait; implement `remove_agent_packages` on `OCIPackageManager` (idempotent).
- `OnHostCleaner` gains a `package_remover` and deletes the agent's `packages/<agent_id>` dir on clean/purge.
- Share a single `Arc<OCIPackageManager>` between the cleaner and the supervisor builder.