### PR TITLE
feat: shared filesystem support [NR-579370] [NR-579374]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Remember that the keywords that you can use are the following:
 
 ### enhancement
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
+- Add support for `shared_filesystem` in on-host agent types.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.
 - On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 - On-host health config: replaced the flat `health.http:` / `health.file:` fields with an explicit `checks:` list. Each entry is discriminated by `kind:` (`Process`, `Http`, or `File`). The previously implicit supervised-process health check is now declared as `kind: Process`. An omitted or empty `checks:` list disables health reporting entirely.

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -4,7 +4,7 @@ use super::templateable_value::TemplateableValue;
 use crate::agent_type::definition::{Variables, include_packages_variables};
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::runtime_config::on_host::executable::Executable;
-use crate::agent_type::runtime_config::on_host::filesystem::FileSystem;
+use crate::agent_type::runtime_config::on_host::filesystem::{FileSystem, SharedFileSystem};
 use crate::agent_type::runtime_config::on_host::package::{Package, PackageID};
 use crate::agent_type::runtime_config::on_host::rendered::RenderedPackages;
 use crate::agent_type::templates::Templateable;
@@ -30,6 +30,8 @@ pub struct OnHost {
     health: Option<OnHostHealthConfig>,
     #[serde(default)]
     filesystem: FileSystem,
+    #[serde(default)]
+    shared_filesystem: SharedFileSystem,
     #[serde(default)]
     packages: Packages,
 }
@@ -83,6 +85,7 @@ impl Templateable for OnHost {
                 .map(|health| health.template_with(&extended_vars))
                 .transpose()?,
             filesystem: self.filesystem.template_with(&extended_vars)?,
+            shared_filesystem: self.shared_filesystem.template_with(&extended_vars)?,
             packages: rendered_packages,
         })
     }
@@ -656,6 +659,7 @@ executables:
             enable_file_logging: TemplateableValue::default(),
             health: None,
             filesystem: FileSystem::default(),
+            shared_filesystem: SharedFileSystem::default(),
             packages: Default::default(),
         };
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -127,24 +127,55 @@ impl From<SafePath> for PathBuf {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct DirEntriesMap(HashMap<SafePath, String>);
 
+impl FileSystem {
+    /// Whether no entries are declared.
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Templates each entry and roots it under `base_dir`, prepending `base_dir` to each relative
+    /// top-level key (the only place a final on-disk path is constructed).
+    fn render_entries(
+        self,
+        base_dir: &Path,
+        variables: &Variables,
+    ) -> Result<HashMap<PathBuf, rendered::RenderedEntry>, AgentTypeError> {
+        self.0
+            .into_iter()
+            .map(|(key, entry)| {
+                let path = base_dir.join(&key);
+                Ok((path, entry.template_with(variables)?))
+            })
+            .collect()
+    }
+}
+
 impl Templateable for FileSystem {
     type Output = rendered::FileSystem;
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
         let base_dir = PathBuf::from(filesystem_agent_dir(variables)?);
-
-        let entries = self
-            .0
-            .into_iter()
-            .map(|(key, entry)| {
-                // The only place we construct a final-on-disk path: prepend the sub-agent's
-                // dedicated filesystem dir to the user-provided relative top-level key.
-                let path = base_dir.join(&key);
-                Ok((path, entry.template_with(variables)?))
-            })
-            .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-
+        let entries = self.render_entries(&base_dir, variables)?;
         Ok(rendered::FileSystem::new(entries))
+    }
+}
+
+/// Files and directories shared across sub-agents, rooted at `${nr-sub:shared_filesystem_dir}`.
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct SharedFileSystem(FileSystem);
+
+impl Templateable for SharedFileSystem {
+    type Output = rendered::SharedFileSystem;
+
+    fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
+        // Skip resolving the shared base when nothing is declared: an unused shared filesystem
+        // must not require `${nr-sub:shared_filesystem_dir}` to be present.
+        if self.0.is_empty() {
+            return Ok(rendered::SharedFileSystem::new(HashMap::new()));
+        }
+        let base_dir = PathBuf::from(shared_filesystem_dir(variables)?);
+        let entries = self.0.render_entries(&base_dir, variables)?;
+        Ok(rendered::SharedFileSystem::new(entries))
     }
 }
 
