### PR TITLE
feat: add post download hook for ebpf agent type

### DIFF
--- a/.github/workflows/component_onhost_e2e.yml
+++ b/.github/workflows/component_onhost_e2e.yml
@@ -31,7 +31,7 @@ env:
   HOST_E2E_INFRA_AGENT_VERSION: "1.78.0"
   HOST_E2E_NRDOT_VERSION: "1.21.0"
   HOST_E2E_REDIS_VERSION: "0.0.1"
-  HOST_E2E_EBPF_AGENT_VERSION: "1.4.3"
+  HOST_E2E_EBPF_AGENT_VERSION: "0.0.1"
 
 jobs:
   build-packages:
@@ -51,10 +51,7 @@ jobs:
       matrix:
         group:
           - remote-config
-          # TODO: re-enable once newrelic/ebpf-agent-artifacts has a published OCI artifact
-          # (blocked on newrelic-ebpf-agent's add-oci-packaging-ac branch being merged and
-          # dispatched at least once). Until then it always fails with "manifest unknown".
-          # - ebpf-agent
+          - ebpf-agent
           - infra-agent
           - nrdot-agent
           - proxy

--- a/.github/workflows/component_onhost_e2e.yml
+++ b/.github/workflows/component_onhost_e2e.yml
@@ -31,6 +31,7 @@ env:
   HOST_E2E_INFRA_AGENT_VERSION: "1.78.0"
   HOST_E2E_NRDOT_VERSION: "1.21.0"
   HOST_E2E_REDIS_VERSION: "0.0.1"
+  HOST_E2E_EBPF_AGENT_VERSION: "1.4.3"
 
 jobs:
   build-packages:
@@ -50,7 +51,10 @@ jobs:
       matrix:
         group:
           - remote-config
-          - ebpf-agent
+          # TODO: re-enable once newrelic/ebpf-agent-artifacts has a published OCI artifact
+          # (blocked on newrelic-ebpf-agent's add-oci-packaging-ac branch being merged and
+          # dispatched at least once). Until then it always fails with "manifest unknown".
+          # - ebpf-agent
           - infra-agent
           - nrdot-agent
           - proxy
@@ -86,7 +90,8 @@ jobs:
             --recipes-repo-branch "main" \
             --infra-agent-version "${{ env.HOST_E2E_INFRA_AGENT_VERSION }}" \
             --nrdot-version "${{ env.HOST_E2E_NRDOT_VERSION }}" \
-            --redis-version "${{ env.HOST_E2E_REDIS_VERSION }}"
+            --redis-version "${{ env.HOST_E2E_REDIS_VERSION }}" \
+            --ebpf-agent-version "${{ env.HOST_E2E_EBPF_AGENT_VERSION }}"
 
       - name: Report test result to New Relic
         if: always()

--- a/.github/workflows/on_demand_staging_e2e.yml
+++ b/.github/workflows/on_demand_staging_e2e.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   HOST_E2E_INFRA_AGENT_VERSION: "1.78.0"
   HOST_E2E_NRDOT_VERSION: "1.21.0"
+  HOST_E2E_EBPF_AGENT_VERSION: "1.4.3"
   HOST_E2E_REDIS_VERSION: "0.0.1"
 
 jobs:
@@ -34,7 +35,10 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - ebpf-agent
+          # TODO: re-enable once newrelic/ebpf-agent-artifacts has a published OCI artifact
+          # (blocked on newrelic-ebpf-agent's add-oci-packaging-ac branch being merged and
+          # dispatched at least once). Until then it always fails with "manifest unknown".
+          # - ebpf-agent
           - remote-config
           - infra-agent
           - nrdot-agent
@@ -67,6 +71,7 @@ jobs:
             --infra-agent-version "${{ env.HOST_E2E_INFRA_AGENT_VERSION }}" \
             --nrdot-version "${{ env.HOST_E2E_NRDOT_VERSION }}" \
             --redis-version "${{ env.HOST_E2E_REDIS_VERSION }}"
+            --ebpf-agent-version "${{ env.HOST_E2E_EBPF_AGENT_VERSION }}"
 
       - name: Report test result to New Relic
         if: always()

--- a/.github/workflows/on_demand_staging_e2e.yml
+++ b/.github/workflows/on_demand_staging_e2e.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   HOST_E2E_INFRA_AGENT_VERSION: "1.78.0"
   HOST_E2E_NRDOT_VERSION: "1.21.0"
-  HOST_E2E_EBPF_AGENT_VERSION: "1.4.3"
+  HOST_E2E_EBPF_AGENT_VERSION: "0.0.1"
   HOST_E2E_REDIS_VERSION: "0.0.1"
 
 jobs:
@@ -35,10 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          # TODO: re-enable once newrelic/ebpf-agent-artifacts has a published OCI artifact
-          # (blocked on newrelic-ebpf-agent's add-oci-packaging-ac branch being merged and
-          # dispatched at least once). Until then it always fails with "manifest unknown".
-          # - ebpf-agent
+          - ebpf-agent
           - remote-config
           - infra-agent
           - nrdot-agent
@@ -70,7 +67,7 @@ jobs:
             --recipes-repo-branch "main" \
             --infra-agent-version "${{ env.HOST_E2E_INFRA_AGENT_VERSION }}" \
             --nrdot-version "${{ env.HOST_E2E_NRDOT_VERSION }}" \
-            --redis-version "${{ env.HOST_E2E_REDIS_VERSION }}"
+            --redis-version "${{ env.HOST_E2E_REDIS_VERSION }}" \
             --ebpf-agent-version "${{ env.HOST_E2E_EBPF_AGENT_VERSION }}"
 
       - name: Report test result to New Relic

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.ebpf-0.1.0.yaml
@@ -5,7 +5,7 @@ platform: host
 operating_system: linux
 protocol_version: "1.0"
 variables:
-  config_agent:
+  config:
     DEPLOYMENT_NAME:
       description: "Unique name for the deployment to identify data posting via eBPF Agent."
       type: string
@@ -14,7 +14,7 @@ variables:
       description: "Endpoint to export data to Newrelic."
       type: string
       required: false
-      default: otlp.nr-data.net:4317
+      default: otlp.nr-data.net:443
     LOG_LEVEL:
       description: "To configure the log level in increasing order of verboseness."
       type: string
@@ -195,6 +195,221 @@ variables:
       type: string
       required: false
       default: ""
