### PR TITLE
fix: add trigger always post download hook

### DIFF
--- a/agent-control/src/package/oci/package_manager.rs
+++ b/agent-control/src/package/oci/package_manager.rs
@@ -121,7 +121,7 @@ where
     /// The package is first downloaded to `temp_package_path` and then extracted to `package_path`.
     fn install_archive(
         &self,
-        package_data: PackageData,
+        package_data: &PackageData,
         tmp_download_path: &Path,
         install_path: &Path,
     ) -> Result<InstalledPackageData, OCIPackageManagerError> {
@@ -131,27 +131,40 @@ where
 
         let downloaded_package = self
             .downloader
-            .download(&package_data, tmp_download_path)
+            .download(package_data, tmp_download_path)
             .map_err(OCIPackageManagerError::Download)?;
 
         self.extract_package(&downloaded_package, install_path)
             .inspect_err(|e| warn!("OCI package installation failed: {}", e))?;
-
-        // Execute post-download hook if configured
-        if let Some(ref hook) = package_data.post_download_hook {
-            debug!(
-                "Executing post-download hook for package {}",
-                package_data.id
-            );
-            let executor = PostDownloadHookExecutor::new(install_path.to_path_buf());
-            executor.execute(hook)?;
-        }
 
         debug!("OCI package installed at {}", install_path.display());
         Ok(InstalledPackageData {
             id: package_data.id.clone(),
             installation_path: install_path.to_path_buf(),
         })
+    }
+
+    // The hook runs on **every** install, including when the package files were already present on
+    // disk (an Agent Control restart, or a rollback to a previously-installed version). This is
+    // intentional: the hook performs host-side setup/validation that can go stale (kernel changes,
+    // missing headers, removed directories), so skipping it when the files are present could start
+    // an agent whose prerequisites are no longer met. A non-zero exit fails the install so the
+    // agent is not started.
+    fn run_post_download_hook(
+        &self,
+        package_data: &PackageData,
+        install_path: &Path,
+    ) -> Result<(), OCIPackageManagerError> {
+        let Some(hook) = package_data.post_download_hook.as_ref() else {
+            return Ok(());
+        };
+        debug!(
+            "Executing post-download hook for package {}",
+            package_data.id
+        );
+        let executor = PostDownloadHookExecutor::new(install_path.to_path_buf());
+        executor.execute(hook)?;
+        Ok(())
     }
 
     /// Extract the downloaded package file from `download_filepath` to `extract_dir`.