@@ -223,6 +254,15 @@ impl Templateable for FilesystemEntry {
 
 fn filesystem_agent_dir(variables: &Variables) -> Result<String, AgentTypeError> {
     let key = Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR);
+    match variables.get(&key).and_then(Variable::get_final_value) {
+        Some(TrivialValue::String(s)) => Ok(s.clone()),
+        _ => Err(AgentTypeError::MissingValue(key)),
+    }
+}
+
+/// Resolves `${nr-sub:shared_filesystem_dir}`, the base for the shared filesystem tree.
+fn shared_filesystem_dir(variables: &Variables) -> Result<String, AgentTypeError> {
+    let key = Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR);
     match variables.get(&key).and_then(Variable::get_final_value) {
         Some(TrivialValue::String(s)) => Ok(s.clone()),
         _ => Err(AgentTypeError::MissingValue(key)),
@@ -1237,5 +1277,111 @@ persistent-dir:
         assert!(!tmp_dir.path().join("ephemeral-dir").exists());
         assert!(tmp_dir.path().join("persistent.txt").exists());
         assert!(tmp_dir.path().join("persistent-dir").is_dir());
+    }
+
+    /// Builds the reserved variable holding the shared filesystem base dir.
+    fn shared_variables(shared_dir: &Path, remote_dir: &Path) -> Variables {
+        Variables::from_iter(vec![
+            (
+                Namespace::SubAgent
+                    .namespaced_name(AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR),
+                Variable::new_final_string_variable(shared_dir.to_string_lossy()),
+            ),
+            (
+                Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_REMOTE_DIR),
+                Variable::new_final_string_variable(remote_dir.to_string_lossy()),
+            ),
+        ])
+    }
+
+    /// The shared filesystem renders against `${nr-sub:shared_filesystem_dir}` and writes its tree there
+    #[test]
+    fn shared_filesystem_renders_and_writes_to_shared_base() {
+        let tmp_dir = TempDir::new().unwrap();
+        let shared = tmp_dir.path().join("shared-filesystem");
+        let yaml = r#"
+infra-agent-ohi-configs:
+  kind: dir
+  entries:
+    nri-redis.yaml:
+      kind: file
+      text: "integration: redis"
+"#;
+        serde_saphyr::from_str::<SharedFileSystem>(yaml)
+            .unwrap()
+            .template_with(&shared_variables(&shared, tmp_dir.path()))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(shared.join("infra-agent-ohi-configs/nri-redis.yaml")).unwrap(),
+            "integration: redis"
+        );
+    }
+
+    #[test]
+    fn shared_filesystem_write_does_not_prune_other_entries() {
+        let tmp_dir = TempDir::new().unwrap();
+        let shared = tmp_dir.path().join("shared-filesystem");
+        let variables = shared_variables(&shared, tmp_dir.path());
+
+        // Two sub-agents write different entries into the same shared base.
+        for (name, content) in [("agent-a.yaml", "a"), ("agent-b.yaml", "b")] {
+            let yaml = format!("{name}:\n  kind: file\n  text: {content}");
+            serde_saphyr::from_str::<SharedFileSystem>(&yaml)
+                .unwrap()
+                .template_with(&variables)
+                .unwrap()
+                .write(&LocalFile, &DirectoryManagerFs)
+                .unwrap();
+        }
+
+        assert!(shared.join("agent-a.yaml").exists(),);
+        assert!(shared.join("agent-b.yaml").exists());
+    }
+
+    #[test]
+    fn shared_filesystem_supports_copy_from_file() {
+        let tmp_dir = TempDir::new().unwrap();
+        let remote = tmp_dir.path();
+        let shared = remote.join("shared-filesystem");
+        let source = remote.join("packages").join("nri-redis");
+        let source_bytes = [0xFFu8, 0x00, b'b', b'i', b'n'];
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, source_bytes).unwrap();
+
+        // Built from structs (not YAML) to keep the source path platform-native.
+        let shared_fs = SharedFileSystem(FileSystem(HashMap::from([(
+            PathBuf::from("nri-redis").try_into().unwrap(),
+            FilesystemEntry::File {
+                text: None,
+                copy_from_file: Some(TemplateableValue::from_template(
+                    source.to_string_lossy().to_string(),
+                )),
+                persistent: false,
+            },
+        )])));
+
+        shared_fs
+            .template_with(&shared_variables(&shared, remote))
+            .unwrap()
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(shared.join("nri-redis")).unwrap(),
+            source_bytes
+        );
+    }
+
+    /// An empty (unused) shared filesystem renders even when `shared_filesystem_dir` is absent.
+    #[test]
+    fn empty_shared_filesystem_renders_without_shared_dir_variable() {
+        SharedFileSystem::default()
+            .template_with(&Variables::default())
+            .expect("empty shared filesystem must render without the shared dir variable")
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -1321,12 +1321,12 @@ infra-agent-ohi-configs:
     }
 
     #[test]