+    PROXY_URL:
+      description: "Full proxy URL for exporting data to New Relic (format '<scheme>://<user>:<pass>@<host>:<port>'). Empty = no proxy. Maps to NEW_RELIC_PROXY_URL."
+      type: string
+      required: false
+      default: ""
+    LABELS:
+      description: "Custom labels applied to all entities. Format 'key1:value1;key2:value2'. Maps to NEW_RELIC_LABELS."
+      type: string
+      required: false
+      default: ""
+    REPORT_APM_DATA:
+      description: "eBPF APM data reporting: 'true' (always), 'false' (never), or 'auto' (only if no APM/OTel agent detected)."
+      type: string
+      required: false
+      default: "true"
+    REPORT_NETWORK_METRICS:
+      description: "Network metrics reporting: 'true', 'false', or 'auto'."
+      type: string
+      required: false
+      default: "true"
+    JVM_METRICS_REPORTING:
+      description: "Enable/disable JVM metrics collection and reporting."
+      type: string
+      required: false
+      default: "true"
+    REPORT_AI_METRICS:
+      description: "AI monitoring: 'true' (always), 'false' (never), or 'auto' (only if no APM/OTel agent detected)."
+      type: string
+      required: false
+      default: "false"
+    PROXY_HOST:
+      description: "Proxy hostname for OTLP export (empty = no proxy). Maps to NEW_RELIC_PROXY_HOST."
+      type: string
+      required: false
+      default: ""
+    PROXY_PORT:
+      description: "Proxy port. Maps to NEW_RELIC_PROXY_PORT."
+      type: string
+      required: false
+      default: "8080"
+    PROXY_SCHEME:
+      description: "Proxy URL scheme: http or https. Maps to NEW_RELIC_PROXY_SCHEME."
+      type: string
+      required: false
+      default: "http"
+    PROXY_USER:
+      description: "Username for proxy Basic Auth. Maps to NEW_RELIC_PROXY_USER."
+      type: string
+      required: false
+      default: ""
+    PROXY_PASS:
+      description: "Password for proxy Basic Auth. Maps to NEW_RELIC_PROXY_PASS."
+      type: string
+      required: false
+      default: ""
+    DOWNLOADED_PACKAGED_HEADERS_PATH:
+      description: "Path where downloaded packaged linux headers are placed."
+      type: string
+      required: false
+      default: ""
+    DISTRO_KERNEL_HEADERS_PATH:
+      description: "Path to the installed distribution linux headers."
+      type: string
+      required: false
+      default: ""
+    REPORT_LOGS:
+      description: "Log reporting: 'true' (always), 'false' (never), or 'auto'."
+      type: string
+      required: false
+      default: "false"
+    GENAI_CAPTURE_MESSAGE_CONTENT:
+      description: "Capture message content for GenAI interactions."
+      type: string
+      required: false
+      default: "false"
+    INCLUDE_PORT_IN_SERVER_ENTITY_IDENTIFICATION:
+      description: "Include the port in the server entity name."
+      type: string
+      required: false
+      default: "true"
+    DROP_ALL_DATA_FOR_ENTITY_NAME_REGEX:
+      description: "Regex of service names to drop all data for."
+      type: string
+      required: false
+      default: ""
+    KEEP_ALL_DATA_FOR_ENTITY_NAME_REGEX:
+      description: "Regex of service names to keep (bypasses the drop regex)."
+      type: string
+      required: false
+      default: ""
+    DROP_ALL_DATA_FOR_APM_AGENT_ENABLED_ENTITY:
+      description: "Drop all data for entities with NewRelic/OTEL APM agents running."
+      type: string
+      required: false
+      default: "false"
+    DROP_APM_DATA_FOR_ENTITY_NAME:
+      description: "Comma separated entity names to drop APM data for."
+      type: string
+      required: false
+      default: ""
+    KEEP_APM_DATA_FOR_ENTITY_NAME:
+      description: "Comma separated entity names to keep APM data for (bypasses drop)."
+      type: string
+      required: false
+      default: ""
+    DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME:
+      description: "Comma separated entity names to drop network metrics for."
+      type: string
+      required: false
+      default: ""
+    KEEP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME:
+      description: "Comma separated entity names to keep network metrics for (bypasses drop)."
+      type: string
+      required: false
+      default: ""
+    APPLICATION_LOG_REPORTING_ENABLED:
+      description: "Enable log collection from matching entities."
+      type: string
+      required: false
+      default: "true"
+    APPLICATION_LOG_FILE_REGEX:
+      description: "Regex of log file names to include."
+      type: string
+      required: false
+      default: ".*.log$"
+    APPLICATION_LOG_LEVEL_THRESHOLD:
+      description: "Minimum log level to report (TRACE, DEBUG, INFO, WARN, ERROR)."
+      type: string
+      required: false
+      default: "INFO"
+    MAX_LOG_SAMPLES_PER_MINUTE:
+      description: "Max log samples collected per minute per entity."
+      type: string
+      required: false
+      default: "10000"
+    KEEP_STDSTREAM_LOG_FOR_ENTITY_REGEX:
+      description: "Regex of entity names to keep stdout/stderr logs from."
+      type: string
+      required: false
+      default: ".*"
+    KEEP_FILE_LOG_FOR_ENTITY_REGEX:
+      description: "Regex of entity names to keep file logs from."
+      type: string
+      required: false
+      default: ".*"
+    PROTOCOLS_SPANS_UNLINKED_MAX:
+      description: "Max unlinked spans reported per protocol. 0 disables the limit."
+      type: string
+      required: false
+      default: "100"
+    PROTOCOLS_SPANS_UNLINKED_ERROR_QUOTA_PCT:
+      description: "Percentage of the unlinked span quota reserved for error spans."
+      type: string
+      required: false
+      default: "30"
+    PROTOCOLS_THRIFT_ENABLED:
+      description: "Enable Thrift protocol."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_THRIFT_SPANS_ENABLED:
+      description: "Enable Thrift spans."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_THRIFT_SPANS_SAMPLING_LATENCY:
+      description: "Thrift spans sampling latency threshold."
+      type: string
+      required: false
+      default: "p50"
+    PROTOCOLS_THRIFT_SPANS_SAMPLING_ERROR_RATE:
+      description: "Thrift error rate threshold for span export [1-100]."
+      type: string
+      required: false
+      default: ""
+    PROTOCOLS_DYNAMODB_ENABLED:
+      description: "Enable DynamoDB protocol."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_DYNAMODB_SPANS_ENABLED:
+      description: "Enable DynamoDB spans."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_DYNAMODB_SPANS_SAMPLING_LATENCY:
+      description: "DynamoDB spans sampling latency threshold."
+      type: string
+      required: false
+      default: "p50"
+    PROTOCOLS_MSSQL_ENABLED:
+      description: "Enable MSSQL protocol."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_MSSQL_SPANS_ENABLED:
+      description: "Enable MSSQL spans."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_MSSQL_SPANS_SAMPLING_LATENCY:
+      description: "MSSQL spans sampling latency threshold."
+      type: string
+      required: false
+      default: "p50"
+    PROTOCOLS_KAFKA_ENABLED:
+      description: "Enable Kafka protocol."
+      type: string
+      required: false
+      default: "true"
+    PROTOCOLS_AMQP_ENABLED:
+      description: "Enable AMQP protocol."
+      type: string
+      required: false
+      default: "true"
   backoff_delay:
     description: "seconds until next retry if agent fails to start"
     type: string
