### PR TITLE
feat: add binary size comparasion to the pipelines

### DIFF
--- a/.github/actions/binary-size-baseline/action.yml
+++ b/.github/actions/binary-size-baseline/action.yml
@@ -1,0 +1,58 @@
+name: 'Binary size baseline check'
+description: 'Restores a cached binary-size baseline, checks against it, and optionally republishes it'
+inputs:
+  current-file:
+    description: 'Path to the current sizes file (name size-in-bytes per line)'
+    required: false
+    default: 'binary-size/current.txt'
+  baseline-file:
+    description: 'Path to write/read the baseline sizes file'
+    required: false
+    default: 'binary-size/baseline.txt'
+  cache-key:
+    description: 'Exact cache key to save the baseline under'
+    required: true
+  cache-restore-prefix:
+    description: 'Cache key prefix used to restore the latest baseline (restore-keys)'
+    required: true
+  threshold:
+    description: 'Max allowed percent growth over baseline before failing'
+    required: false
+    default: '10'
+  enforce:
+    description: "If 'false', never fail the job on a regression (still produces the summary table)"
+    required: false
+    default: 'true'
+  publish-baseline:
+    description: "If 'true', republish current sizes as the new baseline (only if the check passed, when enforced)"
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore binary size baseline
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ inputs.baseline-file }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: |
+          ${{ inputs.cache-restore-prefix }}
+
+    - name: Check binary size against baseline
+      id: check
+      shell: bash
+      continue-on-error: ${{ inputs.enforce == 'false' }}
+      run: bash .github/scripts/binary-size.sh check "${{ inputs.current-file }}" "${{ inputs.baseline-file }}" "${{ inputs.threshold }}"
+
+    # Always publish when not enforcing (e.g. main); otherwise only if the check passed.
+    - name: Publish new baseline
+      if: ${{ inputs.publish-baseline == 'true' && (inputs.enforce == 'false' || steps.check.outcome == 'success') }}
+      shell: bash
+      run: cp "${{ inputs.current-file }}" "${{ inputs.baseline-file }}"
+
+    - name: Save binary size baseline
+      if: ${{ inputs.publish-baseline == 'true' && (inputs.enforce == 'false' || steps.check.outcome == 'success') }}
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ inputs.baseline-file }}
+        key: ${{ inputs.cache-key }}

