### PR TITLE
fix: net fails on dependencies and chartmuseum

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[net]
+retry = 10
+
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]
 

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -212,7 +212,7 @@ jobs:
           identifier: 'test-dev'
           restore-strategy: 'nearest'
           save-cache: false
-      
+
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ./.github/actions/rust-cache
         # We have faced issues 'hashFiles('**/Cargo.lock') failed.' in this job. As we couldn't pinpoint
@@ -319,6 +319,18 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
+      - name: Preload chartmuseum image into Minikube
+        env:
+          CHARTMUSEUM_IMAGE: ghcr.io/helm/chartmuseum:v0.16.3
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || echo "ghcr login failed, continuing with anonymous pull"
+          for i in 1 2 3 4 5; do
+            docker pull "$CHARTMUSEUM_IMAGE" && break
+            echo "chartmuseum image pull failed (attempt $i/5), retrying in 5s..."
+            sleep 5
+          done
+          minikube image load "$CHARTMUSEUM_IMAGE"
+
       - uses: ./.github/actions/install-rust-toolchain
         with:
           targets: >-
@@ -342,10 +354,19 @@ jobs:
         with:
           tool: cargo-zigbuild@0.20.1
 
+      - name: Fetch cargo dependencies
+        run: |
+          for i in 1 2 3; do
+            cargo fetch --locked && break
+            echo "cargo fetch failed (attempt $i/3), retrying in 10s..."
+            sleep 10
+          done
+
       - name: Run k8s integration tests
         env:
           # Tilt configs
           ARCH: amd64
+          CARGO_NET_OFFLINE: "true"
         run: make -C agent-control test/k8s/integration-${{ matrix.group }}
 
   k8s-e2e-tests:

--- a/agent-control/tests/k8s/Tiltfile
+++ b/agent-control/tests/k8s/Tiltfile
@@ -73,14 +73,34 @@ helm_repo(
   resource_name='chartmuseum-repo',
   )
 
+# Pre-pull the chart with retry: helm fetches the chart tgz from GitHub release assets, which can
+# time out. Retrying the pull (not the pod) and installing from the local copy keeps setup reliable.
+local_resource(
+  'chartmuseum-chart-pull',
+  cmd='''set -eu
+rm -rf local/chartmuseum-chart
+for i in 1 2 3 4 5; do
+  helm pull chartmuseum/chartmuseum --untar --untardir local/chartmuseum-chart && exit 0
+  echo "helm pull chartmuseum failed (attempt $i/5), retrying in 5s..."
+  sleep 5
+done
+exit 1
+''',
+  resource_deps=['chartmuseum-repo'],
+)
+
 helm_resource(
   'chartmuseum',
-  'chartmuseum/chartmuseum',
+  'local/chartmuseum-chart/chartmuseum',
   namespace='default',
   release_name='chartmuseum',
-  resource_deps=['chartmuseum-repo'],
-  # activate API to upload charts
-  flags=['--set=env.open.DISABLE_API=false'],
+  resource_deps=['chartmuseum-chart-pull'],
+  flags=[
+    '--set=env.open.DISABLE_API=false',
+    '--set=image.repository=ghcr.io/helm/chartmuseum',
+    '--set=image.tag=v0.16.3',
+    '--set=image.pullPolicy=IfNotPresent',
+  ],
   port_forwards=['8080']
 )
 


### PR DESCRIPTION
Makes the CI setup resilient to transient network failures when downloading dependencies and artifacts, without adding any retry around the tests themselves. Covers the download points that were failing intermittently in the k8s / checks jobs.

***CHANGES***
---

Cargo dependencies
- .cargo/config.toml: [net] retry = 10 (up from the default 3). Applies to every cargo network op across all jobs; only affects downloads.
- k8s job: a dedicated cargo fetch --locked step with retry, and the test step runs with CARGO_NET_OFFLINE=true, so once deps are fetched a network hiccup can't fail the tests (and the download retry can't mask a flaky test).

chartmuseum container image
- Preload step in the workflow: docker pull (with retry) + minikube image load of ghcr.io/helm/chartmuseum:v0.16.3 (ghcr login to avoid anonymous rate limits).
- Tilt file pins the image (image.tag=v0.16.3, pullPolicy: IfNotPresent) so the pod uses the side-loaded image instead of pulling at runtime.

chartmuseum helm chart
- Tilt file pre-pulls the chart with retry into a local dir and installs from that local copy, so helm upgrade --install no longer downloads the chart tgz from GitHub release assets at runtime (that download was timing out).


