### PR TITLE
fix(packaging): preserve local_config.yaml on RPM reinstall and uninstall

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ nfpms: # deb and rpm are only built for linux targets
           mode: 0700
       - src: build/package/config.yaml
         dst: /etc/newrelic-agent-control/local-data/agent-control/local_config.yaml
-        type: config
+        type: config|noreplace
         file_info:
           mode: 0600
       - src: build/package/newrelic-agent-control.service


### PR DESCRIPTION
Mark local_config.yaml as config|noreplace in the RPM package to prevent it from being overwritten on reinstall or renamed to .rpmsave on uninstall.

## Context
On RedHat and SUSE systems, uninstalling the package renamed the user's `local_config.yaml` to `local_config.yaml.rpmsave` instead of leaving it in place. On reinstall, `local_config.yaml` is created with the package template, discarding user configuration (license key, fleet ID, etc.).

This did not affect Debian/Ubuntu because dpkg uses noreplace semantics by default.

## Technical details
nfpm's `type: config` maps to RPM's `%config`, which overwrites modified files on upgrade and renames them to `.rpmsave` on uninstall. Adding `|noreplace` maps to `%config(noreplace)`, which leaves the existing file untouched on upgrade (saving the new template as `.rpmnew`) and leaves it in place on uninstall.