### PR TITLE
feat: ensure filesystem validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Remember that the keywords that you can use are the following:
 ### enhancement
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.
+- On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 
 ## v1.18.0 - 2026-07-06
 
@@ -30,7 +31,6 @@ Remember that the keywords that you can use are the following:
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
-- On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Remember that the keywords that you can use are the following:
 - On-host agents: removed command-based version checking. Agent version is now determined from OCI package metadata, eliminating the need for `deployment.version` configuration in agent type definitions.
 - Replace filesystem in on-host agent-type definitions with an explicit, recursive, tagged-kind tree: every entry declares `kind: file | dir | dir_content_from_map`, and `dir` entries nest via `entries:`.
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
+- On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -540,7 +540,7 @@ nri-redis:
                 copy_from_file: Some(TemplateableValue::from_template(
                     source.to_string_lossy().to_string(),
                 )),
-                persistent: TemplateableValue::default(),
+                persistent: false,
             },
         )]));
 
@@ -583,7 +583,7 @@ nri-redis:
                     copy_from_file: Some(TemplateableValue::from_template(
                         source.to_string_lossy().to_string(),
                     )),
-                    persistent: TemplateableValue::default(),
+                    persistent: false,
                 },
             )]));
 
@@ -617,7 +617,7 @@ nri-redis:
             FilesystemEntry::File {
                 text,
                 copy_from_file,
-                persistent: TemplateableValue::default(),
+                persistent: false,
             },
         )]));
 
@@ -645,7 +645,7 @@ nri-redis:
                 copy_from_file: Some(TemplateableValue::from_template(
                     source.to_string_lossy().to_string(),
                 )),
-                persistent: TemplateableValue::default(),
+                persistent: false,
             },
         )]));
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -79,7 +79,7 @@ pub enum FilesystemEntry {
         copy_from_file: Option<TemplateableValue<String>>,
         /// The persistency attribute marking it's lifecicle.
         #[serde(default)]
-        persistent: TemplateableValue<bool>,
+        persistent: bool,
     },
     /// An explicitly declared directory. Children, if any, live under `entries:`.
     Dir {
@@ -88,7 +88,7 @@ pub enum FilesystemEntry {
         entries: HashMap<SafePath, FilesystemEntry>,
         /// The persistency attribute marking it's lifecicle.
         #[serde(default)]
-        persistent: TemplateableValue<bool>,
+        persistent: bool,
     },
     /// A directory whose set of files is computed at deploy time from a `map[string]yaml`
     /// variable. Map keys become filenames; values become file contents.
@@ -196,7 +196,7 @@ impl Templateable for FilesystemEntry {
                 };
                 Ok(rendered::RenderedEntry::File {
                     content,
-                    persistent: persistent.template_with(variables)?,
+                    persistent,
                 })
             }
             FilesystemEntry::Dir {
@@ -209,7 +209,7 @@ impl Templateable for FilesystemEntry {
                     .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
                 Ok(rendered::RenderedEntry::Dir {
                     children,
-                    persistent: persistent.template_with(variables)?,
+                    persistent,
                 })
             }
             FilesystemEntry::DirContentFromMap { source } => {
@@ -385,7 +385,7 @@ fn check_entry_persistence(
 ) {
     match entry {
         FilesystemEntry::File { persistent, .. } => {
-            if ancestor_ephemeral && is_declared_persistent(persistent) {
+            if ancestor_ephemeral && *persistent {
                 errors.push(persistence_error(path));
             }
         }
@@ -393,12 +393,12 @@ fn check_entry_persistence(
             entries,
             persistent,
         } => {
-            if ancestor_ephemeral && is_declared_persistent(persistent) {
+            if ancestor_ephemeral && *persistent {
                 errors.push(persistence_error(path));
             }
             // A child sits under a non-persistent ancestor if one already existed up the chain, or
-            // if this directory is itself (literally) declared non-persistent.
-            let child_ancestor_ephemeral = ancestor_ephemeral || is_declared_ephemeral(persistent);
+            // if this directory is itself declared non-persistent.
+            let child_ancestor_ephemeral = ancestor_ephemeral || !persistent;
             for (child_key, child) in entries {
                 check_entry_persistence(
                     &path.join(child_key),
@@ -412,17 +412,6 @@ fn check_entry_persistence(
         // can neither be a persistent entry nor a parent of one.
         FilesystemEntry::DirContentFromMap { .. } => {}
     }
-}
-
-/// Whether the flag is literally `persistent: true`.
-fn is_declared_persistent(persistent: &TemplateableValue<bool>) -> bool {
-    persistent.template == "true"
-}
-
-/// Whether the flag is literally non-persistent: omitted (empty default) or `persistent: false`.
-/// A templated value is neither definitely persistent nor definitely ephemeral.
-fn is_declared_ephemeral(persistent: &TemplateableValue<bool>) -> bool {
-    persistent.template.is_empty() || persistent.template == "false"
 }
 
 fn persistence_error(path: &Path) -> String {
@@ -474,7 +463,7 @@ mod tests {
             FilesystemEntry::File {
                 text: Some(TemplateableValue::from_template("hello".to_string())),
                 copy_from_file: None,
-                persistent: TemplateableValue::default(),
+                persistent: false,
             },
         )]));
 
@@ -681,7 +670,7 @@ nri-redis:
             PathBuf::from("any").try_into().unwrap(),
             FilesystemEntry::Dir {
                 entries: HashMap::new(),
-                persistent: TemplateableValue::default(),
+                persistent: false,
             },
         )]));
 
@@ -939,8 +928,8 @@ foo:
         );
     }
 
