### PR TITLE
docs: stop enforcing missing_docs on agent-control lib and binaries

### DIFF
--- a/agent-control/src/bin/main_k8s.rs
+++ b/agent-control/src/bin/main_k8s.rs
@@ -2,7 +2,6 @@
 //!
 //! It implements the basic functionality of parsing the command line arguments and either
 //! performing one-shot actions or starting the main agent control process.
-#![warn(missing_docs)]
 
 use newrelic_agent_control::agent_control::run::AgentControlRunner;
 use newrelic_agent_control::agent_control::run::k8s::AGENT_CONTROL_MODE_K8S;

--- a/agent-control/src/bin/main_onhost.rs
+++ b/agent-control/src/bin/main_onhost.rs
@@ -2,7 +2,6 @@
 //!
 //! It implements the basic functionality of parsing the command line arguments and either
 //! performing one-shot actions or starting the main agent control process.
-#![warn(missing_docs)]
 use newrelic_agent_control::agent_control::run::AgentControlRunner;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::command::{Command, Context};

--- a/agent-control/src/lib.rs
+++ b/agent-control/src/lib.rs
@@ -3,8 +3,6 @@
 //! This library provides the core functionality for Agent Control. The different binaries generated
 //! by this project will consume this library.
 
-#![deny(missing_docs)]
-
 pub mod agent_control;
 pub mod agent_type;
 pub mod checkers;


### PR DESCRIPTION
Removes the `missing_docs` lint from the agent-control lib and binaries (added in #2637), which was noisy for daily work. The lint stays enabled on the other crates (`fs`, `self-replacer`, `wrapper_with_default`).