### PR TITLE
feat(version): report all package versions in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Remember that the keywords that you can use are the following:
 ## Unreleased
 
 ### bugfix
+- Added identifying attributes for each package specified in the agentType as `package.version.<id>`.
 - RPM packages now restore `local_config.yaml` from the `.rpmsave` backup left by a prior uninstall.
 
 ### enhancement

--- a/agent-control/src/agent_control/defaults.rs
+++ b/agent-control/src/agent_control/defaults.rs
@@ -39,6 +39,10 @@ pub const OPAMP_SUPERVISOR_KEY: &str = "supervisor.key";
 /// OpAMP attribute key for the agent version.
 pub const OPAMP_AGENT_VERSION_ATTRIBUTE_KEY: &str = "agent.version";
 
+/// OpAMP attribute key prefix for per-package versions. The full key is built as
+/// `package.version.<package_id>`, where `<package_id>` is the id declared in the agent type.
+pub const OPAMP_PACKAGE_VERSION_ATTRIBUTE_KEY_PREFIX: &str = "package.version";
+
 /// File name holding the agent environment variables.
 pub const ENVIRONMENT_VARIABLES_FILE_NAME: &str = "environment_variables.yaml";
 

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -2,7 +2,9 @@
 //! and version checks for a single sub-agent.
 
 use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::defaults::OPAMP_AGENT_VERSION_ATTRIBUTE_KEY;
+use crate::agent_control::defaults::{
+    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY, OPAMP_PACKAGE_VERSION_ATTRIBUTE_KEY_PREFIX,
+};
 use crate::agent_type::runtime_config::health_config::rendered::OnHostHealthConfig;
 use crate::agent_type::runtime_config::on_host::filesystem::rendered::{
     FileSystem, FileSystemEntriesError, SharedFileSystem,
@@ -318,14 +320,25 @@ where
             version=%version,
             "Agent version determined from OCI package; publishing AgentAttributesUpdated event"
         );
+        let mut identifying_attributes = HashMap::from([(
+            OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
+            version.into(),
+        )]);
+
+        // Per-package versions as identifying attributes: `package.version.<id>`.
+        self.packages_config
+            .iter()
+            .for_each(|(package_id, package)| {
+                identifying_attributes.insert(
+                    format!("{OPAMP_PACKAGE_VERSION_ATTRIBUTE_KEY_PREFIX}.{package_id}"),
+                    package.download.oci.version.to_string().into(),
+                );
+            });
 
         publish_update_attributes_event(
             &sub_agent_internal_publisher,
             SubAgentInternalEvent::AgentAttributesUpdated(AgentDescription {
-                identifying_attributes: HashMap::from([(
-                    OPAMP_AGENT_VERSION_ATTRIBUTE_KEY.to_string(),
-                    version.into(),
-                )]),
+                identifying_attributes,
                 ..Default::default()
             }),
         );
