### PR TITLE
feat: modify infra agent agent types

### DIFF
--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -74,9 +74,6 @@ deployment:
           kind: file
           text: |
             ${nr-var:config_agent}
-    integrations.d:
-      kind: dir_content_from_map
-      source: ${nr-var:config_integrations}
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
@@ -89,6 +86,29 @@ deployment:
         # ephemeral so AC reclaims it on every (re)start instead of letting it grow unbounded.
         tmp:
           kind: dir
+  shared_filesystem:
+    # OHIs config folders.
+    # infra-agent is configured through NRIA_PLUGIN_DIR, to read configs from this folder.
+    infra-agent-ohi-configs:
+      kind: dir_content_from_map
+      persistent: true
+      source: ${nr-var:config_integrations}
+    # OHIs binaries folder.
+    # infra-agent is configured through NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR and NRIA_SAFE_BIN_DIR,
+    # to read binaries from this folder.
+    infra-agent-ohi-binaries:
+      kind: dir
+      persistent: true
+      entries:
+        nri-flex:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}/integrations/nri-flex
+        nri-docker:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}/integrations/nri-docker
+        nri-prometheus:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}/integrations/nri-prometheus
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}/newrelic-infra
@@ -102,10 +122,10 @@ deployment:
         # For the same reason we are also changing the location of the integration binaries.
         NRIA_AGENT_DIR: "${nr-sub:filesystem_agent_dir}/newrelic-infra"
         NRIA_AGENT_TEMP_DIR: "${nr-sub:filesystem_agent_dir}/newrelic-infra/tmp"
-        NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"
-        NRIA_SAFE_BIN_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"
+        NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-binaries"
+        NRIA_SAFE_BIN_DIR: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-binaries"
         # Config folders where integrations and logging configs parsed from local/remote values are stored and looked for.
-        NRIA_PLUGIN_DIR: "${nr-sub:filesystem_agent_dir}/integrations.d"
+        NRIA_PLUGIN_DIR: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-configs"
         NRIA_LOGGING_CONFIGS_DIR: "${nr-sub:filesystem_agent_dir}/logging.d"
         # Where parsers.conf and out_newrelic.so are placed and fb.db will be created
         NRIA_LOGGING_HOME_DIR: "${nr-sub:packages.infra-agent.dir}/logging"

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -70,9 +70,6 @@ deployment:
           kind: file
           text: |
             ${nr-var:config_agent}
-    integrations.d:
-      kind: dir_content_from_map
-      source: ${nr-var:config_integrations}
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
@@ -94,6 +91,33 @@ deployment:
             logging:
               kind: dir
               persistent: true
+  shared_filesystem:
+    # OHIs config folders.
+    # infra-agent is configured through NRIA_PLUGIN_DIR, to read configs from this folder.
+    infra-agent-ohi-configs:
+      kind: dir_content_from_map
+      source: ${nr-var:config_integrations}
+    # OHIs binaries folder.
+    # infra-agent is configured through NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR and NRIA_SAFE_BIN_DIR,
+    # to read binaries from this folder.
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-flex.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nri-flex.exe
+        nri-prometheus.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nri-prometheus.exe
+        nr-winpkg.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nr-winpkg.exe
+        nri-winservices.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nri-winservices.exe
+        windows_exporter.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\windows_exporter.exe
   executables:
     - id: newrelic-infra
       path: ${nr-sub:packages.infra-agent.dir}\\newrelic-infra.exe
@@ -112,10 +136,10 @@ deployment:
         # To avoid disks exhaustion issues, a default log rotation policy is applied to this log file.
         NRIA_LOG_ROTATE_MAX_SIZE_MB: "50"
         NRIA_LOG_ROTATE_MAX_FILES: "5"
-        NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:packages.infra-agent.dir}\\integrations"
-        NRIA_SAFE_BIN_DIR: "${nr-sub:packages.infra-agent.dir}\\integrations"
+        NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:shared_filesystem_dir}\\infra-agent-ohi-binaries"
+        NRIA_SAFE_BIN_DIR: "${nr-sub:shared_filesystem_dir}\\infra-agent-ohi-binaries"
         # Config folders where integrations and logging configs parsed from local/remote values are stored and looked for.
