### PR TITLE
Feat: dynamic canaries

### DIFF
--- a/.github/workflows/scheduled_onhost_canary_config_rotation.yml
+++ b/.github/workflows/scheduled_onhost_canary_config_rotation.yml
@@ -36,14 +36,24 @@ env:
   # We don't have 'latest' OCI packages, so I've set them to a fixed version.
   #   First  -> NRInfra 1.77.1  (canaries-infra-config)
   #   Second -> NRDOT   1.19.0  (canaries-nrdot)
-  AGENT_SPECS_LINUX: >-
+  AGENT_SPECS_LINUX_PRODUCTION: >-
     NRInfra:1.77.1:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGM3Yi1lYjAyLTc1MmQtOGViOC0zNDYyMWM2ZDRkMzQ
     NRDOT:1.19.0:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGM3Yy05M2Y3LTcyMjctODJmZS01OGYwMjcyMDViMDI
   #   First  -> NRInfra 1.77.1  (canaries-infra-config-windows)
   #   Second -> NRDOT   1.19.0  (canaries-nrdot-windows)
-  AGENT_SPECS_WINDOWS: >-
+  AGENT_SPECS_WINDOWS_PRODUCTION: >-
     NRInfra:1.77.1:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGNjNC0zNmU1LTdmMmQtYjIyMS1mM2ZjY2QzOTAwOTg
     NRDOT:1.19.0:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGNjNC1kMTE0LTdmMzktYWRmZS02ZTY4ZWFiYWZkY2Y
+  #   First  -> NRInfra 1.77.1  (canaries-infra-config)
+  #   Second -> NRDOT   1.19.0  (canaries-nrdot)
+  AGENT_SPECS_LINUX_STAGING: >-
+    NRInfra:1.77.1:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5ZjViZTItYjdkYy03YmM5LTg0OTUtYTIyMmI5NTYyZDAy
+    NRDOT:1.19.0:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5ZjViZTMtNmU3YS03NzA0LWI0NjgtOTAwMDY1NjgyMWJj
+  #   First  -> NRInfra 1.77.1  (canaries-infra-config-windows)
+  #   Second -> NRDOT   1.19.0  (canaries-nrdot-windows)
+  AGENT_SPECS_WINDOWS_STAGING: >-
+    NRInfra:1.77.1:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5ZjViZTMtNmU3YS03NzA0LWI0NjgtOTAwMDY1NjgyMWJj
+    NRDOT:1.19.0:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5ZjViZTQtOWFkZS03MWVjLTg0NTMtYjlkOTExMGViODc3
 
 jobs:
   rotate-config-deployment:
@@ -65,20 +75,22 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           ENVIRONMENT: ${{ matrix.environment }}
         run: |
-          # Pick this platform's fleet id (per environment) and its ordered spec list.
+          # Pick this platform+environment's fleet id and its ordered spec list.
           if [ "${PLATFORM}" = "windows" ]; then
-            SPECS_STR="${AGENT_SPECS_WINDOWS}"
             if [ "${ENVIRONMENT}" = "production" ]; then
               FLEET_ID="${WINDOWS_FLEET_ID_PRODUCTION}"
+              SPECS_STR="${AGENT_SPECS_WINDOWS_PRODUCTION}"
             else
               FLEET_ID="${WINDOWS_FLEET_ID_STAGING}"
+              SPECS_STR="${AGENT_SPECS_WINDOWS_STAGING}"
             fi
           else
-            SPECS_STR="${AGENT_SPECS_LINUX}"
             if [ "${ENVIRONMENT}" = "production" ]; then
               FLEET_ID="${FLEET_ID_PRODUCTION}"
+              SPECS_STR="${AGENT_SPECS_LINUX_PRODUCTION}"
             else
               FLEET_ID="${FLEET_ID_STAGING}"
+              SPECS_STR="${AGENT_SPECS_LINUX_STAGING}"
             fi
           fi
 