--- a/.github/scripts/binary-size.sh
+++ b/.github/scripts/binary-size.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Binary size tooling for CI. Subcommands:
+#   measure        <archives-dir> <output-file>  # extract sizes from packaged tar.gz/zip (nightly/prerelease)
+#   measure-local  <output-file> <name=path>...  # stat already-built local binaries (PR check)
+#   check          <current-file> <baseline-file> [threshold-percent, default 10]
+set -euo pipefail
+
+# Binaries packaged by .goreleaser.yml; keep in sync by hand with Cargo.toml's [[bin]] entries.
+RELEASE_ARCHIVE_BIN_NAMES='newrelic-agent-control newrelic-agent-control.exe newrelic-agent-control-cli newrelic-agent-control-cli.exe'
+
+measure_size() {
+  # Writes "<key> <size-bytes>" per binary; key = version-stripped archive name + binary name.
+  local src="$1" out="$2" base key tmp size
+  : > "$out"
+  local bin_names="$RELEASE_ARCHIVE_BIN_NAMES"
+
+  # Drop the version (2nd underscore-separated field) from a goreleaser archive base name.
+  strip_version() {
+    awk -F_ '{ out=$1; for (i=3; i<=NF; i++) out=out"_"$i; print out }'
+  }
+
+  while IFS= read -r archive; do
+    base=$(basename "$archive")
+    case "$base" in
+      *.tar.gz) key=$(printf '%s' "${base%.tar.gz}" | strip_version) ;;
+      *.zip)    key=$(printf '%s' "${base%.zip}" | strip_version) ;;
+      *) continue ;;
+    esac
+
+    tmp=$(mktemp -d)
+    case "$base" in
+      *.tar.gz) tar -xzf "$archive" -C "$tmp" ;;
+      *.zip)    unzip -q "$archive" -d "$tmp" ;;
+    esac
+
+    for name in $bin_names; do
+      while IFS= read -r b; do
+        [ -n "$b" ] || continue
+        size=$(wc -c < "$b" | tr -d '[:space:]')
+        if [ "$size" -eq 0 ]; then
+          echo "::error::Extracted binary '$b' (from $archive) is 0 bytes; refusing to record a corrupt size." >&2
+          exit 1
+        fi
+        echo "${key}::${name} ${size}" >> "$out"
+      done < <(find "$tmp" -type f -name "$name")
+    done
+
+    rm -rf "$tmp"
+  done < <(find "$src" -type f \( -name '*.tar.gz' -o -name '*.zip' \))
+
+  sort -o "$out" "$out"
+  cat "$out"
+}
+
+measure_local_size() {
+  # Measures already-built local binaries; each arg is "<name>=<path>".
+  local out="$1" pair name path size
+  shift
+  : > "$out"
+  for pair in "$@"; do
+    name="${pair%%=*}"
+    path="${pair#*=}"
+    size=$(stat -c%s "$path")
+    if [ "$size" -eq 0 ]; then
+      echo "::error::Binary '$path' is 0 bytes; refusing to record a corrupt size." >&2
+      exit 1
+    fi
+    echo "${name} ${size}" >> "$out"
+  done
+  cat "$out"
+}
+
+check_size() {
+  # Fails when a binary grows more than THRESHOLD% over baseline; sizes files are "<name> <size>" lines.
+  local current_file="$1" baseline_file="$2" threshold="${3:-10}"
+  local summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+  local status=0 name current baseline delta pretty exceeds icon delta_h
+
+  # Renders a plain or "archive::binary" key as a friendly `binary` (platform) label.
+  label() {
+    case "$1" in
+      *::*)
+        local arch="${1%%::*}" bin="${1##*::}"
+        printf '`%s` (%s)' "$bin" "${arch#*_}"
+        ;;
+      *) printf '`%s`' "$1" ;;
+    esac
+  }
+
+  # Format a byte count as a human-readable size (keeps the sign for deltas).
+  human() {
+    awk -v b="$1" 'BEGIN {
+      s = (b < 0) ? "-" : ""; a = (b < 0) ? -b : b;
+      split("B KiB MiB GiB", u, " "); i = 1;
+      while (a >= 1024 && i < 4) { a /= 1024; i++ }
+      if (i == 1) printf "%s%d %s", s, a, u[i];
+      else        printf "%s%.1f %s", s, a, u[i];
+    }'
+  }
+
+  # No baseline yet (e.g. first run before main has published one): skip, do not fail.
+  if [[ ! -s "$baseline_file" ]]; then
+    echo "No baseline found; skipping binary size check."
+    exit 0
+  fi
+
+  {
+    echo "## Binary size check"
+    echo ""
+    echo "Fails when a binary grows more than **+${threshold}%** over the baseline."
+    echo ""
+    echo "| | Binary | Baseline | Current | Δ | Change |"
+    echo "|---|---|---|---|---|---|"
+  } >> "$summary"
+
+  while read -r name current; do
+    [[ -z "$name" ]] && continue
+    baseline=$(awk -v n="$name" '$1 == n { print $2 }' "$baseline_file")
+
+    # New binary with no baseline: report but do not fail.
+    if [[ -z "$baseline" ]]; then
+      echo "| ⭐ | $(label "$name") | (new) | $(human "$current") | n/a | n/a |" >> "$summary"
+      continue
+    fi
+
+    # baseline=0 means a corrupt cached entry; dividing by it would abort the whole script.
+    if (( baseline <= 0 )); then
+      echo "| ⚠️ | $(label "$name") | (invalid: 0 B) | $(human "$current") | n/a | n/a |" >> "$summary"
+      echo "::error::Binary '$name' has an invalid cached baseline size of ${baseline}B; skipping comparison for it."
+      status=1
+      continue
+    fi
+
+    delta=$(( current - baseline ))
+
+    # Single awk computation for both, so decision and display can never disagree.
+    read -r pretty exceeds < <(awk -v c="$current" -v b="$baseline" -v t="$threshold" 'BEGIN {
+      pct = (c - b) * 100.0 / b
+      printf "%+.1f%% %d\n", pct, (pct > t) ? 1 : 0
+    }')
+
+    # Pick an indicator: red over the limit, green shrinking, grey unchanged, yellow growing.
+    if (( exceeds )); then icon="🔴"
+    elif (( delta < 0 )); then icon="🟢"
+    elif (( delta == 0 )); then icon="⚪"
+    else icon="🟡"
+    fi
+
+    delta_h=$(human "$delta"); (( delta > 0 )) && delta_h="+${delta_h}"
+    echo "| $icon | $(label "$name") | $(human "$baseline") | $(human "$current") | $delta_h | $pretty |" >> "$summary"
+
+    if (( exceeds )); then
+      echo "::error::Binary '$name' grew $pretty (baseline ${baseline}B, current ${current}B), exceeds +${threshold}%."
+      status=1
+    fi
+  done < "$current_file"
+
+  {
+    echo ""
+    echo "Legend: 🟢 smaller · ⚪ unchanged · 🟡 larger (within limit) · 🔴 over +${threshold}% · ⭐ new · ⚠️ invalid baseline"
+  } >> "$summary"
+
+  exit $status
+}
+
+cmd="${1:?usage: binary-size.sh <measure|measure-local|check> ...}"
+shift
+case "$cmd" in
+  measure)       measure_size "$@" ;;
+  measure-local) measure_local_size "$@" ;;
+  check)         check_size "$@" ;;
+  *) echo "Unknown subcommand: $cmd" >&2; exit 64 ;;
+esac

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,40 @@ jobs:
       pfx_certificate_base64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
       pfx_passphrase: ${{ secrets.OHAI_PFX_PASSPHRASE }}
 