-        NRIA_PLUGIN_DIR: "${nr-sub:filesystem_agent_dir}\\integrations.d"
+        NRIA_PLUGIN_DIR: "${nr-sub:shared_filesystem_dir}\\infra-agent-ohi-configs"
         NRIA_LOGGING_CONFIGS_DIR: "${nr-sub:filesystem_agent_dir}\\logging.d"
         # Where fluent-bit exe is installed
         NRIA_LOGGING_BIN_DIR: "${nr-sub:packages.infra-agent.dir}\\logging"

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -107,6 +107,7 @@ impl TemplateRenderer {
 #[allow(missing_docs)]
 pub(crate) mod tests {
     use std::path::PathBuf;
+    use std::str::FromStr;
 
     use super::*;
     use crate::agent_type::runtime_config::on_host::executable::rendered as exec_rendered;
@@ -126,7 +127,12 @@ pub(crate) mod tests {
     }
 
     pub fn testing_agent_attributes(agent_id: &AgentID) -> AgentAttributes {
-        AgentAttributes::try_new(agent_id.clone(), PathBuf::default()).unwrap()
+        #[cfg(windows)]
+        let root = "C:\\";
+        #[cfg(not(windows))]
+        let root = "/";
+
+        AgentAttributes::try_new(agent_id.clone(), PathBuf::from_str(root).unwrap()).unwrap()
     }
 
     #[test]

--- a/test/e2e-runner/src/linux/scenarios/infra_agent.rs
+++ b/test/e2e-runner/src/linux/scenarios/infra_agent.rs
@@ -1,7 +1,7 @@
 use crate::common::config::{DEBUG_LOGGING_CONFIG, update_config, write_agent_local_config};
 use crate::common::nrql::Region;
 use crate::common::on_drop::CleanUp;
-use crate::common::test::retry_panic;
+use crate::common::test::{TestResult, retry_panic};
 use crate::common::{InstallationArgs, RecipeData};
 use crate::{
     common::nrql,
@@ -10,8 +10,14 @@ use crate::{
         install::{install_agent_control_from_recipe, tear_down_test},
     },
 };
+use std::path::Path;
 use std::time::Duration;
 use tracing::info;
+
+const SHARED_FILESYSTEM_DIR: &str = "/var/lib/newrelic-agent-control/shared-filesystem";
+const SHARED_OHI_BINARIES_DIR: &str = "infra-agent-ohi-binaries";
+const SHARED_OHI_CONFIGS_DIR: &str = "infra-agent-ohi-configs";
+const EMBEDDED_OHI_BINARIES: [&str; 3] = ["nri-flex", "nri-docker", "nri-prometheus"];
 
 pub fn test_installation_with_infra_agent(args: InstallationArgs) {
     let infra_version = args
@@ -66,6 +72,10 @@ config_logging:
         file: /var/log/syslog
         attributes:
           host.id: {test_id}
+config_integrations:
+  nri-e2e-check.yaml: |
+    integrations:
+      - name: nri-e2e-check
 version: {}
 "#,
             infra_version
@@ -91,5 +101,32 @@ version: {}
         nrql::check_query_results_are_not_empty(&recipe_data.args, &nrql_query)
     });
 
+    info!("Checking embedded OHI binaries and configs were copied to the shared filesystem");
+    retry_panic(
+        30,
+        Duration::from_secs(2),
+        "shared filesystem OHI binaries and configs",
+        check_ohi_shared_filesystem,
+    );
+
     info!("Test completed successfully");
+}
+
+fn check_ohi_shared_filesystem() -> TestResult<()> {
+    let binaries_dir = Path::new(SHARED_FILESYSTEM_DIR).join(SHARED_OHI_BINARIES_DIR);
+    for binary in EMBEDDED_OHI_BINARIES {
+        let path = binaries_dir.join(binary);
+        if !path.is_file() {
+            return Err(format!("expected OHI binary not found at {}", path.display()).into());
+        }
+    }
+
+    let config_path = Path::new(SHARED_FILESYSTEM_DIR)
+        .join(SHARED_OHI_CONFIGS_DIR)
+        .join("nri-e2e-check.yaml");
+    if !config_path.is_file() {
+        return Err(format!("expected OHI config not found at {}", config_path.display()).into());
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Update infra-agent agent type to use the shared filesystem.

* `integrations.d` is removed in favour of the new shared folder for configs.
* `integrations` is removed in favour of the new shared folder for binaries.
* all embedded binaries are copied to the shared folder for binaries. fluent bit stays the same.
* `testing_agent_attributes` was modified to include as `remote_dir` the "root" path. Otherwise, `all_agent_type_definitions_are_resilient_linux` and it's windows counterpart would fail.
* modified infra agent e2e tests to verify that shared folders and files are created.