@@ -205,103 +420,118 @@ variables:
     type: bool
     required: false
     default: false
+  oci:
+    repository:
+      description: "Package repository name"
+      type: string
+      required: false
+      default: newrelic/ebpf-agent-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/ebpf-agent-artifacts" ]
+  version:
+    description: "Agent version"
+    type: string
+    required: true
 deployment:
-  health:
-    interval: 60s
-    initial_delay: 0s
-    timeout: 15s
-    checks:
-      - kind: Process
   enable_file_logging: ${nr-var:enable_file_logging}
+  packages:
+    ebpf-agent:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrebpfagent/jwks.json
+      post_download_hook:
+        path: /bin/bash
+        args:
+          - post_download.sh
   executables:
-    - id: nr-ebpf-agent-client
-      path: /usr/bin/nr-ebpf-agent-client
-      env:
-        NEW_RELIC_LICENSE_KEY: "${nr-env:NEW_RELIC_LICENSE_KEY}"
-        DEPLOYMENT_NAME: "${nr-var:config_agent.DEPLOYMENT_NAME}"
-        OTLP_ENDPOINT: "${nr-var:config_agent.OTLP_ENDPOINT}"
-        NEW_RELIC_LOG_LEVEL: "${nr-var:config_agent.LOG_LEVEL}"
-        NEW_RELIC_LOG_FILE_PATH: "${nr-var:config_agent.LOG_FILE_PATH}"
-        DROP_DATA_FOR_ENTITY: "${nr-var:config_agent.DROP_DATA_FOR_ENTITY}"
-        TLS_ENABLED: "${nr-var:config_agent.TLS_ENABLED}"
-        TLS_AUTOGENERATE_CERT_ENABLED: "${nr-var:config_agent.TLS_AUTOGENERATE_CERT_ENABLED}"
-        TLS_CERT_PATH: "${nr-var:config_agent.TLS_CERT_PATH}"
-        TLS_CERT_FILE: "${nr-var:config_agent.TLS_CERT_FILE}"
-        TLS_KEY_FILE: "${nr-var:config_agent.TLS_KEY_FILE}"
-        TLS_CA_FILE: "${nr-var:config_agent.TLS_CA_FILE}"
-        TABLE_STORE_DATA_LIMIT_MB: "${nr-var:config_agent.TABLE_STORE_DATA_LIMIT_MB}"
-        PROTOCOLS_HTTP_ENABLED: "${nr-var:config_agent.PROTOCOLS_HTTP_ENABLED}"
-        PROTOCOLS_HTTP_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_ENABLED}"
-        PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE}"
-        PROTOCOLS_MYSQL_ENABLED: "${nr-var:config_agent.PROTOCOLS_MYSQL_ENABLED}"
-        PROTOCOLS_MYSQL_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_MYSQL_SPANS_ENABLED}"
-        PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_PGSQL_ENABLED: "${nr-var:config_agent.PROTOCOLS_PGSQL_ENABLED}"
-        PROTOCOLS_PGSQL_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_PGSQL_SPANS_ENABLED}"
-        PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_CASS_ENABLED: "${nr-var:config_agent.PROTOCOLS_CASS_ENABLED}"
-        PROTOCOLS_CASS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_CASS_SPANS_ENABLED}"
-        PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_REDIS_ENABLED: "${nr-var:config_agent.PROTOCOLS_REDIS_ENABLED}"
-        PROTOCOLS_REDIS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_REDIS_SPANS_ENABLED}"
-        PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_MONGODB_ENABLED: "${nr-var:config_agent.PROTOCOLS_MONGODB_ENABLED}"
-        PROTOCOLS_MONGODB_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_MONGODB_SPANS_ENABLED}"
-        PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_KAFKA_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_KAFKA_SPANS_ENABLED}"
-        PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_AMQP_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_AMQP_SPANS_ENABLED}"
-        PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_DNS_ENABLED: "${nr-var:config_agent.PROTOCOLS_DNS_ENABLED}"
-        PROTOCOLS_DNS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_DNS_SPANS_ENABLED}"
-        PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY}"
-      restart_policy:
-        backoff_strategy:
-          type: fixed
-          backoff_delay: ${nr-var:backoff_delay}
     - id: nr-ebpf-agent
