### PR TITLE
fix: unsigned package test and other failure tests

### DIFF
--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -212,7 +212,7 @@ fn test_ac_self_update_fails_for_unsigned_package_with_oci_registry() {
 
     let dirs = TempBasePaths::default();
 
-    create_self_update_local_config(&opamp_server, &signer, &dirs.local_dir(), true);
+    create_self_update_no_cooldown_config(&opamp_server, &signer, &dirs.local_dir(), true);
 
     let mut agent_control = start_agent_control_with_custom_config(
         dirs.base_paths().clone(),
@@ -314,7 +314,7 @@ fn test_ac_self_update_fails_for_missing_version_with_oci_registry() {
     let dirs = TempBasePaths::default();
 
     // Disables signature verification to make sure the test reaches the package fetch step, which should fail for a non-existent version.
-    create_self_update_local_config(&opamp_server, &signer, &dirs.local_dir(), false);
+    create_self_update_no_cooldown_config(&opamp_server, &signer, &dirs.local_dir(), false);
 
     let mut agent_control = start_agent_control_with_custom_config(
         dirs.base_paths().clone(),
@@ -371,7 +371,7 @@ fn test_ac_self_update_fails_when_binary_verification_fails_with_oci_registry() 
 
     let new_version_tag = push_signed_invalid_fake_ac_package(&signer);
 
-    create_self_update_local_config(&opamp_server, &signer, &dirs.local_dir(), true);
+    create_self_update_no_cooldown_config(&opamp_server, &signer, &dirs.local_dir(), true);
 
     let mut agent_control = start_agent_control_with_custom_config(
         dirs.base_paths().clone(),
@@ -550,6 +550,45 @@ fn create_self_update_local_config(
             signer.jwks_url().to_string(),
         )
         .write(local_dir.to_path_buf());
+}
+
+/// Self-update local config with a zero-cooldown backoff, so the gate never suppresses the retry
+/// and the real failure stays the reported status instead of the transient "suppressed" cooldown
+/// message (the cause of the flakiness).
+fn create_self_update_no_cooldown_config(
+    opamp_server: &FakeServer,
+    signer: &OCISigner,
+    local_dir: &Path,
+    signature_verification_enabled: bool,
+) {
+    let config = format!(
+        r#"
+host_id: integration-test
+fleet_control:
+  endpoint: {}
+  poll_interval: 1s
+  signature_validation:
+    public_key_server_url: {}
+agents: {{}}
+oci:
+  registry: {OCI_TEST_REGISTRY_URL}
+self_update:
+  enabled: true
+  signature_verification_enabled: {signature_verification_enabled}
+  upgrade_backoff:
+    base_delay: 0s
+    max_delay: 0s
+  package:
+    download:
+      oci:
+        repository: test
+        public_key_url: {}
+"#,
+        opamp_server.endpoint(),
+        opamp_server.jwks_endpoint(),
+        signer.jwks_url()
+    );
+    create_local_config(AGENT_CONTROL_ID, config, local_dir.to_path_buf());
 }
 
 /// Pushes an invalid fake agent-control binary package to the OCI registry and signs it.


### PR DESCRIPTION
ISSUE
---
Each of these tests waits for the remote-config status to be Failed with a specific message (signature verification, requested version does not exist, pre-flight check failed). That message only shows up when an upgrade attempt actually runs and fails.

The problem: after the first failure, the self-update backoff gate goes into a cooldown. From then on, every poll just reports a generic, stable message: upgrade to X suppressed: retrying after previous failure. The fake OpAMP server only keeps the last status, so the real error message gets overwritten by the "suppressed" one almost right away.

With the default backoff (starts at 30s and keeps growing), that cooldown lasts way longer than the test's polling window, so the test almost always reads "suppressed" and eventually times out. It only passed when a poll happened to land on the short moment where the real error was still the latest status. That timing is why it was flaky, and why it kept failing on the slower Windows CI.

FIX
---
Add create_self_update_no_cooldown_config: a self-update config with the backoff set to zero (upgrade_backoff.base_delay: 0s, max_delay: 0s), with signature_verification_enabled as a parameter, and make the three failing tests use it.

With a zero delay the gate never sees now < next_attempt_at, so it never goes into cooldown and never suppresses. Every poll runs the attempt again and reports the real error, so the real error is now the status that stays, and the test reliably sees it.