+  # Early-warning only: doesn't block build-image/upload/canaries, alerts via its own Slack message.
+  binary-size-check:
+    name: Check binary size vs previous nightly
+    runs-on: ubuntu-latest
+    needs: [ build-packages ]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Download built binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: built-binaries-0.100.${{ github.run_id }}
+          path: ./artifacts
+
+      # Measure from the published archives, same as the prerelease check, so both use identical keys.
+      - name: Measure binary sizes
+        id: measure
+        run: |
+          mkdir -p binary-size
+          bash .github/scripts/binary-size.sh measure artifacts binary-size/current.txt
+          # Fail loudly instead of silently disabling the check if the layout changes.
+          if [ ! -s binary-size/current.txt ]; then
+            echo "::error::No release binaries found in the built-binaries artifact"
+            exit 1
+          fi
+
+      # Only advances the baseline if the check passed, so a regression isn't baked in.
+      - name: Binary size baseline check
+        uses: ./.github/actions/binary-size-baseline
+        with:
+          cache-key: binary-size-nightly-${{ github.run_id }}
+          cache-restore-prefix: binary-size-nightly-
+          publish-baseline: 'true'
+
   build-image:
     name: Build and Push nightly image
     uses: ./.github/workflows/component_image.yml
@@ -235,4 +269,13 @@ jobs:
     uses: ./.github/workflows/component_send_warning_via_slack.yml
     with:
       message: "Nightly workflow failed"
+    secrets: inherit
+
+  # Dedicated alert so an infra-only flake here doesn't dilute the generic failure alert above.
+  notify-binary-size-regression:
+    if: ${{ always() && needs.binary-size-check.result == 'failure' }}
+    needs: [ binary-size-check ]
+    uses: ./.github/workflows/component_send_warning_via_slack.yml
+    with:
+      message: "Nightly binary size check failed"
     secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,6 +34,80 @@ jobs:
       pfx_certificate_base64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
       pfx_passphrase: ${{ secrets.OHAI_PFX_PASSPHRASE }}
 
+  # Compares against the previous GA release; upload depends on this, so a regression blocks publishing.
+  binary-size-check:
+    name: Check binary size vs previous release
+    runs-on: ubuntu-latest
+    needs: [ build-packages ]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Download this release's built artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: built-binaries-${{ github.event.release.tag_name }}
+          path: ./current
+
+      # --exclude-pre-releases ensures "previous" is the last GA, not another rc.
+      - name: Resolve previous release
+        id: prev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          ok=false
+          prev=""
+          for i in 1 2 3; do
+            if prev=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 30 --exclude-drafts --exclude-pre-releases \
+                --json tagName,createdAt \
+                --jq '[.[] | select(.tagName != env.CURRENT_TAG)] | sort_by(.createdAt) | reverse | .[0].tagName // ""'); then
+              ok=true
+              break
+            fi
+            echo "gh release list failed (attempt $i/3), retrying in 5s..."
+            sleep 5
+          done
+          if ! $ok; then
+            echo "::error::gh release list failed after 3 attempts"
+            exit 1
+          fi
+          echo "tag=$prev" >> "$GITHUB_OUTPUT"
+          if [ -z "$prev" ]; then
+            echo "No previous release found; binary size check will be skipped."
+          else
+            echo "Comparing against previous release: $prev"
+          fi
+
+      - name: Download previous release archives
+        if: steps.prev.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p previous
+          ok=false
+          for i in 1 2 3; do
+            if gh release download "${{ steps.prev.outputs.tag }}" --repo "$GITHUB_REPOSITORY" \
+                --dir ./previous --pattern '*.tar.gz' --pattern '*.zip' --clobber; then
+              ok=true
+              break
+            fi
+            echo "gh release download failed (attempt $i/3), retrying in 5s..."
+            sleep 5
+          done
+          $ok
+
+      - name: Measure and compare binary sizes
+        if: steps.prev.outputs.tag != ''
+        run: |
+          mkdir -p binary-size
+          echo "Current release binaries:"
+          bash .github/scripts/binary-size.sh measure current binary-size/current.txt
+          echo "Previous release binaries:"
+          bash .github/scripts/binary-size.sh measure previous binary-size/baseline.txt
+          bash .github/scripts/binary-size.sh check binary-size/current.txt binary-size/baseline.txt 10
+
   build-image:
     name: Build and Push container image
     needs: [ third-party-notices-check ]
