### PR TITLE
fix(test): compile error

### DIFF
--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -736,6 +736,7 @@ pub mod tests {
             vec![],
             None,
             packages,
+            Some("core".to_string()),
             MockPackageManager::new_arc(),
             false,
             PathBuf::default(),


### PR DESCRIPTION
This PR Fixes a compile error on tests, probably caused by a bad merge/rebase.