### PR TITLE
feat: add copy_from_file support for per-agent filesystem [NR-579370]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Remember that the keywords that you can use are the following:
  - bugfix      => Patch
 
 ## Unreleased
+
+### enhacement
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 
 ## v1.18.0 - 2026-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ Remember that the keywords that you can use are the following:
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
+<<<<<<< HEAD
 - Removing an agent from the fleet now also deletes its installed packages from disk.
+=======
+- Add support for `copy_file_from` for on-host "in-agent filesystem"
+>>>>>>> 9f6892161 (chore: update changelog)
 
 ### 🐞 Bug fixes
 - On-host self-update: an empty `version: ""` pushed from Fleet Control now behaves the same as an absent `version` field (no-op, no update attempted). Previously it silently triggered a pull of the `:latest` OCI tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Remember that the keywords that you can use are the following:
  - bugfix      => Patch
 
 ## Unreleased
+- Add support for `copy_from_file` for on-host "in-agent" filesystem.
 
 ## v1.18.0 - 2026-07-06
 
@@ -28,7 +29,6 @@ Remember that the keywords that you can use are the following:
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
-- Add support for `copy_from_file` for on-host "in-agent" filesystem.
 
 ### 🐞 Bug fixes
 - On-host self-update: an empty `version: ""` pushed from Fleet Control now behaves the same as an absent `version` field (no-op, no update attempted). Previously it silently triggered a pull of the `:latest` OCI tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,7 @@ Remember that the keywords that you can use are the following:
 - On-host filesystem entries now accept a `persistent` flag (default `false`): ephemeral entries are deleted on sub-agent stop, persistent entries survive until the agent is removed from the fleet. Reconciliation across writes is driven by a `.ac-managed-paths.json` manifest (reserved filename — agent types must not declare it) so paths Agent Control no longer owns are deleted while sub-agent-created files are preserved.
 - Include new 'shared-filesystem-dir` variable for Agent Types.
 - Extend internal `fs` crate with a copy operation.
-<<<<<<< HEAD
-- Removing an agent from the fleet now also deletes its installed packages from disk.
-=======
-- Add support for `copy_file_from` for on-host "in-agent filesystem"
->>>>>>> 9f6892161 (chore: update changelog)
+- Add support for `copy_from_file` for on-host "in-agent" filesystem.
 
 ### 🐞 Bug fixes
 - On-host self-update: an empty `version: ""` pushed from Fleet Control now behaves the same as an absent `version` field (no-op, no update attempted). Previously it silently triggered a pull of the `:latest` OCI tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Remember that the keywords that you can use are the following:
 
 ## Unreleased
 