@@ -60,7 +134,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     name: Upload to S3
-    needs: [ build-packages ]
+    needs: [ build-packages, binary-size-check ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -183,6 +183,22 @@ jobs:
       - name: Build onhost in release mode
         run: cargo zigbuild --release --package newrelic_agent_control --bin newrelic-agent-control --target x86_64-unknown-linux-musl
 
+      - name: Measure release binary sizes
+        run: |
+          mkdir -p binary-size
+          bash .github/scripts/binary-size.sh measure-local binary-size/current.txt \
+            "newrelic-agent-control-k8s=target/x86_64-unknown-linux-musl/release/newrelic-agent-control-k8s" \
+            "newrelic-agent-control=target/x86_64-unknown-linux-musl/release/newrelic-agent-control"
+
+      # Enforced on PRs/merge queue; on main it only republishes the baseline for future PRs.
+      - name: Binary size baseline check
+        uses: ./.github/actions/binary-size-baseline
+        with:
+          cache-key: binary-size-baseline-${{ github.sha }}
+          cache-restore-prefix: binary-size-baseline-
+          enforce: ${{ github.ref != 'refs/heads/main' }}
+          publish-baseline: ${{ github.ref == 'refs/heads/main' }}
+
   unit-docs-onhost-integration-tests:
     name: Unit, docs and onhost integration tests
     runs-on: ${{ matrix.os }}

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -128,6 +128,8 @@ oci-test-utils = { path = "../test/crates/oci-test-utils" }
 glob = "0.3.3"
 toml = "1.1.3"
 
+# If you add/remove/rename a [[bin]] target below, also update
+# .github/scripts/binary-size.sh's RELEASE_ARCHIVE_BIN_NAMES (used by the binary-size CI checks).
 [[bin]]
 name = "newrelic-agent-control-k8s"
 path = "src/bin/main_k8s.rs"


### PR DESCRIPTION
Adds a binary size regression check to the release pipelines, so an unexpected size increase in the release binaries.

- `measure-release-binaries.sh` extracts binary sizes from the published archives (version-agnostic keys, so the same binary matches across releases).
- `check-binary-size.sh` compares current vs. baseline, prints a table to the job summary, and fails if any binary grows past the threshold. New binaries are reported, not failed.
- Baselines are stored via `actions/cache`, scoped to the branch that wrote them (plus its base/default branch) that's why the PR baseline is only published from `main`, so every branch shares the same reference.

**PR**
---
<img width="663" height="355" alt="image" src="https://github.com/user-attachments/assets/77f17c0e-2898-4925-a901-68657b9d349b" />
<img width="734" height="278" alt="image" src="https://github.com/user-attachments/assets/b7190d18-1432-417b-9866-23df963c4ab1" />
<img width="240" height="42" alt="image" src="https://github.com/user-attachments/assets/bbad08c5-bb17-43f6-9305-37f6d681d7b5" />

**NIGHTLY**
---
<img width="851" height="624" alt="image" src="https://github.com/user-attachments/assets/a9bc3475-e883-4d94-a9b3-bd1b07eab43e" />
<img width="872" height="552" alt="image" src="https://github.com/user-attachments/assets/086a004a-898b-477f-a1fd-b4e1acba514c" />
<img width="291" height="97" alt="image" src="https://github.com/user-attachments/assets/b8634e0b-cd54-4f99-ba7b-515d46229066" />


**RELEASE**
---
<img width="897" height="523" alt="image" src="https://github.com/user-attachments/assets/a186b6e6-6765-463e-9804-1d67f36ba651" />