-    fn shared_filesystem_write_does_not_prune_other_entries() {
+    fn shared_filesystem_write_mutiple_times() {
         let tmp_dir = TempDir::new().unwrap();
         let shared = tmp_dir.path().join("shared-filesystem");
         let variables = shared_variables(&shared, tmp_dir.path());
 
-        // Two sub-agents write different entries into the same shared base.
+        // Two sub-agents can write entries into the same shared base, both should remain.
         for (name, content) in [("agent-a.yaml", "a"), ("agent-b.yaml", "b")] {
             let yaml = format!("{name}:\n  kind: file\n  text: {content}");
             serde_saphyr::from_str::<SharedFileSystem>(&yaml)
@@ -1337,7 +1337,7 @@ infra-agent-ohi-configs:
                 .unwrap();
         }
 
-        assert!(shared.join("agent-a.yaml").exists(),);
+        assert!(shared.join("agent-a.yaml").exists());
         assert!(shared.join("agent-b.yaml").exists());
     }
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -168,8 +168,8 @@ impl Templateable for SharedFileSystem {
     type Output = rendered::SharedFileSystem;
 
     fn template_with(self, variables: &Variables) -> Result<Self::Output, AgentTypeError> {
-        // Skip resolving the shared base when nothing is declared: an unused shared filesystem
-        // must not require `${nr-sub:shared_filesystem_dir}` to be present.
+        // Return early if no shared entries are declared. Agent Types that don't use shared-filesystem aren't
+        // enforced to provide the `${nr-sub:shared_filesystem_dir}` variable.
         if self.0.is_empty() {
             return Ok(rendered::SharedFileSystem::new(HashMap::new()));
         }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -143,6 +143,32 @@ impl FileSystem {
     }
 }
 
+/// Rendered shared filesystem tree, materialized under the base shared across sub-agents.
+// TODO: there is no clean-up implemented at the moment (content written by agent remains there even if
+// the corresponding agent is not present anymore).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SharedFileSystem {
+    entries: HashMap<PathBuf, RenderedEntry>,
+}
+
+impl SharedFileSystem {
+    pub(super) fn new(entries: HashMap<PathBuf, RenderedEntry>) -> Self {
+        Self { entries }
+    }
+
+    /// Materializes the declared tree on disk. Existing files are overwritten; nothing is pruned.
+    pub fn write(
+        &self,
+        file_ops: &(impl FileWriter + FileCopier),
+        dir_manager: &impl DirectoryManager,
+    ) -> Result<(), FileSystemEntriesError> {
+        for (path, entry) in &self.entries {
+            entry.write(path, file_ops, dir_manager)?;
+        }
+        Ok(())
+    }
+}
+
 /// Creates `dir` (and any missing parents), with error context. Safe if it already exists.
 fn ensure_dir(
     dir_manager: &impl DirectoryManager,
@@ -212,6 +238,12 @@ mod tests {
     use super::*;
 
     impl FileSystem {
+        pub(crate) fn test_empty() -> Self {
+            Self::new(HashMap::new())
+        }
+    }
+
+    impl SharedFileSystem {
         pub(crate) fn test_empty() -> Self {
             Self::new(HashMap::new())
         }

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -19,9 +19,9 @@ pub struct OnHost {
     pub enable_file_logging: bool,
     /// Enables and define health checks configuration.
     pub health: Option<OnHostHealthConfig>,
-    /// Files and directories to materialize on disk.
+    /// Files and directories to materialize on disk for each agent.
     pub filesystem: FileSystem,
-    /// Files and directories to materialize in the base shared across sub-agents (write-only).
+    /// Files and directories to materialize in the base shared across sub-agents.
     pub shared_filesystem: SharedFileSystem,
     /// Packages to download for this agent.
     pub packages: RenderedPackages,

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -3,7 +3,10 @@ use crate::agent_type::runtime_config::on_host::package::PackageID;
 use crate::agent_type::runtime_config::on_host::package::rendered::Package;
 use crate::agent_type::runtime_config::{
     health_config::rendered::OnHostHealthConfig,
-    on_host::{executable::rendered::Executable, filesystem::rendered::FileSystem},
+    on_host::{
+        executable::rendered::Executable,
+        filesystem::rendered::{FileSystem, SharedFileSystem},
+    },
 };
 use std::collections::HashMap;
 
@@ -18,6 +21,8 @@ pub struct OnHost {
     pub health: Option<OnHostHealthConfig>,
     /// Files and directories to materialize on disk.
     pub filesystem: FileSystem,
+    /// Files and directories to materialize in the base shared across sub-agents (write-only).
+    pub shared_filesystem: SharedFileSystem,
     /// Packages to download for this agent.
     pub packages: RenderedPackages,
 }

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -169,6 +169,7 @@ where
             on_host.enable_file_logging,
             self.logging_path.to_path_buf(),
             on_host.filesystem,
+            on_host.shared_filesystem,
         ))
     }
 }

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -5,7 +5,7 @@ use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
 use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthConfig;
 use crate::agent_type::runtime_config::on_host::filesystem::rendered::{
-    FileSystem, FileSystemEntriesError,
+    FileSystem, FileSystemEntriesError, SharedFileSystem,
 };
 use crate::agent_type::runtime_config::on_host::rendered::RenderedPackages;
 use crate::checkers::health::health_checker::{Health, HealthCheckerError, spawn_health_checker};
@@ -106,6 +106,7 @@ where
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
     filesystem: FileSystem,
+    shared_filesystem: SharedFileSystem,
 }
 
 impl<PM> SupervisorStarter for NotStartedSupervisorOnHost<PM>
@@ -193,6 +194,7 @@ where
             onhost_config.enable_file_logging,
             logging_path,
             onhost_config.filesystem,
+            onhost_config.shared_filesystem,
         );
 
         // No explicit file deletion is needed on apply: spin_up re-renders the filesystem. Its