@@ -666,6 +679,9 @@ pub mod tests {
     use crate::agent_type::runtime_config::health_config::HealthCheckTimeout;
     use crate::agent_type::runtime_config::on_host::executable::rendered::{Args, Env, Executable};
     use crate::agent_type::runtime_config::on_host::filesystem::FileSystem as ParsedFileSystem;
+    use crate::agent_type::runtime_config::on_host::package::rendered::{
+        Download, Oci, Package, Repository, Version,
+    };
     use crate::agent_type::runtime_config::on_host::rendered::OnHost;
     use crate::agent_type::runtime_config::rendered::{Deployment, Runtime};
     use crate::agent_type::runtime_config::restart_policy::rendered::RestartPolicyConfig;
@@ -682,8 +698,10 @@ pub mod tests {
     use crate::sub_agent::on_host::command::restart_policy::{Backoff, RestartPolicy};
     use crate::sub_agent::supervisor::Supervisor;
     use crate::utils::retry::retry;
+    use opamp_client::operation::settings::DescriptionValueType;
     use serde::Deserialize;
     use std::collections::HashMap;
+    use std::str::FromStr;
     use std::{
         fs, thread,
         time::{Duration, Instant},
@@ -692,6 +710,73 @@ pub mod tests {
 
     fn get_empty_packages() -> RenderedPackages {
         HashMap::new()
+    }
+
+    fn test_package_with_version(version: &str) -> Package {
+        Package {
+            download: Download {
+                oci: Oci {
+                    repository: Repository::from_str("newrelic/test").unwrap(),
+                    version: Version::from_str(version).unwrap(),
+                    public_key_url: None,
+                },
+            },
+            post_download_hook: None,
+        }
+    }
+
+    #[test]
+    fn test_check_subagent_version_publishes_per_package_identifying_attributes() {
+        let agent_identity = AgentIdentity::from((
+            AgentID::try_from("multi-pkg-agent").unwrap(),
+            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
+        ));
+
+        let packages: RenderedPackages = HashMap::from([
+            ("core".to_string(), test_package_with_version("1.0.0")),
+            ("plugin-b".to_string(), test_package_with_version("2.3.4")),
+        ]);
+
+        let supervisor = NotStartedSupervisorOnHost::new(
+            agent_identity,
+            vec![],
+            None,
+            packages,
+            MockPackageManager::new_arc(),
+            false,
+            PathBuf::default(),
+            FileSystem::test_empty(),
+            SharedFileSystem::test_empty(),
+        );
+
+        let (publisher, consumer) = pub_sub();
+        supervisor.check_subagent_version(publisher);
+
+        let event = consumer
+            .as_ref()
+            .try_recv()
+            .expect("expected an AgentAttributesUpdated event");
+
+        let SubAgentInternalEvent::AgentAttributesUpdated(desc) = event else {
+            panic!("expected AgentAttributesUpdated, got {event:?}");
+        };
+
+        // Identifying: agent.version reports the lowest-id package's version ("core" → "1.0.0").
+        assert_eq!(
+            desc.identifying_attributes
+                .get(OPAMP_AGENT_VERSION_ATTRIBUTE_KEY),
+            Some(&DescriptionValueType::String("1.0.0".to_string()))
+        );
+
+        // Identifying: package.version.<id> is present for every package.
+        assert_eq!(
+            desc.identifying_attributes.get("package.version.core"),
+            Some(&DescriptionValueType::String("1.0.0".to_string()))
+        );
+        assert_eq!(
+            desc.identifying_attributes.get("package.version.plugin-b"),
+            Some(&DescriptionValueType::String("2.3.4".to_string()))
+        );
     }
 
     #[derive(Clone, Deserialize)]

--- a/agent-control/tests/on_host/scenarios/attributes.rs
+++ b/agent-control/tests/on_host/scenarios/attributes.rs
@@ -14,8 +14,9 @@ use fake_opamp_server::FakeServer;
 use newrelic_agent_control::agent_control::agent_id::AgentID;
 use newrelic_agent_control::agent_control::defaults::{
     AGENT_CONTROL_NAMESPACE, HOST_NAME_ATTRIBUTE_KEY, OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
-    OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE, OPAMP_SERVICE_VERSION, OPAMP_SUPERVISOR_KEY,
-    OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE, PARENT_AGENT_ID_ATTRIBUTE_KEY,
+    OPAMP_PACKAGE_VERSION_ATTRIBUTE_KEY_PREFIX, OPAMP_SERVICE_NAME, OPAMP_SERVICE_NAMESPACE,
+    OPAMP_SERVICE_VERSION, OPAMP_SUPERVISOR_KEY, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
+    PARENT_AGENT_ID_ATTRIBUTE_KEY,
 };
 use newrelic_agent_control::agent_control::run::on_host::{
     AGENT_CONTROL_MODE_ON_HOST, OCI_TEST_REGISTRY_URL,
@@ -118,6 +119,7 @@ fn test_attributes_from_an_existing_agent_type_with_oci_registry() {
 
     let version = "1.0.0";
     let agent_id = "attributes-test-agent";
+    let package_id = "package-test-agent";
 
     #[cfg(target_family = "unix")]
     let (script_name, script_content) = ("sleep.sh", "#!/bin/bash\nsleep 60\n");
@@ -133,7 +135,7 @@ fn test_attributes_from_an_existing_agent_type_with_oci_registry() {
 
     let packages = format!(
         r#"
-{agent_id}:
+{package_id}:
   type: tar
   download:
     oci:
@@ -141,13 +143,13 @@ fn test_attributes_from_an_existing_agent_type_with_oci_registry() {
       version: ${{nr-var:package_version}}
       public_key_url: {public_key_url}
 "#,
-        agent_id = agent_id,
+        package_id = package_id,
         public_key_url = signer.jwks_url()
     );
 
     #[cfg(target_family = "unix")]
     let executables = {
-        let script_path = format!("${{{{nr-sub:packages.{}.dir}}}}/sleep.sh", agent_id);
+        let script_path = format!("${{{{nr-sub:packages.{}.dir}}}}/sleep.sh", package_id);
         format!(
             r#"[
         {{
@@ -162,7 +164,7 @@ fn test_attributes_from_an_existing_agent_type_with_oci_registry() {
 
     #[cfg(target_family = "windows")]
     let executables = {
-        let script_path = format!("${{{{nr-sub:packages.{}.dir}}}}\\\\sleep.ps1", agent_id);
+        let script_path = format!("${{{{nr-sub:packages.{}.dir}}}}\\\\sleep.ps1", package_id);
         format!(
             r#"[
         {{
@@ -240,6 +242,10 @@ agents:
         ),
         (
             OPAMP_AGENT_VERSION_ATTRIBUTE_KEY,
+            Value::StringValue(version.to_string()),
+        ),
+        (
+            format!("{OPAMP_PACKAGE_VERSION_ATTRIBUTE_KEY_PREFIX}.{package_id}").as_str(),
             Value::StringValue(version.to_string()),
         ),
     ]));

--- a/docs/package_manager.md
+++ b/docs/package_manager.md
@@ -286,6 +286,8 @@ If needed, you can run a local OCI registry using [zot](https://github.com/proje
 $ ./tools/oci-registry.sh run  
 ```
 
+This is needed to execute tests with ignore "needs oci registry" and having suffix 'with_oci_registry'.
+
 Notice that AC is already configured to use HTTP as protocol when connecting to `localhost:5001` if executed/built __without__ `--release`.
 
 ## Agent Types Management


### PR DESCRIPTION
This PRs adds the version of the packages as identifying attributes. 
We could also report them as non-identifying, but I did not want to diverge with the existing attribute
