### PR TITLE
feat: Multipackage agent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Remember that the keywords that you can use are the following:
 - RPM packages now restore `local_config.yaml` from the `.rpmsave` backup left by a prior uninstall.
 
 ### enhancement
+- On-host agent-type parsing now validates `version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `version_package` will be used to know which version to report as `agent.version`.
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - Add support for `shared_filesystem` in on-host agent types.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Remember that the keywords that you can use are the following:
 - RPM packages now restore `local_config.yaml` from the `.rpmsave` backup left by a prior uninstall.
 
 ### enhancement
-- On-host agent-type parsing now validates `reported_version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `version_package` will be used to know which version to report as `agent.version`.
+- On-host agent-type parsing now validates `reported_version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `reported_version_package` will be used to know which version to report as `agent.version`.
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - Add support for `shared_filesystem` in on-host agent types.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Remember that the keywords that you can use are the following:
 - RPM packages now restore `local_config.yaml` from the `.rpmsave` backup left by a prior uninstall.
 
 ### enhancement
-- On-host agent-type parsing now validates `version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `version_package` will be used to know which version to report as `agent.version`.
+- On-host agent-type parsing now validates `reported_version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `version_package` will be used to know which version to report as `agent.version`.
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - Add support for `shared_filesystem` in on-host agent types.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -258,12 +258,12 @@ deployment:
 The resolved value of that `version` field is published as `agent.version`.
 
 When an agent type defines **more than one package**, the package to report is selected explicitly
-with the top-level `deployment.version_package` field, which must name one of the declared
+with the top-level `deployment.reported_version_package` field, which must name one of the declared
 packages:
 
 ```yaml
 deployment:
-  version_package: newrelic-infra   # required when more than one package is declared
+  reported_version_package: newrelic-infra   # required when more than one package is declared
   packages:
     newrelic-infra:
       download:
@@ -279,8 +279,8 @@ deployment:
 
 Rules:
 
-* With **one** package, `version_package` is optional and defaults to that sole package.
-* With **more than one** package, `version_package` is **required** and must reference a declared
+* With **one** package, `reported_version_package` is optional and defaults to that sole package.
+* With **more than one** package, `reported_version_package` is **required** and must reference a declared
   package id; otherwise the agent type fails validation at parse time.
 * With **no** packages, no `agent.version` is reported.
 