@@ -372,33 +385,32 @@ where
     ) -> Result<InstalledPackageData, OCIPackageManagerError> {
         let package_path = get_package_path(&self.remote_dir, agent_id, &package_data)?;
 
-        if package_path.exists() {
+        let installed_package = if package_path.exists() {
             debug!(
                 "Package already installed at {}. Skipping download and extraction.",
                 package_path.display()
             );
 
-            let installed_package = InstalledPackageData {
-                id: package_data.id,
-                installation_path: package_path,
-            };
+            InstalledPackageData {
+                id: package_data.id.clone(),
+                installation_path: package_path.clone(),
+            }
+        } else {
+            let temp_package_path =
+                get_temp_package_path(&self.remote_dir, agent_id, &package_data)?;
 
-            self.retain_packages(agent_id, installed_package.clone())?;
+            let installed_package = self
+                .install_archive(&package_data, &temp_package_path, &package_path)
+                .inspect_err(|_| _ = self.directory_manager.delete(&temp_package_path))?;
 
-            return Ok(installed_package);
-        }
+            self.directory_manager
+                .delete(&temp_package_path)
+                .map_err(OCIPackageManagerError::Install)?;
 
-        let temp_package_path = get_temp_package_path(&self.remote_dir, agent_id, &package_data)?;
+            installed_package
+        };
 
-        // If we face an error during installation, we must ensure the temporary directory is deleted.
-        // We hide the error of the folder if something else went wrong.
-        let installed_package = self
-            .install_archive(package_data, &temp_package_path, &package_path)
-            .inspect_err(|_| _ = self.directory_manager.delete(&temp_package_path))?;
-
-        self.directory_manager
-            .delete(&temp_package_path)
-            .map_err(OCIPackageManagerError::Install)?;
+        self.run_post_download_hook(&package_data, &package_path)?;
 
         self.retain_packages(agent_id, installed_package.clone())?;
 
@@ -936,6 +948,112 @@ mod tests {
 
         assert_eq!(installed.installation_path, install_dir);
         assert_eq!(installed.id, TEST_PACKAGE_ID);
+    }
+
+    #[test]
+    fn test_install_runs_hook_even_when_package_already_present() {
+        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
+        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
+        use std::collections::HashMap;
+
+        let mut downloader = MockOCIDownloader::new();
+        let agent_id = AgentID::try_from("agent-id").unwrap();
+        let mut package_data = test_package_data();
+        package_data.post_download_hook = Some(PostDownloadHook {
+            path: "nr-agent-control-nonexistent-hook-command".to_string(),
+            args: Args(vec![]),
+            env: Env(HashMap::new()),
+        });
+
+        let remote_dir = tempdir().unwrap();
+        let install_dir = get_package_path(remote_dir.path(), &agent_id, &package_data).unwrap();
+        std::fs::create_dir_all(&install_dir).expect("Failed to create dir");
+
+        downloader.expect_download().times(0);
+
+        let pm = OCIPackageManager::new(
+            downloader,
+            DirectoryManagerFs,
+            PathBuf::from(remote_dir.path()),
+        );
+
+        let result = pm.install(&agent_id, package_data);
+        assert!(matches!(
+            result,
+            Err(OCIPackageManagerError::PostDownloadHook(_))
+        ));
+    }
+
+    #[test]
+    fn test_install_fails_when_post_download_hook_fails() {
+        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
+        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
+        use std::collections::HashMap;
+
+        let mut downloader = MockOCIDownloader::new();
+        let agent_id = AgentID::try_from("agent-id").unwrap();
+        let mut package_data = test_package_data();
+        package_data.post_download_hook = Some(PostDownloadHook {
+            path: "nr-agent-control-nonexistent-hook-command".to_string(),
+            args: Args(vec![]),
+            env: Env(HashMap::new()),
+        });
+
+        let root_dir = tempdir().unwrap();
+        let download_dir =
+            get_temp_package_path(root_dir.path(), &agent_id, &package_data).unwrap();
+
+        downloader
+            .expect_download()
+            .with(eq(package_data.clone()), eq(download_dir.clone()))
+            .once()
+            .returning(move |_, _| Ok(fake_compressed_package(&download_dir)));
+
+        let pm = OCIPackageManager::new(
+            downloader,
+            DirectoryManagerFs,
+            PathBuf::from(root_dir.path()),
+        );
+
+        let result = pm.install(&agent_id, package_data);
+        assert!(matches!(
+            result,
+            Err(OCIPackageManagerError::PostDownloadHook(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_runs_successful_hook_when_package_already_present() {
+        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
+        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
+        use std::collections::HashMap;
+
+        let mut downloader = MockOCIDownloader::new();
+        let agent_id = AgentID::try_from("agent-id").unwrap();
+        let mut package_data = test_package_data();
+        package_data.post_download_hook = Some(PostDownloadHook {
+            path: "/usr/bin/true".to_string(),
+            args: Args(vec![]),
+            env: Env(HashMap::new()),
+        });
+
+        let remote_dir = tempdir().unwrap();
+        let install_dir = get_package_path(remote_dir.path(), &agent_id, &package_data).unwrap();
+        std::fs::create_dir_all(&install_dir).expect("Failed to create dir");
+
+        downloader.expect_download().times(0);
+
+        let pm = OCIPackageManager::new(
+            downloader,
+            DirectoryManagerFs,
+            PathBuf::from(remote_dir.path()),
+        );
+
+        let installed = pm
+            .install(&agent_id, package_data)
+            .expect("install with a successful hook should succeed");
+        assert_eq!(installed.installation_path, install_dir);
     }
 
     #[test]

--- a/agent-control/src/package/oci/package_manager.rs
+++ b/agent-control/src/package/oci/package_manager.rs
@@ -399,6 +399,8 @@ where
             let temp_package_path =
                 get_temp_package_path(&self.remote_dir, agent_id, &package_data)?;
 
+            // If we face an error during installation, we must ensure the temporary directory is deleted.
+            // We hide the error of the folder if something else went wrong.
             let installed_package = self
                 .install_archive(&package_data, &temp_package_path, &package_path)
                 .inspect_err(|_| _ = self.directory_manager.delete(&temp_package_path))?;
@@ -457,13 +459,17 @@ mod tests {
 
     use super::*;
 
-    use crate::agent_type::runtime_config::on_host::package::rendered::{Oci, Repository, Version};
+    use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
+    use crate::agent_type::runtime_config::on_host::package::rendered::{
+        Oci, PostDownloadHook, Repository, Version,
+    };
     use crate::oci::artifact_definitions::PackageMediaType;
     use crate::package::oci::downloader::tests::MockOCIDownloader;
     use crate::utils::extract::tests::TestDataHelper;
     use fs::directory_manager::mock::MockDirectoryManager;
     use fs::file::writer::FileWriter;
     use mockall::predicate::eq;
+    use std::collections::HashMap;
 
     use tempfile::tempdir;
 
@@ -952,10 +958,6 @@ mod tests {
 
     #[test]
     fn test_install_runs_hook_even_when_package_already_present() {
-        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
-        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
-        use std::collections::HashMap;
-
         let mut downloader = MockOCIDownloader::new();
         let agent_id = AgentID::try_from("agent-id").unwrap();
         let mut package_data = test_package_data();
@@ -969,6 +971,7 @@ mod tests {
         let install_dir = get_package_path(remote_dir.path(), &agent_id, &package_data).unwrap();
         std::fs::create_dir_all(&install_dir).expect("Failed to create dir");
 
+        // Package already on disk, so no download.
         downloader.expect_download().times(0);
 
         let pm = OCIPackageManager::new(
@@ -977,6 +980,8 @@ mod tests {
             PathBuf::from(remote_dir.path()),
         );
 
+        // The hook always fails, so a PostDownloadHook error proves it ran. If it were skipped when
+        // the package is already present (pre-fix behavior), install() would return Ok.
         let result = pm.install(&agent_id, package_data);
         assert!(matches!(
             result,
@@ -986,10 +991,6 @@ mod tests {
 
     #[test]
     fn test_install_fails_when_post_download_hook_fails() {
-        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
-        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
-        use std::collections::HashMap;
-
         let mut downloader = MockOCIDownloader::new();
         let agent_id = AgentID::try_from("agent-id").unwrap();
         let mut package_data = test_package_data();
@@ -1022,19 +1023,17 @@ mod tests {
         ));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_install_runs_successful_hook_when_package_already_present() {
-        use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env};
-        use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
-        use std::collections::HashMap;
-
         let mut downloader = MockOCIDownloader::new();
         let agent_id = AgentID::try_from("agent-id").unwrap();
         let mut package_data = test_package_data();
+        // Cross-platform hook that exits 0 with no side effects: run the test binary with `--list`,
+        // which makes the test harness list its tests and exit successfully.
+        let test_bin = std::env::current_exe().expect("path to the running test executable");
         package_data.post_download_hook = Some(PostDownloadHook {
-            path: "/usr/bin/true".to_string(),
-            args: Args(vec![]),
+            path: test_bin.to_string_lossy().to_string(),
+            args: Args(vec!["--list".to_string()]),
             env: Env(HashMap::new()),
         });
 
@@ -1042,6 +1041,7 @@ mod tests {
         let install_dir = get_package_path(remote_dir.path(), &agent_id, &package_data).unwrap();
         std::fs::create_dir_all(&install_dir).expect("Failed to create dir");
 
+        // Package already on disk, so no download.
         downloader.expect_download().times(0);
 
         let pm = OCIPackageManager::new(

--- a/agent-control/tests/on_host/oci_package_manager.rs
+++ b/agent-control/tests/on_host/oci_package_manager.rs
@@ -1,11 +1,15 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::oci_package_manager::{TestDataHelper, new_testing_oci_package_manager};
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
+use newrelic_agent_control::agent_type::runtime_config::on_host::executable::rendered::{
+    Args, Env,
+};
 use newrelic_agent_control::agent_type::runtime_config::on_host::package::rendered::{
-    Oci, Repository, Version,
+    Oci, PostDownloadHook, Repository, Version,
 };
 use newrelic_agent_control::package::manager::{PackageData, PackageManager};
 use newrelic_agent_control::package::oci::package_manager::get_package_path;
@@ -140,21 +144,11 @@ fn test_install_skips_download_if_exists_with_oci_registry() {
     );
 }
 
-// Verifies that the post-download hook runs on *every* install, including when the package files
-// are already present on disk (an Agent Control restart or a rollback to a previously-installed
-// version). The hook appends a line to a counter file each time it runs; after two installs of the
-// same package the file must contain two lines even though the second install skips download and
-// extraction.
+// The hook must run on every install, even when the package is already on disk (AC restart or
+// rollback). It appends one line per run, so two installs of the same package give two lines.
 #[test]
-#[cfg(unix)]
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_install_runs_hook_on_every_install_even_when_present_with_oci_registry() {
-    use newrelic_agent_control::agent_type::runtime_config::on_host::executable::rendered::{
-        Args, Env,
-    };
-    use newrelic_agent_control::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
-    use std::collections::HashMap;
-
     const FILENAME: &str = "payload.txt";
 
     let dir = tempdir().unwrap();
@@ -171,17 +165,11 @@ fn test_install_runs_hook_on_every_install_even_when_present_with_oci_registry()
     let reference = PackagePublisher::new(tokio_runtime().handle().clone(), OCI_TEST_REGISTRY_URL)
         .push(&file_to_push, PackageMediaType::TarGz);
 
+    // Cross-platform hook: the test binary invokes the ignored `post_download_hook_probe` below,
+    // which appends a line to `NR_HOOK_COUNTER_FILE` per run (works on Windows too, no shell script).
     let hook_dir = tempdir().unwrap();
     let counter_path = hook_dir.path().join("hook-runs.count");
-    let script_path = hook_dir.path().join("hook.sh");
-    std::fs::write(
-        &script_path,
-        format!(
-            "#!/bin/bash\necho run >> '{}'\nexit 0\n",
-            counter_path.display()
-        ),
-    )
-    .unwrap();
+    let test_bin = std::env::current_exe().expect("path to the running test executable");
 
     let temp_dir = tempdir().unwrap();
     let base_path = temp_dir.path().to_path_buf();
@@ -198,9 +186,16 @@ fn test_install_runs_hook_on_every_install_even_when_present_with_oci_registry()
             public_key_url: None,
         },
         post_download_hook: Some(PostDownloadHook {
-            path: "/bin/bash".to_string(),
-            args: Args(vec![script_path.to_string_lossy().to_string()]),
-            env: Env(HashMap::new()),
+            path: test_bin.to_string_lossy().to_string(),
+            // Filter to the probe by name, plus `--ignored`.
+            args: Args(vec![
+                "post_download_hook_probe".to_string(),
+                "--ignored".to_string(),
+            ]),
+            env: Env(HashMap::from([(
+                "NR_HOOK_COUNTER_FILE".to_string(),
+                counter_path.to_string_lossy().to_string(),
+            )])),
         }),
     };
 
@@ -227,4 +222,23 @@ fn test_install_runs_hook_on_every_install_even_when_present_with_oci_registry()
         2,
         "hook should run again on the second install even though the package is already present"
     );
+}
+
+// Not a real test: invoked as the post-download hook (via the test binary, so it's cross-platform).
+// Appends one line to `NR_HOOK_COUNTER_FILE` per run so the caller can count hook executions; no-op
+// if the var is unset.
+#[test]
+#[ignore = "helper invoked as a post-download hook, not a standalone test"]
+fn post_download_hook_probe() {
+    use std::io::Write;
+
+    let Ok(counter_path) = std::env::var("NR_HOOK_COUNTER_FILE") else {
+        return;
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(counter_path)
+        .expect("open hook counter file");
+    writeln!(file, "run").expect("append to hook counter file");
 }

--- a/agent-control/tests/on_host/oci_package_manager.rs
+++ b/agent-control/tests/on_host/oci_package_manager.rs
@@ -139,3 +139,92 @@ fn test_install_skips_download_if_exists_with_oci_registry() {
         "The package manager overwrote the existing files! It should have skipped download/extraction."
     );
 }
+
+// Verifies that the post-download hook runs on *every* install, including when the package files
+// are already present on disk (an Agent Control restart or a rollback to a previously-installed
+// version). The hook appends a line to a counter file each time it runs; after two installs of the
+// same package the file must contain two lines even though the second install skips download and
+// extraction.
+#[test]
+#[cfg(unix)]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+fn test_install_runs_hook_on_every_install_even_when_present_with_oci_registry() {
+    use newrelic_agent_control::agent_type::runtime_config::on_host::executable::rendered::{
+        Args, Env,
+    };
+    use newrelic_agent_control::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
+    use std::collections::HashMap;
+
+    const FILENAME: &str = "payload.txt";
+
+    let dir = tempdir().unwrap();
+    let content_dir = tempdir().unwrap();
+    let file_to_push = dir.path().join("layer_digest.tar.gz");
+
+    TestDataHelper::compress_tar_gz(
+        content_dir.path(),
+        file_to_push.as_path(),
+        "PAYLOAD",
+        FILENAME,
+    );
+
+    let reference = PackagePublisher::new(tokio_runtime().handle().clone(), OCI_TEST_REGISTRY_URL)
+        .push(&file_to_push, PackageMediaType::TarGz);
+
+    let hook_dir = tempdir().unwrap();
+    let counter_path = hook_dir.path().join("hook-runs.count");
+    let script_path = hook_dir.path().join("hook.sh");
+    std::fs::write(
+        &script_path,
+        format!(
+            "#!/bin/bash\necho run >> '{}'\nexit 0\n",
+            counter_path.display()
+        ),
+    )
+    .unwrap();
+
+    let temp_dir = tempdir().unwrap();
+    let base_path = temp_dir.path().to_path_buf();
+    let package_manager =
+        new_testing_oci_package_manager(base_path.clone(), OCI_TEST_REGISTRY_URL.to_string());
+
+    let agent_id = AgentID::try_from("test-agent").unwrap();
+
+    let package_data = PackageData {
+        id: "test-package-hook-every-install".to_string(),
+        oci: Oci {
+            repository: Repository::from_str(reference.repository()).unwrap(),
+            version: Version::from_str(reference.tag().unwrap()).unwrap(),
+            public_key_url: None,
+        },
+        post_download_hook: Some(PostDownloadHook {
+            path: "/bin/bash".to_string(),
+            args: Args(vec![script_path.to_string_lossy().to_string()]),
+            env: Env(HashMap::new()),
+        }),
+    };
+
+    let count_lines = || {
+        std::fs::read_to_string(&counter_path)
+            .map(|c| c.lines().count())
+            .unwrap_or(0)
+    };
+
+    package_manager
+        .install(&agent_id, package_data.clone())
+        .expect("first install failed");
+    assert_eq!(
+        count_lines(),
+        1,
+        "hook should have run once after first install"
+    );
+
+    package_manager
+        .install(&agent_id, package_data)
+        .expect("second install failed");
+    assert_eq!(
+        count_lines(),
+        2,
+        "hook should run again on the second install even though the package is already present"
+    );
+}

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -624,14 +624,17 @@ Note that a Package version. Can be:
 
 **Post-Download Hook:**
 
-The `post_download_hook` is an optional field that allows executing a custom script after the package is downloaded and extracted. This is useful for:
+The `post_download_hook` is an optional field that allows executing a custom script as part of installing the package. This is useful for:
 - Installing system dependencies
 - Compiling native code
 - Performing system configuration
 - Validating installation requirements
 - Running setup scripts that cannot be handled through simple file extraction
 
-The hook runs with a hardcoded timeout of 300 seconds (5 minutes) and is not configurable. If the script exits with a non-zero status code, the package installation fails.
+The hook runs with a hardcoded timeout of 300 seconds (5 minutes) and is not configurable. If the script exits with a non-zero status code, the package installation fails and the sub-agent's executables are not started. On failure the package is **not** removed from disk; the hook is re-attempted on the next install.
+
+> [!IMPORTANT]
+> The hook runs on **every** install, not only when a new version is downloaded. If the package version is already present on disk, Agent Control skips the download, signature verification and extraction, **but it still runs the hook**. Because `install()` is invoked on every sub-agent start (i.e. every Agent Control restart) and on every config apply (as well as on version changes and rollbacks to an already-present version), the hook can run frequently. **Write hooks to be idempotent, fast and deterministic.**
 
 ```yaml
   post_download_hook:


### PR DESCRIPTION
The post_download_hook was only executed as part of the download+extraction path inside install_archive. When a package was already present on disk, install() return early without running the hook. This left two gaps:

- Agent Control restart: the package is persisted under stored_packages, so on restart install() saw the files already present and skipped the hook entirely the agent could start without its host-side prerequisites being (re)validated.
- Rollback to a previously-installed version: same situation the older package is still on disk, so switching back to it never re-ran the hook.

Decouple the hook from the download/extraction step and run it on every install, whether the package was just downloaded or was already present on disk. A non-zero hook exit fails the install so the agent is not started. The package folder is not deleted on failure the safety guarantee comes from install() returning Err, which prevents the supervisor from starting the executables (verified in both SupervisorOnHost::start() and apply()).

- install_archive now only downloads and extracts (takes &PackageData); the hook block was moved out of it.
- New helper run_post_download_hook(&PackageData, &Path): runs the configured hook (if any) with its working directory set to the package dir; no-op when no hook is configured.
- install() restructured so the "package already present" and "freshly downloaded" branches both produce the InstalledPackageData, and the hook runs unconditionally afterwards, before retain_packages.