-    /// Persistent flag defaults to false; explicit `persistent: true` and templated values both
-    /// parse correctly. Independent per variant.
+    /// Persistent flag defaults to false; explicit `persistent: true` parses to `true`, and the
+    /// flag on `dir_content_from_map` is ignored. Independent per variant.
     #[test]
     fn persistent_field_parses_per_variant() {
         let yaml = r#"
@@ -964,16 +953,16 @@ map-with-ignored-persistent:
 
         match parsed.0.get(&key("default-file")).unwrap() {
             FilesystemEntry::File { persistent, .. } => {
-                assert_eq!(persistent.template, "");
+                assert!(!persistent);
             }
             other => panic!("unexpected variant: {other:?}"),
         }
         match parsed.0.get(&key("persistent-file")).unwrap() {
-            FilesystemEntry::File { persistent, .. } => assert_eq!(persistent.template, "true"),
+            FilesystemEntry::File { persistent, .. } => assert!(persistent),
             other => panic!("unexpected variant: {other:?}"),
         }
         match parsed.0.get(&key("persistent-dir")).unwrap() {
-            FilesystemEntry::Dir { persistent, .. } => assert_eq!(persistent.template, "true"),
+            FilesystemEntry::Dir { persistent, .. } => assert!(persistent),
             other => panic!("unexpected variant: {other:?}"),
         }
         match parsed.0.get(&key("map-with-ignored-persistent")).unwrap() {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -35,8 +35,22 @@ pub mod rendered;
 ///
 /// Every entry is tagged with a `kind:`. `dir` entries may contain further entries under
 /// `entries:`, recursively.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
+
+impl<'de> Deserialize<'de> for FileSystem {
+    /// Deserializes the entry tree and then validates that persistence is declared consistently
+    /// down every branch: an entry marked `persistent: true` must not sit under a non-persistent
+    /// parent directory.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let entries = HashMap::<SafePath, FilesystemEntry>::deserialize(deserializer)?;
+        validate_persistence_hierarchy(&entries).map_err(D::Error::custom)?;
+        Ok(FileSystem(entries))
+    }
+}
 
 /// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
 /// The `file` and `dir` variants carry a `persistent` flag (default `false`):
@@ -340,6 +354,85 @@ fn check_basedir_escape_safety(path: &Path) -> Result<(), String> {
             comp.as_os_str().to_string_lossy()
         )),
     })
+}
+
+/// Validates that persistence is declared consistently down every branch of the tree.
+///
+/// A non-persistent directory is deleted recursively when the sub-agent stops, taking every
+/// descendant with it. A `persistent: true` entry under a non-persistent parent would silently
+/// never survive a restart, so we require the user to declare the whole chain `persistent: true`.
+fn validate_persistence_hierarchy(
+    entries: &HashMap<SafePath, FilesystemEntry>,
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+    for (key, entry) in entries {
+        check_entry_persistence(key.as_ref(), entry, false, &mut errors);
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join(", "))
+    }
+}
+
+/// Recursively checks a single entry (at `path`) and its subtree. `ancestor_ephemeral` is `true`
+/// when some parent directory up the chain is declared non-persistent.
+fn check_entry_persistence(
+    path: &Path,
+    entry: &FilesystemEntry,
+    ancestor_ephemeral: bool,
+    errors: &mut Vec<String>,
+) {
+    match entry {
+        FilesystemEntry::File { persistent, .. } => {
+            if ancestor_ephemeral && is_declared_persistent(persistent) {
+                errors.push(persistence_error(path));
+            }
+        }
+        FilesystemEntry::Dir {
+            entries,
+            persistent,
+        } => {
+            if ancestor_ephemeral && is_declared_persistent(persistent) {
+                errors.push(persistence_error(path));
+            }
+            // A child sits under a non-persistent ancestor if one already existed up the chain, or
+            // if this directory is itself (literally) declared non-persistent.
+            let child_ancestor_ephemeral = ancestor_ephemeral || is_declared_ephemeral(persistent);
+            for (child_key, child) in entries {
+                check_entry_persistence(
+                    &path.join(child_key),
+                    child,
+                    child_ancestor_ephemeral,
+                    errors,
+                );
+            }
+        }
+        // `dir_content_from_map` is always ephemeral and cannot declare persistent children, so it
+        // can neither be a persistent entry nor a parent of one.
+        FilesystemEntry::DirContentFromMap { .. } => {}
+    }
+}
+
+/// Whether the flag is literally `persistent: true`.
+fn is_declared_persistent(persistent: &TemplateableValue<bool>) -> bool {
+    persistent.template == "true"
+}
+
+/// Whether the flag is literally non-persistent: omitted (empty default) or `persistent: false`.
+/// A templated value is neither definitely persistent nor definitely ephemeral.
+fn is_declared_ephemeral(persistent: &TemplateableValue<bool>) -> bool {
+    persistent.template.is_empty() || persistent.template == "false"
+}
+
+fn persistence_error(path: &Path) -> String {
+    format!(
+        "path `{}` is declared `persistent: true` but a parent directory is not persistent; a \
+         non-persistent parent is deleted when the sub-agent stops and takes its children with it, \
+         so the child's persistence has no effect. Declare every parent directory as \
+         `persistent: true`",
+        path.display()
+    )
 }
 
 #[cfg(test)]