--- a/.github/workflows/scheduled_onhost_canary_config_rotation.yml
+++ b/.github/workflows/scheduled_onhost_canary_config_rotation.yml
@@ -1,0 +1,110 @@
+name: 🔁🐤 Scheduled onhost canary config rotation
+
+# Every 6 hours, deploy the *next* config version in an ordered set to the
+# canary fleet using test/onhost-canaries/scripts/fleet_deployment.sh.
+# Each run advances one step through the set; after the last entry it wraps
+# back to the first. This is a rotation (one deployment per run), not a matrix
+# fan-out.
+
+on:
+  schedule:
+    # Every 6 hours (UTC). Minute offset from :00 to dodge the top-of-hour
+    # scheduler backlog that delays cron workflows on GitHub-hosted runners.
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never overlap rotation runs (each run already deploys every environment/platform combination).
+  group: scheduled-onhost-canary-config-rotation
+  cancel-in-progress: false
+
+env:
+  # AC Staging Account `host-canaries-staging` fleet
+  FLEET_ID_STAGING: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA"
+  WINDOWS_FLEET_ID_STAGING: "MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTljMjNjYy0yM2I2LTc1OTYtODBkNy0yMzAzYWIyYzcwMTA"
+  # AC US Production Account `host-canaries-production` fleet
+  FLEET_ID_PRODUCTION: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWFlM2EyLTA3OTctNzczYS05Y2JjLWMzNzZkMjAwMWFkZg"
+  WINDOWS_FLEET_ID_PRODUCTION: "NjQyNTg2NXxOR0VQfEZMRUVUfDAxOWMyMjljLWVhYTQtN2JmNi04YWIyLTU2ZWI0YjE2ZWZjZQ"
+
+  # Ordered set of agent specs to rotate through, one per line:
+  #   <agentType>:<version>:<configVersionId>
+  # Agent type, version and config version are paired here so they always rotate
+  # together and stay matched. One deployment per run advances to the next entry,
+  # wrapping to the first after the last.
+  # We don't have 'latest' OCI packages, so I've set them to a fixed version.
+  #   First  -> NRInfra 1.77.1  (canaries-infra-config)
+  #   Second -> NRDOT   1.19.0  (canaries-nrdot)
+  AGENT_SPECS_LINUX: >-
+    NRInfra:1.77.1:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGM3Yi1lYjAyLTc1MmQtOGViOC0zNDYyMWM2ZDRkMzQ
+    NRDOT:1.19.0:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGM3Yy05M2Y3LTcyMjctODJmZS01OGYwMjcyMDViMDI
+  #   First  -> NRInfra 1.77.1  (canaries-infra-config-windows)
+  #   Second -> NRDOT   1.19.0  (canaries-nrdot-windows)
+  AGENT_SPECS_WINDOWS: >-
+    NRInfra:1.77.1:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGNjNC0zNmU1LTdmMmQtYjIyMS1mM2ZjY2QzOTAwOTg
+    NRDOT:1.19.0:NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnwwMTlmNGNjNC1kMTE0LTdmMzktYWRmZS02ZTY4ZWFiYWZkY2Y
+
+jobs:
+  rotate-config-deployment:
+    name: Deploy next config in rotation (${{ matrix.environment }} / ${{ matrix.platform }})
+    runs-on: linux-4-core-nr-control
+    strategy:
+      # Every run deploys all environment/platform combinations; a failure on one
+      # must not skip the others.
+      fail-fast: false
+      matrix:
+        environment: [staging, production]
+        platform: [linux, windows]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Resolve fleet and select agent spec (rotating)
+        id: target
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          ENVIRONMENT: ${{ matrix.environment }}
+        run: |
+          # Pick this platform's fleet id (per environment) and its ordered spec list.
+          if [ "${PLATFORM}" = "windows" ]; then
+            SPECS_STR="${AGENT_SPECS_WINDOWS}"
+            if [ "${ENVIRONMENT}" = "production" ]; then
+              FLEET_ID="${WINDOWS_FLEET_ID_PRODUCTION}"
+            else
+              FLEET_ID="${WINDOWS_FLEET_ID_STAGING}"
+            fi
+          else
+            SPECS_STR="${AGENT_SPECS_LINUX}"
+            if [ "${ENVIRONMENT}" = "production" ]; then
+              FLEET_ID="${FLEET_ID_PRODUCTION}"
+            else
+              FLEET_ID="${FLEET_ID_STAGING}"
+            fi
+          fi
+
+          # Split the whitespace-separated specs. Each entry is a full
+          # <agentType>:<version>:<configVersionId> spec.
+          read -ra SPECS <<< "${SPECS_STR}"
+          COUNT=${#SPECS[@]}
+
+          # github.run_number increments on every run of this workflow, so
+          # ((run_number - 1) % COUNT) walks the set in order starting at the
+          # first entry and wraps back to the first after the last. Both platforms
+          # share the same run number, so they rotate to the same position.
+          RUN_NUMBER=${{ github.run_number }}
+          INDEX=$(( (RUN_NUMBER - 1) % COUNT ))
+          SPEC="${SPECS[$INDEX]}"
+
+          echo "[${PLATFORM}] rotation: run #${RUN_NUMBER} -> index ${INDEX} of ${COUNT} -> ${SPEC}"
+          echo "fleet_id=${FLEET_ID}" >> "$GITHUB_OUTPUT"
+          echo "spec=${SPEC}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and deploy fleet deployment
+        env:
+          NEW_RELIC_API_KEY: ${{ matrix.environment == 'production' && secrets.AC_PROD_E2E_API_KEY || secrets.AC_FC_STAG_E2E_API_KEY }}
+          FLEET_ID: ${{ steps.target.outputs.fleet_id }}
+          ENVIRONMENT: ${{ matrix.environment }}
+        run: |
+          chmod +x test/onhost-canaries/scripts/fleet_deployment.sh
+          test/onhost-canaries/scripts/fleet_deployment.sh \
+            "${{ steps.target.outputs.spec }}"

--- a/test/onhost-canaries/scripts/README.md
+++ b/test/onhost-canaries/scripts/README.md
@@ -4,12 +4,12 @@ Script to create and trigger Fleet Control deployments for on-host canaries.
 
 ## Overview
 
-The `fleet_deployment.sh` script creates a Fleet Control deployment that defines the desired state of agents in a fleet and triggers the rollout through the ring deployment policy.
+The `fleet_deployment.sh` script creates a Fleet Control deployment that defines the desired state of agents in a fleet and triggers the rollout through the ring deployment policy. It drives the [New Relic CLI](https://github.com/newrelic/newrelic-cli) (`newrelic fleetcontrol deployment ...`) rather than calling NerdGraph directly.
 
 ### Two-Step Process
 
-1. **fleetControlCreateFleetDeployment** — Creates the deployment definition
-2. **fleetControlDeploy** — Pushes it through the ring policy to the fleet
+1. **`newrelic fleetcontrol deployment create`** — Creates the deployment definition
+2. **`newrelic fleetcontrol deployment deploy`** — Pushes it through the ring policy to the fleet
 
 ## Prerequisites
 
@@ -18,17 +18,20 @@ The `fleet_deployment.sh` script creates a Fleet Control deployment that defines
 - `bash` (tested with bash 5.x)
 - `curl`
 - `jq`
+- `newrelic` CLI — installed automatically by the script if not already on `PATH`
 
 ### Required Environment Variables
 
 Set these environment variables before running the script:
 
 ```bash
-export NEW_RELIC_API_KEY="<your-api-key>"      # NerdGraph User API key
+export NEW_RELIC_API_KEY="<your-api-key>"      # NerdGraph User API key (NRAK-...)
 export FLEET_ID="<fleet-entity-guid>"          # Fleet entity GUID
-export SCOPE_ORG_ID="<organization-guid>"      # Organization GUID for deployment scope
 export ENVIRONMENT="staging"                   # "staging" or "production"
 ```
+
+> The deployment scope (organization) is derived automatically by the CLI from the API key.
+> `ENVIRONMENT` is mapped to the CLI's `NEW_RELIC_REGION` (`staging` → `Staging`, `production` → `US`).
 
 ## Usage
 
@@ -72,7 +75,6 @@ Deploy Infrastructure Agent version 1.76.1 with a specific configuration:
 ```bash
 export NEW_RELIC_API_KEY="NRAK-XXXX"
 export FLEET_ID="MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA"
-export SCOPE_ORG_ID="9d789cca-f661-458d-be06-882d1e6e409d"
 export ENVIRONMENT="staging"
 
 ./fleet_deployment.sh "NRInfra:1.76.1:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5YzdhYWEtNmM4My03NWFhLWIzYmEtOTE0MjIzZDU0Mjk1"
@@ -101,9 +103,8 @@ Example output:
 [2026-06-10 11:34:52] =======================================
 [2026-06-10 11:34:52] Fleet Deployment Script
 [2026-06-10 11:34:52] =======================================
-[2026-06-10 11:34:52] Environment  : staging
+[2026-06-10 11:34:52] Environment  : staging (region: Staging)
 [2026-06-10 11:34:52] Fleet ID     : MTIyMTMwNjh8TkdFUHxGTEVFVHwwMTlhZTNiNS01Yjg5LTdkNjYtYWU0MC1lNmZkOTY2ZDFhMDA
-[2026-06-10 11:34:52] Scope Org ID : 9d789cca-f661-458d-be06-882d1e6e409d
 [2026-06-10 11:34:52] Deployment   : canary-deployment-20260610-113452
 [2026-06-10 11:34:52] Agents       : NRInfra:1.76.1:MTIyMTMwNjh8TkdFUHxBR0VOVF9DT05GSUdVUkFUSU9OX1ZFUlNJT058MDE5YzdhYWEtNmM4My03NWFhLWIzYmEtOTE0MjIzZDU0Mjk1
 [2026-06-10 11:34:52] =======================================

--- a/test/onhost-canaries/scripts/fleet_deployment.sh
+++ b/test/onhost-canaries/scripts/fleet_deployment.sh
@@ -5,9 +5,12 @@
 # Generic script to create Fleet Control deployments for on-host canaries.
 # Defines the DESIRED STATE of agents in a fleet and triggers the rollout.
 #
+# Uses the New Relic CLI (`newrelic fleetcontrol deployment ...`) instead of
+# hand-rolled NerdGraph mutations.
+#
 # TWO-STEP PROCESS:
-#   1. fleetControlCreateFleetDeployment  →  creates the deployment definition
-#   2. fleetControlDeploy                 →  pushes it through the ring policy
+#   1. newrelic fleetcontrol deployment create  →  creates the deployment definition
+#   2. newrelic fleetcontrol deployment deploy  →  pushes it through the ring policy
 #
 # ---------------------------------------------------------------------------
 # USAGE
@@ -27,17 +30,18 @@
 # ---------------------------------------------------------------------------
 # REQUIRED environment variables
 # ---------------------------------------------------------------------------
-#   NEW_RELIC_API_KEY   NerdGraph User API key
+#   NEW_RELIC_API_KEY   NerdGraph User API key (NRAK-...)
 #   FLEET_ID            Fleet entity GUID
-#   SCOPE_ORG_ID        Organization GUID used as deployment scope
 #   ENVIRONMENT         "staging" or "production"
+#
+# Note: the deployment scope (organization) is derived automatically by the CLI from the API key
 
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
 # Validate required environment variables
 # ---------------------------------------------------------------------------
-REQUIRED_VARS=(NEW_RELIC_API_KEY FLEET_ID SCOPE_ORG_ID ENVIRONMENT)
+REQUIRED_VARS=(NEW_RELIC_API_KEY FLEET_ID ENVIRONMENT)
 for var in "${REQUIRED_VARS[@]}"; do
   if [[ -z "${!var:-}" ]]; then
     echo "ERROR: Required environment variable '${var}' is not set." >&2
@@ -61,16 +65,21 @@ fi
 # ---------------------------------------------------------------------------
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 DEPLOYMENT_NAME="canary-deployment-${TIMESTAMP}"
-# When a new fleet is created both rings are always created, all hosts added to a fleet are added to default unless
-# they are moved to canary; to warrant all hosts are always deployed, we always deploy both rings, even if in the vast
-# majority of cases only default exists.
-RINGS_TO_DEPLOY='["canary", "default"]'
+# When a new fleet is created both rings are always created; all hosts added to
+# a fleet land in `default` unless moved to `canary`. To guarantee every host is
+# always deployed we always deploy both rings, even though in the vast majority
+# of cases only `default` exists. The CLI expects a comma-separated list.
+RINGS_TO_DEPLOY="canary,default"
 
+# The New Relic CLI reads NEW_RELIC_REGION from the environment. Map the
+# script's ENVIRONMENT onto the CLI region: staging → Staging, production → US.
 if [[ "${ENVIRONMENT}" == "production" ]]; then
-  NERDGRAPH_URL="https://api.newrelic.com/graphql"
+  export NEW_RELIC_REGION="US"
 else
-  NERDGRAPH_URL="https://staging-api.newrelic.com/graphql"
+  export NEW_RELIC_REGION="Staging"
 fi
+
+NEWRELIC_CLI_INSTALL_URL="https://download.newrelic.com/install/newrelic-cli/scripts/install.sh"
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -80,101 +89,59 @@ log() {
 }
 
 # ---------------------------------------------------------------------------
-# NerdGraph helper
+# Ensure the New Relic CLI is available; install it if missing (matches the
+# manual bootstrap on fresh canary hosts).
 # ---------------------------------------------------------------------------
-call_nerdgraph() {
-  local mutation="$1"
-  local payload
-  payload=$(jq -n --arg query "${mutation}" '{"query": $query}')
-
-  local response
-  response=$(
-    curl --fail --silent --show-error \
-      --max-time 30 \
-      -X POST "${NERDGRAPH_URL}" \
-      -H "Content-Type: application/json" \
-      -H "API-Key: ${NEW_RELIC_API_KEY}" \
-      -d "${payload}"
-  )
-
-  if echo "${response}" | jq -e '.errors' > /dev/null 2>&1; then
-    log "ERROR: NerdGraph returned errors:" >&2
-    echo "${response}" | jq '.errors' >&2
-    exit 1
+ensure_newrelic_cli() {
+  if command -v newrelic > /dev/null 2>&1; then
+    return
   fi
 
-  echo "${response}"
-}
+  log "New Relic CLI not found — installing from ${NEWRELIC_CLI_INSTALL_URL}..."
+  curl -Ls "${NEWRELIC_CLI_INSTALL_URL}" | bash
 
-# ---------------------------------------------------------------------------
-# Build a single agent GraphQL input fragment from a spec string.
-#
-# Spec format: <agentType>:<version>:<configVersionId>
-# ---------------------------------------------------------------------------
-parse_agent_spec() {
-  local spec="$1"
-  local agent_type version config_id
-
-  IFS=':' read -r agent_type version config_id <<< "${spec}"
-
-  if [[ -z "${agent_type}" || -z "${version}" || -z "${config_id:-}" ]]; then
-    log "ERROR: Invalid agent spec '${spec}'. Expected <agentType>:<version>:<configVersionId>" >&2
+  if ! command -v newrelic > /dev/null 2>&1; then
+    log "ERROR: New Relic CLI installation failed — 'newrelic' still not on PATH." >&2
     exit 1
   fi
-
-  printf '{configurationVersionList: {id: "%s"}, agentType: "%s", version: "%s"}' \
-    "${config_id}" "${agent_type}" "${version}"
-}
-
-# ---------------------------------------------------------------------------
-# Build the agents GraphQL input array from one or more pre-built agent
-# fragments. `paste -sd ','` uses comma as a separator between lines, so no
-# trailing comma is produced.
-#   [{agentType: "..."}]                        # single
-#   [{agentType: "..."}, {agentType: "..."}]    # multiple
-# ---------------------------------------------------------------------------
-build_agents_input() {
-  local joined
-  joined=$(printf '%s\n' "$@" | paste -sd ',')
-  echo "[${joined}]"
 }
 
 # ---------------------------------------------------------------------------
 # Step 1: Create a fleet deployment definition
 # ---------------------------------------------------------------------------
 create_fleet_deployment() {
-  local agents_input="$1"
-
   log "Creating deployment '${DEPLOYMENT_NAME}' on fleet '${FLEET_ID}'..."
-  log "Agents input: ${agents_input}"
 
-  local mutation
-  mutation="mutation {
-  fleetControlCreateFleetDeployment(
-    fleetDeployment: {
-      agents: ${agents_input}
-      fleetId: \"${FLEET_ID}\"
-      scope: {type: ORGANIZATION, id: \"${SCOPE_ORG_ID}\"}
-      name: \"${DEPLOYMENT_NAME}\"
-    }
-  ) {
-    entity {
-      name
-      id
-      description
-    }
-  }
-}"
+  # Build the repeated --agent arguments from the agent specs. The CLI's
+  # --agent value uses the same <agentType>:<version>:<configVersionId> format
+  # this script accepts as positional args, so specs pass straight through.
+  # NOTE: assumes --agent is a repeatable flag for multiple agents. Verify with
+  #       `newrelic fleetcontrol deployment create --help` if this ever changes.
+  local agent_args=()
+  for spec in "$@"; do
+    if [[ "${spec}" != *:*:* ]]; then
+      log "ERROR: Invalid agent spec '${spec}'. Expected <agentType>:<version>:<configVersionId>" >&2
+      exit 1
+    fi
+    agent_args+=(--agent "${spec}")
+  done
 
   local response
-  response=$(call_nerdgraph "${mutation}")
+  response=$(
+    newrelic fleetcontrol deployment create \
+      --fleet-id "${FLEET_ID}" \
+      --name "${DEPLOYMENT_NAME}" \
+      "${agent_args[@]}"
+  )
+
+  # Surface the raw CLI response for debugging.
+  echo "${response}" >&2
 
   local deployment_id
-  deployment_id=$(echo "${response}" | jq -r '.data.fleetControlCreateFleetDeployment.entity.id')
+  deployment_id=$(echo "${response}" | jq -r '.result.id')
 
   if [[ -z "${deployment_id}" || "${deployment_id}" == "null" ]]; then
-    log "ERROR: Failed to extract deployment ID from response:" >&2
-    echo "${response}" | jq '.' >&2
+    log "ERROR: Failed to extract deployment ID from CLI response (see above)." >&2
     exit 1
   fi
 
@@ -183,62 +150,36 @@ create_fleet_deployment() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 2: Trigger the deployment through the ring policy
+# Step 2: Trigger the deployment through the ring policy. The CLI monitors
+# rollout progress and exits non-zero on failure, so `set -e` handles errors.
 # ---------------------------------------------------------------------------
 trigger_deployment() {
   local deployment_id="$1"
 
-  log "Triggering deployment '${deployment_id}'..."
+  log "Triggering deployment '${deployment_id}' (rings: ${RINGS_TO_DEPLOY})..."
 
-  local mutation
-  mutation="mutation {
-  fleetControlDeploy(
-    id: \"${deployment_id}\"
-    policy: {ringDeploymentPolicy: {ringsToDeploy: ${RINGS_TO_DEPLOY}}}
-  ) {
-    id
-  }
-}"
+  newrelic fleetcontrol deployment deploy \
+    --deployment-id "${deployment_id}" \
+    --rings-to-deploy "${RINGS_TO_DEPLOY}"
 
-  local response
-  response=$(call_nerdgraph "${mutation}")
-
-  local triggered_id
-  triggered_id=$(echo "${response}" | jq -r '.data.fleetControlDeploy.id')
-
-  if [[ -z "${triggered_id}" || "${triggered_id}" == "null" ]]; then
-    log "ERROR: Deployment trigger failed. Response:" >&2
-    echo "${response}" | jq '.' >&2
-    exit 1
-  fi
-
-  log "Deployment triggered — confirmed ID: ${triggered_id}"
-  echo "${triggered_id}"
+  log "Deployment triggered — confirmed ID: ${deployment_id}"
 }
 
 main() {
   log "======================================="
   log "Fleet Deployment Script"
   log "======================================="
-  log "Environment  : ${ENVIRONMENT}"
+  log "Environment  : ${ENVIRONMENT} (region: ${NEW_RELIC_REGION})"
   log "Fleet ID     : ${FLEET_ID}"
-  log "Scope Org ID : ${SCOPE_ORG_ID}"
   log "Deployment   : ${DEPLOYMENT_NAME}"
   log "Agents       : $*"
   log "======================================="
 
-  # Parse each agent spec into a GraphQL input fragment
-  local agent_fragments=()
-  for spec in "$@"; do
-    agent_fragments+=("$(parse_agent_spec "${spec}")")
-  done
-
-  local agents_input
-  agents_input=$(build_agents_input "${agent_fragments[@]}")
+  ensure_newrelic_cli
 
   # Step 1 — Create the deployment definition
   local deployment_id
-  deployment_id=$(create_fleet_deployment "${agents_input}")
+  deployment_id=$(create_fleet_deployment "$@")
 
   # Step 2 — Trigger the deployment
   trigger_deployment "${deployment_id}"


### PR DESCRIPTION
- Changes fleet_deployment.sh to use the Fleet API in newrelic-cli instead of using Graphql directly.
- Adds a scheduled GitHub Action (every 6h) that rotates the canary fleets through an ordered set of agent config versions, advancing one step per run and wrapping around. Each run fans out over a matrix of environment (staging/production) and platform (linux/windows), deploying via the newrelic-CLI-based fleet_deployment.sh.
  
<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