@@ -227,6 +229,7 @@ where
         file_logging_enable: bool,
         file_logging_path: PathBuf,
         filesystem: FileSystem,
+        shared_filesystem: SharedFileSystem,
     ) -> Self {
         NotStartedSupervisorOnHost {
             agent_identity,
@@ -237,6 +240,7 @@ where
             package_manager,
             packages_config,
             filesystem,
+            shared_filesystem,
         }
     }
 
@@ -339,6 +343,10 @@ where
         }
 
         self.filesystem
+            .write(&LocalFile, &DirectoryManagerFs)
+            .map_err(SupervisorError::FileSystem)?;
+
+        self.shared_filesystem
             .write(&LocalFile, &DirectoryManagerFs)
             .map_err(SupervisorError::FileSystem)?;
 
@@ -757,6 +765,7 @@ pub mod tests {
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -802,6 +811,7 @@ pub mod tests {
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -853,6 +863,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             filesystem,
+            SharedFileSystem::test_empty(),
         );
 
         let (publisher, _consumer) = pub_sub();
@@ -922,6 +933,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             filesystem,
+            SharedFileSystem::test_empty(),
         );
 
         let (publisher, _consumer) = pub_sub();
@@ -965,6 +977,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1014,6 +1027,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1063,6 +1077,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1107,6 +1122,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, _sub_agent_internal_consumer) = pub_sub();
@@ -1170,6 +1186,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (health_publisher, health_consumer) = pub_sub();
@@ -1350,6 +1367,7 @@ persistent.txt:
             true,
             logging_path.clone(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1384,6 +1402,7 @@ persistent.txt:
             enable_file_logging: true,
             health: None,
             filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1476,6 +1495,7 @@ persistent.txt:
             false,
             logging_path.clone(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1510,6 +1530,7 @@ persistent.txt:
             enable_file_logging: true,
             health: None,
             filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1600,6 +1621,7 @@ persistent.txt:
             true,
             logging_path.clone(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1634,6 +1656,7 @@ persistent.txt:
             enable_file_logging: false,
             health: None,
             filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 
@@ -1709,6 +1732,7 @@ persistent.txt:
             false,
             PathBuf::default(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (sub_agent_internal_publisher, sub_agent_internal_consumer) = pub_sub();
@@ -1781,6 +1805,7 @@ persistent.txt:
             false,
             logging_path.clone(),
             FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
         );
 
         let (pub_internal, _sub_internal) = pub_sub();
@@ -1815,6 +1840,7 @@ persistent.txt:
             enable_file_logging: false,
             health: None,
             filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
         };
 

--- a/agent-control/tests/on_host/scenarios.rs
+++ b/agent-control/tests/on_host/scenarios.rs
@@ -19,4 +19,5 @@ mod postdownload_hook;
 mod remote_agent_removal;
 mod restarting_processes;
 mod self_instrumentation_otel;
+mod shared_filesystem;
 mod stale_agent_filesystem_cleanup;

--- a/agent-control/tests/on_host/scenarios/shared_filesystem.rs
+++ b/agent-control/tests/on_host/scenarios/shared_filesystem.rs
@@ -1,0 +1,202 @@
+use std::{fs::read_to_string, path::Path, time::Duration};
+
+use crate::common::agent_control::start_agent_control_with_custom_config;
+use crate::common::base_paths::TempBasePaths;
+use crate::common::retry::retry;
+use crate::common::runtime::tokio_runtime;
+use crate::on_host::consts::NO_CONFIG;
+use crate::on_host::tools::config::{OnHostAgentControlConfigBuilder, create_local_config};
+use crate::on_host::tools::custom_agent_type::CustomAgentType;
+use crate::on_host::tools::instance_id::get_instance_id;
+use fake_opamp_server::FakeServer;
+use newrelic_agent_control::agent_control::agent_id::AgentID;
+use newrelic_agent_control::agent_control::defaults::SHARED_FILESYSTEM_FOLDER_NAME;
+use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
+
+const SHARED_CONFIG_DIR: &str = "infra-agent-ohi-configs";
+
+const SHARED_BIN_DIR: &str = "infra-agent-ohi-binaries";
+
+/// Two OHI agent types each render a "binary" into their own per-agent filesystem, then copy it
+/// into the shared filesystem via `copy_from_file`. This covers the two paths that drive a shared
+/// write: `redis-agent` is present at AC startup (local config), while `mysql-agent` is added at
+/// runtime through an AC-level OpAMP remote config. Both entries coexist under the shared base.
+#[test]
+fn multiple_agents_write_to_shared_filesystem() {
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+    let dirs = TempBasePaths::default();
+
+    let redis_agent = "redis-agent";
+    let mysql_agent = "mysql-agent";
+
+    let redis_type = ohi_binary_agent_type("redis", "nri-redis").build(dirs.local_dir());
+    let mysql_type = ohi_binary_agent_type("mysql", "nri-mysql").build(dirs.local_dir());
+
+    // Only redis-agent is in the local config, so it starts at AC startup. mysql-agent is added
+    // later via remote config; its values file is created up front so it can be assembled then.
+    OnHostAgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
+            r#"
+  {redis_agent}:
+    agent_type: "{redis_type}"
+"#
+        ))
+        .write(dirs.local_dir());
+    create_local_config(
+        redis_agent.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
+    create_local_config(
+        mysql_agent.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
+
+    let _agent_control =
+        start_agent_control_with_custom_config(dirs.base_paths(), AGENT_CONTROL_MODE_ON_HOST);
+
+    let shared_bin_dir = dirs
+        .remote_dir()
+        .join(SHARED_FILESYSTEM_FOLDER_NAME)
+        .join(SHARED_BIN_DIR);
+    let redis_file = shared_bin_dir.join("nri-redis");
+    let mysql_file = shared_bin_dir.join("nri-mysql");
+
+    // AC startup path: redis-agent writes its shared binary.
+    retry(30, Duration::from_secs(1), || {
+        expect_file_content(&redis_file, &binary_payload("nri-redis"))
+    });
+
+    // Add-a-new-agent path: push an AC remote config that also includes mysql-agent.
+    let ac_instance_id = get_instance_id(&AgentID::AgentControl, dirs.base_paths());
+    opamp_server.set_config_response(
+        ac_instance_id,
+        format!(
+            r#"
+agents:
+  {redis_agent}:
+    agent_type: "{redis_type}"
+  {mysql_agent}:
+    agent_type: "{mysql_type}"
+"#
+        ),
+    );
+
+    // mysql-agent is now started and writes its shared binary; redis-agent's file remains.
+    retry(60, Duration::from_secs(1), || {
+        expect_file_content(&mysql_file, &binary_payload("nri-mysql"))?;
+        expect_file_content(&redis_file, &binary_payload("nri-redis"))?;
+        Ok(())
+    });
+}
+
+/// A config update pushed via OpAMP remote config re-renders and rewrites the shared filesystem
+/// entry: the sub-agent re-applies and the file on disk reflects the new value.
+#[test]
+fn shared_filesystem_entry_updated_via_opamp_remote_config() {
+    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
+    let dirs = TempBasePaths::default();
+
+    let agent_id = "ohi-agent";
+
+    let agent_type = CustomAgentType::default()
+        .with_health(None)
+        .with_variables(
+            r#"
+ohi_config:
+  description: "OHI config file content"
+  type: "string"
+  required: false
+  default: "v1"
+"#,
+        )
+        .with_shared_filesystem(Some(&format!(
+            r#"
+{SHARED_CONFIG_DIR}:
+  kind: dir
+  entries:
+    nri-redis.yaml:
+      kind: file
+      text: ${{nr-var:ohi_config}}
+"#
+        )))
+        .build(dirs.local_dir());
+
+    OnHostAgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint())
+        .with_agents(format!(
+            r#"
+  {agent_id}:
+    agent_type: "{agent_type}"
+"#
+        ))
+        .write(dirs.local_dir());
+    create_local_config(
+        agent_id.to_string(),
+        NO_CONFIG.to_string(),
+        dirs.local_dir(),
+    );
+
+    let _agent_control =
+        start_agent_control_with_custom_config(dirs.base_paths(), AGENT_CONTROL_MODE_ON_HOST);
+
+    let shared_file = dirs
+        .remote_dir()
+        .join(SHARED_FILESYSTEM_FOLDER_NAME)
+        .join(SHARED_CONFIG_DIR)
+        .join("nri-redis.yaml");
+
+    // Install: the entry is written with the variable's default value.
+    retry(30, Duration::from_secs(1), || {
+        expect_file_content(&shared_file, "v1")
+    });
+
+    // Update: push new values over OpAMP; the sub-agent re-applies and rewrites the entry.
+    let sub_instance_id = get_instance_id(&AgentID::try_from(agent_id).unwrap(), dirs.base_paths());
+    opamp_server.set_config_response(sub_instance_id, "ohi_config: v2");
+
+    retry(60, Duration::from_secs(1), || {
+        expect_file_content(&shared_file, "v2")
+    });
+}
+
+/// A minimal OHI-style agent type that renders a "binary" into its own per-agent filesystem
+/// (`bin/<binary>`) and then copies it into the shared binaries dir with `copy_from_file`.
+fn ohi_binary_agent_type(type_name: &str, binary: &str) -> CustomAgentType {
+    let payload = binary_payload(binary);
+    CustomAgentType::default()
+        .with_agent_type_id(&format!("test/{type_name}:0.1.0"))
+        .with_health(None)
+        .with_filesystem(Some(&format!(
+            r#"
+bin:
+  kind: dir
+  entries:
+    {binary}:
+      kind: file
+      text: "{payload}"
+"#
+        )))
+        .with_shared_filesystem(Some(&format!(
+            r#"
+{SHARED_BIN_DIR}:
+  kind: dir
+  entries:
+    {binary}:
+      kind: file
+      copy_from_file: ${{nr-sub:filesystem_agent_dir}}/bin/{binary}
+"#
+        )))
+}
+
+fn binary_payload(binary: &str) -> String {
+    format!("{binary}-payload")
+}
+
+fn expect_file_content(path: &Path, expected: &str) -> Result<(), Box<dyn std::error::Error>> {
+    match read_to_string(path) {
+        Ok(contents) if contents == expected => Ok(()),
+        Ok(contents) => Err(format!("unexpected content at {path:?}: {contents:?}").into()),
+        Err(err) => Err(format!("file not present yet at {path:?}: {err}").into()),
+    }
+}

--- a/agent-control/tests/on_host/tools/custom_agent_type.rs
+++ b/agent-control/tests/on_host/tools/custom_agent_type.rs
@@ -1,5 +1,6 @@
 use fs::file::LocalFile;
 use fs::file::writer::FileWriter;
+use newrelic_agent_control::agent_control::defaults::DYNAMIC_AGENT_TYPES_DIR;
 use newrelic_agent_control::agent_control::run::on_host::AGENT_CONTROL_MODE_ON_HOST;
 use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
 use newrelic_agent_control::agent_type::definition::AgentTypeDefinition;
@@ -14,6 +15,7 @@ pub struct CustomAgentType {
     variables: Option<serde_json::Value>,
     executables: Option<serde_json::Value>,
     filesystem: Option<serde_json::Value>,
+    shared_filesystem: Option<serde_json::Value>,
     packages: Option<serde_json::Value>,
     health: Option<serde_json::Value>,
 }
@@ -36,6 +38,7 @@ fake_variable:
             ),
             executables: Some(Self::default_executables()),
             filesystem: None,
