### PR TITLE
fix: preserve local config on rpm reinstall

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ nfpms: # deb and rpm are only built for linux targets
           mode: 0700
       - src: build/package/config.yaml
         dst: /etc/newrelic-agent-control/local-data/agent-control/local_config.yaml
-        type: config
+        type: config|noreplace
         file_info:
           mode: 0600
       - src: build/package/newrelic-agent-control.service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Remember that the keywords that you can use are the following:
 
 ## Unreleased
 
+### bugfix
+- RPM packages now restore `local_config.yaml` from the `.rpmsave` backup left by a prior uninstall.
+
 ### enhancement
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.

--- a/build/package/postinstall.sh
+++ b/build/package/postinstall.sh
@@ -23,6 +23,15 @@ else
 fi
 
 ######################################################################################
+# Newrelic Agent Control - restore config saved by RPM on uninstall
+######################################################################################
+CONFIG_FILE=/etc/newrelic-agent-control/local-data/agent-control/local_config.yaml
+RPMSAVE="${CONFIG_FILE}.rpmsave"
+if [ -f "$RPMSAVE" ]; then
+    mv "$RPMSAVE" "$CONFIG_FILE"
+fi
+
+######################################################################################
 # Newrelic Agent Control
 ######################################################################################
 if command -v systemctl >/dev/null 2>&1; then

--- a/test/e2e-runner/src/linux.rs
+++ b/test/e2e-runner/src/linux.rs
@@ -8,6 +8,8 @@ pub mod scenarios;
 mod bash;
 mod service;
 
+// This default path is also used in the postinstall.sh script of the packages.
+// It must be kept in sync with the path defined in the script.
 const DEFAULT_AC_CONFIG_PATH: &str =
     "/etc/newrelic-agent-control/local-data/agent-control/local_config.yaml";
 


### PR DESCRIPTION
Mark local_config.yaml as config|noreplace in the RPM package to prevent it from being overwritten on reinstall or renamed to .rpmsave on uninstall.

## Context
On RedHat and SUSE systems, uninstalling the package renamed the user's `local_config.yaml` to `local_config.yaml.rpmsave` instead of leaving it in place. On reinstall, `local_config.yaml` is created with the package template, discarding user configuration (license key, fleet ID, etc.).

This did not affect Debian/Ubuntu because dpkg uses noreplace semantics by default.

## Technical details
nfpm's `type: config` maps to RPM's `%config`, which overwrites modified files on upgrade and renames them to `.rpmsave` on uninstall. Adding `|noreplace` maps to `%config(noreplace)`, which leaves the existing file untouched on upgrade (saving the new template as `.rpmnew`) and leaves it in place on uninstall.