-      path: /usr/bin/nr-ebpf-agent
+      path: ${nr-sub:packages.ebpf-agent.dir}/nr-ebpf-agent
       env:
         NEW_RELIC_LICENSE_KEY: "${nr-env:NEW_RELIC_LICENSE_KEY}"
-        DEPLOYMENT_NAME: "${nr-var:config_agent.DEPLOYMENT_NAME}"
-        OTLP_ENDPOINT: "${nr-var:config_agent.OTLP_ENDPOINT}"
-        NEW_RELIC_LOG_LEVEL: "${nr-var:config_agent.LOG_LEVEL}"
-        NEW_RELIC_LOG_FILE_PATH: "${nr-var:config_agent.LOG_FILE_PATH}"
-        DROP_DATA_FOR_ENTITY: "${nr-var:config_agent.DROP_DATA_FOR_ENTITY}"
-        TLS_ENABLED: "${nr-var:config_agent.TLS_ENABLED}"
-        TLS_AUTOGENERATE_CERT_ENABLED: "${nr-var:config_agent.TLS_AUTOGENERATE_CERT_ENABLED}"
-        TLS_CERT_PATH: "${nr-var:config_agent.TLS_CERT_PATH}"
-        TLS_CERT_FILE: "${nr-var:config_agent.TLS_CERT_FILE}"
-        TLS_KEY_FILE: "${nr-var:config_agent.TLS_KEY_FILE}"
-        TLS_CA_FILE: "${nr-var:config_agent.TLS_CA_FILE}"
-        TABLE_STORE_DATA_LIMIT_MB: "${nr-var:config_agent.TABLE_STORE_DATA_LIMIT_MB}"
-        PROTOCOLS_HTTP_ENABLED: "${nr-var:config_agent.PROTOCOLS_HTTP_ENABLED}"
-        PROTOCOLS_HTTP_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_ENABLED}"
-        PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE: "${nr-var:config_agent.PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE}"
-        PROTOCOLS_MYSQL_ENABLED: "${nr-var:config_agent.PROTOCOLS_MYSQL_ENABLED}"
-        PROTOCOLS_MYSQL_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_MYSQL_SPANS_ENABLED}"
-        PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_PGSQL_ENABLED: "${nr-var:config_agent.PROTOCOLS_PGSQL_ENABLED}"
-        PROTOCOLS_PGSQL_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_PGSQL_SPANS_ENABLED}"
-        PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_CASS_ENABLED: "${nr-var:config_agent.PROTOCOLS_CASS_ENABLED}"
-        PROTOCOLS_CASS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_CASS_SPANS_ENABLED}"
-        PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_REDIS_ENABLED: "${nr-var:config_agent.PROTOCOLS_REDIS_ENABLED}"
-        PROTOCOLS_REDIS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_REDIS_SPANS_ENABLED}"
-        PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_MONGODB_ENABLED: "${nr-var:config_agent.PROTOCOLS_MONGODB_ENABLED}"
-        PROTOCOLS_MONGODB_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_MONGODB_SPANS_ENABLED}"
-        PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_KAFKA_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_KAFKA_SPANS_ENABLED}"
-        PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_AMQP_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_AMQP_SPANS_ENABLED}"
-        PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY}"
-        PROTOCOLS_DNS_ENABLED: "${nr-var:config_agent.PROTOCOLS_DNS_ENABLED}"
-        PROTOCOLS_DNS_SPANS_ENABLED: "${nr-var:config_agent.PROTOCOLS_DNS_SPANS_ENABLED}"
-        PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY: "${nr-var:config_agent.PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY}"
+        DEPLOYMENT_NAME: "${nr-var:config.DEPLOYMENT_NAME}"
+        OTLP_ENDPOINT: "${nr-var:config.OTLP_ENDPOINT}"
+        NEW_RELIC_LOG_LEVEL: "${nr-var:config.LOG_LEVEL}"
+        NEW_RELIC_LOG_FILE_PATH: "${nr-var:config.LOG_FILE_PATH}"
+        DROP_DATA_FOR_ENTITY: "${nr-var:config.DROP_DATA_FOR_ENTITY}"
+        TLS_ENABLED: "${nr-var:config.TLS_ENABLED}"
+        TLS_AUTOGENERATE_CERT_ENABLED: "${nr-var:config.TLS_AUTOGENERATE_CERT_ENABLED}"
+        TLS_CERT_PATH: "${nr-var:config.TLS_CERT_PATH}"
+        TLS_CERT_FILE: "${nr-var:config.TLS_CERT_FILE}"
+        TLS_KEY_FILE: "${nr-var:config.TLS_KEY_FILE}"
+        TLS_CA_FILE: "${nr-var:config.TLS_CA_FILE}"
+        TABLE_STORE_DATA_LIMIT_MB: "${nr-var:config.TABLE_STORE_DATA_LIMIT_MB}"
+        PROTOCOLS_HTTP_ENABLED: "${nr-var:config.PROTOCOLS_HTTP_ENABLED}"
+        PROTOCOLS_HTTP_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_HTTP_SPANS_ENABLED}"
+        PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE: "${nr-var:config.PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE}"
+        PROTOCOLS_MYSQL_ENABLED: "${nr-var:config.PROTOCOLS_MYSQL_ENABLED}"
+        PROTOCOLS_MYSQL_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_MYSQL_SPANS_ENABLED}"
+        PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_PGSQL_ENABLED: "${nr-var:config.PROTOCOLS_PGSQL_ENABLED}"
+        PROTOCOLS_PGSQL_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_PGSQL_SPANS_ENABLED}"
+        PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_CASS_ENABLED: "${nr-var:config.PROTOCOLS_CASS_ENABLED}"
+        PROTOCOLS_CASS_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_CASS_SPANS_ENABLED}"
+        PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_REDIS_ENABLED: "${nr-var:config.PROTOCOLS_REDIS_ENABLED}"
+        PROTOCOLS_REDIS_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_REDIS_SPANS_ENABLED}"
+        PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_MONGODB_ENABLED: "${nr-var:config.PROTOCOLS_MONGODB_ENABLED}"
+        PROTOCOLS_MONGODB_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_MONGODB_SPANS_ENABLED}"
+        PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_KAFKA_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_KAFKA_SPANS_ENABLED}"
+        PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_AMQP_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_AMQP_SPANS_ENABLED}"
+        PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_DNS_ENABLED: "${nr-var:config.PROTOCOLS_DNS_ENABLED}"
+        PROTOCOLS_DNS_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_DNS_SPANS_ENABLED}"
+        PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY}"
+        NEW_RELIC_PROXY_URL: "${nr-var:config.PROXY_URL}"
+        NEW_RELIC_LABELS: "${nr-var:config.LABELS}"
+        REPORT_APM_DATA: "${nr-var:config.REPORT_APM_DATA}"
+        REPORT_NETWORK_METRICS: "${nr-var:config.REPORT_NETWORK_METRICS}"
+        JVM_METRICS_REPORTING: "${nr-var:config.JVM_METRICS_REPORTING}"
+        REPORT_AI_METRICS: "${nr-var:config.REPORT_AI_METRICS}"
+        NEW_RELIC_PROXY_HOST: "${nr-var:config.PROXY_HOST}"
+        NEW_RELIC_PROXY_PORT: "${nr-var:config.PROXY_PORT}"
+        NEW_RELIC_PROXY_SCHEME: "${nr-var:config.PROXY_SCHEME}"
+        NEW_RELIC_PROXY_USER: "${nr-var:config.PROXY_USER}"
+        NEW_RELIC_PROXY_PASS: "${nr-var:config.PROXY_PASS}"
+        DOWNLOADED_PACKAGED_HEADERS_PATH: "${nr-var:config.DOWNLOADED_PACKAGED_HEADERS_PATH}"
+        DISTRO_KERNEL_HEADERS_PATH: "${nr-var:config.DISTRO_KERNEL_HEADERS_PATH}"
+        REPORT_LOGS: "${nr-var:config.REPORT_LOGS}"
+        GENAI_CAPTURE_MESSAGE_CONTENT: "${nr-var:config.GENAI_CAPTURE_MESSAGE_CONTENT}"
+        INCLUDE_PORT_IN_SERVER_ENTITY_IDENTIFICATION: "${nr-var:config.INCLUDE_PORT_IN_SERVER_ENTITY_IDENTIFICATION}"
+        DROP_ALL_DATA_FOR_ENTITY_NAME_REGEX: "${nr-var:config.DROP_ALL_DATA_FOR_ENTITY_NAME_REGEX}"
+        KEEP_ALL_DATA_FOR_ENTITY_NAME_REGEX: "${nr-var:config.KEEP_ALL_DATA_FOR_ENTITY_NAME_REGEX}"
+        DROP_ALL_DATA_FOR_APM_AGENT_ENABLED_ENTITY: "${nr-var:config.DROP_ALL_DATA_FOR_APM_AGENT_ENABLED_ENTITY}"
+        DROP_APM_DATA_FOR_ENTITY_NAME: "${nr-var:config.DROP_APM_DATA_FOR_ENTITY_NAME}"
+        KEEP_APM_DATA_FOR_ENTITY_NAME: "${nr-var:config.KEEP_APM_DATA_FOR_ENTITY_NAME}"
+        DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME: "${nr-var:config.DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME}"
+        KEEP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME: "${nr-var:config.KEEP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME}"
+        APPLICATION_LOG_REPORTING_ENABLED: "${nr-var:config.APPLICATION_LOG_REPORTING_ENABLED}"
+        APPLICATION_LOG_FILE_REGEX: "${nr-var:config.APPLICATION_LOG_FILE_REGEX}"
+        APPLICATION_LOG_LEVEL_THRESHOLD: "${nr-var:config.APPLICATION_LOG_LEVEL_THRESHOLD}"
+        MAX_LOG_SAMPLES_PER_MINUTE: "${nr-var:config.MAX_LOG_SAMPLES_PER_MINUTE}"
+        KEEP_STDSTREAM_LOG_FOR_ENTITY_REGEX: "${nr-var:config.KEEP_STDSTREAM_LOG_FOR_ENTITY_REGEX}"
+        KEEP_FILE_LOG_FOR_ENTITY_REGEX: "${nr-var:config.KEEP_FILE_LOG_FOR_ENTITY_REGEX}"
+        PROTOCOLS_SPANS_UNLINKED_MAX: "${nr-var:config.PROTOCOLS_SPANS_UNLINKED_MAX}"
+        PROTOCOLS_SPANS_UNLINKED_ERROR_QUOTA_PCT: "${nr-var:config.PROTOCOLS_SPANS_UNLINKED_ERROR_QUOTA_PCT}"
+        PROTOCOLS_THRIFT_ENABLED: "${nr-var:config.PROTOCOLS_THRIFT_ENABLED}"
+        PROTOCOLS_THRIFT_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_THRIFT_SPANS_ENABLED}"
+        PROTOCOLS_THRIFT_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_THRIFT_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_THRIFT_SPANS_SAMPLING_ERROR_RATE: "${nr-var:config.PROTOCOLS_THRIFT_SPANS_SAMPLING_ERROR_RATE}"
+        PROTOCOLS_DYNAMODB_ENABLED: "${nr-var:config.PROTOCOLS_DYNAMODB_ENABLED}"
+        PROTOCOLS_DYNAMODB_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_DYNAMODB_SPANS_ENABLED}"
+        PROTOCOLS_DYNAMODB_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_DYNAMODB_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_MSSQL_ENABLED: "${nr-var:config.PROTOCOLS_MSSQL_ENABLED}"
+        PROTOCOLS_MSSQL_SPANS_ENABLED: "${nr-var:config.PROTOCOLS_MSSQL_SPANS_ENABLED}"
+        PROTOCOLS_MSSQL_SPANS_SAMPLING_LATENCY: "${nr-var:config.PROTOCOLS_MSSQL_SPANS_SAMPLING_LATENCY}"
+        PROTOCOLS_KAFKA_ENABLED: "${nr-var:config.PROTOCOLS_KAFKA_ENABLED}"
+        PROTOCOLS_AMQP_ENABLED: "${nr-var:config.PROTOCOLS_AMQP_ENABLED}"
       restart_policy:
         backoff_strategy:
           type: fixed