@@ -887,6 +980,159 @@ map-with-ignored-persistent:
             FilesystemEntry::DirContentFromMap { .. } => {}
             other => panic!("unexpected variant: {other:?}"),
         }
+    }
+
+    /// A `persistent: true` entry must have every ancestor directory declared persistent too,
+    /// otherwise a non-persistent parent would wipe it on sub-agent stop. Parsing rejects the
+    /// inconsistent trees.
+    #[rstest]
+    // Top-level persistent entries have no declared parent: always fine.
+    #[case::top_level_persistent_file(
+        r#"
+a.txt:
+  kind: file
+  text: hi
+  persistent: true
+"#,
+        true
+    )]
+    #[case::top_level_persistent_dir(
+        r#"
+d:
+  kind: dir
+  persistent: true
+"#,
+        true
+    )]
+    // Persistent child under a persistent parent: fine.
+    #[case::persistent_child_under_persistent_parent(
+        r#"
+d:
+  kind: dir
+  persistent: true
+  entries:
+    a.txt:
+      kind: file
+      text: hi
+      persistent: true
+"#,
+        true
+    )]
+    // Ephemeral child under a persistent parent: fine (only the reverse is a problem).
+    #[case::ephemeral_child_under_persistent_parent(
+        r#"
+d:
+  kind: dir
+  persistent: true
+  entries:
+    a.txt:
+      kind: file
+      text: hi
+"#,
+        true
+    )]
+    // The whole chain persistent: fine.
+    #[case::deep_chain_all_persistent(
+        r#"
+a:
+  kind: dir
+  persistent: true
+  entries:
+    b:
+      kind: dir
+      persistent: true
+      entries:
+        c.txt:
+          kind: file
+          text: hi
+          persistent: true
+"#,
+        true
+    )]
+    // Persistent file under a parent that omits `persistent` (defaults to ephemeral): rejected.
+    #[case::persistent_file_under_default_parent(
+        r#"
+d:
+  kind: dir
+  entries:
+    a.txt:
+      kind: file
+      text: hi
+      persistent: true
+"#,
+        false
+    )]
+    // Persistent file under an explicitly non-persistent parent: rejected.
+    #[case::persistent_file_under_ephemeral_parent(
+        r#"
+d:
+  kind: dir
+  persistent: false
+  entries:
+    a.txt:
+      kind: file
+      text: hi
+      persistent: true
+"#,
+        false
+    )]
+    // Persistent nested dir under a non-persistent parent: rejected.
+    #[case::persistent_dir_under_ephemeral_parent(
+        r#"
+d:
+  kind: dir
+  entries:
+    inner:
+      kind: dir
+      persistent: true
+"#,
+        false
+    )]
+    // A non-persistent directory anywhere in the chain invalidates deeper persistent entries.
+    #[case::persistent_leaf_under_ephemeral_ancestor(
+        r#"
+a:
+  kind: dir
+  persistent: true
+  entries:
+    b:
+      kind: dir
+      entries:
+        c.txt:
+          kind: file
+          text: hi
+          persistent: true
+"#,
+        false
+    )]
+    fn validates_persistence_hierarchy(#[case] yaml: &str, #[case] should_parse: bool) {
+        let parsed = serde_saphyr::from_str::<FileSystem>(yaml);
+        assert_eq!(
+            parsed.is_ok(),
+            should_parse,
+            "input: {yaml}, parsed: {parsed:?}"
+        );
+    }
+
+    /// The rejection error names the offending path and explains the parent-wins behaviour.
+    #[test]
+    fn persistence_error_reports_path() {
+        let yaml = r#"
+d:
+  kind: dir
+  entries:
+    a.txt:
+      kind: file
+      text: hi
+      persistent: true
+"#;
+        let err = serde_saphyr::from_str::<FileSystem>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("a.txt"), "error should name the path: {msg}");
+        assert!(
+            msg.contains("persistent"),
+            "error should mention persistence: {msg}"
+        );
     }
 
     /// Reconciliation diffs the manifest against the current declared set.

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -77,7 +77,7 @@ pub enum FilesystemEntry {
         /// exclusive with `text`.
         #[serde(default)]
         copy_from_file: Option<TemplateableValue<String>>,
-        /// The persistency attribute marking it's lifecicle.
+        /// The persistency attribute marking its lifecycle.
         #[serde(default)]
         persistent: bool,
     },