-### enhacement
+### enhancement
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 
 ## v1.18.0 - 2026-07-06

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -28,7 +28,7 @@ pub enum AgentTypeError {
     /// A templated string could not be parsed into the target value type.
     #[error("template value not parseable from the string {0}")]
     ValueNotParseableFromString(String),
-    /// A `kind: file` entry did not declare exactly one of `text` or `copy_from_file`.
+    /// A `kind: file` entry is invalid
     #[error("invalid filesystem file entry: {0}")]
     InvalidFileEntry(String),
     /// The configured backoff strategy type is not recognized.

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -28,6 +28,9 @@ pub enum AgentTypeError {
     /// A templated string could not be parsed into the target value type.
     #[error("template value not parseable from the string {0}")]
     ValueNotParseableFromString(String),
+    /// A `kind: file` entry did not declare exactly one of `text` or `copy_from_file`.
+    #[error("invalid filesystem file entry: {0}")]
+    InvalidFileEntry(String),
     /// The configured backoff strategy type is not recognized.
     #[error("unknown backoff strategy type: {0}")]
     UnknownBackoffStrategyType(String),

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -152,7 +152,7 @@ impl Templateable for FilesystemEntry {
             } => {
                 let content = match (text, copy_from_file) {
                     (Some(text), None) => {
-                        rendered::FileContent::Inline(text.template_with(variables)?)
+                        rendered::FileContent::Text(text.template_with(variables)?)
                     }
                     (None, Some(copy_from_file)) => {
                         rendered::FileContent::Copy(copy_from_file.template_with(variables)?.into())
@@ -370,7 +370,7 @@ mod tests {
             HashMap::from([(
                 PathBuf::from("/base/dir/newrelic.yaml"),
                 RenderedEntry::File {
-                    content: rendered::FileContent::Inline("hello".to_string()),
+                    content: rendered::FileContent::Text("hello".to_string()),
                     persistent: false,
                 },
             )]),

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -52,10 +52,16 @@ pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FilesystemEntry {
-    /// A single file with literal or templated content.
+    /// A single file whose bytes come from exactly one of `text` (literal or templated content)
+    /// or `copy_from_file` (a source path copied byte-for-byte, e.g. a downloaded binary).
     File {
-        /// The file's (possibly templated) content.
-        text: TemplateableValue<String>,
+        /// The file's (possibly templated) content. Mutually exclusive with `copy_from_file`.
+        #[serde(default)]
+        text: Option<TemplateableValue<String>>,
+        /// A (possibly templated) source path whose bytes are copied into this entry. Mutually
+        /// exclusive with `text`.
+        #[serde(default)]
+        copy_from_file: Option<TemplateableValue<String>>,
         /// The persistency attribute marking it's lifecicle.
         #[serde(default)]
         persistent: TemplateableValue<bool>,
@@ -139,10 +145,34 @@ impl Templateable for FilesystemEntry {
     /// the top level by [`FileSystem::template_with`].
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         match self {
-            FilesystemEntry::File { text, persistent } => Ok(rendered::RenderedEntry::File {
-                content: text.template_with(variables)?,
-                persistent: persistent.template_with(variables)?,
-            }),
+            FilesystemEntry::File {
+                text,
+                copy_from_file,
+                persistent,
+            } => {
+                let content = match (text, copy_from_file) {
+                    (Some(text), None) => {
+                        rendered::FileContent::Inline(text.template_with(variables)?)
+                    }
+                    (None, Some(copy_from_file)) => {
+                        rendered::FileContent::Copy(copy_from_file.template_with(variables)?.into())
+                    }
+                    (Some(_), Some(_)) => {
+                        return Err(AgentTypeError::InvalidFileEntry(
+                            "cannot declare both `text` and `copy_from_file`".to_string(),
+                        ));
+                    }
+                    (None, None) => {
+                        return Err(AgentTypeError::InvalidFileEntry(
+                            "must declare either `text` or `copy_from_file`".to_string(),
+                        ));
+                    }
+                };
+                Ok(rendered::RenderedEntry::File {
+                    content,
+                    persistent: persistent.template_with(variables)?,
+                })
+            }
             FilesystemEntry::Dir {
                 entries,
                 persistent,
@@ -327,7 +357,8 @@ mod tests {
         let fs_input = FileSystem(HashMap::from([(
             PathBuf::from("newrelic.yaml").try_into().unwrap(),
             FilesystemEntry::File {
-                text: TemplateableValue::from_template("hello".to_string()),
+                text: Some(TemplateableValue::from_template("hello".to_string())),
+                copy_from_file: None,
                 persistent: TemplateableValue::default(),
             },
         )]));
@@ -339,12 +370,135 @@ mod tests {
             HashMap::from([(
                 PathBuf::from("/base/dir/newrelic.yaml"),
                 RenderedEntry::File {
-                    content: "hello".to_string(),
+                    content: rendered::FileContent::Inline("hello".to_string()),
                     persistent: false,
                 },
             )]),
         );
         assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn parses_file_with_copy_from_file() {
+        let yaml = r#"
+nri-redis:
+  kind: file
+  copy_from_file: ${nr-sub:packages.nri-redis.dir}/nri-redis
+"#;
+        let parsed = serde_saphyr::from_str::<FileSystem>(yaml).unwrap();
+        match parsed.0.get(&SafePath(PathBuf::from("nri-redis"))).unwrap() {
+            FilesystemEntry::File {
+                text,
+                copy_from_file,
+                ..
+            } => {
+                assert!(text.is_none(), "text must be absent");
+                assert_eq!(
+                    copy_from_file.as_ref().unwrap().template,
+                    "${nr-sub:packages.nri-redis.dir}/nri-redis"
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copy_from_file_renders_to_copy_content() {
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable("/base/dir"),
+        )]);
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("nri-redis").try_into().unwrap(),
+            FilesystemEntry::File {
+                text: None,
+                copy_from_file: Some(TemplateableValue::from_template(
+                    "/pkg/nri-redis".to_string(),
+                )),
+                persistent: TemplateableValue::default(),
+            },
+        )]));
+
+        let rendered = fs_input.template_with(&variables).unwrap();
+
+        let expected = rendered::FileSystem::new(
+            PathBuf::from("/base/dir"),
+            HashMap::from([(
+                PathBuf::from("/base/dir/nri-redis"),
+                RenderedEntry::File {
+                    content: rendered::FileContent::Copy(PathBuf::from("/pkg/nri-redis")),
+                    persistent: false,
+                },
+            )]),
+        );
+        assert_eq!(rendered, expected);
+    }
+
+    #[rstest]
+    #[case::both(
+        Some(TemplateableValue::from_template("hi".to_string())),
+        Some(TemplateableValue::from_template("/src".to_string()))
+    )]
+    #[case::neither(None, None)]
+    fn file_entry_requires_exactly_one_source(
+        #[case] text: Option<TemplateableValue<String>>,
+        #[case] copy_from_file: Option<TemplateableValue<String>>,
+    ) {
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable("/base/dir"),
+        )]);
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("f").try_into().unwrap(),
+            FilesystemEntry::File {
+                text,
+                copy_from_file,
+                persistent: TemplateableValue::default(),
+            },
+        )]));
+
+        let err = fs_input.template_with(&variables).unwrap_err();
+        assert!(
+            matches!(err, AgentTypeError::InvalidFileEntry(_)),
+            "expected InvalidFileEntry, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn copy_from_file_copies_source_on_write() {
+        let tmp_dir = TempDir::new().unwrap();
+        let base = tmp_dir.path().join("base");
+        let source = tmp_dir.path().join("nri-redis-src");
+        let source_bytes = [0xFFu8, 0x00, b'b', b'i', b'n'];
+        std::fs::write(&source, source_bytes).unwrap();
+
+        let variables = Variables::from_iter(vec![(
+            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+            Variable::new_final_string_variable(base.to_string_lossy()),
+        )]);
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("nri-redis").try_into().unwrap(),
+            FilesystemEntry::File {
+                text: None,
+                copy_from_file: Some(TemplateableValue::from_template(
+                    source.to_string_lossy().to_string(),
+                )),
+                persistent: TemplateableValue::default(),
+            },
+        )]));
+
+        fs_input
+            .template_with(&variables)
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        let dst = base.join("nri-redis");
+        assert_eq!(
+            std::fs::read(&dst).unwrap(),
+            source_bytes,
+            "destination must be a byte-for-byte copy of the source"
+        );
     }
 
     #[test]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -424,25 +424,39 @@ nri-redis:
         }
     }
 