--- a/test/e2e-runner/src/common.rs
+++ b/test/e2e-runner/src/common.rs
@@ -91,6 +91,10 @@ pub struct InstallationArgs {
     #[arg(long)]
     pub nrdot_version: Option<String>,
 
+    /// Version of the eBPF agent OCI image to use in tests
+    #[arg(long)]
+    pub ebpf_agent_version: Option<String>,
+
     /// Version of the Redis OCI image to use in tests
     #[arg(long)]
     pub redis_version: Option<String>,

--- a/test/e2e-runner/src/linux/scenarios/ebpf_agent.rs
+++ b/test/e2e-runner/src/linux/scenarios/ebpf_agent.rs
@@ -21,6 +21,11 @@ pub fn test_ebpf_agent(args: InstallationArgs) {
         .clone()
         .expect("--infra-agent-version is required for this scenario");
 
+    let ebpf_version = args
+        .ebpf_agent_version
+        .clone()
+        .expect("--ebpf-agent-version is required for this scenario");
+
     let staging = args.nr_region == Region::Staging;
 
     let recipe_data = RecipeData {
@@ -56,16 +61,18 @@ agents:
     let ebpf_config = if staging {
         format!(
             r#"
-config_agent:
+config:
   DEPLOYMENT_NAME: {test_id}
   OTLP_ENDPOINT: staging-otlp.nr-data.net:443
+version: {ebpf_version}
     "#
         )
     } else {
         format!(
             r#"
-config_agent:
+config:
   DEPLOYMENT_NAME: {test_id}
+version: {ebpf_version}
     "#
         )
     };

--- a/test/e2e-runner/src/linux/scenarios/ebpf_agent.rs
+++ b/test/e2e-runner/src/linux/scenarios/ebpf_agent.rs
@@ -15,12 +15,14 @@ use config::DEBUG_LOGGING_CONFIG;
 use std::time::Duration;
 use tracing::info;
 
-pub fn test_ebpf_agent(args: InstallationArgs) {
-    let infra_version = args
-        .infra_agent_version
-        .clone()
-        .expect("--infra-agent-version is required for this scenario");
+// Dev OCI packages pre-populated on ghcr.io.
+// When production ebpf-agent OCI ships, delete this scenario's dev-registry wiring and point at the real registry/repo.
+const DEV_OCI_REGISTRY: &str = "ghcr.io";
+const DEV_INFRA_AGENT_REPO: &str = "newrelic/newrelic-agent-control-infrastructure-dev";
+const DEV_INFRA_AGENT_VERSION: &str = "v1.78.0";
+const DEV_EBPF_AGENT_REPO: &str = "newrelic/newrelic-agent-control-ebpf-dev";
 
+pub fn test_ebpf_agent(args: InstallationArgs) {
     let ebpf_version = args
         .ebpf_agent_version
         .clone()
@@ -31,7 +33,7 @@ pub fn test_ebpf_agent(args: InstallationArgs) {
     let recipe_data = RecipeData {
         args,
         monitoring_source: "infra-agent".to_string(),
-        recipe_list: "agent-control,ebpf-agent-installer".to_string(),
+        recipe_list: "agent-control".to_string(),
         ..Default::default()
     };
 
@@ -45,6 +47,8 @@ pub fn test_ebpf_agent(args: InstallationArgs) {
     );
 
     info!("Setup Agent Control config with eBPF");
+    // Point AC at the dev packages on ghcr.io. Signature verification is disabled because the
+    // dev packages are not signed with New Relic's production key.
     let config = format!(
         r#"
 host_id: {test_id}
@@ -53,6 +57,15 @@ agents:
     agent_type: "newrelic/com.newrelic.infrastructure:0.1.0"
   nr-ebpf:
     agent_type: "newrelic/com.newrelic.ebpf:0.1.0"
+oci:
+  registry: {DEV_OCI_REGISTRY}
+agent_type_var_constraints:
+  variants:
+    oci_repository_urls:
+      - {DEV_INFRA_AGENT_REPO}
+      - {DEV_EBPF_AGENT_REPO}
+agent_packages:
+  signature_verification_enabled: false
 {DEBUG_LOGGING_CONFIG}
 "#
     );
@@ -64,7 +77,9 @@ agents:
 config:
   DEPLOYMENT_NAME: {test_id}
   OTLP_ENDPOINT: staging-otlp.nr-data.net:443
-version: {ebpf_version}
+oci:
+  repository: {DEV_EBPF_AGENT_REPO}
+version: "{ebpf_version}"
     "#
         )
     } else {
@@ -72,7 +87,9 @@ version: {ebpf_version}
             r#"
 config:
   DEPLOYMENT_NAME: {test_id}
-version: {ebpf_version}
+oci:
+  repository: {DEV_EBPF_AGENT_REPO}
+version: "{ebpf_version}"
     "#
         )
     };
@@ -85,9 +102,10 @@ version: {ebpf_version}
 config_agent:
   license_key: '{{{{NEW_RELIC_LICENSE_KEY}}}}'
   staging: {staging}
-version: {}
-"#,
-            infra_version
+version: {DEV_INFRA_AGENT_VERSION}
+oci:
+  repository: {DEV_INFRA_AGENT_REPO}
+"#
         ),
     );
 


### PR DESCRIPTION
## Summary
- Adds a `post_download_hook` to the on-host Linux eBPF agent type so Agent Control downloads and manages its own copy of `nr-ebpf-agent` via OCI (same model as infra-agent / otel-collector).
- Restores the `--ebpf-agent-version` e2e plumbing (`ebpf_agent_version` in `common.rs`, `version:` in the generated local config, and the CLI flag in both on-host e2e workflows) — now required since `version` became a mandatory variable on the agent type.
- Temporarily disables the `ebpf-agent` matrix entry in `component_onhost_e2e.yml` and `on_demand_staging_e2e.yml`, until the ebpd oci package is online
