### PR TITLE
chore(health): refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Remember that the keywords that you can use are the following:
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.
 - On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
+- On-host health config: replaced the flat `health.http:` / `health.file:` fields with an explicit `checks:` list. Each entry is discriminated by `kind:` (`Process`, `Http`, or `File`). The previously implicit supervised-process health check is now declared as `kind: Process`. An omitted or empty `checks:` list disables health reporting entirely.
 
 ## v1.18.0 - 2026-07-06
 

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
@@ -210,6 +210,8 @@ deployment:
     interval: 60s
     initial_delay: 0s
     timeout: 15s
+    checks:
+      - kind: Process
   enable_file_logging: ${nr-var:enable_file_logging}
   executables:
     - id: nr-ebpf-agent-client

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -54,9 +54,11 @@ deployment:
     interval: 30s
     initial_delay: 60s
     timeout: 5s
-    http:
-      path: "/v1/status/health"
-      port: ${nr-var:health_port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "/v1/status/health"
+        port: ${nr-var:health_port}
   packages:
     infra-agent:
       download:

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -54,9 +54,11 @@ deployment:
     interval: 30s
     initial_delay: 90s
     timeout: 5s
-    http:
-      path: "${nr-var:health_check.path}"
-      port: ${nr-var:health_check.port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "${nr-var:health_check.path}"
+        port: ${nr-var:health_check.port}
   filesystem:
     otel-config:
       kind: dir

--- a/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-io.opentelemetry.collector-0.1.0.yaml
@@ -34,9 +34,11 @@ deployment:
     interval: 5s
     initial_delay: 5s
     timeout: 5s
-    http:
-      path: "${nr-var:health_check.path}"
-      port: ${nr-var:health_check.port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "${nr-var:health_check.path}"
+        port: ${nr-var:health_check.port}
   filesystem:
     otel-config:
       kind: dir

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -50,9 +50,11 @@ deployment:
     interval: 30s
     initial_delay: 60s
     timeout: 5s
-    http:
-      path: "/v1/status/health"
-      port: ${nr-var:health_port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "/v1/status/health"
+        port: ${nr-var:health_port}
   packages:
     infra-agent:
       download:

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.opentelemetry.collector-0.1.0.yaml
@@ -53,9 +53,11 @@ deployment:
     interval: 30s
     initial_delay: 90s
     timeout: 5s
-    http:
-      path: "${nr-var:health_check.path}"
-      port: ${nr-var:health_check.port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "${nr-var:health_check.path}"
+        port: ${nr-var:health_check.port}
   packages:
     nrdot:
       download:

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -142,9 +142,11 @@ deployment:
   health:
     interval: 5s
     timeout: 5s
-    http:
-      path: "/v1/status"
-      port: 8003
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "/v1/status"
+        port: 8003
   executables:
     - id: newrelic-infra
       path: /usr/bin/newrelic-infra
@@ -187,26 +189,28 @@ In the `backoff_strategy` we have:
 
 #### On Host Health
 
-The `health` section in the deployment configuration is where you can specify how to monitor the health status of the agent. This is critical for maintaining the reliability of your agent and ensuring that it's functioning correctly. Here's how you can define it in the `executables` block:
+The `health` section in the deployment configuration is where you can specify how to monitor the health status of the agent. This is critical for maintaining the reliability of your agent and ensuring that it's functioning correctly. It uses an explicit `checks:` list where every entry is discriminated by an explicit `kind:` field:
 
 ```yaml
 health:
     interval: 5s
     timeout: 5s
-    http:
+    checks:
+      - kind: Process
+      - kind: Http
         path: "/v1/status"
         port: 8003
-        healthy_codes: [200,203,203,204]                 
+        healthy_status_codes: [200, 203, 204]
 ```
 
 In this configuration:
 
 * `interval`: This parameter specifies the frequency at which health checks should be performed.
-* `timeout`: This is the maximum time the agent should wait for a health check response.
-* `http`: This section is for when agents expose their status through an HTTP endpoint. If this method is used, the `path` and `port` should be specified.
-  * `path`: This is the API endpoint for the health check. Typically, it's a URI where the agent returns its current health status.
-  * `port`: This is the port on which the agent's health check endpoint is listening.
-  * `healthy_codes`: This is a list of the HTTP codes the SA will consider as valid ones.
+* `timeout`: This is the maximum time the agent should wait for an HTTP health check response.
+* `checks`: The explicit list of checks to run. Empty (or omitted) means health reporting is disabled. Any single unhealthy check makes the sub-agent unhealthy.
+  * `kind: Process` surfaces the health of the supervised executable. No parameters. Only meaningful when the agent type declares `executables`.
+  * `kind: Http` polls an HTTP endpoint. Fields: `host` (default `127.0.0.1`), `path`, `port`, `headers`, `healthy_status_codes` (empty means the 2xx range is treated as healthy).
+  * `kind: File` reads a health-status file. Field: `path`.
 
 By finely tuning these parameters, developers can closely monitor the agent's performance and address issues instantly. Adopting a robust health check strategy helps minimize downtime and keeps your system resilient and reliable.
 

--- a/agent-control/src/agent_type/definition.rs
+++ b/agent-control/src/agent_type/definition.rs
@@ -470,9 +470,11 @@ deployment:
     interval: 3s
     initial_delay: 3s
     timeout: 10s
-    http:
-      path: /healthz
-      port: 8080
+    checks:
+      - kind: Process
+      - kind: Http
+        path: /healthz
+        port: 8080
   executables:
     - id: otelcol
       path: ${nr-var:bin}/otelcol
@@ -718,9 +720,11 @@ deployment:
     interval: 3s
     initial_delay: 3s
     timeout: 10s
-    http:
-      path: /v1/status
-      port: "${nr-var:status_server_port}"
+    checks:
+      - kind: Process
+      - kind: Http
+        path: /v1/status
+        port: "${nr-var:status_server_port}"
   executables:
     - id: newrelic-infra
       path: /usr/bin/newrelic-infra
@@ -992,10 +996,12 @@ deployment:
     initial_delay: 3s
     timeout: 10s
     {unknown}
-    http:
-      path: /healthz
-      port: 8080
-      {unknown}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: /healthz
+        port: 8080
+        {unknown}
   executables:
     - id: fake_bin
       path: /bin/fake_bin

--- a/agent-control/src/agent_type/runtime_config/health_config.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config.rs
@@ -1,15 +1,13 @@
 //! Health-check configuration for on-host agents (HTTP or file-based checks).
-use duration_str::deserialize_duration;
-use serde::Deserialize;
-use std::{collections::HashMap, time::Duration};
-use wrapper_with_default::WrapperWithDefault;
-
+use super::templateable_value::TemplateableValue;
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
 use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
-
-use super::templateable_value::TemplateableValue;
+use duration_str::deserialize_duration;
+use serde::{Deserialize, Deserializer};
+use std::{collections::HashMap, time::Duration};
+use wrapper_with_default::WrapperWithDefault;
 
 const DEFAULT_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -17,8 +15,8 @@ pub mod rendered;
 
 /// Represents the configuration for health checks.
 ///
-/// This structure includes parameters to define intervals between health checks,
-/// timeouts for checks, and the specific health check method—either HTTP or execute command.
+/// Defines the periodicity/timeout parameters and an explicit list of checks that the on-host
+/// supervisor should run. An empty (or omitted) `checks` list disables health reporting.
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
 pub struct OnHostHealthConfig {
     /// The duration to wait between health checks.
@@ -33,9 +31,30 @@ pub struct OnHostHealthConfig {
     #[serde(default)]
     pub(crate) timeout: HealthCheckTimeout,
 
-    /// Details on the type of health check. Defined by the `HealthCheck` enumeration.
-    #[serde(default, flatten)]
-    pub(crate) check: Option<OnHostHealthCheck>,
+    /// The list of health checks to run. Empty (or absent) means health reporting is disabled.
+    #[serde(default, deserialize_with = "deserialize_checks")]
+    pub(crate) checks: Vec<OnHostHealthCheckDefinition>,
+}
+
+/// Deserializes `checks` and rejects agent-type definitions that declare the `Process` kind more
+/// than once: the runtime `try_new` can only wire a single supervised-executable consumer.
+fn deserialize_checks<'de, D>(deserializer: D) -> Result<Vec<OnHostHealthCheckDefinition>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let checks = <Vec<OnHostHealthCheckDefinition>>::deserialize(deserializer)?;
+    let process_count = checks
+        .iter()
+        .filter(|c| matches!(c, OnHostHealthCheckDefinition::Process))
+        .count();
+    if process_count > 1 {
+        return Err(D::Error::custom(format!(
+            "the 'Process' on-host health check may be declared at most once, found {process_count}"
+        )));
+    }
+    Ok(checks)
 }
 
 /// The maximum duration a health check may run before being considered failed.
@@ -43,15 +62,13 @@ pub struct OnHostHealthConfig {
 #[wrapper_default_value(DEFAULT_HEALTH_CHECK_TIMEOUT)]
 pub struct HealthCheckTimeout(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
-/// Enumeration representing the possible types of health checks.
-///
-/// Variants include `HttpHealth` and `ExecHealth`, corresponding to health checks via HTTP and execute command, respectively.
+/// A single on-host health check declaration.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
-pub(crate) enum OnHostHealthCheck {
-    #[serde(rename = "http")]
-    HttpHealth(HttpHealth),
-    #[serde(rename = "file")]
-    FileHealth(FileHealth),
+#[serde(tag = "kind")]
+pub(crate) enum OnHostHealthCheckDefinition {
+    Process,
+    Http(HttpHealth),
+    File(FileHealth),
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -180,10 +197,11 @@ impl Templateable for OnHostHealthConfig {
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         Ok(Self::Output {
-            check: self
-                .check
-                .map(|check| check.template_with(variables))
-                .transpose()?,
+            checks: self
+                .checks
+                .into_iter()
+                .map(|c| c.template_with(variables))
+                .collect::<Result<Vec<_>, _>>()?,
             interval: self.interval,
             initial_delay: self.initial_delay,
             timeout: self.timeout,
@@ -191,12 +209,13 @@ impl Templateable for OnHostHealthConfig {
     }
 }
 
-impl Templateable for OnHostHealthCheck {
-    type Output = rendered::OnHostHealthCheck;
+impl Templateable for OnHostHealthCheckDefinition {
+    type Output = rendered::OnHostHealthCheckDefinition;
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         Ok(match self {
-            OnHostHealthCheck::HttpHealth(conf) => {
+            OnHostHealthCheckDefinition::Process => rendered::OnHostHealthCheckDefinition::Process,
+            OnHostHealthCheckDefinition::Http(conf) => {
                 let health_conf = rendered::HttpHealth {
                     host: conf.host.template_with(variables)?,
                     path: conf.path.template_with(variables)?,
@@ -204,13 +223,13 @@ impl Templateable for OnHostHealthCheck {
                     headers: conf.headers,
                     healthy_status_codes: conf.healthy_status_codes,
                 };
-                rendered::OnHostHealthCheck::HttpHealth(health_conf)
+                rendered::OnHostHealthCheckDefinition::Http(health_conf)
             }
-            OnHostHealthCheck::FileHealth(conf) => {
+            OnHostHealthCheckDefinition::File(conf) => {
                 let health_conf = FileHealth {
                     path: conf.path.template_with(variables)?,
                 };
-                rendered::OnHostHealthCheck::FileHealth(health_conf)
+                rendered::OnHostHealthCheckDefinition::File(health_conf)
             }
         })
     }
@@ -258,5 +277,74 @@ impl Templateable for TemplateableValue<HttpPath> {
             HttpPath(templated_string)
         };
         Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_the_three_kinds() {
+        let yaml = r#"
+interval: 5s
+initial_delay: 1s
+timeout: 3s
+checks:
+  - kind: Process
+  - kind: Http
+    path: /healthz
+    port: 8080
+  - kind: File
+    path: /var/lib/health.yaml
+"#;
+        let cfg: OnHostHealthConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(cfg.checks.len(), 3);
+        assert!(matches!(
+            cfg.checks[0],
+            OnHostHealthCheckDefinition::Process
+        ));
+        assert!(matches!(
+            cfg.checks[1],
+            OnHostHealthCheckDefinition::Http(_)
+        ));
+        assert!(matches!(
+            cfg.checks[2],
+            OnHostHealthCheckDefinition::File(_)
+        ));
+    }
+
+    #[test]
+    fn empty_or_missing_checks_defaults_to_empty_list() {
+        let cfg: OnHostHealthConfig = serde_saphyr::from_str("interval: 5s\n").unwrap();
+        assert!(cfg.checks.is_empty());
+
+        let cfg: OnHostHealthConfig = serde_saphyr::from_str("interval: 5s\nchecks: []\n").unwrap();
+        assert!(cfg.checks.is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        let yaml = r#"
+checks:
+  - kind: Bogus
+"#;
+        assert!(serde_saphyr::from_str::<OnHostHealthConfig>(yaml).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_process_check_at_parse_time() {
+        let yaml = r#"
+checks:
+  - kind: Process
+  - kind: Process
+"#;
+        let err = serde_saphyr::from_str::<OnHostHealthConfig>(yaml)
+            .expect_err("duplicate Process kind must be rejected at parse time");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'Process'") && msg.contains("at most once"),
+            "unexpected error message: {msg}"
+        );
     }
 }

--- a/agent-control/src/agent_type/runtime_config/health_config/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config/rendered.rs
@@ -15,14 +15,19 @@ pub struct OnHostHealthConfig {
     pub(crate) initial_delay: InitialDelay,
     /// The maximum duration a health check may run before considered failed.
     pub(crate) timeout: HealthCheckTimeout,
-    /// Details on the type of health check. Defined by the `HealthCheck` enumeration.
-    pub(crate) check: Option<OnHostHealthCheck>,
+    /// The list of health checks to run. Empty means health reporting is disabled.
+    pub(crate) checks: Vec<OnHostHealthCheckDefinition>,
 }
 
+/// A single rendered on-host health check.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum OnHostHealthCheck {
-    HttpHealth(HttpHealth),
-    FileHealth(FileHealth),
+pub(crate) enum OnHostHealthCheckDefinition {
+    /// Process probe.
+    Process,
+    /// HTTP endpoint probe.
+    Http(HttpHealth),
+    /// File-based probe.
+    File(FileHealth),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -708,9 +708,11 @@ health:
   interval: 3s
   initial_delay: 3s
   timeout: 10s
-  http:
-    path: /healthz
-    port: 8080
+  checks:
+    - kind: Process
+    - kind: Http
+      path: /healthz
+      port: 8080
 executables:
   - id: otelcol
     path: ${nr-var:bin}/otelcol

--- a/agent-control/src/checkers/health/on_host/health_checker.rs
+++ b/agent-control/src/checkers/health/on_host/health_checker.rs
@@ -2,12 +2,13 @@
 use super::exec::ExecHealthChecker;
 use super::file::FileHealthChecker;
 use super::http::HttpHealthChecker;
-use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthCheck;
+use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthCheckDefinition;
 use crate::checkers::health::health_checker::{HealthChecker, HealthCheckerError, Healthy};
 use crate::checkers::health::with_start_time::{HealthWithStartTime, StartTime};
 use crate::event::channel::EventConsumer;
 use crate::http::client::HttpClient;
 use std::path::PathBuf;
+use tracing::{debug, warn};
 
 /// A single on-host health-check source.
 pub enum OnHostHealthChecker {
@@ -25,34 +26,55 @@ pub struct OnHostHealthCheckers {
 }
 
 impl OnHostHealthCheckers {
+    /// Builds the aggregate checker from the explicit list of check definitions.
+    ///
+    /// Returns `Ok(None)` when the list is empty: health reporting is then disabled for the
+    /// sub-agent. Returns `Err` only when a specific checker (e.g. `Http`) fails to initialize.
     pub(crate) fn try_new(
         exec_health_consumer: EventConsumer<(String, HealthWithStartTime)>,
         http_client: HttpClient,
-        health_check_type: Option<OnHostHealthCheck>,
+        checks: &[OnHostHealthCheckDefinition],
         start_time: StartTime,
-    ) -> Result<Self, HealthCheckerError> {
-        let mut health_checkers = vec![OnHostHealthChecker::Exec(ExecHealthChecker::new(
-            exec_health_consumer,
-        ))];
-        match health_check_type {
-            Some(OnHostHealthCheck::HttpHealth(http_config)) => {
-                health_checkers.push(OnHostHealthChecker::Http(HttpHealthChecker::new(
-                    http_client,
-                    http_config,
-                    start_time,
-                )?));
-            }
-            Some(OnHostHealthCheck::FileHealth(file_config)) => {
-                health_checkers.push(OnHostHealthChecker::File(FileHealthChecker::new(
-                    PathBuf::from(file_config.path),
-                )));
-            }
-            _ => {}
+    ) -> Result<Option<Self>, HealthCheckerError> {
+        if checks.is_empty() {
+            debug!("No health checks configured: no health-checker is built");
+            return Ok(None);
         }
-        Ok(OnHostHealthCheckers {
+
+        let mut health_checkers = Vec::new();
+        let mut exec_consumer = Some(exec_health_consumer);
+
+        for check in checks {
+            match check {
+                OnHostHealthCheckDefinition::Process => {
+                    if let Some(consumer) = exec_consumer.take() {
+                        health_checkers
+                            .push(OnHostHealthChecker::Exec(ExecHealthChecker::new(consumer)));
+                    } else {
+                        warn!(
+                            "Multiple 'Process' health checks slipped past parse-time validation; only the first is honored"
+                        );
+                    }
+                }
+                OnHostHealthCheckDefinition::Http(http_config) => {
+                    health_checkers.push(OnHostHealthChecker::Http(HttpHealthChecker::new(
+                        http_client.clone(),
+                        http_config.clone(),
+                        start_time,
+                    )?));
+                }
+                OnHostHealthCheckDefinition::File(file_config) => {
+                    health_checkers.push(OnHostHealthChecker::File(FileHealthChecker::new(
+                        PathBuf::from(file_config.path.clone()),
+                    )));
+                }
+            }
+        }
+
+        Ok(Some(OnHostHealthCheckers {
             health_checkers,
             start_time,
-        })
+        }))
     }
 }
 
@@ -88,11 +110,18 @@ impl HealthChecker for OnHostHealthCheckers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_type::runtime_config::health_config::rendered::HttpHealth;
+    use crate::agent_type::runtime_config::health_config::{
+        FileHealth, HttpHost, HttpPath, HttpPort,
+    };
     use crate::checkers::health::health_checker::Unhealthy;
     use crate::checkers::health::with_start_time::StartTime;
     use crate::event::channel::pub_sub;
+    use crate::http::config::{HttpConfig, ProxyConfig};
+    use std::collections::HashMap;
     use std::fs::File;
     use std::io::Write;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     #[test]
@@ -309,5 +338,66 @@ status_time_unix_nano: 1725444001
             health_with_start_time.last_error(),
             Some("executable exec1 failed: exec error".to_string())
         );
+    }
+
+    #[test]
+    fn try_new_returns_none_for_empty_checks() {
+        let (_publisher, consumer) = pub_sub();
+        let http_client = HttpClient::new(HttpConfig::new(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            ProxyConfig::default(),
+        ))
+        .unwrap();
+
+        let result =
+            OnHostHealthCheckers::try_new(consumer, http_client, &[], StartTime::now()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn try_new_builds_all_declared_kinds() {
+        let (_publisher, consumer) = pub_sub();
+        let http_client = HttpClient::new(HttpConfig::new(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            ProxyConfig::default(),
+        ))
+        .unwrap();
+
+        // Despite being not allowed, the builder does not error out if two processes are defined
+        let checks = vec![
+            OnHostHealthCheckDefinition::Process,
+            OnHostHealthCheckDefinition::Process,
+            OnHostHealthCheckDefinition::Http(HttpHealth {
+                host: HttpHost::from("127.0.0.1".to_string()),
+                path: HttpPath::from("/healthz".to_string()),
+                port: HttpPort::from(8080u16),
+                headers: HashMap::new(),
+                healthy_status_codes: vec![],
+            }),
+            OnHostHealthCheckDefinition::File(FileHealth {
+                path: "/tmp/health.yaml".to_string(),
+            }),
+        ];
+
+        let result =
+            OnHostHealthCheckers::try_new(consumer, http_client, &checks, StartTime::now())
+                .unwrap()
+                .expect("should build");
+
+        assert_eq!(result.health_checkers.len(), 3);
+        assert!(matches!(
+            result.health_checkers[0],
+            OnHostHealthChecker::Exec(_)
+        ));
+        assert!(matches!(
+            result.health_checkers[1],
+            OnHostHealthChecker::Http(_)
+        ));
+        assert!(matches!(
+            result.health_checkers[2],
+            OnHostHealthChecker::File(_)
+        ));
     }
 }

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -245,21 +245,30 @@ where
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
         health_consumer: EventConsumer<(String, HealthWithStartTime)>,
-        health_config: &OnHostHealthConfig,
-    ) -> Result<StartedThreadContext, SupervisorError> {
+        health_config: &Option<OnHostHealthConfig>,
+    ) -> Result<Option<StartedThreadContext>, SupervisorError> {
+        let Some(health_config) = health_config else {
+            debug!("No health_config: health-checker thread will not be started");
+            return Ok(None);
+        };
+
         let start_time = StartTime::now();
-        let client_timeout = Duration::from(health_config.clone().timeout);
+        let client_timeout = Duration::from(health_config.timeout);
         let http_config = HttpConfig::new(client_timeout, client_timeout, ProxyConfig::default());
         let http_client = HttpClient::new(http_config).map_err(|err| {
             HealthCheckerError::Generic(format!("could not build the http client: {err}"))
         })?;
 
-        let health_checker = OnHostHealthCheckers::try_new(
+        let Some(health_checker) = OnHostHealthCheckers::try_new(
             health_consumer,
             http_client,
-            health_config.check.clone(),
+            &health_config.checks,
             start_time,
-        )?;
+        )?
+        else {
+            debug!("No health_checker: no health-checker thread will not be started");
+            return Ok(None);
+        };
 
         let started_thread_context = spawn_health_checker(
             self.agent_identity.id.clone(),
@@ -269,7 +278,7 @@ where
             health_config.initial_delay,
             start_time,
         );
-        Ok(started_thread_context)
+        Ok(Some(started_thread_context))
     }
 
     /// Runs the agent version check (if configured), publishing detected attributes as events.
@@ -342,12 +351,12 @@ where
 
         self.check_subagent_version(sub_agent_internal_publisher.clone());
 
-        if let Some(ref health_config) = self.health_config {
-            thread_contexts.push(self.start_health_check(
-                sub_agent_internal_publisher.clone(),
-                health_consumer,
-                health_config,
-            )?);
+        if let Some(ctx) = self.start_health_check(
+            sub_agent_internal_publisher.clone(),
+            health_consumer,
+            &self.health_config,
+        )? {
+            thread_contexts.push(ctx);
         }
 
         Ok(StartedSupervisorOnHost {
@@ -1678,11 +1687,13 @@ persistent.txt:
 
     #[test]
     fn test_health_checker_thread_publishes_periodically_when_health_config_set() {
+        use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthCheckDefinition;
+
         let health_config = OnHostHealthConfig {
             interval: HealthCheckInterval::from(Duration::from_millis(50)),
             initial_delay: InitialDelay::from(Duration::ZERO),
             timeout: HealthCheckTimeout::from(Duration::from_secs(1)),
-            check: None,
+            checks: vec![OnHostHealthCheckDefinition::Process],
         };
 
         let agent_identity = AgentIdentity::from((

--- a/agent-control/tests/on_host/scenarios/health_check.rs
+++ b/agent-control/tests/on_host/scenarios/health_check.rs
@@ -30,8 +30,9 @@ fn test_file_health_without_supervisor() {
 interval: 1s
 initial_delay: 0s
 timeout: 1s
-file:
-  path: '{}'
+checks:
+  - kind: File
+    path: '{}'
 "#,
         health_file_path.to_str().unwrap()
     );
@@ -133,9 +134,10 @@ fn test_http_health_without_supervisor() {
 interval: 1s
 initial_delay: 0s
 timeout: 1s
-http:
-  path: /health
-  port: {}
+checks:
+  - kind: Http
+    path: /health
+    port: {}
 "#,
         health_server.port(),
     );

--- a/agent-control/tests/on_host/scenarios/multiple_executables.rs
+++ b/agent-control/tests/on_host/scenarios/multiple_executables.rs
@@ -29,7 +29,9 @@ fn onhost_subagent_multiple_executables_some_failed_launching() {
                 {"id": "unknown", "path": "unknown-command"}
             ]"#,
         ))
-        .with_health(Some(r#"{"interval": "1s", "initial_delay": "2s"}"#))
+        .with_health(Some(
+            r#"{"interval": "1s", "initial_delay": "2s", "checks": [{ "kind": "Process"}]}"#,
+        ))
         .build(dirs.local_dir());
 
     let agents = format!(
@@ -77,7 +79,7 @@ fn onhost_subagent_multiple_executables_some_commands_failed_after_max_retries()
                 }
             ]"#,
         ))
-        .with_health(Some(r#"{"interval": "1s", "initial_delay": "2s"}"#))
+        .with_health(Some(r#"{"interval": "1s", "initial_delay": "2s", "checks": [{ "kind": "Process"}]}"#))
         .build(dirs.local_dir());
 
     let agents = format!(

--- a/agent-control/tests/on_host/scenarios/opamp.rs
+++ b/agent-control/tests/on_host/scenarios/opamp.rs
@@ -390,10 +390,11 @@ fn onhost_executable_less_reports_local_effective_config() {
 interval: 2s
 initial_delay: 0s
 timeout: 1s
-file:
-  path: '{}'
-  should_be_present: true
-  unhealthy_string: ".*(unhealthy|fatal|error).*"
+checks:
+  - kind: File
+    path: '{}'
+    should_be_present: true
+    unhealthy_string: ".*(unhealthy|fatal|error).*"
 "#,
         health_file_path.to_string_lossy()
     );

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -43,6 +43,8 @@ fake_variable:
 interval: 60s
 initial_delay: 0s
 timeout: 15s
+checks:
+  - kind: Process
 "#,
                 )
                 .unwrap(),
@@ -194,7 +196,8 @@ impl CustomAgentType {
         let parsed_agent_type = AgentTypeDefinition::from_slice(self.to_string().as_bytes());
         assert!(
             parsed_agent_type.is_ok(),
-            "CustomAgentType did not produce valid AgentTypeDefinition:\n{}",
+            "CustomAgentType did not produce valid AgentTypeDefinition: {}\n{}",
+            parsed_agent_type.err().unwrap(),
             self
         );
 

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -209,9 +209,11 @@ deployment:
     interval: 5s
     initial_delay: 5s
     timeout: 5s
-    http:
-      path: "/v1/status/health"
-      port: ${nr-var:health_port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "/v1/status/health"
+        port: ${nr-var:health_port}
   packages:
     infra-agent:
       download:
@@ -259,9 +261,11 @@ deployment:
     interval: 5s
     initial_delay: 5s
     timeout: 5s
-    http:
-      path: "/v1/status/health"
-      port: ${nr-var:health_port}
+    checks:
+      - kind: Process
+      - kind: Http
+        path: "/v1/status/health"
+        port: ${nr-var:health_port}
   packages:
     infra-agent:
       download:
@@ -781,19 +785,35 @@ When set, this redirects the `stdout` and `stderr` of the created process to fil
 
 Enables periodically checking the health of the sub-agent. See [Health status](#health-status) below for more details. Accepts the following values:
 
-- `interval`: Periodicity of the check. A duration string.
-- `initial_delay`: Initial delay before the first health check is performed. A duration string.
-- `timeout`: Maximum duration a health check may run before considered failed.
-- `http` or `file`: The type of health check used.
-  - `http` means that the supervisor for this sub-agent will attempt to query an HTTP endpoint and will decide on healthiness depending on the status code. Accepts the following fields:
-    - `host`, string.
-    - `path`, string.
-    - `port`, a number.
+- `interval`: Periodicity of the check. A duration string. Default `60s`.
+- `initial_delay`: Initial delay before the first health check is performed. A duration string. Default zero.
+- `timeout`: Maximum duration an HTTP health check may run before considered failed. A duration string. Default `15s`.
+- `checks`: An explicit list of health checks to run. Each entry is discriminated by a `kind:` field. If `checks` is omitted or empty, no health thread is spawned and health is not reported. The aggregate result is unhealthy as soon as any single check is unhealthy. Supported kinds:
+  - `Process`: aggregates the health of the supervised executables. It surfaces launch failures (unable to spawn the binary), restart-policy exhaustion, and healthy-after-warmup transitions. Takes no parameters. Only makes sense when the agent type declares `executables`. Declaring it more than once is not allowed.
+  - `Http`: queries an HTTP endpoint and derives health from its status code. Fields:
+    - `host`: string, defaults to `127.0.0.1`.
+    - `path`: string, defaults to `/`.
+    - `port`: number, defaults to `80`.
     - `headers`: key-value pairs for authentication or other required info.
-    - `healthy_status_codes`: The status codes that mean a healthy state. If not set, as of now the 200s will be considered healthy and the rest unhealthy.
-  - `file` means that the supervisor for this sub-agent will attempt to read a file and find expected contents. Failing to do so, or reading information that means an unhealthy state, will mark the sub-agent as unhealthy. Accepts `path` as its only field.
+    - `healthy_status_codes`: the status codes that mean a healthy state. If not set, the 2xx range is considered healthy and everything else unhealthy.
+  - `File`: reads a file and expects a specific health-payload schema. Failing to read the file, or reading a payload indicating an unhealthy state, marks the sub-agent as unhealthy. Fields:
+    - `path`: string, path to the health-status file.
 
-If no health configuration is defined, AC will use the exceeding of the restart policy (if also defined) to determine if the sub-agent should be labelled as unhealthy.
+Example combining supervised-process health with an HTTP probe:
+
+```yaml
+health:
+  interval: 30s
+  initial_delay: 60s
+  timeout: 5s
+  checks:
+    - kind: Process
+    - kind: Http
+      path: "/v1/status/health"
+      port: ${nr-var:health_port}
+```
+
+If `health:` is omitted, or `checks` is empty, no health checking is performed and the sub-agent does not report health at all — the restart policy will still be honored, but its outcome is not surfaced as unhealthy.
 
 #### Kubernetes namespace usage
 

--- a/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
+++ b/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
@@ -229,6 +229,8 @@ deployment:
     interval: 60s
     initial_delay: 0s
     timeout: 15s
+    checks:
+      - kind: Process
   packages:
     test-package:
       type: tar


### PR DESCRIPTION
This PRs is changing the Health configuration:
 - to surface the "Process"  health check that was added under the hood
 - to be more similar to the K8s one:
```yaml
  health:
    interval: 30s
    initial_delay: 30s
    checks:
      - namespace: ${nr-ac:namespace}
        name: ${nr-sub:agent_id}
        kind: HelmReleaseWorkload
        target_namespace: ${nr-ac:namespace_agents}
```

therefore the configuration changes as follows

- old
```yaml
  health:
    interval: 30s
    initial_delay: 60s
    timeout: 5s
    http:
      path: "/v1/status/health"
      port: ${nr-var:health_port}
```

- new
```yaml
  health:
    interval: 30s
    initial_delay: 60s
    timeout: 5s
    checks:
      - kind: Process
      - kind: Http
        path: "/v1/status/health"
        port: ${nr-var:health_port}
```

Everything else should stay the same.
I decided to reject two "processes" checks since they are meainingless and we cannot duplicate the channel reader