-    #[test]
-    fn copy_from_file_renders_to_copy_content() {
-        let variables = Variables::from_iter(vec![
+    /// Builds the reserved variables a filesystem render needs: the per-agent base dir and the
+    /// remote dir that confines `copy_from_file` sources. Paths are passed through so callers can
+    /// use real (absolute, platform-native) directories.
+    fn fs_variables(agent_dir: &Path, remote_dir: &Path) -> Variables {
+        Variables::from_iter(vec![
             (
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-                Variable::new_final_string_variable("/data/filesystem/agent"),
+                Variable::new_final_string_variable(agent_dir.to_string_lossy()),
             ),
             (
                 Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
-                Variable::new_final_string_variable("/data"),
+                Variable::new_final_string_variable(remote_dir.to_string_lossy()),
             ),
-        ]);
+        ])
+    }
+
+    #[test]
+    fn copy_from_file_renders_to_copy_content() {
+        // A real temp dir gives an absolute, platform-native base (`/data`-style literals are not
+        // absolute on Windows, so they would fail the `is_within_base` confinement check there).
+        let tmp_dir = TempDir::new().unwrap();
+        let remote = tmp_dir.path();
+        let agent_dir = remote.join("filesystem").join("agent");
+        // A source within the remote dir (a package binary) is allowed.
+        let source = remote.join("packages").join("nri-redis");
+
+        let variables = fs_variables(&agent_dir, remote);
         let fs_input = FileSystem(HashMap::from([(
             PathBuf::from("nri-redis").try_into().unwrap(),
             FilesystemEntry::File {
                 text: None,
-                // A source within the remote dir (a package binary) is allowed.
                 copy_from_file: Some(TemplateableValue::from_template(
-                    "/data/packages/nri-redis".to_string(),
+                    source.to_string_lossy().to_string(),
                 )),
                 persistent: TemplateableValue::default(),
             },
@@ -451,11 +465,11 @@ nri-redis:
         let rendered = fs_input.template_with(&variables).unwrap();
 
         let expected = rendered::FileSystem::new(
-            PathBuf::from("/data/filesystem/agent"),
+            agent_dir.clone(),
             HashMap::from([(
-                PathBuf::from("/data/filesystem/agent/nri-redis"),
+                agent_dir.join("nri-redis"),
                 RenderedEntry::File {
-                    content: rendered::FileContent::Copy(PathBuf::from("/data/packages/nri-redis")),
+                    content: rendered::FileContent::Copy(source),
                     persistent: false,
                 },
             )]),
@@ -463,36 +477,43 @@ nri-redis:
         assert_eq!(rendered, expected);
     }
 
-    /// A `copy_from_file` source outside `${nr-sub:remote_dir}` (an absolute host path, or a
-    /// `..` traversal out of the base) is rejected at template time.
-    #[rstest]
-    #[case::absolute_host_path("/etc/shadow")]
-    #[case::escapes_base("/data/../etc/shadow")]
-    fn copy_from_file_outside_base_is_rejected(#[case] source: &str) {
-        let variables = Variables::from_iter(vec![
-            (
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-                Variable::new_final_string_variable("/data/filesystem/agent"),
-            ),
-            (
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
-                Variable::new_final_string_variable("/data"),
-            ),
-        ]);
-        let fs_input = FileSystem(HashMap::from([(
-            PathBuf::from("nri-redis").try_into().unwrap(),
-            FilesystemEntry::File {
-                text: None,
-                copy_from_file: Some(TemplateableValue::from_template(source.to_string())),
-                persistent: TemplateableValue::default(),
-            },
-        )]));
+    /// A `copy_from_file` source outside `${nr-sub:remote_dir}` (an absolute path elsewhere on the
+    /// host, or a `..` traversal out of the base) is rejected at template time.
+    #[test]
+    fn copy_from_file_outside_base_is_rejected() {
+        let tmp_dir = TempDir::new().unwrap();
+        let remote = tmp_dir.path();
+        let agent_dir = remote.join("filesystem").join("agent");
 
-        let err = fs_input.template_with(&variables).unwrap_err();
-        assert!(
-            matches!(err, AgentTypeError::InvalidFileEntry(_)),
-            "expected InvalidFileEntry, got {err:?}"
-        );
+        // An absolute path outside the remote dir (a sibling of it), and a `..` escape out of it.
+        // Both are built from the temp dir so they stay absolute and platform-native.
+        let outside_sibling = remote
+            .parent()
+            .expect("temp dir has a parent")
+            .join("outside-secret");
+        let escapes_base = remote.join("..").join("outside-secret");
+
+        for source in [outside_sibling, escapes_base] {
+            let fs_input = FileSystem(HashMap::from([(
+                PathBuf::from("nri-redis").try_into().unwrap(),
+                FilesystemEntry::File {
+                    text: None,
+                    copy_from_file: Some(TemplateableValue::from_template(
+                        source.to_string_lossy().to_string(),
+                    )),
+                    persistent: TemplateableValue::default(),
+                },
+            )]));
+
+            let err = fs_input
+                .template_with(&fs_variables(&agent_dir, remote))
+                .unwrap_err();
+            assert!(
+                matches!(err, AgentTypeError::InvalidFileEntry(_)),
+                "source {} should be rejected, got {err:?}",
+                source.display()
+            );
+        }
     }
 
     #[rstest]
@@ -533,17 +554,8 @@ nri-redis:
         let source_bytes = [0xFFu8, 0x00, b'b', b'i', b'n'];
         std::fs::write(&source, source_bytes).unwrap();
 
-        let variables = Variables::from_iter(vec![
-            (
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-                Variable::new_final_string_variable(base.to_string_lossy()),
-            ),
-            // Source lives directly under the (temp) remote dir, so it passes confinement.
-            (
-                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
-                Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
-            ),
-        ]);
+        // Source lives directly under the (temp) remote dir, so it passes confinement.
+        let variables = fs_variables(&base, tmp_dir.path());
         let fs_input = FileSystem(HashMap::from([(
             PathBuf::from("nri-redis").try_into().unwrap(),
             FilesystemEntry::File {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -19,6 +19,7 @@ use crate::agent_type::{
     agent_attributes::AgentAttributes,
     definition::Variables,
     error::AgentTypeError,
+    runtime_config::on_host::managed_paths::is_within_base,
     runtime_config::templateable_value::TemplateableValue,
     templates::Templateable,
     trivial_value::TrivialValue,
@@ -155,7 +156,18 @@ impl Templateable for FilesystemEntry {
                         rendered::FileContent::Text(text.template_with(variables)?)
                     }
                     (None, Some(copy_from_file)) => {
-                        rendered::FileContent::Copy(copy_from_file.template_with(variables)?.into())
+                        let source = PathBuf::from(copy_from_file.template_with(variables)?);
+                        // `copy_from_file` may access to `${nr-sub:remote_dir}` (files in the agent filesystem)
+                        // never arbitrary files from the host.
+                        let base = copy_source_base(variables)?;
+                        if !is_within_base(&source, &base) {
+                            return Err(AgentTypeError::InvalidFileEntry(format!(
+                                "`copy_from_file` source `{}` is outside the allowed base `{}`",
+                                source.display(),
+                                base.display()
+                            )));
+                        }
+                        rendered::FileContent::Copy(source)
                     }
                     (Some(_), Some(_)) => {
                         return Err(AgentTypeError::InvalidFileEntry(
@@ -203,6 +215,16 @@ fn filesystem_agent_dir(variables: &Variables) -> Result<String, AgentTypeError>
     let key = Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR);
     match variables.get(&key).and_then(Variable::get_final_value) {
         Some(TrivialValue::String(s)) => Ok(s.clone()),
+        _ => Err(AgentTypeError::MissingValue(key)),
+    }
+}
+
+/// The root a `copy_from_file` source must stay within: the sub-agent's AC data dir
+/// (`${nr-sub:remote_dir}`), which contains packages and the per-agent and shared filesystem dirs.
+fn copy_source_base(variables: &Variables) -> Result<PathBuf, AgentTypeError> {
+    let key = Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR);
+    match variables.get(&key).and_then(Variable::get_final_value) {
+        Some(TrivialValue::String(s)) => Ok(PathBuf::from(s)),
         _ => Err(AgentTypeError::MissingValue(key)),
     }
 }
@@ -404,16 +426,23 @@ nri-redis:
 
     #[test]
     fn copy_from_file_renders_to_copy_content() {
-        let variables = Variables::from_iter(vec![(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable("/base/dir"),
-        )]);
+        let variables = Variables::from_iter(vec![
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable("/data/filesystem/agent"),
+            ),
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+                Variable::new_final_string_variable("/data"),
+            ),
+        ]);
         let fs_input = FileSystem(HashMap::from([(
             PathBuf::from("nri-redis").try_into().unwrap(),
             FilesystemEntry::File {
                 text: None,
+                // A source within the remote dir (a package binary) is allowed.
                 copy_from_file: Some(TemplateableValue::from_template(
-                    "/pkg/nri-redis".to_string(),
+                    "/data/packages/nri-redis".to_string(),
                 )),
                 persistent: TemplateableValue::default(),
             },
@@ -422,16 +451,48 @@ nri-redis:
         let rendered = fs_input.template_with(&variables).unwrap();
 
         let expected = rendered::FileSystem::new(
-            PathBuf::from("/base/dir"),
+            PathBuf::from("/data/filesystem/agent"),
             HashMap::from([(
-                PathBuf::from("/base/dir/nri-redis"),
+                PathBuf::from("/data/filesystem/agent/nri-redis"),
                 RenderedEntry::File {
-                    content: rendered::FileContent::Copy(PathBuf::from("/pkg/nri-redis")),
+                    content: rendered::FileContent::Copy(PathBuf::from("/data/packages/nri-redis")),
                     persistent: false,
                 },
             )]),
         );
         assert_eq!(rendered, expected);
+    }
+
+    /// A `copy_from_file` source outside `${nr-sub:remote_dir}` (an absolute host path, or a
+    /// `..` traversal out of the base) is rejected at template time.
+    #[rstest]
+    #[case::absolute_host_path("/etc/shadow")]
+    #[case::escapes_base("/data/../etc/shadow")]
+    fn copy_from_file_outside_base_is_rejected(#[case] source: &str) {
+        let variables = Variables::from_iter(vec![
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable("/data/filesystem/agent"),
+            ),
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+                Variable::new_final_string_variable("/data"),
+            ),
+        ]);
+        let fs_input = FileSystem(HashMap::from([(
+            PathBuf::from("nri-redis").try_into().unwrap(),
+            FilesystemEntry::File {
+                text: None,
+                copy_from_file: Some(TemplateableValue::from_template(source.to_string())),
+                persistent: TemplateableValue::default(),
+            },
+        )]));
+
+        let err = fs_input.template_with(&variables).unwrap_err();
+        assert!(
+            matches!(err, AgentTypeError::InvalidFileEntry(_)),
+            "expected InvalidFileEntry, got {err:?}"
+        );
     }
 
     #[rstest]
@@ -472,10 +533,17 @@ nri-redis:
         let source_bytes = [0xFFu8, 0x00, b'b', b'i', b'n'];
         std::fs::write(&source, source_bytes).unwrap();
 
-        let variables = Variables::from_iter(vec![(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable(base.to_string_lossy()),
-        )]);
+        let variables = Variables::from_iter(vec![
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
+                Variable::new_final_string_variable(base.to_string_lossy()),
+            ),
+            // Source lives directly under the (temp) remote dir, so it passes confinement.
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+                Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
+            ),
+        ]);
         let fs_input = FileSystem(HashMap::from([(
             PathBuf::from("nri-redis").try_into().unwrap(),
             FilesystemEntry::File {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -1,6 +1,9 @@
 //! Rendered filesystem tree and the logic to materialize it on disk.
 use crate::agent_type::runtime_config::on_host::managed_paths::{ManagedPaths, delete_path};
-use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
+use fs::{
+    directory_manager::DirectoryManager,
+    file::{copier::FileCopier, writer::FileWriter},
+};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -25,13 +28,22 @@ pub struct FileSystem {
     pub(super) entries: HashMap<PathBuf, RenderedEntry>,
 }
 
+/// The source of a rendered file's bytes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FileContent {
+    /// Literal (rendered) content written verbatim.
+    Inline(String),
+    /// An on-disk source file to copy byte-for-byte into place (used by `copy_from_file`).
+    Copy(PathBuf),
+}
+
 /// A single rendered filesystem entry.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RenderedEntry {
-    /// A file with the given content.
+    /// A file whose bytes come either from inline content or from a copied source file.
     File {
-        /// The rendered content from the file.
-        content: String,
+        /// Where the file's bytes come from.
+        content: FileContent,
         /// The persistency attribute marking it's lifecicle.
         persistent: bool,
     },
@@ -77,28 +89,32 @@ impl RenderedEntry {
         }
     }
 
-    /// Materializes this entry (and its subtree) on disk at `path`.
+    /// Materializes this entry (and its subtree) on disk at `path`. `file_ops` provides both the
+    /// write and copy capabilities (a single type, [`LocalFile`], implements both in production).
     fn write(
         &self,
         path: &Path,
-        file_writer: &impl FileWriter,
+        file_ops: &(impl FileWriter + FileCopier),
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         match self {
-            Self::File { content, .. } => write_file(file_writer, dir_manager, path, content),
+            Self::File { content, .. } => match content {
+                FileContent::Inline(text) => write_file(file_ops, dir_manager, path, text),
+                FileContent::Copy(source) => copy_file(file_ops, dir_manager, path, source),
+            },
             Self::Dir { children, .. } => {
                 ensure_dir(dir_manager, path)?;
                 for (sub_path, child) in children {
                     let child_path = path.join(sub_path);
                     trace!("Recursing into child entry {}", child_path.display());
-                    child.write(&child_path, file_writer, dir_manager)?;
+                    child.write(&child_path, file_ops, dir_manager)?;
                 }
                 Ok(())
             }
             Self::DirContentFromMap { files, .. } => {
                 ensure_dir(dir_manager, path)?;
                 for (file_name, content) in files {
-                    write_file(file_writer, dir_manager, &path.join(file_name), content)?;
+                    write_file(file_ops, dir_manager, &path.join(file_name), content)?;
                 }
                 Ok(())
             }
@@ -138,7 +154,7 @@ impl FileSystem {
     /// writes the declared tree, then updates the manifest.
     pub fn write(
         &self,
-        file_writer: &impl FileWriter,
+        file_ops: &(impl FileWriter + FileCopier),
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         let managed = self.managed_paths();
@@ -149,7 +165,7 @@ impl FileSystem {
         managed.prune_stale(&prev_declared, &curr_declared);
 
         for (path, entry) in &self.entries {
-            entry.write(path, file_writer, dir_manager)?;
+            entry.write(path, file_ops, dir_manager)?;
         }
 
         managed.save(&curr_declared);
@@ -211,6 +227,27 @@ fn write_file(
     file_writer
         .write(path, content.to_owned())
         .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
+}
+
+/// Copies `source` to `path`, creating its parent directory first. Overwrites an existing file.
+fn copy_file(
+    file_copier: &impl FileCopier,
+    dir_manager: &impl DirectoryManager,
+    path: &Path,
+    source: &Path,
+) -> Result<(), FileSystemEntriesError> {
+    trace!(
+        "Copying filesystem entry from {} to {}",
+        source.display(),
+        path.display()
+    );
+    let parent = path
+        .parent()
+        .ok_or_else(|| FileSystemEntriesError(format!("{} has no parent dir", path.display())))?;
+    ensure_dir(dir_manager, parent)?;
+    file_copier
+        .copy(source, path)
+        .map_err(|err| FileSystemEntriesError(format!("copying {source:?} to {path:?}: {err}")))
 }
 
 /// Error produced while writing the rendered filesystem tree to disk.

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -32,7 +32,7 @@ pub struct FileSystem {
 #[derive(Debug, Clone, PartialEq)]
 pub enum FileContent {
     /// Literal (rendered) content written verbatim.
-    Inline(String),
+    Text(String),
     /// An on-disk source file to copy byte-for-byte into place (used by `copy_from_file`).
     Copy(PathBuf),
 }
@@ -99,7 +99,7 @@ impl RenderedEntry {
     ) -> Result<(), FileSystemEntriesError> {
         match self {
             Self::File { content, .. } => match content {
-                FileContent::Inline(text) => write_file(file_ops, dir_manager, path, text),
+                FileContent::Text(text) => write_file(file_ops, dir_manager, path, text),
                 FileContent::Copy(source) => copy_file(file_ops, dir_manager, path, source),
             },
             Self::Dir { children, .. } => {


### PR DESCRIPTION
## Summary

Adds a `copy_from_file` content source to `kind: file` entries in an agent type's `filesystem:`
block. Until now a file entry could only carry inline (`text`) content; with `copy_from_file` a
file entry's bytes are copied byte-for-byte from an existing on-disk path (typically a binary
extracted from a downloaded OCI package).

## Scope

**This PR extends the per-agent `filesystem:` capability only.** A `copy_from_file` entry is
written into the sub-agent's own dedicated directory (`${nr-sub:filesystem_agent_dir}`), exactly
like every other filesystem entry today. **It does NOT add the shared filesystem yet** (it will be introduced in follow-up PRs).

## Example

```yaml
# In an agent type's on-host deployment `filesystem:` block.
deployment:
  on_host:
    packages:
      nri-redis:
        # ... OCI download coordinates; extracted under ${nr-sub:packages.nri-redis.dir}
    filesystem:
      # Inline content (unchanged, existing behaviour).
      newrelic-infra.yaml:
        kind: file
        text: ${nr-var:config_agent}

      # NEW: copy a binary from the downloaded package into the sub-agent's own dir.
      # `copy_from_file` is the source path; the entry key is the destination filename.
      # Note: integrations will actually use the 'to be introduced' shared-filesystem instead.
      integrations:
        kind: dir
        entries:
          nri-redis:
            kind: file
            copy_from_file: ${nr-sub:packages.nri-redis.dir}/nri-redis
```

## Security

After https://github.com/newrelic/newrelic-agent-control/pull/2663#discussion_r3521232877, the PR was updated to **restrict* the files that can be copied to `${nr-sub:remote_dir}` sub-folders. Any origin outside that path is rejected as invalid configuration.