--- a/agent-control/src/agent_type/README.md
+++ b/agent-control/src/agent_type/README.md
@@ -255,9 +255,36 @@ deployment:
           version: ${nr-var:package_version}
 ```
 
-The resolved value of that `version` field is published as `agent.version`. Which package reports
-the version when an agent type defines more than one is not yet finalized. See
-[On Host Packages](#on-host-packages) for the full package configuration.
+The resolved value of that `version` field is published as `agent.version`.
+
+When an agent type defines **more than one package**, the package to report is selected explicitly
+with the top-level `deployment.version_package` field, which must name one of the declared
+packages:
+
+```yaml
+deployment:
+  version_package: newrelic-infra   # required when more than one package is declared
+  packages:
+    newrelic-infra:
+      download:
+        oci:
+          repository: newrelic-infra
+          version: ${nr-var:package_version}
+    nri-flex:
+      download:
+        oci:
+          repository: nri-flex
+          version: ${nr-var:flex_version}
+```
+
+Rules:
+
+* With **one** package, `version_package` is optional and defaults to that sole package.
+* With **more than one** package, `version_package` is **required** and must reference a declared
+  package id; otherwise the agent type fails validation at parse time.
+* With **no** packages, no `agent.version` is reported.
+
+See [On Host Packages](#on-host-packages) for the full package configuration.
 
 ### Kubernetes Deployment
 

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -20,12 +20,27 @@ pub mod rendered;
 ///
 /// It contains the instructions of what are the agent binaries, command-line arguments, the environment variables passed to it and the restart policy of the supervisor.
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[serde(try_from = "OnHostRaw")]
 pub struct OnHost {
+    executables: Vec<Executable>,
+    enable_file_logging: TemplateableValue<bool>,
+    /// Enables and defines health checks configuration.
+    health: Option<OnHostHealthConfig>,
+    filesystem: FileSystem,
+    packages: Packages,
+    shared_filesystem: SharedFileSystem,
+    /// Package whose OCI version is reported as the `agent.version` identifying attribute.
+    version_package: Option<PackageID>,
+}
+
+type Packages = HashMap<PackageID, Package>;
+
+#[derive(Debug, Deserialize)]
+struct OnHostRaw {
     #[serde(deserialize_with = "deserialize_executables", default)]
     executables: Vec<Executable>,
     #[serde(default)]
     enable_file_logging: TemplateableValue<bool>,
-    /// Enables and define health checks configuration.
     #[serde(default)]
     health: Option<OnHostHealthConfig>,
     #[serde(default)]
@@ -34,9 +49,61 @@ pub struct OnHost {
     shared_filesystem: SharedFileSystem,
     #[serde(default)]
     packages: Packages,
+    #[serde(default)]
+    version_package: Option<PackageID>,
 }
 
-type Packages = HashMap<PackageID, Package>;
+impl TryFrom<OnHostRaw> for OnHost {
+    type Error = String;
+
+    fn try_from(raw: OnHostRaw) -> Result<Self, Self::Error> {
+        let version_package = resolve_version_package(&raw.packages, raw.version_package)?;
+        Ok(OnHost {
+            executables: raw.executables,
+            enable_file_logging: raw.enable_file_logging,
+            health: raw.health,
+            filesystem: raw.filesystem,
+            shared_filesystem: raw.shared_filesystem,
+            packages: raw.packages,
+            version_package,
+        })
+    }
+}
+
+/// Resolves which package's OCI version is reported as `agent.version`:
+/// - an explicit `version_package` must reference a declared package;
+/// - with no packages declared, there is nothing to report (`None`);
+/// - with exactly one package, it defaults to that package;
+/// - with more than one package, `version_package` is required.
+fn resolve_version_package(
+    packages: &Packages,
+    declared: Option<PackageID>,
+) -> Result<Option<PackageID>, String> {
+    if let Some(id) = declared {
+        if packages.contains_key(&id) {
+            return Ok(Some(id));
+        }
+        return Err(format!(
+            "`version_package` references unknown package `{id}`; declared packages: [{}]",
+            sorted_package_ids(packages)
+        ));
+    }
+
+    match packages.len() {
+        0 => Ok(None),
+        1 => Ok(packages.keys().next().cloned()),
+        _ => Err(format!(
+            "`version_package` is required when more than one package is defined; declared packages: [{}]",
+            sorted_package_ids(packages)
+        )),
+    }
+}
+
+fn sorted_package_ids(packages: &Packages) -> String {
+    let mut ids = packages.keys().cloned().collect::<Vec<_>>();
+    ids.sort();
+    ids.join(", ")
+}
 
 impl OnHost {
     /// The files and directories this Agent Type declares in the shared filesystem.
@@ -96,6 +163,7 @@ impl Templateable for OnHost {
             filesystem: self.filesystem.template_with(&extended_vars)?,
             shared_filesystem: self.shared_filesystem.template_with(&extended_vars)?,
             packages: rendered_packages,
+            version_package: self.version_package,
         })
     }
 }
@@ -231,6 +299,106 @@ packages:
                 .to_string_lossy()
                 .to_string(),
         );
+    }
+
+    #[test]
+    fn version_package_defaults_to_sole_package() {
+        let yaml = r#"
+packages:
+  infra:
+    download:
+      oci:
+        repository: newrelic-infra
+        version: "1.2.3"
+"#;
+        let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(on_host.version_package, Some("infra".to_string()));
+    }
+
+    #[test]
+    fn version_package_explicit_selection_with_multiple_packages() {
+        let yaml = r#"
+version_package: infra
+packages:
+  infra:
+    download:
+      oci:
+        repository: newrelic-infra
+        version: "1.2.3"
+  flex:
+    download:
+      oci:
+        repository: nri-flex
+        version: "4.5.6"
+"#;
+        let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(on_host.version_package, Some("infra".to_string()));
+    }
+
+    #[test]
+    fn version_package_required_when_multiple_packages() {
+        let yaml = r#"
+packages:
+  infra:
+    download:
+      oci:
+        repository: newrelic-infra
+        version: "1.2.3"
+  flex:
+    download:
+      oci:
+        repository: nri-flex
+        version: "4.5.6"
+"#;
+        let err = serde_saphyr::from_str::<OnHost>(yaml)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("version_package") && err.contains("required"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("flex") && err.contains("infra"),
+            "error should list declared package ids: {err}"
+        );
+    }
+
+    #[test]
+    fn version_package_referencing_unknown_id_errors() {
+        let yaml = r#"
+version_package: does-not-exist
+packages:
+  infra:
+    download:
+      oci:
+        repository: newrelic-infra
+        version: "1.2.3"
+"#;
+        let err = serde_saphyr::from_str::<OnHost>(yaml)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown package"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn version_package_set_without_packages_errors() {
+        let yaml = "version_package: infra\n";
+        let err = serde_saphyr::from_str::<OnHost>(yaml)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown package"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn no_packages_yields_no_version_package() {
+        let yaml = r#"
+executables:
+  - id: test
+    path: /bin/true
+    args: []
+"#;
+        let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(on_host.version_package, None);
     }
 
     #[test]
@@ -670,6 +838,7 @@ executables:
             filesystem: FileSystem::default(),
             shared_filesystem: SharedFileSystem::default(),
             packages: Default::default(),
+            version_package: None,
         };
 
         // Compare the default OnHost instance with the parsed instance
@@ -748,6 +917,7 @@ executables:
         backoff_delay: 1s
         max_retries: 3
         last_retry_interval: 30s
+version_package: otel-first
 packages:
   otel-first:
     download:

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -29,7 +29,7 @@ pub struct OnHost {
     packages: Packages,
     shared_filesystem: SharedFileSystem,
     /// Package whose OCI version is reported as the `agent.version` identifying attribute.
-    version_package: Option<PackageID>,
+    reported_version_package: Option<PackageID>,
 }
 
 type Packages = HashMap<PackageID, Package>;
@@ -58,7 +58,7 @@ impl<'de> Deserialize<'de> for OnHost {
         }
 
         let raw = OnHostRaw::deserialize(deserializer)?;
-        let version_package = resolve_version_package(&raw.packages, raw.version_package)?;
+        let reported_version_package = resolve_version_package(&raw.packages, raw.version_package)?;
         Ok(OnHost {
             executables: raw.executables,
             enable_file_logging: raw.enable_file_logging,
@@ -66,7 +66,7 @@ impl<'de> Deserialize<'de> for OnHost {
             filesystem: raw.filesystem,
             shared_filesystem: raw.shared_filesystem,
             packages: raw.packages,
-            version_package,
+            reported_version_package,
         })
     }
 }
@@ -158,7 +158,7 @@ impl Templateable for OnHost {
             filesystem: self.filesystem.template_with(&extended_vars)?,
             shared_filesystem: self.shared_filesystem.template_with(&extended_vars)?,
             packages: rendered_packages,
-            version_package: self.version_package,
+            reported_version_package: self.reported_version_package,
         })
     }
 }
@@ -307,7 +307,7 @@ packages:
         version: "1.2.3"
 "#;
         let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
-        assert_eq!(on_host.version_package, Some("infra".to_string()));
+        assert_eq!(on_host.reported_version_package, Some("infra".to_string()));
     }
 
     #[test]
@@ -327,7 +327,7 @@ packages:
         version: "4.5.6"
 "#;
         let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
-        assert_eq!(on_host.version_package, Some("infra".to_string()));
+        assert_eq!(on_host.reported_version_package, Some("infra".to_string()));
     }
 
     #[test]
@@ -393,7 +393,7 @@ executables:
     args: []
 "#;
         let on_host: OnHost = serde_saphyr::from_str(yaml).unwrap();
-        assert_eq!(on_host.version_package, None);
+        assert_eq!(on_host.reported_version_package, None);
     }
 
     #[test]
@@ -833,7 +833,7 @@ executables:
             filesystem: FileSystem::default(),
             shared_filesystem: SharedFileSystem::default(),
             packages: Default::default(),
-            version_package: None,
+            reported_version_package: None,
         };
 
         // Compare the default OnHost instance with the parsed instance

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -85,7 +85,7 @@ fn resolve_version_package(
         }
         return Err(format!(
             "`version_package` references unknown package `{id}`; declared packages: [{}]",
-            sorted_package_ids(packages)
+            packages.keys().cloned().collect::<Vec<_>>().join(", ")
         ));
     }
 
@@ -94,15 +94,9 @@ fn resolve_version_package(
         1 => Ok(packages.keys().next().cloned()),
         _ => Err(format!(
             "`version_package` is required when more than one package is defined; declared packages: [{}]",
-            sorted_package_ids(packages)
+            packages.keys().cloned().collect::<Vec<_>>().join(", ")
         )),
     }
-}
-
-fn sorted_package_ids(packages: &Packages) -> String {
-    let mut ids = packages.keys().cloned().collect::<Vec<_>>();
-    ids.sort();
-    ids.join(", ")
 }
 
 impl OnHost {

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -19,8 +19,7 @@ pub mod rendered;
 /// The definition for an on-host supervisor.
 ///
 /// It contains the instructions of what are the agent binaries, command-line arguments, the environment variables passed to it and the restart policy of the supervisor.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-#[serde(try_from = "OnHostRaw")]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct OnHost {
     executables: Vec<Executable>,
     enable_file_logging: TemplateableValue<bool>,
@@ -35,28 +34,30 @@ pub struct OnHost {
 
 type Packages = HashMap<PackageID, Package>;
 
-#[derive(Debug, Deserialize)]
-struct OnHostRaw {
-    #[serde(deserialize_with = "deserialize_executables", default)]
-    executables: Vec<Executable>,
-    #[serde(default)]
-    enable_file_logging: TemplateableValue<bool>,
-    #[serde(default)]
-    health: Option<OnHostHealthConfig>,
-    #[serde(default)]
-    filesystem: FileSystem,
-    #[serde(default)]
-    shared_filesystem: SharedFileSystem,
-    #[serde(default)]
-    packages: Packages,
-    #[serde(default)]
-    version_package: Option<PackageID>,
-}
+impl<'de> Deserialize<'de> for OnHost {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct OnHostRaw {
+            #[serde(deserialize_with = "deserialize_executables", default)]
+            executables: Vec<Executable>,
+            #[serde(default)]
+            enable_file_logging: TemplateableValue<bool>,
+            #[serde(default)]
+            health: Option<OnHostHealthConfig>,
+            #[serde(default)]
+            filesystem: FileSystem,
+            #[serde(default)]
+            shared_filesystem: SharedFileSystem,
+            #[serde(default)]
+            packages: Packages,
+            #[serde(default)]
+            version_package: Option<PackageID>,
+        }
 
-impl TryFrom<OnHostRaw> for OnHost {
-    type Error = String;
-
-    fn try_from(raw: OnHostRaw) -> Result<Self, Self::Error> {
+        let raw = OnHostRaw::deserialize(deserializer)?;
         let version_package = resolve_version_package(&raw.packages, raw.version_package)?;
         Ok(OnHost {
             executables: raw.executables,
@@ -75,27 +76,27 @@ impl TryFrom<OnHostRaw> for OnHost {
 /// - with no packages declared, there is nothing to report (`None`);
 /// - with exactly one package, it defaults to that package;
 /// - with more than one package, `version_package` is required.
-fn resolve_version_package(
+fn resolve_version_package<E: serde::de::Error>(
     packages: &Packages,
     declared: Option<PackageID>,
-) -> Result<Option<PackageID>, String> {
+) -> Result<Option<PackageID>, E> {
     if let Some(id) = declared {
         if packages.contains_key(&id) {
             return Ok(Some(id));
         }
-        return Err(format!(
+        return Err(E::custom(format!(
             "`version_package` references unknown package `{id}`; declared packages: [{}]",
             packages.keys().cloned().collect::<Vec<_>>().join(", ")
-        ));
+        )));
     }
 
     match packages.len() {
         0 => Ok(None),
         1 => Ok(packages.keys().next().cloned()),
-        _ => Err(format!(
+        _ => Err(E::custom(format!(
             "`version_package` is required when more than one package is defined; declared packages: [{}]",
             packages.keys().cloned().collect::<Vec<_>>().join(", ")
-        )),
+        ))),
     }
 }
 

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -58,7 +58,8 @@ impl<'de> Deserialize<'de> for OnHost {
         }
 
         let raw = OnHostRaw::deserialize(deserializer)?;
-        let reported_version_package = resolve_reported_version_package(&raw.packages, raw.reported_version_package)?;
+        let reported_version_package =
+            resolve_reported_version_package(&raw.packages, raw.reported_version_package)?;
         Ok(OnHost {
             executables: raw.executables,
             enable_file_logging: raw.enable_file_logging,

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -54,11 +54,11 @@ impl<'de> Deserialize<'de> for OnHost {
             #[serde(default)]
             packages: Packages,
             #[serde(default)]
-            version_package: Option<PackageID>,
+            reported_version_package: Option<PackageID>,
         }
 
         let raw = OnHostRaw::deserialize(deserializer)?;
-        let reported_version_package = resolve_version_package(&raw.packages, raw.version_package)?;
+        let reported_version_package = resolve_reported_version_package(&raw.packages, raw.reported_version_package)?;
         Ok(OnHost {
             executables: raw.executables,
             enable_file_logging: raw.enable_file_logging,
@@ -72,11 +72,11 @@ impl<'de> Deserialize<'de> for OnHost {
 }
 
 /// Resolves which package's OCI version is reported as `agent.version`:
-/// - an explicit `version_package` must reference a declared package;
+/// - an explicit `reported_version_package` must reference a declared package;
 /// - with no packages declared, there is nothing to report (`None`);
 /// - with exactly one package, it defaults to that package;
-/// - with more than one package, `version_package` is required.
-fn resolve_version_package<E: serde::de::Error>(
+/// - with more than one package, `reported_version_package` is required.
+fn resolve_reported_version_package<E: serde::de::Error>(
     packages: &Packages,
     declared: Option<PackageID>,
 ) -> Result<Option<PackageID>, E> {
@@ -85,7 +85,7 @@ fn resolve_version_package<E: serde::de::Error>(
             return Ok(Some(id));
         }
         return Err(E::custom(format!(
-            "`version_package` references unknown package `{id}`; declared packages: [{}]",
+            "`reported_version_package` references unknown package `{id}`; declared packages: [{}]",
             packages.keys().cloned().collect::<Vec<_>>().join(", ")
         )));
     }
@@ -94,7 +94,7 @@ fn resolve_version_package<E: serde::de::Error>(
         0 => Ok(None),
         1 => Ok(packages.keys().next().cloned()),
         _ => Err(E::custom(format!(
-            "`version_package` is required when more than one package is defined; declared packages: [{}]",
+            "`reported_version_package` is required when more than one package is defined; declared packages: [{}]",
             packages.keys().cloned().collect::<Vec<_>>().join(", ")
         ))),
     }
@@ -297,7 +297,7 @@ packages:
     }
 
     #[test]
-    fn version_package_defaults_to_sole_package() {
+    fn reported_version_package_defaults_to_sole_package() {
         let yaml = r#"
 packages:
   infra:
@@ -311,9 +311,9 @@ packages:
     }
 
     #[test]
-    fn version_package_explicit_selection_with_multiple_packages() {
+    fn reported_version_package_explicit_selection_with_multiple_packages() {
         let yaml = r#"
-version_package: infra
+reported_version_package: infra
 packages:
   infra:
     download:
@@ -331,7 +331,7 @@ packages:
     }
 
     #[test]
-    fn version_package_required_when_multiple_packages() {
+    fn reported_version_package_required_when_multiple_packages() {
         let yaml = r#"
 packages:
   infra:
@@ -349,7 +349,7 @@ packages:
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("version_package") && err.contains("required"),
+            err.contains("reported_version_package") && err.contains("required"),
             "unexpected error: {err}"
         );
         assert!(
@@ -359,9 +359,9 @@ packages:
     }
 
     #[test]
-    fn version_package_referencing_unknown_id_errors() {
+    fn reported_version_package_referencing_unknown_id_errors() {
         let yaml = r#"
-version_package: does-not-exist
+reported_version_package: does-not-exist
 packages:
   infra:
     download:
@@ -376,8 +376,8 @@ packages:
     }
 
     #[test]
-    fn version_package_set_without_packages_errors() {
-        let yaml = "version_package: infra\n";
+    fn reported_version_package_set_without_packages_errors() {
+        let yaml = "reported_version_package: infra\n";
         let err = serde_saphyr::from_str::<OnHost>(yaml)
             .unwrap_err()
             .to_string();
@@ -385,7 +385,7 @@ packages:
     }
 
     #[test]
-    fn no_packages_yields_no_version_package() {
+    fn no_packages_yields_no_reported_version_package() {
         let yaml = r#"
 executables:
   - id: test
@@ -912,7 +912,7 @@ executables:
         backoff_delay: 1s
         max_retries: 3
         last_retry_interval: 30s
-version_package: otel-first
+reported_version_package: otel-first
 packages:
   otel-first:
     download:

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -25,6 +25,8 @@ pub struct OnHost {
     pub shared_filesystem: SharedFileSystem,
     /// Packages to download for this agent.
     pub packages: RenderedPackages,
+    /// Main OCI Package version reported as the `agent.version`.
+    pub version_package: Option<PackageID>,
 }
 
 /// Rendered packages keyed by their [`PackageID`].

--- a/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/rendered.rs
@@ -26,7 +26,7 @@ pub struct OnHost {
     /// Packages to download for this agent.
     pub packages: RenderedPackages,
     /// Main OCI Package version reported as the `agent.version`.
-    pub version_package: Option<PackageID>,
+    pub reported_version_package: Option<PackageID>,
 }
 
 /// Rendered packages keyed by their [`PackageID`].

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -170,7 +170,8 @@ where
             self.logging_path.to_path_buf(),
             on_host.filesystem,
             on_host.shared_filesystem,
-        ))
+        )
+        .with_version_package(on_host.version_package))
     }
 }
 

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -165,13 +165,13 @@ where
             executables,
             on_host.health,
             on_host.packages,
+            on_host.reported_version_package,
             self.package_manager.clone(),
             on_host.enable_file_logging,
             self.logging_path.to_path_buf(),
             on_host.filesystem,
             on_host.shared_filesystem,
-        )
-        .with_version_package(on_host.version_package))
+        ))
     }
 }
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -107,7 +107,7 @@ where
     health_config: Option<OnHostHealthConfig>,
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
-    version_package: Option<PackageID>,
+    reported_version_package: Option<PackageID>,
     filesystem: FileSystem,
     shared_filesystem: SharedFileSystem,
 }
@@ -193,6 +193,7 @@ where
             executables,
             onhost_config.health,
             onhost_config.packages,
+            onhost_config.reported_version_package,
             package_manager,
             onhost_config.enable_file_logging,
             logging_path,
@@ -228,6 +229,7 @@ where
         executables: Vec<ExecutableData>,
         health_config: Option<OnHostHealthConfig>,
         packages_config: RenderedPackages,
+        reported_version_package: Option<PackageID>,
         package_manager: Arc<PM>,
         file_logging_enable: bool,
         file_logging_path: PathBuf,
@@ -242,18 +244,10 @@ where
             health_config,
             package_manager,
             packages_config,
-            version_package: None,
+            reported_version_package,
             filesystem,
             shared_filesystem,
         }
-    }
-
-    /// Sets the package whose OCI version is reported as `agent.version`. When left unset (`None`),
-    /// [`check_subagent_version`](Self::check_subagent_version) falls back to the sole configured
-    /// package.
-    pub fn with_version_package(mut self, version_package: Option<PackageID>) -> Self {
-        self.version_package = version_package;
-        self
     }
 
     fn start_health_check(
@@ -329,7 +323,7 @@ where
     }
 
     fn version_package_to_report(&self) -> Option<(&PackageID, &RenderedPackage)> {
-        if let Some(id) = &self.version_package {
+        if let Some(id) = &self.reported_version_package {
             return self.packages_config.get_key_value(id);
         }
 
@@ -705,6 +699,7 @@ pub mod tests {
     use crate::sub_agent::on_host::command::restart_policy::{Backoff, RestartPolicy};
     use crate::sub_agent::supervisor::Supervisor;
     use crate::utils::retry::retry;
+    use rstest::rstest;
     use serde::Deserialize;
     use std::collections::HashMap;
     use std::{
@@ -732,7 +727,7 @@ pub mod tests {
 
     fn supervisor_with_packages(
         packages: RenderedPackages,
-        version_package: Option<PackageID>,
+        reported_version_package: Option<PackageID>,
     ) -> NotStartedSupervisorOnHost<MockPackageManager> {
         let agent_identity = AgentIdentity::from((
             AgentID::try_from("test-agent".to_string()).unwrap(),
@@ -743,62 +738,54 @@ pub mod tests {
             vec![],
             None,
             packages,
+            reported_version_package,
             Arc::new(MockPackageManager::new()),
             false,
             PathBuf::from("/tmp"),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         )
-        .with_version_package(version_package)
     }
 
-    #[test]
-    fn version_package_to_report_selects_configured_package() {
-        let packages = RenderedPackages::from([
-            (
-                "infra".to_string(),
-                rendered_package("newrelic-infra", "1.2.3"),
-            ),
-            ("flex".to_string(), rendered_package("nri-flex", "4.5.6")),
-        ]);
-        let supervisor = supervisor_with_packages(packages, Some("flex".to_string()));
+    #[rstest]
+    // An explicit reported_version_package selects that package among several.
+    #[case::selects_configured_package(
+        vec![("infra", "newrelic-infra", "1.2.3"), ("flex", "nri-flex", "4.5.6")],
+        Some("flex".to_string()),
+        Some(("flex", "4.5.6")),
+    )]
+    // With a sole package and no explicit selection, it defaults to that package.
+    #[case::defaults_to_sole_package(
+        vec![("infra", "newrelic-infra", "1.2.3")],
+        None,
+        Some(("infra", "1.2.3")),
+    )]
+    // No packages: nothing to report.
+    #[case::none_without_packages(vec![], None, None)]
+    // No reported_version_package + multiple packages is ambiguous: nothing is reported.
+    #[case::none_when_ambiguous(
+        vec![("infra", "newrelic-infra", "1.2.3"), ("flex", "nri-flex", "4.5.6")],
+        None,
+        None,
+    )]
+    fn version_package_to_report(
+        #[case] packages: Vec<(&str, &str, &str)>,
+        #[case] reported_version_package: Option<PackageID>,
+        #[case] expected: Option<(&str, &str)>,
+    ) {
+        let packages = packages
+            .into_iter()
+            .map(|(id, repository, version)| {
+                (id.to_string(), rendered_package(repository, version))
+            })
+            .collect();
+        let supervisor = supervisor_with_packages(packages, reported_version_package);
 
-        let (id, package) = supervisor.version_package_to_report().unwrap();
-        assert_eq!(id, "flex");
-        assert_eq!(package.download.oci.version.to_string(), "4.5.6");
-    }
-
-    #[test]
-    fn version_package_to_report_defaults_to_sole_package() {
-        let packages = RenderedPackages::from([(
-            "infra".to_string(),
-            rendered_package("newrelic-infra", "1.2.3"),
-        )]);
-        let supervisor = supervisor_with_packages(packages, None);
-
-        let (id, package) = supervisor.version_package_to_report().unwrap();
-        assert_eq!(id, "infra");
-        assert_eq!(package.download.oci.version.to_string(), "1.2.3");
-    }
-
-    #[test]
-    fn version_package_to_report_none_without_packages() {
-        let supervisor = supervisor_with_packages(get_empty_packages(), None);
-        assert!(supervisor.version_package_to_report().is_none());
-    }
-
-    #[test]
-    fn version_package_to_report_none_when_ambiguous() {
-        // No version_package + multiple packages is ambiguous: nothing is reported.
-        let packages = RenderedPackages::from([
-            (
-                "infra".to_string(),
-                rendered_package("newrelic-infra", "1.2.3"),
-            ),
-            ("flex".to_string(), rendered_package("nri-flex", "4.5.6")),
-        ]);
-        let supervisor = supervisor_with_packages(packages, None);
-        assert!(supervisor.version_package_to_report().is_none());
+        let reported = supervisor
+            .version_package_to_report()
+            .map(|(id, package)| (id.as_str(), package.download.oci.version.to_string()));
+        let expected = expected.map(|(id, version)| (id, version.to_string()));
+        assert_eq!(reported, expected);
     }
 
     #[derive(Clone, Deserialize)]
@@ -868,6 +855,7 @@ pub mod tests {
             executable_data,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -914,6 +902,7 @@ pub mod tests {
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -966,6 +955,7 @@ persistent.txt:
             vec![],
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1036,6 +1026,7 @@ persistent.txt:
             vec![],
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1080,6 +1071,7 @@ persistent.txt:
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1130,6 +1122,7 @@ persistent.txt:
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1180,6 +1173,7 @@ persistent.txt:
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1225,6 +1219,7 @@ persistent.txt:
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1289,6 +1284,7 @@ persistent.txt:
             executables,
             None,
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1470,6 +1466,7 @@ persistent.txt:
             vec![exec_data_1],
             None,
             get_empty_packages(),
+            None,
             Arc::new(MockPackageManager::new()),
             true,
             logging_path.clone(),
@@ -1511,7 +1508,7 @@ persistent.txt:
             filesystem: FileSystem::test_empty(),
             shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
-            version_package: None,
+            reported_version_package: None,
         };
 
         let runtime = Runtime {
@@ -1563,261 +1560,6 @@ persistent.txt:
     }
 
     #[test]
-    fn test_supervisor_reloading_enables_file_logging() {
-        let dir = tempfile::tempdir().unwrap();
-        let logging_path = dir.path().to_path_buf();
-
-        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
-        let unique_str_1 = "run1_unique_string";
-        let args_1 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_1.to_string(),
-            ]
-        } else {
-            vec![unique_str_1.to_string()]
-        };
-
-        let exec_data_1 = ExecutableData {
-            id: "echo-agent".to_string(),
-            bin: echo_cmd.to_string(),
-            args: args_1,
-            env: HashMap::new(),
-            shutdown_timeout: Duration::from_secs(5),
-            restart_policy: RestartPolicy::default(),
-        };
-
-        let agent_identity = AgentIdentity::from((
-            AgentID::try_from("test-agent".to_string()).unwrap(),
-            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
-        ));
-
-        // Start with logging DISABLED
-        let supervisor = NotStartedSupervisorOnHost::new(
-            agent_identity.clone(),
-            vec![exec_data_1],
-            None,
-            get_empty_packages(),
-            Arc::new(MockPackageManager::new()),
-            false,
-            logging_path.clone(),
-            FileSystem::test_empty(),
-            SharedFileSystem::test_empty(),
-        );
-
-        let (pub_internal, _sub_internal) = pub_sub();
-        let started_supervisor = supervisor
-            .spin_up(pub_internal.clone())
-            .expect("failed to start");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        let unique_str_2 = "run2_unique_string";
-        let args_2 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_2.to_string(),
-            ]
-        } else {
-            vec![unique_str_2.to_string()]
-        };
-
-        let executable_rendered = Executable {
-            id: "echo-agent".to_string(),
-            path: echo_cmd.to_string(),
-            args: Args(args_2),
-            env: Env(HashMap::new()),
-            restart_policy: RestartPolicyConfig::default(),
-        };
-
-        // ENABLING file logging on reload
-        let on_host_config = OnHost {
-            executables: vec![executable_rendered],
-            enable_file_logging: true,
-            health: None,
-            filesystem: FileSystem::test_empty(),
-            shared_filesystem: SharedFileSystem::test_empty(),
-            packages: get_empty_packages(),
-            version_package: None,
-        };
-
-        let runtime = Runtime {
-            deployment: Deployment::Host(on_host_config.clone()),
-        };
-
-        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
-
-        let started_supervisor = started_supervisor
-            .apply(effective_agent)
-            .expect("failed to apply");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        started_supervisor.stop().expect("failed to stop");
-
-        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
-        assert!(
-            agent_logs_dir.exists(),
-            "Log directory {:?} should exist",
-            agent_logs_dir
-        );
-
-        let all_contents = fs::read_dir(agent_logs_dir)
-            .expect("should find logs dir")
-            .map(|entry| entry.expect("entry").path())
-            .filter(|p| {
-                // The `echo` commands should write to stdout, so we look for these files only.
-                // Filtering by prefix because the timestamp is appended to the file name.
-                p.file_name()
-                    .is_some_and(|n| n.to_string_lossy().ends_with(STDOUT_LOG_FILE_NAME_SUFFIX))
-            })
-            .map(|p| fs::read_to_string(p).unwrap_or_default())
-            // we just merge all contents
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(
-            !all_contents.contains(unique_str_1),
-            "First run log SHOULD NOT be found (it was disabled)"
-        );
-
-        assert!(
-            all_contents.contains(unique_str_2),
-            "Second run log SHOULD be found (it was enabled)"
-        );
-    }
-
-    #[test]
-    fn test_supervisor_reloading_disables_file_logging() {
-        let dir = tempfile::tempdir().unwrap();
-        let logging_path = dir.path().to_path_buf();
-
-        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
-        let unique_str_1 = "run1_unique_string";
-        let args_1 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_1.to_string(),
-            ]
-        } else {
-            vec![unique_str_1.to_string()]
-        };
-
-        let exec_data_1 = ExecutableData {
-            id: "echo-agent".to_string(),
-            bin: echo_cmd.to_string(),
-            args: args_1,
-            env: HashMap::new(),
-            shutdown_timeout: Duration::from_secs(5),
-            restart_policy: RestartPolicy::default(),
-        };
-
-        let agent_identity = AgentIdentity::from((
-            AgentID::try_from("test-agent".to_string()).unwrap(),
-            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
-        ));
-
-        // Start with logging ENABLED
-        let supervisor = NotStartedSupervisorOnHost::new(
-            agent_identity.clone(),
-            vec![exec_data_1],
-            None,
-            get_empty_packages(),
-            Arc::new(MockPackageManager::new()),
-            true,
-            logging_path.clone(),
-            FileSystem::test_empty(),
-            SharedFileSystem::test_empty(),
-        );
-
-        let (pub_internal, _sub_internal) = pub_sub();
-        let started_supervisor = supervisor
-            .spin_up(pub_internal.clone())
-            .expect("failed to start");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        let unique_str_2 = "run2_unique_string";
-        let args_2 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_2.to_string(),
-            ]
-        } else {
-            vec![unique_str_2.to_string()]
-        };
-
-        let executable_rendered = Executable {
-            id: "echo-agent".to_string(),
-            path: echo_cmd.to_string(),
-            args: Args(args_2),
-            env: Env(HashMap::new()),
-            restart_policy: RestartPolicyConfig::default(),
-        };
-
-        // DISABLING file logging on reload
-        let on_host_config = OnHost {
-            executables: vec![executable_rendered],
-            enable_file_logging: false,
-            health: None,
-            filesystem: FileSystem::test_empty(),
-            shared_filesystem: SharedFileSystem::test_empty(),
-            packages: get_empty_packages(),
-            version_package: None,
-        };
-
-        let runtime = Runtime {
-            deployment: Deployment::Host(on_host_config.clone()),
-        };
-
-        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
-
-        let started_supervisor = started_supervisor
-            .apply(effective_agent)
-            .expect("failed to apply");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        started_supervisor.stop().expect("failed to stop");
-
-        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
-        assert!(
-            agent_logs_dir.exists(),
-            "Log directory {:?} should exist (from first run)",
-            agent_logs_dir
-        );
-
-        let all_contents = fs::read_dir(agent_logs_dir)
-            .expect("should find logs dir")
-            .map(|entry| entry.expect("entry").path())
-            .filter(|p| {
-                // The `echo` commands should write to stdout, so we look for these files only.
-                // Filtering by prefix because the timestamp is appended to the file name.
-                p.file_name()
-                    .is_some_and(|n| n.to_string_lossy().ends_with(STDOUT_LOG_FILE_NAME_SUFFIX))
-            })
-            .map(|p| fs::read_to_string(p).unwrap_or_default())
-            // we just merge all contents to handle the corner case of multiple log files
-            // e.g. hourly log rotation while the test is running
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(
-            all_contents.contains(unique_str_1),
-            "First run log SHOULD be found (it was enabled)"
-        );
-
-        assert!(
-            !all_contents.contains(unique_str_2),
-            "Second run log SHOULD NOT be found (it was disabled)"
-        );
-    }
-
-    #[test]
     fn test_health_checker_thread_publishes_periodically_when_health_config_set() {
         use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthCheckDefinition;
 
@@ -1838,6 +1580,7 @@ persistent.txt:
             vec![],
             Some(health_config),
             get_empty_packages(),
+            None,
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),
@@ -1872,108 +1615,5 @@ persistent.txt:
         .expect("expected at least 2 AgentHealthInfo events from the health thread");
 
         started.stop().expect("supervisor should stop");
-    }
-
-    #[test]
-    fn test_supervisor_reloading_keeps_file_logging_disabled() {
-        let dir = tempfile::tempdir().unwrap();
-        let logging_path = dir.path().to_path_buf();
-
-        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
-        let unique_str_1 = "run1_unique_string";
-        let args_1 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_1.to_string(),
-            ]
-        } else {
-            vec![unique_str_1.to_string()]
-        };
-
-        let exec_data_1 = ExecutableData {
-            id: "echo-agent".to_string(),
-            bin: echo_cmd.to_string(),
-            args: args_1,
-            env: HashMap::new(),
-            shutdown_timeout: Duration::from_secs(5),
-            restart_policy: RestartPolicy::default(),
-        };
-
-        let agent_identity = AgentIdentity::from((
-            AgentID::try_from("test-agent".to_string()).unwrap(),
-            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
-        ));
-
-        // Start with logging DISABLED
-        let supervisor = NotStartedSupervisorOnHost::new(
-            agent_identity.clone(),
-            vec![exec_data_1],
-            None,
-            get_empty_packages(),
-            Arc::new(MockPackageManager::new()),
-            false,
-            logging_path.clone(),
-            FileSystem::test_empty(),
-            SharedFileSystem::test_empty(),
-        );
-
-        let (pub_internal, _sub_internal) = pub_sub();
-        let started_supervisor = supervisor
-            .spin_up(pub_internal.clone())
-            .expect("failed to start");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        let unique_str_2 = "run2_unique_string";
-        let args_2 = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "echo".to_string(),
-                unique_str_2.to_string(),
-            ]
-        } else {
-            vec![unique_str_2.to_string()]
-        };
-
-        let executable_rendered = Executable {
-            id: "echo-agent".to_string(),
-            path: echo_cmd.to_string(),
-            args: Args(args_2),
-            env: Env(HashMap::new()),
-            restart_policy: RestartPolicyConfig::default(),
-        };
-
-        // KEEP logging DISABLED on reload
-        let on_host_config = OnHost {
-            executables: vec![executable_rendered],
-            enable_file_logging: false,
-            health: None,
-            filesystem: FileSystem::test_empty(),
-            shared_filesystem: SharedFileSystem::test_empty(),
-            packages: get_empty_packages(),
-            version_package: None,
-        };
-
-        let runtime = Runtime {
-            deployment: Deployment::Host(on_host_config.clone()),
-        };
-
-        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
-
-        let started_supervisor = started_supervisor
-            .apply(effective_agent)
-            .expect("failed to apply");
-
-        std::thread::sleep(Duration::from_secs(2));
-
-        started_supervisor.stop().expect("failed to stop");
-
-        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
-        assert!(
-            !agent_logs_dir.exists(),
-            "Log directory {:?} should NOT exist",
-            agent_logs_dir
-        );
     }
 }

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -676,7 +676,6 @@ pub mod tests {
     use crate::sub_agent::on_host::command::restart_policy::{Backoff, RestartPolicy};
     use crate::sub_agent::supervisor::Supervisor;
     use crate::utils::retry::retry;
-    use rstest::rstest;
     use serde::Deserialize;
     use std::collections::HashMap;
     use std::{

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -7,6 +7,8 @@ use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthConf
 use crate::agent_type::runtime_config::on_host::filesystem::rendered::{
     FileSystem, FileSystemEntriesError, SharedFileSystem,
 };
+use crate::agent_type::runtime_config::on_host::package::PackageID;
+use crate::agent_type::runtime_config::on_host::package::rendered::Package as RenderedPackage;
 use crate::agent_type::runtime_config::on_host::rendered::RenderedPackages;
 use crate::checkers::health::health_checker::{Health, HealthCheckerError, spawn_health_checker};
 use crate::checkers::health::health_checker::{Healthy, Unhealthy};
@@ -105,6 +107,7 @@ where
     health_config: Option<OnHostHealthConfig>,
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
+    version_package: Option<PackageID>,
     filesystem: FileSystem,
     shared_filesystem: SharedFileSystem,
 }
@@ -239,9 +242,18 @@ where
             health_config,
             package_manager,
             packages_config,
+            version_package: None,
             filesystem,
             shared_filesystem,
         }
+    }
+
+    /// Sets the package whose OCI version is reported as `agent.version`. When left unset (`None`),
+    /// [`check_subagent_version`](Self::check_subagent_version) falls back to the sole configured
+    /// package.
+    pub fn with_version_package(mut self, version_package: Option<PackageID>) -> Self {
+        self.version_package = version_package;
+        self
     }
 
     fn start_health_check(
@@ -289,27 +301,12 @@ where
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) {
-        // Report the version from the OCI package configuration.
-        // `packages_config` is a HashMap, so we pick by the lowest package id to get a stable
-        // result (iteration order is not deterministic). Today agent types have a single package;
-        // TODO: for complex OHIs with multiple packages we need a deliberate strategy to choose
-        // which version to report (e.g. mark a primary package in the agent type definition).
-        let Some((package_id, package)) = self.packages_config.iter().min_by_key(|(id, _)| *id)
-        else {
-            warn!(
-                agent_type=%self.agent_identity.agent_type_id,
-                "Unable to determine agent version: no packages configured"
-            );
+        // Report the version from the OCI package configuration. The package is selected explicitly
+        // by the agent type's `version_package` (resolved at parse time). When it is unset we fall
+        // back to the sole configured package; anything else is ambiguous and reports nothing.
+        let Some((package_id, package)) = self.version_package_to_report() else {
             return;
         };
-
-        if self.packages_config.len() > 1 {
-            warn!(
-                agent_type=%self.agent_identity.agent_type_id,
-                packages_count=%self.packages_config.len(),
-                "Multiple packages configured; reporting the version of the package with the lowest id"
-            );
-        }
 
         let version = package.download.oci.version.to_string();
         info!(
@@ -329,6 +326,39 @@ where
                 ..Default::default()
             }),
         );
+    }
+
+    fn version_package_to_report(&self) -> Option<(&PackageID, &RenderedPackage)> {
+        if let Some(id) = &self.version_package {
+            let entry = self.packages_config.get_key_value(id);
+            if entry.is_none() {
+                warn!(
+                    agent_type=%self.agent_identity.agent_type_id,
+                    version_package=%id,
+                    "Configured version_package not found among rendered packages; not reporting agent.version"
+                );
+            }
+            return entry;
+        }
+
+        match self.packages_config.len() {
+            0 => {
+                warn!(
+                    agent_type=%self.agent_identity.agent_type_id,
+                    "Unable to determine agent version: no packages configured"
+                );
+                None
+            }
+            1 => self.packages_config.iter().next(),
+            _ => {
+                warn!(
+                    agent_type=%self.agent_identity.agent_type_id,
+                    packages_count=%self.packages_config.len(),
+                    "Multiple packages configured but no version_package set; not reporting agent.version"
+                );
+                None
+            }
+        }
     }
 
     fn spin_up(
@@ -666,6 +696,7 @@ pub mod tests {
     use crate::agent_type::runtime_config::health_config::HealthCheckTimeout;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
     use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
+    use crate::agent_type::runtime_config::on_host::package::rendered::{Download, Oci};
     use crate::agent_type::runtime_config::on_host::rendered::OnHost;
     use crate::agent_type::runtime_config::rendered::{Deployment, Runtime};
     use crate::agent_type::runtime_config::restart_policy::rendered::RestartPolicyConfig;
@@ -692,6 +723,90 @@ pub mod tests {
 
     fn get_empty_packages() -> RenderedPackages {
         HashMap::new()
+    }
+
+    fn rendered_package(repository: &str, version: &str) -> RenderedPackage {
+        RenderedPackage {
+            download: Download {
+                oci: Oci {
+                    repository: repository.parse().unwrap(),
+                    version: version.parse().unwrap(),
+                    public_key_url: None,
+                },
+            },
+            post_download_hook: None,
+        }
+    }
+
+    fn supervisor_with_packages(
+        packages: RenderedPackages,
+        version_package: Option<PackageID>,
+    ) -> NotStartedSupervisorOnHost<MockPackageManager> {
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("test-agent".to_string()).unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+        NotStartedSupervisorOnHost::new(
+            agent_identity,
+            vec![],
+            None,
+            packages,
+            Arc::new(MockPackageManager::new()),
+            false,
+            PathBuf::from("/tmp"),
+            FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
+        )
+        .with_version_package(version_package)
+    }
+
+    #[test]
+    fn version_package_to_report_selects_configured_package() {
+        let packages = RenderedPackages::from([
+            (
+                "infra".to_string(),
+                rendered_package("newrelic-infra", "1.2.3"),
+            ),
+            ("flex".to_string(), rendered_package("nri-flex", "4.5.6")),
+        ]);
+        let supervisor = supervisor_with_packages(packages, Some("flex".to_string()));
+
+        let (id, package) = supervisor.version_package_to_report().unwrap();
+        assert_eq!(id, "flex");
+        assert_eq!(package.download.oci.version.to_string(), "4.5.6");
+    }
+
+    #[test]
+    fn version_package_to_report_defaults_to_sole_package() {
+        let packages = RenderedPackages::from([(
+            "infra".to_string(),
+            rendered_package("newrelic-infra", "1.2.3"),
+        )]);
+        let supervisor = supervisor_with_packages(packages, None);
+
+        let (id, package) = supervisor.version_package_to_report().unwrap();
+        assert_eq!(id, "infra");
+        assert_eq!(package.download.oci.version.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn version_package_to_report_none_without_packages() {
+        let supervisor = supervisor_with_packages(get_empty_packages(), None);
+        assert!(supervisor.version_package_to_report().is_none());
+    }
+
+    #[test]
+    fn version_package_to_report_none_when_ambiguous() {
+        // No version_package + multiple packages is ambiguous: nothing is reported.
+        let packages = RenderedPackages::from([
+            (
+                "infra".to_string(),
+                rendered_package("newrelic-infra", "1.2.3"),
+            ),
+            ("flex".to_string(), rendered_package("nri-flex", "4.5.6")),
+        ]);
+        let supervisor = supervisor_with_packages(packages, None);
+        assert!(supervisor.version_package_to_report().is_none());
     }
 
     #[derive(Clone, Deserialize)]
@@ -1404,6 +1519,7 @@ persistent.txt:
             filesystem: FileSystem::test_empty(),
             shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
+            version_package: None,
         };
 
         let runtime = Runtime {
@@ -1532,6 +1648,7 @@ persistent.txt:
             filesystem: FileSystem::test_empty(),
             shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
+            version_package: None,
         };
 
         let runtime = Runtime {
@@ -1658,6 +1775,7 @@ persistent.txt:
             filesystem: FileSystem::test_empty(),
             shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
+            version_package: None,
         };
 
         let runtime = Runtime {
@@ -1842,6 +1960,7 @@ persistent.txt:
             filesystem: FileSystem::test_empty(),
             shared_filesystem: SharedFileSystem::test_empty(),
             packages: get_empty_packages(),
+            version_package: None,
         };
 
         let runtime = Runtime {

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -8,7 +8,6 @@ use crate::agent_type::runtime_config::on_host::filesystem::rendered::{
     FileSystem, FileSystemEntriesError, SharedFileSystem,
 };
 use crate::agent_type::runtime_config::on_host::package::PackageID;
-use crate::agent_type::runtime_config::on_host::package::rendered::Package as RenderedPackage;
 use crate::agent_type::runtime_config::on_host::rendered::RenderedPackages;
 use crate::checkers::health::health_checker::{Health, HealthCheckerError, spawn_health_checker};
 use crate::checkers::health::health_checker::{Healthy, Unhealthy};
@@ -295,9 +294,14 @@ where
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) {
-        // Report the version from the OCI package selected as the agent type's version package
-        // (resolved at parse time). Nothing to report when no package was selected.
-        let Some((package_id, package)) = self.version_package_to_report() else {
+        // Report the version from the OCI package selected as the agent type's version package.
+        // `reported_version_package` is resolved and validated at parse time: it is `Some` and
+        // present in `packages_config` whenever there is anything to report.
+        let Some((package_id, package)) = self
+            .reported_version_package
+            .as_ref()
+            .and_then(|id| self.packages_config.get_key_value(id))
+        else {
             return;
         };
 
@@ -319,12 +323,6 @@ where
                 ..Default::default()
             }),
         );
-    }
-
-    fn version_package_to_report(&self) -> Option<(&PackageID, &RenderedPackage)> {
-        // `reported_version_package` is resolved and validated at parse time.
-        let id = self.reported_version_package.as_ref()?;
-        self.packages_config.get_key_value(id)
     }
 
     fn spin_up(
@@ -662,7 +660,6 @@ pub mod tests {
     use crate::agent_type::runtime_config::health_config::HealthCheckTimeout;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
     use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
-    use crate::agent_type::runtime_config::on_host::package::rendered::{Download, Oci};
     use crate::agent_type::runtime_config::on_host::rendered::OnHost;
     use crate::agent_type::runtime_config::rendered::{Deployment, Runtime};
     use crate::agent_type::runtime_config::restart_policy::rendered::RestartPolicyConfig;
@@ -690,70 +687,6 @@ pub mod tests {
 
     fn get_empty_packages() -> RenderedPackages {
         HashMap::new()
-    }
-
-    fn rendered_package(repository: &str, version: &str) -> RenderedPackage {
-        RenderedPackage {
-            download: Download {
-                oci: Oci {
-                    repository: repository.parse().unwrap(),
-                    version: version.parse().unwrap(),
-                    public_key_url: None,
-                },
-            },
-            post_download_hook: None,
-        }
-    }
-
-    fn supervisor_with_packages(
-        packages: RenderedPackages,
-        reported_version_package: Option<PackageID>,
-    ) -> NotStartedSupervisorOnHost<MockPackageManager> {
-        let agent_identity = AgentIdentity::from((
-            AgentID::try_from("test-agent".to_string()).unwrap(),
-            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
-        ));
-        NotStartedSupervisorOnHost::new(
-            agent_identity,
-            vec![],
-            None,
-            packages,
-            reported_version_package,
-            Arc::new(MockPackageManager::new()),
-            false,
-            PathBuf::from("/tmp"),
-            FileSystem::test_empty(),
-            SharedFileSystem::test_empty(),
-        )
-    }
-
-    #[rstest]
-    // The resolved package is looked up among the configured packages and reported.
-    #[case::reports_resolved_package(
-        vec![("infra", "newrelic-infra", "1.2.3"), ("flex", "nri-flex", "4.5.6")],
-        Some("flex".to_string()),
-        Some(("flex", "4.5.6")),
-    )]
-    // No package resolved (only possible with no packages configured): nothing to report.
-    #[case::none_when_unset(vec![], None, None)]
-    fn version_package_to_report(
-        #[case] packages: Vec<(&str, &str, &str)>,
-        #[case] reported_version_package: Option<PackageID>,
-        #[case] expected: Option<(&str, &str)>,
-    ) {
-        let packages = packages
-            .into_iter()
-            .map(|(id, repository, version)| {
-                (id.to_string(), rendered_package(repository, version))
-            })
-            .collect();
-        let supervisor = supervisor_with_packages(packages, reported_version_package);
-
-        let reported = supervisor
-            .version_package_to_report()
-            .map(|(id, package)| (id.as_str(), package.download.oci.version.to_string()));
-        let expected = expected.map(|(id, version)| (id, version.to_string()));
-        assert_eq!(reported, expected);
     }
 
     #[derive(Clone, Deserialize)]

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -1460,6 +1460,263 @@ persistent.txt:
     }
 
     #[test]
+    fn test_supervisor_reloading_enables_file_logging() {
+        let dir = tempfile::tempdir().unwrap();
+        let logging_path = dir.path().to_path_buf();
+
+        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
+        let unique_str_1 = "run1_unique_string";
+        let args_1 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_1.to_string(),
+            ]
+        } else {
+            vec![unique_str_1.to_string()]
+        };
+
+        let exec_data_1 = ExecutableData {
+            id: "echo-agent".to_string(),
+            bin: echo_cmd.to_string(),
+            args: args_1,
+            env: HashMap::new(),
+            shutdown_timeout: Duration::from_secs(5),
+            restart_policy: RestartPolicy::default(),
+        };
+
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("test-agent".to_string()).unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        // Start with logging DISABLED
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity.clone(),
+            vec![exec_data_1],
+            None,
+            get_empty_packages(),
+            None,
+            Arc::new(MockPackageManager::new()),
+            false,
+            logging_path.clone(),
+            FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
+        );
+
+        let (pub_internal, _sub_internal) = pub_sub();
+        let started_supervisor = supervisor
+            .spin_up(pub_internal.clone())
+            .expect("failed to start");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        let unique_str_2 = "run2_unique_string";
+        let args_2 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_2.to_string(),
+            ]
+        } else {
+            vec![unique_str_2.to_string()]
+        };
+
+        let executable_rendered = Executable {
+            id: "echo-agent".to_string(),
+            path: echo_cmd.to_string(),
+            args: Args(args_2),
+            env: Env(HashMap::new()),
+            restart_policy: RestartPolicyConfig::default(),
+        };
+
+        // ENABLING file logging on reload
+        let on_host_config = OnHost {
+            executables: vec![executable_rendered],
+            enable_file_logging: true,
+            health: None,
+            filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
+            packages: get_empty_packages(),
+            reported_version_package: None,
+        };
+
+        let runtime = Runtime {
+            deployment: Deployment::Host(on_host_config.clone()),
+        };
+
+        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
+
+        let started_supervisor = started_supervisor
+            .apply(effective_agent)
+            .expect("failed to apply");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        started_supervisor.stop().expect("failed to stop");
+
+        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
+        assert!(
+            agent_logs_dir.exists(),
+            "Log directory {:?} should exist",
+            agent_logs_dir
+        );
+
+        let all_contents = fs::read_dir(agent_logs_dir)
+            .expect("should find logs dir")
+            .map(|entry| entry.expect("entry").path())
+            .filter(|p| {
+                // The `echo` commands should write to stdout, so we look for these files only.
+                // Filtering by prefix because the timestamp is appended to the file name.
+                p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().ends_with(STDOUT_LOG_FILE_NAME_SUFFIX))
+            })
+            .map(|p| fs::read_to_string(p).unwrap_or_default())
+            // we just merge all contents
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            !all_contents.contains(unique_str_1),
+            "First run log SHOULD NOT be found (it was disabled)"
+        );
+
+        assert!(
+            all_contents.contains(unique_str_2),
+            "Second run log SHOULD be found (it was enabled)"
+        );
+    }
+
+    #[test]
+    fn test_supervisor_reloading_disables_file_logging() {
+        let dir = tempfile::tempdir().unwrap();
+        let logging_path = dir.path().to_path_buf();
+
+        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
+        let unique_str_1 = "run1_unique_string";
+        let args_1 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_1.to_string(),
+            ]
+        } else {
+            vec![unique_str_1.to_string()]
+        };
+
+        let exec_data_1 = ExecutableData {
+            id: "echo-agent".to_string(),
+            bin: echo_cmd.to_string(),
+            args: args_1,
+            env: HashMap::new(),
+            shutdown_timeout: Duration::from_secs(5),
+            restart_policy: RestartPolicy::default(),
+        };
+
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("test-agent".to_string()).unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        // Start with logging ENABLED
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity.clone(),
+            vec![exec_data_1],
+            None,
+            get_empty_packages(),
+            None,
+            Arc::new(MockPackageManager::new()),
+            true,
+            logging_path.clone(),
+            FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
+        );
+
+        let (pub_internal, _sub_internal) = pub_sub();
+        let started_supervisor = supervisor
+            .spin_up(pub_internal.clone())
+            .expect("failed to start");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        let unique_str_2 = "run2_unique_string";
+        let args_2 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_2.to_string(),
+            ]
+        } else {
+            vec![unique_str_2.to_string()]
+        };
+
+        let executable_rendered = Executable {
+            id: "echo-agent".to_string(),
+            path: echo_cmd.to_string(),
+            args: Args(args_2),
+            env: Env(HashMap::new()),
+            restart_policy: RestartPolicyConfig::default(),
+        };
+
+        // DISABLING file logging on reload
+        let on_host_config = OnHost {
+            executables: vec![executable_rendered],
+            enable_file_logging: false,
+            health: None,
+            filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
+            packages: get_empty_packages(),
+            reported_version_package: None,
+        };
+
+        let runtime = Runtime {
+            deployment: Deployment::Host(on_host_config.clone()),
+        };
+
+        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
+
+        let started_supervisor = started_supervisor
+            .apply(effective_agent)
+            .expect("failed to apply");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        started_supervisor.stop().expect("failed to stop");
+
+        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
+        assert!(
+            agent_logs_dir.exists(),
+            "Log directory {:?} should exist (from first run)",
+            agent_logs_dir
+        );
+
+        let all_contents = fs::read_dir(agent_logs_dir)
+            .expect("should find logs dir")
+            .map(|entry| entry.expect("entry").path())
+            .filter(|p| {
+                // The `echo` commands should write to stdout, so we look for these files only.
+                // Filtering by prefix because the timestamp is appended to the file name.
+                p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().ends_with(STDOUT_LOG_FILE_NAME_SUFFIX))
+            })
+            .map(|p| fs::read_to_string(p).unwrap_or_default())
+            // we just merge all contents to handle the corner case of multiple log files
+            // e.g. hourly log rotation while the test is running
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            all_contents.contains(unique_str_1),
+            "First run log SHOULD be found (it was enabled)"
+        );
+
+        assert!(
+            !all_contents.contains(unique_str_2),
+            "Second run log SHOULD NOT be found (it was disabled)"
+        );
+    }
+
+    #[test]
     fn test_health_checker_thread_publishes_periodically_when_health_config_set() {
         use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthCheckDefinition;
 
@@ -1515,5 +1772,109 @@ persistent.txt:
         .expect("expected at least 2 AgentHealthInfo events from the health thread");
 
         started.stop().expect("supervisor should stop");
+    }
+
+    #[test]
+    fn test_supervisor_reloading_keeps_file_logging_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let logging_path = dir.path().to_path_buf();
+
+        let echo_cmd = if cfg!(windows) { "cmd" } else { "echo" };
+        let unique_str_1 = "run1_unique_string";
+        let args_1 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_1.to_string(),
+            ]
+        } else {
+            vec![unique_str_1.to_string()]
+        };
+
+        let exec_data_1 = ExecutableData {
+            id: "echo-agent".to_string(),
+            bin: echo_cmd.to_string(),
+            args: args_1,
+            env: HashMap::new(),
+            shutdown_timeout: Duration::from_secs(5),
+            restart_policy: RestartPolicy::default(),
+        };
+
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("test-agent".to_string()).unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        // Start with logging DISABLED
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity.clone(),
+            vec![exec_data_1],
+            None,
+            get_empty_packages(),
+            None,
+            Arc::new(MockPackageManager::new()),
+            false,
+            logging_path.clone(),
+            FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
+        );
+
+        let (pub_internal, _sub_internal) = pub_sub();
+        let started_supervisor = supervisor
+            .spin_up(pub_internal.clone())
+            .expect("failed to start");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        let unique_str_2 = "run2_unique_string";
+        let args_2 = if cfg!(windows) {
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                unique_str_2.to_string(),
+            ]
+        } else {
+            vec![unique_str_2.to_string()]
+        };
+
+        let executable_rendered = Executable {
+            id: "echo-agent".to_string(),
+            path: echo_cmd.to_string(),
+            args: Args(args_2),
+            env: Env(HashMap::new()),
+            restart_policy: RestartPolicyConfig::default(),
+        };
+
+        // KEEP logging DISABLED on reload
+        let on_host_config = OnHost {
+            executables: vec![executable_rendered],
+            enable_file_logging: false,
+            health: None,
+            filesystem: FileSystem::test_empty(),
+            shared_filesystem: SharedFileSystem::test_empty(),
+            packages: get_empty_packages(),
+            reported_version_package: None,
+        };
+
+        let runtime = Runtime {
+            deployment: Deployment::Host(on_host_config.clone()),
+        };
+
+        let effective_agent = EffectiveAgent::new(agent_identity.clone(), runtime);
+
+        let started_supervisor = started_supervisor
+            .apply(effective_agent)
+            .expect("failed to apply");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        started_supervisor.stop().expect("failed to stop");
+
+        let agent_logs_dir = logging_path.join(agent_identity.id.to_string());
+        assert!(
+            !agent_logs_dir.exists(),
+            "Log directory {:?} should NOT exist",
+            agent_logs_dir
+        );
     }
 }

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -330,15 +330,7 @@ where
 
     fn version_package_to_report(&self) -> Option<(&PackageID, &RenderedPackage)> {
         if let Some(id) = &self.version_package {
-            let entry = self.packages_config.get_key_value(id);
-            if entry.is_none() {
-                warn!(
-                    agent_type=%self.agent_identity.agent_type_id,
-                    version_package=%id,
-                    "Configured version_package not found among rendered packages; not reporting agent.version"
-                );
-            }
-            return entry;
+            return self.packages_config.get_key_value(id);
         }
 
         match self.packages_config.len() {

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -295,9 +295,8 @@ where
         &self,
         sub_agent_internal_publisher: EventPublisher<SubAgentInternalEvent>,
     ) {
-        // Report the version from the OCI package configuration. The package is selected explicitly
-        // by the agent type's `version_package` (resolved at parse time). When it is unset we fall
-        // back to the sole configured package; anything else is ambiguous and reports nothing.
+        // Report the version from the OCI package selected as the agent type's version package
+        // (resolved at parse time). Nothing to report when no package was selected.
         let Some((package_id, package)) = self.version_package_to_report() else {
             return;
         };
@@ -323,28 +322,9 @@ where
     }
 
     fn version_package_to_report(&self) -> Option<(&PackageID, &RenderedPackage)> {
-        if let Some(id) = &self.reported_version_package {
-            return self.packages_config.get_key_value(id);
-        }
-
-        match self.packages_config.len() {
-            0 => {
-                warn!(
-                    agent_type=%self.agent_identity.agent_type_id,
-                    "Unable to determine agent version: no packages configured"
-                );
-                None
-            }
-            1 => self.packages_config.iter().next(),
-            _ => {
-                warn!(
-                    agent_type=%self.agent_identity.agent_type_id,
-                    packages_count=%self.packages_config.len(),
-                    "Multiple packages configured but no version_package set; not reporting agent.version"
-                );
-                None
-            }
-        }
+        // `reported_version_package` is resolved and validated at parse time.
+        let id = self.reported_version_package.as_ref()?;
+        self.packages_config.get_key_value(id)
     }
 
     fn spin_up(
@@ -748,26 +728,14 @@ pub mod tests {
     }
 
     #[rstest]
-    // An explicit reported_version_package selects that package among several.
-    #[case::selects_configured_package(
+    // The resolved package is looked up among the configured packages and reported.
+    #[case::reports_resolved_package(
         vec![("infra", "newrelic-infra", "1.2.3"), ("flex", "nri-flex", "4.5.6")],
         Some("flex".to_string()),
         Some(("flex", "4.5.6")),
     )]
-    // With a sole package and no explicit selection, it defaults to that package.
-    #[case::defaults_to_sole_package(
-        vec![("infra", "newrelic-infra", "1.2.3")],
-        None,
-        Some(("infra", "1.2.3")),
-    )]
-    // No packages: nothing to report.
-    #[case::none_without_packages(vec![], None, None)]
-    // No reported_version_package + multiple packages is ambiguous: nothing is reported.
-    #[case::none_when_ambiguous(
-        vec![("infra", "newrelic-infra", "1.2.3"), ("flex", "nri-flex", "4.5.6")],
-        None,
-        None,
-    )]
+    // No package resolved (only possible with no packages configured): nothing to report.
+    #[case::none_when_unset(vec![], None, None)]
     fn version_package_to_report(
         #[case] packages: Vec<(&str, &str, &str)>,
         #[case] reported_version_package: Option<PackageID>,


### PR DESCRIPTION
On-host agent-type parsing now validates `version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. 
This `version_package` will be used to know which version to report as `agent.version`.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