@@ -86,7 +86,7 @@ pub enum FilesystemEntry {
         /// The directory's child entries.
         #[serde(default)]
         entries: HashMap<SafePath, FilesystemEntry>,
-        /// The persistency attribute marking it's lifecicle.
+        /// The persistency attribute marking its lifecycle.
         #[serde(default)]
         persistent: bool,
     },

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -44,14 +44,14 @@ pub enum RenderedEntry {
     File {
         /// Where the file's bytes come from.
         content: FileContent,
-        /// The persistency attribute marking it's lifecicle.
+        /// The persistency attribute marking its lifecycle.
         persistent: bool,
     },
     /// A directory containing child entries keyed by their relative path.
     Dir {
         /// The dictionary containing each children path and the entry.
         children: HashMap<PathBuf, RenderedEntry>,
-        /// The persistency attribute marking it's lifecicle.
+        /// The persistency attribute marking its lifecycle.
         persistent: bool,
     },
     /// A directory whose files were projected from a map (filename to content).

--- a/agent-control/src/agent_type/runtime_config/on_host/managed_paths.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/managed_paths.rs
@@ -5,6 +5,11 @@
 //! declared". The manifest is read from an agent-writable location, so its entries are vetted
 //! against a base directory before any deletion.
 
+use fs::directory_manager::{DirectoryManager, DirectoryManagerFs};
+use fs::file::LocalFile;
+use fs::file::deleter::FileDeleter;
+use fs::file::reader::FileReader;
+use fs::file::writer::FileWriter;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io;
@@ -20,8 +25,8 @@ struct ManagedPathsManifest {
 impl ManagedPathsManifest {
     /// Loads the manifest at `path`. A missing or malformed file yields an empty manifest (logged).
     fn load(path: &Path) -> Self {
-        let raw = match std::fs::read(path) {
-            Ok(b) => b,
+        let raw = match LocalFile.read(path) {
+            Ok(s) => s,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Self::default(),
             Err(err) => {
                 warn!(
@@ -32,7 +37,7 @@ impl ManagedPathsManifest {
                 return Self::default();
             }
         };
-        serde_json::from_slice(&raw).unwrap_or_else(|err| {
+        serde_json::from_str(&raw).unwrap_or_else(|err| {
             warn!(?err, ?path, "managed-paths manifest is malformed, ignoring");
             Self::default()
         })
@@ -41,11 +46,11 @@ impl ManagedPathsManifest {
     /// Serializes the manifest to `path`, creating its parent directory if needed.
     fn save(&self, path: &Path) -> io::Result<()> {
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            DirectoryManagerFs.create(parent)?;
         }
-        let body = serde_json::to_vec(self)
+        let body = serde_json::to_string(self)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-        std::fs::write(path, body)
+        LocalFile.write(path, body)
     }
 }
 
@@ -129,9 +134,9 @@ pub fn is_within_base(path: &Path, base_dir: &Path) -> bool {
 pub fn delete_path(path: &Path) -> io::Result<()> {
     trace!("Deleting path {}", path.display());
     if path.is_dir() {
-        std::fs::remove_dir_all(path)
+        DirectoryManagerFs.delete(path)
     } else {
-        std::fs::remove_file(path)
+        LocalFile.delete(path)
     }
 }
 


### PR DESCRIPTION
 Adds parse-time validation of on-host agent-type filesystems that rejects any entry marked persistent: true whose parent directory chain isn't also persistent. This prevents a silent footgun: a non-persistent parent is deleted recursively on sub-agent stop, wiping persistent children regardless of their own flag, so the child's persistence never takes effect. Templated persistent values (resolved after parsing) are skipped to avoid false  positives, and the error names the offending path and explains the parent-wins behaviour.      
<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