+            shared_filesystem: None,
             packages: None,
             health: Some(
                 serde_saphyr::from_str(
@@ -83,6 +86,9 @@ impl Display for CustomAgentType {
         }
         if let Some(filesystem) = self.filesystem.as_ref() {
             deployment.insert("filesystem".into(), filesystem.clone());
+        }
+        if let Some(shared_filesystem) = self.shared_filesystem.as_ref() {
+            deployment.insert("shared_filesystem".into(), shared_filesystem.clone());
         }
         if let Some(health) = self.health.as_ref() {
             deployment.insert("health".into(), health.clone());
@@ -141,6 +147,7 @@ impl CustomAgentType {
             executables: None,
             health: None,
             filesystem: None,
+            shared_filesystem: None,
             packages: None,
         }
     }
@@ -166,6 +173,13 @@ impl CustomAgentType {
         }
     }
 
+    pub fn with_shared_filesystem(self, shared_filesystem: Option<&str>) -> Self {
+        Self {
+            shared_filesystem: shared_filesystem.map(|f| serde_saphyr::from_str(f).unwrap()),
+            ..self
+        }
+    }
+
     pub fn with_packages(self, packages: Option<&str>) -> Self {
         Self {
             packages: packages.map(|f| serde_saphyr::from_str(f).unwrap()),
@@ -180,18 +194,33 @@ impl CustomAgentType {
         }
     }
 
+    pub fn with_agent_type_id(self, agent_type_id: &str) -> Self {
+        Self {
+            agent_type_id: AgentTypeID::try_from(agent_type_id).unwrap(),
+            ..self
+        }
+    }
+
     pub fn without_deployment(self) -> Self {
         Self {
             executables: None,
             health: None,
             filesystem: None,
+            shared_filesystem: None,
             ..self
         }
     }
 
-    /// Writes the custom agent type and returns its id as string.
+    /// Writes the custom agent type and returns its id as string. The file name is derived from the
+    /// full agent type id (namespace, name and version) so several distinct types can coexist in
+    /// the dynamic agent types dir (the loader reads every file there); two ids sharing only a name
+    /// would otherwise clobber each other.
     pub fn build(self, local_dir: PathBuf) -> String {
-        let agent_type_file_path = local_dir.join(DYNAMIC_AGENT_TYPE_FILENAME);
+        // The id (`namespace/name:version`) has `/` and `:`, which are not portable in file names.
+        let file_stem = self.agent_type_id.to_string().replace(['/', ':'], "_");
+        let agent_type_file_path = local_dir
+            .join(DYNAMIC_AGENT_TYPES_DIR)
+            .join(format!("{file_stem}.yaml"));
 
         let parsed_agent_type = AgentTypeDefinition::from_slice(self.to_string().as_bytes());
         assert!(

--- a/docs/AC_repositories_and_files.md
+++ b/docs/AC_repositories_and_files.md
@@ -27,6 +27,8 @@ The remote configurations and in general any files expected to dynamically chang
 its own files here; these survive restarts **unless they live inside a directory AC declared as ephemeral** (the default), which AC
 wipes on stop and before each re-render. To keep agent-created data across restarts, place it under a `persistent` directory or a path
 AC doesn't manage. See [Persistence in Filesystem](./INTEGRATING_AGENTS.md#persistence-in-filesystem).
+- `shared-filesystem` is a directory shared across all sub-agents (not suffixed per agent) where an agent type's `shared_filesystem`
+entries are written, so other sub-agents (e.g. the infrastructure agent) can read them. See [`shared_filesystem`](./INTEGRATING_AGENTS.md#shared_filesystem).
 
 #### Logs
 The directory inside `[...]/log/<agent-id>` will store the logs if file logging was configured, 
@@ -76,12 +78,17 @@ The following shows the directory structure used by Agent Control, assuming an e
     │       │    └── nr-infra
     │       │         ├── instance_id.yaml
     │       │         └── remote_config.yaml 
-    │       └── filesystem
-    │            └── nr-infra
-    │                ├── integrations.d
-    │                │   └── nri-redis.yaml
-    │                └── config
-    │                      └── newrelic-infra.yml
+    │       ├── filesystem
+    │       │    └── nr-infra
+    │       │        ├── integrations.d
+    │       │        │   └── nri-redis.yaml
+    │       │        └── config
+    │       │              └── newrelic-infra.yml
+    │       └── shared-filesystem
+    │            ├── infra-agent-ohi-configs
+    │            │   └── nri-redis.yaml
+    │            └── infra-agent-ohi-binaries
+    │                └── nri-redis
     └── log
         └── newrelic-agent-control
             |── agent-control
@@ -113,6 +120,11 @@ C:\ProgramData\New Relic\newrelic-agent-control
 │       │    └─── [...] Data files created by the infra agent
 │       └── config
 │             └── newrelic-infra.yml
+├───shared-filesystem
+│   ├───infra-agent-ohi-configs
+│   │       nri-redis.yaml
+│   └───infra-agent-ohi-binaries
+│           nri-redis.exe
 ├───fleet-data
 │   ├───agent-control
 │   │       instance_id.yaml

--- a/docs/AC_repositories_and_files.md
+++ b/docs/AC_repositories_and_files.md
@@ -78,17 +78,12 @@ The following shows the directory structure used by Agent Control, assuming an e
     │       │    └── nr-infra
     │       │         ├── instance_id.yaml
     │       │         └── remote_config.yaml 
-    │       ├── filesystem
-    │       │    └── nr-infra
-    │       │        ├── integrations.d
-    │       │        │   └── nri-redis.yaml
-    │       │        └── config
-    │       │              └── newrelic-infra.yml
-    │       └── shared-filesystem
-    │            ├── infra-agent-ohi-configs
-    │            │   └── nri-redis.yaml
-    │            └── infra-agent-ohi-binaries
-    │                └── nri-redis
+    │       └── filesystem
+    │            └── nr-infra
+    │                ├── integrations.d
+    │                │   └── nri-redis.yaml
+    │                └── config
+    │                      └── newrelic-infra.yml
     └── log
         └── newrelic-agent-control
             |── agent-control
@@ -120,11 +115,6 @@ C:\ProgramData\New Relic\newrelic-agent-control
 │       │    └─── [...] Data files created by the infra agent
 │       └── config
 │             └── newrelic-infra.yml
-├───shared-filesystem
-│   ├───infra-agent-ohi-configs
-│   │       nri-redis.yaml
-│   └───infra-agent-ohi-binaries
-│           nri-redis.exe
 ├───fleet-data
 │   ├───agent-control
 │   │       instance_id.yaml

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -343,7 +343,9 @@ We have some global metadata available both for on-host and k8s. Be aware that t
 For **on-host**, we have:
 
 - `host_id`: contains an identifier calculated from the retrieved information about the host, such as the hostname or cloud-related data (when available).
-- `filesystem_agent_dir`: contains the absolute path to a dedicated file system directory for this sub-agent. The default value in Linux systems is `/var/lib/newrelic_agent_control/filesystem/<AGENT_ID>`. Note how the agent type definition uses this variable for content added via the `filesystem` field (see below).
+- `filesystem_agent_dir`: contains the absolute path to a dedicated file system directory for this sub-agent. The default value in Linux systems is `/var/lib/newrelic-agent-control/filesystem/<AGENT_ID>`. Note how the agent type definition uses this variable for content added via the `filesystem` field (see below).
+- `shared_filesystem_dir`: contains the absolute path to a file system directory shared across all sub-agents. The default value in Linux systems is `/var/lib/newrelic-agent-control/shared-filesystem`. Unlike `filesystem_agent_dir`, it is **not** suffixed with the agent id. Used by the `shared_filesystem` field (see below).
+- `remote_dir`: contains the absolute path to Agent Control's data directory (the parent of the `filesystem`, `shared-filesystem` and package directories). The default value in Linux systems is `/var/lib/newrelic-agent-control`. A `copy_from_file` source must resolve to a path within this directory.
 
 For **k8s**, we have:
 
@@ -517,13 +519,16 @@ agent/integrations.d/
 
 ###### Entry kinds reference
 
-**`file`** — a single file with literal or templated content.
+**`file`** — a single file whose bytes come from exactly one of `text` (inline content) or `copy_from_file` (a copied source file).
 
-| Field        | Required | Default | Description                                                  |
-|--------------|----------|---------|--------------------------------------------------------------|
-| `kind`       | yes      | —       | Must be `file`.                                              |
-| `text`       | yes      | —       | File body. May reference `${nr-var:…}` / `${nr-sub:…}`.      |
-| `persistent` | no       | `false` | If `true`, survives sub-agent stop/restart.                  |
+| Field            | Required | Default | Description                                                                                                      |
+|------------------|----------|---------|------------------------------------------------------------------------------------------------------------------|
+| `kind`           | yes      | —       | Must be `file`.                                                                                                  |
+| `text`           | *        | —       | Inline file body. May reference `${nr-var:…}` / `${nr-sub:…}`. Mutually exclusive with `copy_from_file`.         |
+| `copy_from_file` | *        | —       | Path of a source file whose bytes are copied into this entry (e.g. a binary from a package dir). Mutually exclusive with `text`. |
+| `persistent`     | no       | `false` | If `true`, survives sub-agent stop/restart.                                                                     |
+
+*Exactly one of `text` or `copy_from_file` is required. `copy_from_file` copies the source byte-for-byte, preserving its permissions (e.g. the executable bit on Unix), and its source must resolve to a path within `${nr-sub:remote_dir}`.
 
 **`dir`** — an explicitly declared directory. Its children, if any, live under `entries:`.
 
@@ -565,6 +570,32 @@ Every `file` and `dir` entry accepts a boolean `persistent:` (default `false`). 
 | Removed from fleet | Filesystem dir deleted by ResourceCleaner       | Filesystem dir deleted by ResourceCleaner |
 
 Agent-process-created files are never declared, so `write` leaves them untouched **except** files inside an *ephemeral* directory, which are wiped along with it on stop and before each (re)write. To keep agent-created content across restarts, place it under a `persistent` directory.
+
+##### `shared_filesystem`
+
+Like [`filesystem`](#filesystem), but the tree is written under a directory **shared across all sub-agents** (`${nr-sub:shared_filesystem_dir}`, e.g. `/var/lib/newrelic-agent-control/shared-filesystem`) instead of the per-agent directory. It accepts the exact same schema (`kind: file | dir | dir_content_from_map`, nested `entries:`, and `copy_from_file`).
+
+This lets one sub-agent expose files to another that Agent Control does not supervise directly. For example, an On-Host Integration (OHI) agent type can write its configuration and copy its binary into the shared location so the infrastructure agent (a separate sub-agent) can discover and run it:
+
+```yaml
+shared_filesystem:
+  # OHI configuration the infrastructure agent reads.
+  infra-agent-ohi-configs:
+    kind: dir
+    entries:
+      nri-redis.yaml:
+        kind: file
+        text: ${nr-var:config_integration}
+  # OHI binary, copied from this agent's package dir into the shared location.
+  infra-agent-ohi-binaries:
+    kind: dir
+    entries:
+      nri-redis:
+        kind: file
+        copy_from_file: ${nr-sub:packages.nri-redis.dir}/nri-redis
+```
+
+> ⚠️ **Note:** The shared filesystem is under active development. Cleanup (removal on uninstall/reconfigure) is not implemented yet, this behavior is expected to change.
 
 ##### `packages`
 


### PR DESCRIPTION
## Summary

Adds a `shared_filesystem:` block to on-host agent types. Its entries are materialized under the
base shared across sub-agents (`${nr-sub:shared_filesystem_dir}` →
`/var/lib/newrelic-agent-control/shared-filesystem`) instead of the per-agent dir. This is how an
OHI agent type makes its config and binaries available to the infra-agent, which reads them from a
shared location.

## Out of scope

- **Cleanup on uninstall** Removing shared entries on uninstall/reconfigure is a separate, deferred task. As a result, the `persistent` field for the shared filesystem is ignored.
- **Handle concurrent writes**: two agents writing to the same file at the same time could cause race-conditions. This should be tackled when implementing the clean-up mechanism.
- Extended integration tests (with cleanup) and e2e.

## Changes

- Added shared-filesystem support
- Added integration tests for Agent Types using shared-filesystem
- Extended the CustomAgentType tooling to support multiple agent-types and the shared-filesystem field
- Updated Agent Type docs (including a callout for the missing cleanup support)

## YAML example

```yaml
deployment:
  on_host:
    packages:
      nri-redis:
        # ... OCI download coordinates; extracted under ${nr-sub:packages.nri-redis.dir}
    shared_filesystem:
      # Config the infra-agent reads, placed in the shared location.
      infra-agent-ohi-configs:
        kind: dir
        entries:
          nri-redis.yaml:
            kind: file
            text: ${nr-var:config_integration}
      # The OHI binary, copied into a sibling shared folder.
      infra-agent-ohi-binaries:
        kind: dir
        entries:
          nri-redis:
            kind: file
            copy_from_file: ${nr-sub:packages.nri-redis.dir}/nri-redis
```


