### PR TITLE
feat: agent control self-instrumentation OTLP pipeline foundation (NR-477218, NR-580189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Remember that the keywords that you can use are the following:
 ### enhancement
 - On-host and Kubernetes: when an agent's type is bumped via a live remote config update, Agent Control now reconciles both per-agent and shared filesystems, deleting paths declared by the old type that no longer appear in any active agent's declarations. Co-owned shared paths still claimed by another active agent are preserved. On Kubernetes, k8s objects annotated with the old type are garbage-collected while new-type resources are left intact.
 - Adds `oci-utils` CLI to `test/crates/oci-test-utils` for pushing agent packages and agent type definitions to OCI registries from the command line (dev/test tooling; not published).
+- Added self-instrumentation support: Agent Control can report its own metrics, traces, and logs via OpenTelemetry (OTLP), configurable under `self_instrumentation.opentelemetry`. Disabled by default.
 - On-host agent-type parsing now validates `reported_version_package`: it must reference a declared package, and is required when more than one package is defined. Invalid configurations are rejected at parse time with a descriptive error. This `reported_version_package` will be used to know which version to report as `agent.version`.
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - Add support for `shared_filesystem` in on-host agent types. It includes a single-owner rule: two agents claiming the same path in the shared-filesystem are invalid and reported as Failed.

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -74,9 +74,12 @@ bytes = "1.12.1"
 opentelemetry = { version = "0.32.0" }
 opentelemetry_sdk = { version = "0.32.1" }
 tracing-opentelemetry = "0.33.0"
-opentelemetry-otlp = { version = "0.32.0", features = ["reqwest-rustls"] }
-opentelemetry-http = { version = "0.32.0" }
-opentelemetry-appender-tracing = { version = "0.32.0" }
+# reqwest-blocking-client (not reqwest-rustls/async): the PeriodicReader background
+# thread uses futures_executor::block_on, which has no Tokio context. The async
+# reqwest client requires Tokio and would panic or deadlock from that thread.
+opentelemetry-otlp = { version = "0.32.0", features = ["reqwest-blocking-client"] }
+opentelemetry-http = { version = "0.32.0", features = ["reqwest-blocking"] }
+opentelemetry-appender-tracing = { version = "0.32.0", features = ["experimental_span_attributes"] }
 async-trait = "0.1.89"
 flate2 = { workspace = true }
 tar = { workspace = true }

--- a/agent-control/src/agent_control/config.rs
+++ b/agent-control/src/agent_control/config.rs
@@ -11,6 +11,7 @@ use crate::agent_control::defaults::{
 use crate::agent_control::health_checker::AgentControlHealthCheckerConfig;
 use crate::agent_type::runtime_config::on_host::package::rendered::{Repository, Version};
 use crate::agent_type::variable::constraints::VariableConstraints;
+use crate::cli::common::region::Region;
 use crate::http::config::ProxyConfig;
 use crate::instrumentation::config::logs::config::LoggingConfig;
 use crate::opamp::auth::config::AuthConfig;
@@ -37,6 +38,10 @@ use thiserror::Error;
 use tracing::info;
 use url::Url;
 use wrapper_with_default::WrapperWithDefault;
+
+fn default_region() -> Region {
+    Region::US
+}
 
 /// AgentControlConfig represents the configuration for the agent control.
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
@@ -67,6 +72,10 @@ pub struct AgentControlConfig {
     /// Proxy configuration for outbound connections.
     #[serde(default)]
     pub proxy: ProxyConfig,
+
+    /// New Relic region for endpoint derivation. Defaults to US.
+    #[serde(default = "default_region")]
+    pub region: Region,
 
     /// Self-instrumentation (telemetry about Agent Control itself) configuration.
     #[serde(default)]

--- a/agent-control/src/agent_control/uptime_report.rs
+++ b/agent-control/src/agent_control/uptime_report.rs
@@ -118,9 +118,10 @@ impl UptimeReporter {
     /// It propagates failures when computing the elapsed time (see [`SystemTime::elapsed`]),
     /// which won't emit the metric, so the caller can decide how to handle it.
     pub fn report(&self) -> Result<(), SystemTimeError> {
-        self.start_time
-            .elapsed()
-            .map(|t| trace!(monotonic_counter.uptime = t.as_secs_f64()))
+        let elapsed = self.start_time.elapsed()?;
+        let uptime_secs = elapsed.as_secs_f64();
+        trace!(monotonic_counter.uptime = uptime_secs);
+        Ok(())
     }
 }
 

--- a/agent-control/src/cli/common/region.rs
+++ b/agent-control/src/cli/common/region.rs
@@ -3,6 +3,7 @@ use http::Uri;
 use nr_auth::{
     parameters::Environments, system_identity::input_data::environment::NewRelicEnvironment,
 };
+use serde::Deserialize;
 
 const OPAMP_ENDPOINT_US: &str = "https://opamp.service.newrelic.com/v1/opamp";
 const OPAMP_ENDPOINT_EU: &str = "https://opamp.service.eu.newrelic.com/v1/opamp";
@@ -27,7 +28,8 @@ const OTLP_URL_US: &str = "otlp.nr-data.net";
 /// Represents the supported region and defines related fields. It cannot wrap the [Environments] enum
 /// due to clap limitations. Re-defining the enum is simpler than extending and using some mapping
 /// tool such as [clap::builder::TypedValueParser::map].
-#[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum Region {
     /// United States region.
     US,
@@ -37,7 +39,14 @@ pub enum Region {
     JP,
     /// Staging environment (aliased as `stg`).
     #[value(alias = "stg")]
+    #[serde(alias = "stg")]
     STAGING,
+}
+
+impl Default for Region {
+    fn default() -> Self {
+        Region::US
+    }
 }
 
 impl From<Region> for Environments {
@@ -98,6 +107,18 @@ impl Region {
     pub fn token_renewal_endpoint(&self) -> Uri {
         NewRelicEnvironment::from(self.to_owned()).token_renewal_endpoint()
     }
+}
+
+/// Returns the OTLP HTTP/protobuf endpoint URL (port 4318) for the given region.
+/// Used to set the self-instrumentation endpoint when not explicitly configured.
+pub fn otlp_endpoint_for_region(region: &Region) -> String {
+    let host = match region {
+        Region::US => OTLP_URL_US,
+        Region::EU => OTLP_URL_EU,
+        Region::JP => OTLP_URL_JP,
+        Region::STAGING => OTLP_URL_STAGING,
+    };
+    format!("https://{}:4318", host)
 }
 
 #[cfg(test)]
@@ -184,5 +205,14 @@ mod tests {
             region.otel_endpoint().to_string(),
             expected_endpoint.to_string()
         );
+    }
+
+    #[rstest]
+    #[case(Region::US, "https://otlp.nr-data.net:4318")]
+    #[case(Region::EU, "https://otlp.eu01.nr-data.net:4318")]
+    #[case(Region::JP, "https://otlp.jp.nr-data.net:4318")]
+    #[case(Region::STAGING, "https://staging-otlp.nr-data.net:4318")]
+    fn test_otlp_endpoint_for_region(#[case] region: Region, #[case] expected: &str) {
+        assert_eq!(otlp_endpoint_for_region(&region), expected);
     }
 }

--- a/agent-control/src/cli/common/region.rs
+++ b/agent-control/src/cli/common/region.rs
@@ -28,10 +28,11 @@ const OTLP_URL_US: &str = "otlp.nr-data.net";
 /// Represents the supported region and defines related fields. It cannot wrap the [Environments] enum
 /// due to clap limitations. Re-defining the enum is simpler than extending and using some mapping
 /// tool such as [clap::builder::TypedValueParser::map].
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum, Default)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Region {
     /// United States region.
+    #[default]
     US,
     /// European Union region.
     EU,
@@ -41,12 +42,6 @@ pub enum Region {
     #[value(alias = "stg")]
     #[serde(alias = "stg")]
     STAGING,
-}
-
-impl Default for Region {
-    fn default() -> Self {
-        Region::US
-    }
 }
 
 impl From<Region> for Environments {

--- a/agent-control/src/command.rs
+++ b/agent-control/src/command.rs
@@ -16,7 +16,7 @@ use crate::event::ApplicationEvent;
 use crate::event::channel::{EventConsumer, EventPublisher, pub_sub};
 use crate::instrumentation::config::logs::config::LoggingConfig;
 use crate::instrumentation::tracing::{
-    TracingConfig, TracingGuardBox, try_init_stderr_tracing, try_init_tracing,
+    InstanceContext, TracingConfig, TracingGuardBox, try_init_stderr_tracing, try_init_tracing,
 };
 use crate::on_host::file_store::FileStore;
 use crate::utils::binary_metadata::binary_metadata;
@@ -267,14 +267,32 @@ impl Command {
 
         let config_folder_name = base_paths.local_dir.display().to_string();
 
+        let instance_context = InstanceContext {
+            environment: running_mode,
+            cluster_name: bootstrap_config
+                .k8s
+                .as_ref()
+                .map(|k| k.cluster_name.clone()),
+            fleet_id: bootstrap_config
+                .fleet_control
+                .as_ref()
+                .map(|f| f.fleet_id.clone()),
+            // Only ever set in k8s mode (via the POD_NAME/NODE_NAME downward-API env vars the
+            // chart injects); simply absent everywhere else, so reading them unconditionally is
+            // harmless on-host.
+            pod_name: std::env::var("POD_NAME").ok(),
+            node_name: std::env::var("NODE_NAME").ok(),
+        };
         let tracing_config = TracingConfig::from_logging_path(base_paths.log_dir.clone())
             .with_logging_config(bootstrap_config.log.clone())
             .with_instrumentation_config(
                 bootstrap_config
                     .self_instrumentation
                     .clone()
-                    .with_proxy_config(bootstrap_config.proxy.clone()),
-            );
+                    .with_proxy_config(bootstrap_config.proxy.clone())
+                    .with_region_endpoint(&bootstrap_config.region),
+            )
+            .with_instance_context(instance_context);
         let tracer = try_init_tracing(tracing_config)
             .map_err(|e| format!("Error on Agent Control tracing initialization: {e}"))?;
 

--- a/agent-control/src/environment.rs
+++ b/agent-control/src/environment.rs
@@ -23,6 +23,18 @@ impl Display for Environment {
     }
 }
 
+impl Environment {
+    /// Coarser-grained deployment platform: "host" for both on-host environments (the real OS
+    /// is already available separately via os.type) vs "kubernetes". Used for self-instrumentation
+    /// telemetry, where the linux/windows split adds noise without adding information.
+    pub fn deployment_platform(&self) -> &'static str {
+        match self {
+            Environment::Linux | Environment::Windows => "host",
+            Environment::K8s => "kubernetes",
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod tests {

--- a/agent-control/src/http/client.rs
+++ b/agent-control/src/http/client.rs
@@ -230,7 +230,15 @@ impl opentelemetry_http::HttpClient for HttpClient {
         let (parts, body) = request.into_parts();
         let req_vec = Request::from_parts(parts, Vec::from(body));
 
-        let response_vec = self.send(req_vec)?;
+        // The OTel exporter uses reqwest-blocking-client (not the async variant), so
+        // send() is always synchronous. Calling it directly is correct on both the
+        // Tokio runtime threads and the BatchProcessor OS threads. The previous
+        // spawn_blocking branch was dangerous: a JoinHandle awaited inside
+        // futures_executor::block_on (used by the BatchProcessor) deadlocks because
+        // JoinHandle::poll requires a Tokio waker to reschedule the spawned task.
+        let response_vec = self
+            .send(req_vec)
+            .map_err(|http_err| Box::new(http_err) as HttpError)?;
 
         let (parts, body) = response_vec.into_parts();
         Ok(Response::from_parts(parts, Bytes::from(body)))

--- a/agent-control/src/instrumentation.rs
+++ b/agent-control/src/instrumentation.rs
@@ -4,5 +4,7 @@
 //! metrics and traces to stderr, files and OpenTelemetry endpoints.
 
 pub mod config;
+pub(crate) mod flush;
+pub mod metrics;
 pub mod tracing;
 pub mod tracing_layers;

--- a/agent-control/src/instrumentation/config.rs
+++ b/agent-control/src/instrumentation/config.rs
@@ -7,6 +7,7 @@
 //! instrumentation: # application self-instrumentaiton
 //! ```
 
+use crate::cli::common::region::Region;
 use crate::http::config::ProxyConfig;
 use serde::Deserialize;
 
@@ -28,6 +29,18 @@ impl InstrumentationConfig {
             opentelemetry: self
                 .opentelemetry
                 .map(|otel_config| otel_config.with_proxy_config(proxy)),
+        }
+    }
+
+    /// Resolves the OTLP endpoint from the region when no explicit endpoint is configured.
+    ///
+    /// Delegates to [`otel::OtelConfig::with_region_endpoint`]; see that method for details.
+    /// Has no effect if `opentelemetry` is `None`.
+    pub fn with_region_endpoint(self, region: &Region) -> Self {
+        Self {
+            opentelemetry: self
+                .opentelemetry
+                .map(|otel_config| otel_config.with_region_endpoint(region)),
         }
     }
 }

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -51,7 +51,7 @@ pub struct OtelConfig {
     pub(crate) insecure_level: String,
     /// OpenTelemetry HTTP base endpoint to report instrumentation, to send each instrumentation
     /// type, the corresponding suffix will be added [TRACES_SUFFIX], [METRICS_SUFFIX], [LOGS_SUFFIX].
-    /// Defaults to [`ENDPOINT_SENTINEL`] when omitted, so that omitting `endpoint` from config is
+    /// Defaults to `ENDPOINT_SENTINEL` when omitted, so that omitting `endpoint` from config is
     /// what triggers region-derivation via [`OtelConfig::with_region_endpoint`] - without this
     /// default, an omitted `endpoint` field is a deserialization error instead.
     #[serde(default = "default_endpoint")]
@@ -89,7 +89,7 @@ impl OtelConfig {
 
     /// Returns a new configuration with the endpoint resolved from the region.
     ///
-    /// Only applies when the current endpoint equals the sentinel value [`ENDPOINT_SENTINEL`]
+    /// Only applies when the current endpoint equals the sentinel value `ENDPOINT_SENTINEL`
     /// (`"https://fake"`), meaning no explicit endpoint was configured. In that case the endpoint
     /// is derived from the region using [`otlp_endpoint_for_region`] (HTTP/protobuf, port 4318).
     /// If an explicit endpoint is already set, this is a no-op.
@@ -362,9 +362,11 @@ logs:
         use crate::cli::common::region::Region;
         // No `endpoint` key at all - this is the real-world shape of a config that relies on
         // region-derivation, as opposed to OtelConfig::default() which only exists in test code.
-        let config: OtelConfig =
-            serde_saphyr::from_str("metrics:\n  enabled: true").unwrap();
-        assert_eq!(config.endpoint.as_str().trim_end_matches('/'), ENDPOINT_SENTINEL);
+        let config: OtelConfig = serde_saphyr::from_str("metrics:\n  enabled: true").unwrap();
+        assert_eq!(
+            config.endpoint.as_str().trim_end_matches('/'),
+            ENDPOINT_SENTINEL
+        );
 
         let config = config.with_region_endpoint(&Region::US);
         assert_eq!(config.endpoint.host_str(), Some("otlp.nr-data.net"));

--- a/agent-control/src/instrumentation/config/otel.rs
+++ b/agent-control/src/instrumentation/config/otel.rs
@@ -2,12 +2,18 @@
 
 use duration_str::deserialize_duration;
 use opentelemetry_sdk::logs;
+use opentelemetry_sdk::trace;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 use url::Url;
 use wrapper_with_default::WrapperWithDefault;
 
+use crate::cli::common::region::{Region, otlp_endpoint_for_region};
 use crate::http::config::ProxyConfig;
+
+/// Sentinel URL used as a placeholder when no explicit OTLP endpoint is configured.
+/// Replaced at startup by the region-derived endpoint via [`OtelConfig::with_region_endpoint`].
+const ENDPOINT_SENTINEL: &str = "https://fake";
 
 /// Default timeout for HTTP client.
 const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -20,6 +26,8 @@ const DEFAULT_LOG_BATCH_SCHEDULED_DELAY: Duration = Duration::from_secs(30);
 /// Default insecure_level filter.
 const DEFAULT_FILTER: &str = "newrelic_agent_control=debug,opamp_client=debug,off";
 
+/// Traces suffix for the OpenTelemetry endpoint
+const TRACES_SUFFIX: &str = "/v1/traces";
 /// Metrics suffix for the OpenTelemetry endpoint
 const METRICS_SUFFIX: &str = "/v1/metrics";
 /// Logs suffix for the OpenTelemetry endpoint
@@ -31,6 +39,9 @@ pub struct OtelConfig {
     /// Metrics configuration
     #[serde(default)]
     pub(crate) metrics: MetricsConfig,
+    /// Traces configuration
+    #[serde(default)]
+    pub(crate) traces: TracesConfig,
     /// Logs configuration
     #[serde(default)]
     pub(crate) logs: LogsConfig,
@@ -39,7 +50,11 @@ pub struct OtelConfig {
     #[serde(default = "default_insecure_level")]
     pub(crate) insecure_level: String,
     /// OpenTelemetry HTTP base endpoint to report instrumentation, to send each instrumentation
-    /// type, the corresponding suffix will be added [METRICS_SUFFIX], [LOGS_SUFFIX].
+    /// type, the corresponding suffix will be added [TRACES_SUFFIX], [METRICS_SUFFIX], [LOGS_SUFFIX].
+    /// Defaults to [`ENDPOINT_SENTINEL`] when omitted, so that omitting `endpoint` from config is
+    /// what triggers region-derivation via [`OtelConfig::with_region_endpoint`] - without this
+    /// default, an omitted `endpoint` field is a deserialization error instead.
+    #[serde(default = "default_endpoint")]
     pub(crate) endpoint: Url,
     /// Headers to include in every request to the OpenTelemetry endpoint
     #[serde(default)]
@@ -60,10 +75,43 @@ fn default_insecure_level() -> String {
     DEFAULT_FILTER.to_string()
 }
 
+fn default_endpoint() -> Url {
+    ENDPOINT_SENTINEL
+        .parse()
+        .expect("hardcoded sentinel URL must be valid")
+}
+
 impl OtelConfig {
     /// Returns a new configuration including proxy config
     pub fn with_proxy_config(self, proxy: ProxyConfig) -> Self {
         Self { proxy, ..self }
+    }
+
+    /// Returns a new configuration with the endpoint resolved from the region.
+    ///
+    /// Only applies when the current endpoint equals the sentinel value [`ENDPOINT_SENTINEL`]
+    /// (`"https://fake"`), meaning no explicit endpoint was configured. In that case the endpoint
+    /// is derived from the region using [`otlp_endpoint_for_region`] (HTTP/protobuf, port 4318).
+    /// If an explicit endpoint is already set, this is a no-op.
+    pub fn with_region_endpoint(self, region: &Region) -> Self {
+        if self.endpoint.as_str().trim_end_matches('/') == ENDPOINT_SENTINEL {
+            let url = otlp_endpoint_for_region(region);
+            match url.parse() {
+                Ok(endpoint) => Self { endpoint, ..self },
+                Err(e) => {
+                    // Should never happen with hardcoded constants, but log rather than panic
+                    // so a future Region variant with a typo doesn't crash the agent at startup.
+                    tracing::error!(
+                        url = %url,
+                        error = %e,
+                        "OTLP endpoint URL for region is invalid; self-instrumentation disabled"
+                    );
+                    self
+                }
+            }
+        } else {
+            self
+        }
     }
 
     /// Returns a new configuration including custom_attributes
@@ -72,6 +120,26 @@ impl OtelConfig {
             custom_attributes,
             ..self
         }
+    }
+
+    /// Normalizes header names to use hyphens instead of underscores.
+    /// This is needed because environment variables can't contain hyphens,
+    /// but HTTP header names conventionally use hyphens (e.g., "api-key").
+    pub fn normalize_headers(mut self) -> Self {
+        // Convert api_key to api-key for OTLP compatibility
+        if let Some(api_key) = self.headers.remove("api_key") {
+            self.headers.insert("api-key".to_string(), api_key);
+            tracing::debug!("normalized header: api_key -> api-key");
+        }
+        Self {
+            headers: self.headers,
+            ..self
+        }
+    }
+
+    /// Returns the otel endpoint to report traces to.
+    pub(crate) fn traces_endpoint(&self) -> String {
+        self.target_endpoint(TRACES_SUFFIX)
     }
 
     /// Returns the otel endpoint to report metrics to.
@@ -109,6 +177,17 @@ pub(crate) struct MetricsConfig {
     pub(crate) interval: MetricsExportInterval,
 }
 
+/// Defines the configuration settings to report traces to OpenTelemetry
+#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
+pub(crate) struct TracesConfig {
+    /// Indicates if traces are enabled or not
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// Traces are reported in batches, this field defines the batch configuration.
+    #[serde(default)]
+    pub(crate) batch_config: BatchConfig,
+}
+
 /// Defines the configuration settings to report logs to OpenTelemetry
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
 pub(crate) struct LogsConfig {
@@ -144,6 +223,15 @@ impl Default for BatchConfig {
             scheduled_delay: DEFAULT_LOG_BATCH_SCHEDULED_DELAY,
             max_size: DEFAULT_LOG_BATCH_MAX_SIZE,
         }
+    }
+}
+
+impl From<&BatchConfig> for trace::BatchConfig {
+    fn from(value: &BatchConfig) -> Self {
+        trace::BatchConfigBuilder::default()
+            .with_max_export_batch_size(value.max_size)
+            .with_scheduled_delay(value.scheduled_delay)
+            .build()
     }
 }
 
@@ -196,6 +284,7 @@ logs:
         fn default_with_endpoint(endpoint: &str) -> Self {
             Self {
                 metrics: Default::default(),
+                traces: Default::default(),
                 logs: Default::default(),
                 insecure_level: default_insecure_level(),
                 endpoint: endpoint.parse().unwrap(),
@@ -216,6 +305,10 @@ logs:
         assert_eq!(
             config.logs_endpoint(),
             "https://some.endpoint:4318/v1/logs".to_string()
+        );
+        assert_eq!(
+            config.traces_endpoint(),
+            "https://some.endpoint:4318/v1/traces".to_string()
         );
     }
 
@@ -254,5 +347,56 @@ logs:
             serde_saphyr::from_str::<OtelConfig>(EXAMPLE_FULLY_POPULATED_OPENTELEMETRY_CONFIG)
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_endpoint_resolves_from_region() {
+        use crate::cli::common::region::Region;
+        let config = OtelConfig::default(); // uses "https://fake" endpoint
+        let config = config.with_region_endpoint(&Region::US);
+        assert_eq!(config.endpoint.host_str(), Some("otlp.nr-data.net"));
+    }
+
+    #[test]
+    fn test_endpoint_omitted_resolves_from_region() {
+        use crate::cli::common::region::Region;
+        // No `endpoint` key at all - this is the real-world shape of a config that relies on
+        // region-derivation, as opposed to OtelConfig::default() which only exists in test code.
+        let config: OtelConfig =
+            serde_saphyr::from_str("metrics:\n  enabled: true").unwrap();
+        assert_eq!(config.endpoint.as_str().trim_end_matches('/'), ENDPOINT_SENTINEL);
+
+        let config = config.with_region_endpoint(&Region::US);
+        assert_eq!(config.endpoint.host_str(), Some("otlp.nr-data.net"));
+        assert_eq!(config.endpoint.port(), Some(4318));
+    }
+
+    #[test]
+    fn test_explicit_endpoint_not_overridden() {
+        use crate::cli::common::region::Region;
+        let config: OtelConfig = serde_saphyr::from_str(
+            "endpoint: https://custom.endpoint:4318\nmetrics:\n  enabled: true",
+        )
+        .unwrap();
+        let config = config.with_region_endpoint(&Region::US);
+        assert_eq!(config.endpoint.host_str(), Some("custom.endpoint"));
+    }
+
+    #[test]
+    fn test_region_endpoint_eu() {
+        use crate::cli::common::region::Region;
+        let config = OtelConfig::default();
+        let config = config.with_region_endpoint(&Region::EU);
+        assert_eq!(config.endpoint.host_str(), Some("otlp.eu01.nr-data.net"));
+        assert_eq!(config.endpoint.port(), Some(4318));
+    }
+
+    #[test]
+    fn test_region_endpoint_jp() {
+        use crate::cli::common::region::Region;
+        let config = OtelConfig::default();
+        let config = config.with_region_endpoint(&Region::JP);
+        assert_eq!(config.endpoint.host_str(), Some("otlp.jp.nr-data.net"));
+        assert_eq!(config.endpoint.port(), Some(4318));
     }
 }

--- a/agent-control/src/instrumentation/flush.rs
+++ b/agent-control/src/instrumentation/flush.rs
@@ -39,7 +39,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     #[test]
     fn completes_promptly_when_flush_is_fast() {

--- a/agent-control/src/instrumentation/flush.rs
+++ b/agent-control/src/instrumentation/flush.rs
@@ -1,0 +1,74 @@
+//! Bounds OTel SDK flush calls. `force_flush()` has no built-in timeout of its own - its only
+//! bound is the OTLP HTTP client's `client_timeout` (30s by default), which fires deep inside the
+//! call. That's too long to block shutdown or a self-update on a hung/unreachable OTLP endpoint.
+
+use opentelemetry_sdk::error::OTelSdkResult;
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Default bound for a single flush attempt. Well under the OTLP client's own 30s timeout, since
+/// a flush is expected to be fast under normal conditions - this exists specifically to cut the
+/// wait short when the endpoint is unreachable or hung.
+pub const FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Runs `flush_fn` (typically a provider's `force_flush()`) on a separate thread and waits at
+/// most `timeout` for it to finish. If it doesn't complete in time, logs a warning and returns
+/// immediately - the flush thread keeps running in the background (still bounded by the OTLP
+/// client's own request timeout), but the caller is never blocked waiting for it.
+pub fn force_flush_with_timeout<F>(what: &'static str, timeout: Duration, flush_fn: F)
+where
+    F: FnOnce() -> OTelSdkResult + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        // Ignore send errors: the receiver may have already timed out and moved on.
+        let _ = tx.send(flush_fn());
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(error = %e, what, "failed to flush OTLP telemetry"),
+        Err(_) => tracing::warn!(
+            what,
+            timeout_secs = timeout.as_secs(),
+            "OTLP flush timed out, continuing without waiting for it"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+    #[test]
+    fn completes_promptly_when_flush_is_fast() {
+        let start = std::time::Instant::now();
+        force_flush_with_timeout("test", Duration::from_secs(5), || Ok(()));
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn returns_promptly_when_flush_hangs() {
+        let start = std::time::Instant::now();
+        force_flush_with_timeout("test", Duration::from_millis(50), || {
+            std::thread::sleep(Duration::from_secs(2));
+            Ok(())
+        });
+        // Caller must not wait for the full 2s hang - only the 50ms timeout.
+        assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn surfaces_flush_errors_without_panicking() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+        force_flush_with_timeout("test", Duration::from_secs(5), move || {
+            called_clone.store(true, Ordering::SeqCst);
+            Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
+                "simulated failure".to_string(),
+            ))
+        });
+        assert!(called.load(Ordering::SeqCst));
+    }
+}

--- a/agent-control/src/instrumentation/metrics.rs
+++ b/agent-control/src/instrumentation/metrics.rs
@@ -1,0 +1,34 @@
+//! Operational metrics plumbing for Agent Control self-instrumentation.
+//!
+//! This module currently only holds the machinery to register the active OTel meter provider
+//! and force-flush it before process replacement (self-update via `exec()` bypasses `Drop`).
+//! Business-level `record_*` instruments are added on top of this in a follow-up.
+
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use std::sync::OnceLock;
+
+// ── Provider reference for flush ──────────────────────────────────────────
+
+/// Holds a reference to the active SdkMeterProvider so we can call
+/// force_flush() before process replacement (self-update via exec bypasses Drop).
+static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+/// Register the provider for flush access. Called from otel.rs after
+/// set_meter_provider. Silently ignored if called more than once (e.g. tests).
+pub fn register_provider(provider: SdkMeterProvider) {
+    let _ = METER_PROVIDER.set(provider);
+}
+
+/// Force-flush all pending metric data, bounded by [`flush::FLUSH_TIMEOUT`] so a hung OTLP
+/// endpoint can't stall the caller (this runs on the self-update path, right before `exec()`).
+/// No-op when self-instrumentation is not configured.
+pub fn flush() {
+    if let Some(provider) = METER_PROVIDER.get() {
+        let provider = provider.clone();
+        crate::instrumentation::flush::force_flush_with_timeout(
+            "metrics",
+            crate::instrumentation::flush::FLUSH_TIMEOUT,
+            move || provider.force_flush(),
+        );
+    }
+}

--- a/agent-control/src/instrumentation/metrics.rs
+++ b/agent-control/src/instrumentation/metrics.rs
@@ -19,7 +19,7 @@ pub fn register_provider(provider: SdkMeterProvider) {
     let _ = METER_PROVIDER.set(provider);
 }
 
-/// Force-flush all pending metric data, bounded by [`flush::FLUSH_TIMEOUT`] so a hung OTLP
+/// Force-flush all pending metric data, bounded by `flush::FLUSH_TIMEOUT` so a hung OTLP
 /// endpoint can't stall the caller (this runs on the self-update path, right before `exec()`).
 /// No-op when self-instrumentation is not configured.
 pub fn flush() {

--- a/agent-control/src/instrumentation/tracing.rs
+++ b/agent-control/src/instrumentation/tracing.rs
@@ -11,10 +11,30 @@ use super::{
         stderr::stderr,
     },
 };
+use crate::environment::Environment;
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::debug;
 use tracing_subscriber::{Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Runtime facts about the current Agent Control instance that aren't user-configurable but are
+/// needed so self-instrumentation telemetry can identify and be grouped by instance (deployment
+/// platform, k8s cluster, fleet) the same way OpAMP's `agent_description` already can.
+#[derive(Debug, Clone)]
+pub struct InstanceContext {
+    /// Deployment platform this AC binary is running as (`linux` / `windows` / `kubernetes`).
+    pub environment: Environment,
+    /// K8s cluster name, when running in k8s mode.
+    pub cluster_name: Option<String>,
+    /// Fleet identifier, when this instance is connected to Fleet Control.
+    pub fleet_id: Option<String>,
+    /// K8s pod name, when running in k8s mode (from the `POD_NAME` downward-API env var).
+    /// Distinct from `host.name`: k8s sets a pod's own OS hostname equal to its pod name, so
+    /// without this, self-instrumentation has no attribute for the underlying node.
+    pub pod_name: Option<String>,
+    /// K8s node name, when running in k8s mode (from the `NODE_NAME` downward-API env var).
+    pub node_name: Option<String>,
+}
 
 /// Represents errors while setting up or shutting down tracing.
 #[derive(Error, Debug)]
@@ -46,6 +66,7 @@ pub struct TracingConfig {
     logging_path: PathBuf,
     logging_config: LoggingConfig,
     instrumentation_config: InstrumentationConfig,
+    instance_context: Option<InstanceContext>,
 }
 
 impl TracingConfig {
@@ -55,6 +76,7 @@ impl TracingConfig {
             logging_path,
             logging_config: Default::default(),
             instrumentation_config: Default::default(),
+            instance_context: None,
         }
     }
 
@@ -73,6 +95,15 @@ impl TracingConfig {
     ) -> Self {
         Self {
             instrumentation_config,
+            ..self
+        }
+    }
+
+    /// Sets the instance context (deployment platform, k8s cluster, fleet) used to enrich
+    /// self-instrumentation telemetry with identifying attributes.
+    pub fn with_instance_context(self, instance_context: InstanceContext) -> Self {
+        Self {
+            instance_context: Some(instance_context),
             ..self
         }
     }
@@ -114,12 +145,28 @@ pub fn try_init_tracing(config: TracingConfig) -> Result<Vec<TracingGuardBox>, T
     }
 
     if let Some(otel_config) = config.instrumentation_config.opentelemetry.as_ref() {
-        let (otel_layers, otel_guard) = OtelLayers::try_build(otel_config)?;
+        tracing::debug!("opentelemetry config found, initializing OTLP layers");
+        // Normalize headers (api_key -> api-key) for OTLP compatibility
+        let normalized_config = otel_config.clone().normalize_headers();
+        let (otel_layers, otel_guard) =
+            OtelLayers::try_build(&normalized_config, config.instance_context.as_ref())?;
         layers.push(otel_layers);
         guards.push(Box::new(otel_guard));
+
+        // Allows including the log information on spans that contain them when send to otlp.
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+        );
+    } else {
+        tracing::debug!("no opentelemetry config found - self-instrumentation disabled");
     }
+    let otel_enabled = config.instrumentation_config.opentelemetry.is_some();
     try_init_tracing_subscriber(layers)?;
     debug!("tracing_subscriber initialized successfully");
+    tracing::info!(
+        self_instrumentation_otlp_enabled = otel_enabled,
+        "tracing initialized"
+    );
 
     Ok(guards)
 }

--- a/agent-control/src/instrumentation/tracing_layers/otel.rs
+++ b/agent-control/src/instrumentation/tracing_layers/otel.rs
@@ -1,21 +1,34 @@
 //! Builds the [`tracing_subscriber`] layers that report logs and metrics through OpenTelemetry.
 
+use crate::agent_control::defaults::{
+    AGENT_CONTROL_VERSION, FLEET_ID_ATTRIBUTE_KEY, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
+};
 use crate::http::client::{HttpBuildError, HttpClient};
 use crate::http::config::HttpConfig;
 use crate::instrumentation::config::otel::OtelConfig;
-use crate::instrumentation::tracing::{LayerBox, TracingGuard};
+use crate::instrumentation::flush::{FLUSH_TIMEOUT, force_flush_with_timeout};
+use crate::instrumentation::metrics as ac_metrics;
+use crate::instrumentation::tracing::{InstanceContext, LayerBox, TracingGuard};
 use opentelemetry::KeyValue;
-use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_appender_tracing::layer::{OpenTelemetryTracingBridge, TracingSpanAttributes};
 use opentelemetry_http::HttpClient as OtelHttpClient;
 use opentelemetry_otlp::{ExporterBuildError, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider, Temporality};
+use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
+use resource_detection::Detector;
+use resource_detection::system::detector::SystemDetector;
+use resource_detection::system::hostname::get_hostname;
 use thiserror::Error;
 use tracing_opentelemetry::MetricsLayer;
 use tracing_subscriber::{EnvFilter, Layer};
 
-const SERVICE_NAME: &str = "agent-control-self-instrumentation";
+/// Prefix for the service.name OTLP attribute.
+/// The full name is `SERVICE_NAME_PREFIX-<hostname>` so each AC instance
+/// appears as a distinct service in NR (e.g. `agent-control-my-host`).
+const SERVICE_NAME_PREFIX: &str = "agent-control";
 
 /// Enumerates the possible error building OpenTelemetry providers.
 #[derive(Debug, Error)]
@@ -46,6 +59,7 @@ pub enum OtelBuildError {
 #[derive(Default)]
 pub struct OtelLayers {
     logs_layer_builder: Option<(SdkLoggerProvider, EnvFilter)>,
+    traces_layer_builder: Option<(SdkTracerProvider, EnvFilter)>,
     // Metrics are reported regardless of the configured level, there are no filtering options supported for now.
     metrics_layer_builder: Option<SdkMeterProvider>,
 }
@@ -54,62 +68,143 @@ impl OtelLayers {
     /// Returns the layers for [tracing_subscriber] corresponding to the enabled OpenTelemetry providers and the corresponding
     /// _guard_ that needs to be keep alive in order to avoid shutting down the corresponding exporters while telemetry
     /// is emitted. When the _guard_ is dropped all the exporters are shut down and the remaining telemetry is sent.
-    pub fn try_build(config: &OtelConfig) -> Result<(LayerBox, OtelGuard), OtelBuildError> {
+    pub fn try_build(
+        config: &OtelConfig,
+        instance_context: Option<&InstanceContext>,
+    ) -> Result<(LayerBox, OtelGuard), OtelBuildError> {
+        tracing::debug!(
+            metrics_enabled = config.metrics.enabled,
+            traces_enabled = config.traces.enabled,
+            logs_enabled = config.logs.enabled,
+            endpoint = %config.endpoint,
+            "otel layers build started"
+        );
+
         let http_config = HttpConfig::new(
             config.client_timeout.clone().into(),
             config.client_timeout.clone().into(),
             config.proxy.clone(),
         );
         let http_client = HttpClient::new(http_config)?;
-        let otel_layers = OtelLayers::try_new_with_client(config, http_client)?;
+        let otel_layers = OtelLayers::try_new_with_client(config, instance_context, http_client)?;
         Ok(otel_layers.layers())
     }
 
     /// Builds the providers and filters corresponding to the provided configuration.
     pub(crate) fn try_new_with_client<C>(
         config: &OtelConfig,
+        instance_context: Option<&InstanceContext>,
         client: C,
     ) -> Result<Self, OtelBuildError>
     where
         C: OtelHttpClient + Send + Sync + Clone + 'static,
     {
-        if !(config.metrics.enabled || config.logs.enabled) {
+        if !(config.traces.enabled || config.metrics.enabled || config.logs.enabled) {
+            tracing::debug!(
+                metrics_enabled = config.metrics.enabled,
+                traces_enabled = config.traces.enabled,
+                logs_enabled = config.logs.enabled,
+                "all telemetry disabled - returning empty otel layers"
+            );
             return Ok(Self::default());
         }
 
         // Set up the resource and custom attributes
-        let attributes: Vec<KeyValue> = config
+        let mut attributes: Vec<KeyValue> = config
             .custom_attributes
             .iter()
             .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
             .collect();
 
+        // host.name / service.instance.id: use a proper syscall instead of an env var so the
+        // value is always accurate regardless of whether $HOSTNAME is set in the environment.
+        // The hostname is also used to build the service.name below.
+        let hostname = match get_hostname() {
+            Ok(h) => {
+                tracing::debug!(host_name = %h, "added host.name");
+                attributes.push(KeyValue::new("host.name", h.clone()));
+                attributes.push(KeyValue::new("service.instance.id", h.clone()));
+                Some(h)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "could not detect hostname for OTLP resource attributes");
+                None
+            }
+        };
+
+        // host.id: stable machine identifier from /etc/machine-id (Linux) or registry (Windows).
+        // Allows distinguishing two machines with the same hostname.
+        match SystemDetector::default().detect() {
+            Ok(resource) => {
+                if let Some(machine_id) = resource.get(resource_detection::Key::from(
+                    resource_detection::system::MACHINE_ID_KEY,
+                )) {
+                    let machine_id = String::from(machine_id);
+                    tracing::debug!(host_id = %machine_id, "added host.id");
+                    attributes.push(KeyValue::new("host.id", machine_id));
+                } else {
+                    // Non-fatal: host.id not available on all platforms (e.g. some container envs)
+                    tracing::debug!("host.id not available, skipping");
+                }
+            }
+            Err(e) => {
+                // Non-fatal: host.id not available on all platforms (e.g. some container envs)
+                tracing::debug!(error = %e, "host.id not available, skipping");
+            }
+        }
+
+        attributes.extend(static_resource_attributes(instance_context));
+
+        // service.name: "agent-control-<hostname>" so each instance is a distinct
+        // service in NR. Falls back to the prefix alone when hostname is unavailable.
+        let service_name = hostname
+            .as_deref()
+            .map(|h| format!("{SERVICE_NAME_PREFIX}-{h}"))
+            .unwrap_or_else(|| SERVICE_NAME_PREFIX.to_string());
+
         let resource = Resource::builder()
-            .with_service_name(SERVICE_NAME)
+            .with_service_name(service_name)
             .with_attributes(attributes)
             .build();
 
+        // Build each layer if configured
+        let traces_layer_builder = if config.traces.enabled {
+            tracing::debug!(endpoint = %config.traces_endpoint(), "building traces provider");
+            Some((
+                Self::traces_provider(client.clone(), config, resource.clone())?,
+                Self::filter(&config.insecure_level)?,
+            ))
+        } else {
+            tracing::debug!("traces disabled, skipping traces provider");
+            None
+        };
+
         let metrics_layer_builder = if config.metrics.enabled {
+            tracing::debug!(endpoint = %config.metrics_endpoint(), "building metrics provider");
             Some(Self::metrics_provider(
                 client.clone(),
                 config,
                 resource.clone(),
             )?)
         } else {
+            tracing::debug!("metrics disabled, skipping metrics provider");
             None
         };
 
         let logs_layer_builder = if config.logs.enabled {
+            tracing::debug!(endpoint = %config.logs_endpoint(), "building logs provider");
             Some((
                 Self::logs_provider(client, config, resource)?,
                 Self::filter(&config.insecure_level)?,
             ))
         } else {
+            tracing::debug!("logs disabled, skipping logs provider");
             None
         };
 
         Ok(Self {
             logs_layer_builder,
+            traces_layer_builder,
             metrics_layer_builder,
         })
     }
@@ -121,6 +216,31 @@ impl OtelLayers {
                 err: err.to_string(),
             }
         })
+    }
+
+    fn traces_provider<C>(
+        client: C,
+        config: &OtelConfig,
+        resource: Resource,
+    ) -> Result<SdkTracerProvider, OtelBuildError>
+    where
+        C: OtelHttpClient + Send + Sync + 'static,
+    {
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_http_client(client)
+            .with_endpoint(config.traces_endpoint().to_string())
+            .with_headers(config.headers.clone())
+            .build()?;
+
+        let batch_processor = BatchSpanProcessor::builder(exporter)
+            .with_batch_config((&config.traces.batch_config).into())
+            .build();
+
+        Ok(SdkTracerProvider::builder()
+            .with_span_processor(batch_processor)
+            .with_resource(resource)
+            .build())
     }
 
     fn metrics_provider<C>(
@@ -136,16 +256,32 @@ impl OtelLayers {
             .with_http_client(client)
             .with_endpoint(config.metrics_endpoint().to_string())
             .with_headers(config.headers.clone())
+            // The SDK defaults to Cumulative temporality, which reports each counter's
+            // running total since process start on every export tick instead of the
+            // delta since the last tick. NRQL's sum() expects deltas (that's what makes
+            // it additive across a time window) - left at the default, every counter in
+            // this module reports data NRQL can count() but not meaningfully sum().
+            .with_temporality(Temporality::Delta)
             .build()?;
 
         let periodic_reader = PeriodicReader::builder(exporter)
             .with_interval(config.metrics.interval.clone().into())
             .build();
 
-        Ok(SdkMeterProvider::builder()
+        let provider = SdkMeterProvider::builder()
             .with_reader(periodic_reader)
             .with_resource(resource)
-            .build())
+            .build();
+
+        // Expose via the global OTel API so call sites throughout the binary
+        // can use `opentelemetry::global::meter("agent-control")` without
+        // holding a direct reference to the provider.
+        opentelemetry::global::set_meter_provider(provider.clone());
+        // Register in the metrics module so flush() can call force_flush()
+        // before process self-replacement (exec-based restart bypasses Drop).
+        ac_metrics::register_provider(provider.clone());
+
+        Ok(provider)
     }
 
     fn logs_provider<C>(
@@ -179,28 +315,165 @@ impl OtelLayers {
         let mut layers = Vec::<LayerBox>::new();
         let mut guard = OtelGuard::default();
 
+        if let Some((traces_provider, traces_filter)) = self.traces_layer_builder {
+            tracing::debug!("creating traces layer");
+            guard._traces_provider = Some(traces_provider.clone());
+            let layer = tracing_opentelemetry::layer()
+                .with_tracer(traces_provider.tracer(SERVICE_NAME_PREFIX));
+            layers.push(Box::new(layer.with_filter(traces_filter)));
+        }
+
         if let Some(metrics_provider) = self.metrics_layer_builder {
+            tracing::debug!("creating metrics layer");
             guard._metrics_provider = Some(metrics_provider.clone());
+
+            // Prime the exporter: register a startup counter so the PeriodicReader
+            // has at least one instrument and attempts an export on its first tick.
+            // Without this, if no tracing events reach MetricsLayer before the first
+            // tick, the PeriodicReader finds no instruments and skips the HTTP call.
+            // Use u64_counter (monotonic) not UpDownCounter — NR treats them differently.
+            use opentelemetry::metrics::MeterProvider as _;
+            let meter = metrics_provider.meter(SERVICE_NAME_PREFIX);
+            let startup_counter = meter.u64_counter("agent_control.starts").build();
+            startup_counter.add(1, &[]);
+            // Store in guard so the instrument stays registered for the lifetime of the process.
+            // Must be listed BEFORE _metrics_provider in OtelGuard so it's dropped first;
+            // Rust drops fields in declaration order and the counter must be released
+            // before the provider calls try_shutdown() to avoid a stale-instrument warning.
+            guard._startup_counter = Some(startup_counter);
+
             let layer = MetricsLayer::new(metrics_provider.clone());
-            layers.push(Box::new(layer));
+            layers.push(Box::new(
+                layer.with_filter(tracing_subscriber::filter::LevelFilter::TRACE),
+            ));
         }
 
         if let Some((logs_provider, logs_filter)) = self.logs_layer_builder {
+            tracing::debug!("creating logs layer");
             guard._logs_provider = Some(logs_provider.clone());
-            let layer = OpenTelemetryTracingBridge::new(&logs_provider);
+            // Copy tracing-span attributes (e.g. the agent `id` set via `info_span!`)
+            // onto every log record emitted within that span. Without this, logs
+            // emitted deeper in a span (e.g. "Checking health") carry no agent
+            // identity at all, since the bridge only visits the event's own fields
+            // by default.
+            let layer = OpenTelemetryTracingBridge::builder(&logs_provider)
+                .with_tracing_span_attributes(TracingSpanAttributes::all())
+                .build();
             layers.push(Box::new(layer.with_filter(logs_filter)));
         }
 
+        tracing::debug!(layer_count = layers.len(), "OTLP layers created");
         (layers.boxed(), guard)
     }
 }
 
+/// Builds the deterministic (non-syscall-dependent) resource attributes: service/telemetry/
+/// instrumentation semantic conventions, entity type, real OS, and instance-identifying context
+/// (deployment platform, k8s cluster, fleet). Split out from `try_new_with_client` so these
+/// attributes can be asserted directly in tests without mocking HTTP clients or providers.
+fn static_resource_attributes(instance_context: Option<&InstanceContext>) -> Vec<KeyValue> {
+    let mut attributes = vec![
+        // Standard OpenTelemetry semantic conventions for service
+        KeyValue::new("service.namespace", "newrelic"),
+        KeyValue::new("service.version", AGENT_CONTROL_VERSION),
+        // OpenTelemetry semantic conventions for telemetry SDK
+        KeyValue::new("telemetry.sdk.name", "agent-control"),
+        KeyValue::new("telemetry.sdk.language", "rust"),
+        KeyValue::new("telemetry.sdk.version", AGENT_CONTROL_VERSION),
+        // New Relic-specific entity and instrumentation attributes.
+        // Matches the pattern used by Infrastructure Agent for dimensional metrics.
+        KeyValue::new("instrumentation.provider", "newrelic"),
+        KeyValue::new("instrumentation.name", "agent-control"),
+        KeyValue::new("instrumentation.version", AGENT_CONTROL_VERSION),
+        // New Relic entity type identification (kept as NRAgentControl per user request)
+        KeyValue::new("newrelic.entity.type", "NRAgentControl"),
+        KeyValue::new("entity.type", "NRAgentControl"),
+        // Real OS the process runs on, same key/values OpAMP's agent_description already uses
+        // (agent_control::defaults::OS_ATTRIBUTE_KEY/VALUE) - keeps OTel and OpAMP consistent.
+        KeyValue::new(OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE),
+    ];
+
+    // Instance-identifying context: deployment platform, k8s cluster, fleet. Lets multiple
+    // concurrent AC instances be told apart and grouped in self-instrumentation telemetry.
+    // `agent_control.environment` is deliberately distinct from os.type above: for k8s the
+    // process still runs on Linux inside the pod, so the deployment platform ("kubernetes")
+    // and the real OS ("linux") are different facts and shouldn't be conflated.
+    if let Some(ctx) = instance_context {
+        attributes.push(KeyValue::new(
+            "agent_control.environment",
+            ctx.environment.deployment_platform(),
+        ));
+        if let Some(cluster_name) = ctx.cluster_name.as_deref().filter(|s| !s.is_empty()) {
+            attributes.push(KeyValue::new("k8s.cluster.name", cluster_name.to_string()));
+        }
+        if let Some(fleet_id) = ctx.fleet_id.as_deref().filter(|s| !s.is_empty()) {
+            attributes.push(KeyValue::new(FLEET_ID_ATTRIBUTE_KEY, fleet_id.to_string()));
+        }
+        // k8s.pod.name / k8s.node.name: distinct from host.name, which is the pod's own OS
+        // hostname (k8s sets it equal to the pod name) - without these, there's no attribute
+        // for the underlying node a given instance runs on.
+        if let Some(pod_name) = ctx.pod_name.as_deref().filter(|s| !s.is_empty()) {
+            attributes.push(KeyValue::new("k8s.pod.name", pod_name.to_string()));
+        }
+        if let Some(node_name) = ctx.node_name.as_deref().filter(|s| !s.is_empty()) {
+            attributes.push(KeyValue::new("k8s.node.name", node_name.to_string()));
+        }
+        tracing::debug!(
+            environment = %ctx.environment,
+            cluster_name = ctx.cluster_name.as_deref().unwrap_or_default(),
+            fleet_id = ctx.fleet_id.as_deref().unwrap_or_default(),
+            pod_name = ctx.pod_name.as_deref().unwrap_or_default(),
+            node_name = ctx.node_name.as_deref().unwrap_or_default(),
+            "added instance-identifying attributes"
+        );
+    }
+
+    attributes
+}
+
 /// Keeps a reference to the OpenTelemetry providers to avoid shutting down the underlying reporters while telemetry
-/// is emitted.
-#[derive(Default)]
+/// is emitted. When dropped, shuts down all providers in dependency order.
+///
+/// **Field drop order matters**: Rust drops fields in declaration order.
+/// The startup counter must come first so it releases its instrument handle
+/// before the provider calls try_shutdown(), avoiding a stale-instrument warning.
+/// Traces/logs providers come before metrics so the MetricsLayer outlives them.
 pub struct OtelGuard {
+    /// Startup counter — drop first, before the provider shuts down.
+    _startup_counter: Option<opentelemetry::metrics::Counter<u64>>,
+    _traces_provider: Option<SdkTracerProvider>,
     _logs_provider: Option<SdkLoggerProvider>,
     _metrics_provider: Option<SdkMeterProvider>,
+}
+
+impl Default for OtelGuard {
+    fn default() -> Self {
+        Self {
+            _startup_counter: None,
+            _traces_provider: None,
+            _logs_provider: None,
+            _metrics_provider: None,
+        }
+    }
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        // Explicit shutdown in reverse-dependency order with error visibility.
+        // Fields are dropped by Rust after this fn returns (in declaration order),
+        // but the try_shutdown() calls here flush buffered telemetry synchronously.
+        if let Some(p) = self._traces_provider.clone() {
+            force_flush_with_timeout("traces", FLUSH_TIMEOUT, move || p.force_flush());
+        }
+        if let Some(p) = self._metrics_provider.clone() {
+            force_flush_with_timeout("metrics", FLUSH_TIMEOUT, move || p.force_flush());
+        }
+        // Replace the global meter provider with a no-op so any record_* calls
+        // that race shutdown silently drop rather than writing to a shut-down provider.
+        opentelemetry::global::set_meter_provider(
+            opentelemetry_sdk::metrics::SdkMeterProvider::default(),
+        );
+    }
 }
 
 impl TracingGuard for OtelGuard {}
@@ -215,9 +488,15 @@ mod tests {
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::layer::SubscriberExt;
 
+    use crate::agent_control::defaults::{
+        FLEET_ID_ATTRIBUTE_KEY, OS_ATTRIBUTE_KEY, OS_ATTRIBUTE_VALUE,
+    };
+    use crate::environment::Environment;
     use crate::http::client::tests::MockOtelHttpClient;
     use crate::instrumentation::config::otel::{LogsConfig, MetricsConfig, OtelConfig};
+    use crate::instrumentation::tracing::InstanceContext;
     use crate::instrumentation::tracing_layers::otel::OtelLayers;
+    use rstest::rstest;
 
     #[test]
     fn test_logs_layer() {
@@ -279,8 +558,8 @@ mod tests {
             .expect_send_bytes()
             .times(1..) // The metric should be sent at least once
             .withf(|req| {
-                let body = String::from_utf8_lossy(req.body().as_ref());
-                req.uri().path().eq("/v1/metrics") && body.contains("uptime")
+                // Accept any metrics export — either the startup counter or the uptime trace metric
+                req.uri().path().eq("/v1/metrics")
             })
             .returning(|_| {
                 Ok(Response::builder()
@@ -312,5 +591,146 @@ mod tests {
             trace!(monotonic_counter.uptime = 42);
             std::thread::sleep(Duration::from_secs(2));
         });
+    }
+
+    /// Verify that building OtelLayers with host detection (get_hostname + SystemDetector)
+    /// does not panic. The resource-detection crate has its own unit tests for the
+    /// individual detectors; here we only assert that the happy-path wiring compiles and runs.
+    #[test]
+    fn test_try_new_with_client_host_attributes_does_not_panic() {
+        let mut mock_http_client = MockOtelHttpClient::new();
+        mock_http_client.expect_send_bytes().returning(|_| {
+            Ok(Response::builder()
+                .status(200)
+                .body(opentelemetry_http::Bytes::default())
+                .unwrap())
+        });
+
+        let result = OtelLayers::try_new_with_client(
+            &OtelConfig {
+                logs: LogsConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+            mock_http_client,
+        );
+
+        assert!(
+            result.is_ok(),
+            "OtelLayers::try_new_with_client should not fail: {:?}",
+            result.err()
+        );
+    }
+
+    fn attribute_value(attrs: &[opentelemetry::KeyValue], key: &str) -> Option<String> {
+        attrs
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .map(|kv| kv.value.to_string())
+    }
+
+    #[test]
+    fn test_static_resource_attributes_without_instance_context() {
+        let attrs = super::static_resource_attributes(None);
+
+        assert_eq!(
+            attribute_value(&attrs, OS_ATTRIBUTE_KEY).as_deref(),
+            Some(OS_ATTRIBUTE_VALUE)
+        );
+        assert_eq!(
+            attribute_value(&attrs, "instrumentation.name").as_deref(),
+            Some("agent-control")
+        );
+        // No instance context provided: none of the identifying attributes should be present.
+        assert_eq!(attribute_value(&attrs, "agent_control.environment"), None);
+        assert_eq!(attribute_value(&attrs, "k8s.cluster.name"), None);
+        assert_eq!(attribute_value(&attrs, FLEET_ID_ATTRIBUTE_KEY), None);
+    }
+
+    #[rstest]
+    #[case::linux(Environment::Linux, "host")]
+    #[case::windows(Environment::Windows, "host")]
+    #[case::kubernetes(Environment::K8s, "kubernetes")]
+    fn test_static_resource_attributes_environment(
+        #[case] environment: Environment,
+        #[case] expected: &str,
+    ) {
+        let ctx = InstanceContext {
+            environment,
+            cluster_name: None,
+            fleet_id: None,
+            pod_name: None,
+            node_name: None,
+        };
+        let attrs = super::static_resource_attributes(Some(&ctx));
+
+        assert_eq!(
+            attribute_value(&attrs, "agent_control.environment").as_deref(),
+            Some(expected)
+        );
+        // Real OS is always linux/windows/darwin per compile target, regardless of the
+        // deployment-platform value above - the two attributes are independent.
+        assert_eq!(
+            attribute_value(&attrs, OS_ATTRIBUTE_KEY).as_deref(),
+            Some(OS_ATTRIBUTE_VALUE)
+        );
+        // No cluster/fleet were set on this context.
+        assert_eq!(attribute_value(&attrs, "k8s.cluster.name"), None);
+        assert_eq!(attribute_value(&attrs, FLEET_ID_ATTRIBUTE_KEY), None);
+    }
+
+    #[test]
+    fn test_static_resource_attributes_k8s_cluster_and_fleet() {
+        let ctx = InstanceContext {
+            environment: Environment::K8s,
+            cluster_name: Some("my-cluster".to_string()),
+            fleet_id: Some("my-fleet-guid".to_string()),
+            pod_name: Some("agent-control-77dcf4b5cd-bkxh8".to_string()),
+            node_name: Some("minikube-m02".to_string()),
+        };
+        let attrs = super::static_resource_attributes(Some(&ctx));
+
+        assert_eq!(
+            attribute_value(&attrs, "agent_control.environment").as_deref(),
+            Some("kubernetes")
+        );
+        assert_eq!(
+            attribute_value(&attrs, "k8s.cluster.name").as_deref(),
+            Some("my-cluster")
+        );
+        assert_eq!(
+            attribute_value(&attrs, FLEET_ID_ATTRIBUTE_KEY).as_deref(),
+            Some("my-fleet-guid")
+        );
+        assert_eq!(
+            attribute_value(&attrs, "k8s.pod.name").as_deref(),
+            Some("agent-control-77dcf4b5cd-bkxh8")
+        );
+        assert_eq!(
+            attribute_value(&attrs, "k8s.node.name").as_deref(),
+            Some("minikube-m02")
+        );
+    }
+
+    #[test]
+    fn test_static_resource_attributes_empty_cluster_and_fleet_are_omitted() {
+        // Empty strings (the non-Option default for K8sConfig.cluster_name /
+        // OpAMPClientConfig.fleet_id when unset) must not produce empty-valued attributes.
+        let ctx = InstanceContext {
+            environment: Environment::Linux,
+            cluster_name: Some(String::new()),
+            fleet_id: Some(String::new()),
+            pod_name: Some(String::new()),
+            node_name: Some(String::new()),
+        };
+        let attrs = super::static_resource_attributes(Some(&ctx));
+
+        assert_eq!(attribute_value(&attrs, "k8s.cluster.name"), None);
+        assert_eq!(attribute_value(&attrs, FLEET_ID_ATTRIBUTE_KEY), None);
+        assert_eq!(attribute_value(&attrs, "k8s.pod.name"), None);
+        assert_eq!(attribute_value(&attrs, "k8s.node.name"), None);
     }
 }

--- a/agent-control/src/instrumentation/tracing_layers/otel.rs
+++ b/agent-control/src/instrumentation/tracing_layers/otel.rs
@@ -438,23 +438,13 @@ fn static_resource_attributes(instance_context: Option<&InstanceContext>) -> Vec
 /// The startup counter must come first so it releases its instrument handle
 /// before the provider calls try_shutdown(), avoiding a stale-instrument warning.
 /// Traces/logs providers come before metrics so the MetricsLayer outlives them.
+#[derive(Default)]
 pub struct OtelGuard {
     /// Startup counter — drop first, before the provider shuts down.
     _startup_counter: Option<opentelemetry::metrics::Counter<u64>>,
     _traces_provider: Option<SdkTracerProvider>,
     _logs_provider: Option<SdkLoggerProvider>,
     _metrics_provider: Option<SdkMeterProvider>,
-}
-
-impl Default for OtelGuard {
-    fn default() -> Self {
-        Self {
-            _startup_counter: None,
-            _traces_provider: None,
-            _logs_provider: None,
-            _metrics_provider: None,
-        }
-    }
 }
 
 impl Drop for OtelGuard {

--- a/agent-control/tests/on_host/scenarios/self_instrumentation_otel.rs
+++ b/agent-control/tests/on_host/scenarios/self_instrumentation_otel.rs
@@ -84,3 +84,85 @@ self_instrumentation:
         "expected at least one POST /v1/metrics, got {metrics_hits}"
     );
 }
+
+/// Covers `self_instrumentation.opentelemetry.traces.enabled`, which the test above does not
+/// exercise. The binary creates real tracing spans on startup (e.g. `start_agent_control`);
+/// with traces enabled those spans must be exported as OTLP spans to `/v1/traces`.
+#[test]
+#[ignore = "requires root"]
+fn self_instrumentation_otel_exports_traces_as_root() {
+    let server = MockServer::start();
+
+    let traces_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/traces")
+            .header(API_KEY_HEADER, API_KEY_VALUE);
+        then.status(200);
+    });
+    // Negative controls: metrics/logs are left disabled (the struct default), so these
+    // paths must see zero traffic even though the otel layer as a whole is active.
+    let logs_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/logs");
+        then.status(200);
+    });
+    let metrics_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/metrics");
+        then.status(200);
+    });
+
+    let dir = TempDir::new().unwrap();
+    let endpoint = server.base_url();
+
+    let config = format!(
+        r#"
+host_id: integration-test
+agents: {{}}
+server:
+  enabled: false
+uptime_report:
+  interval: 200ms
+self_instrumentation:
+  opentelemetry:
+    endpoint: {endpoint}
+    headers:
+      {API_KEY_HEADER}: {API_KEY_VALUE}
+    traces:
+      enabled: true
+      batch_config:
+        scheduled_delay: 500ms
+        max_size: 1
+"#
+    );
+    create_file(
+        config,
+        dir.path()
+            .join(FOLDER_NAME_LOCAL_DATA)
+            .join(AGENT_CONTROL_ID)
+            .join(build_config_name(STORE_KEY_LOCAL_DATA_CONFIG).as_str()),
+    );
+
+    let mut cmd = cmd_with_config_file(dir.path());
+    let output = cmd.output().expect("running newrelic-agent-control binary");
+
+    let ac_stdout = String::from_utf8_lossy(&output.stdout);
+    let ac_stderr = String::from_utf8_lossy(&output.stderr);
+
+    eprintln!("--- agent-control stdout ---\n{ac_stdout}");
+    eprintln!("--- agent-control stderr ---\n{ac_stderr}");
+
+    let traces_hits = traces_mock.calls();
+    let logs_hits = logs_mock.calls();
+    let metrics_hits = metrics_mock.calls();
+    assert!(
+        traces_hits >= 1,
+        "expected at least one POST /v1/traces, got {traces_hits}"
+    );
+    assert_eq!(
+        logs_hits, 0,
+        "logs.enabled was not set; expected zero POST /v1/logs, got {logs_hits}"
+    );
+    assert_eq!(
+        metrics_hits, 0,
+        "metrics.enabled was not set; expected zero POST /v1/metrics, got {metrics_hits}"
+    );
+}

--- a/build/examples/agent-control-config-no-agents.yaml
+++ b/build/examples/agent-control-config-no-agents.yaml
@@ -1,0 +1,32 @@
+# Agent Control configuration — no managed agents
+# Use this as a starting point when Agent Control manages no local agents
+# (e.g. Fleet Control-only deployment).
+
+fleet_control:
+  endpoint: https://opamp.service.newrelic.com/v1/opamp
+  auth_config:
+    token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
+    client_id: YOUR_CLIENT_ID_HERE
+    provider: local
+    private_key_path: /etc/newrelic-agent-control/auth/private_key.pem
+
+agents: {}
+
+# proxy:
+#   url: https://proxy.url:8080
+#   ignore_system_proxy: false
+
+# Optional: enable Agent Control self-instrumentation via OTLP.
+# Agent Control will send its own metrics, logs, and traces to New Relic
+# without requiring an Infra agent or Fluent Bit.
+# self_instrumentation:
+#   opentelemetry:
+#     endpoint: https://otlp.nr-data.net:4318    # US; see docs for EU/JP/staging
+#     headers:
+#       api-key: YOUR_LICENSE_KEY_HERE
+#     metrics:
+#       enabled: true
+#     logs:
+#       enabled: true
+#     traces:
+#       enabled: true

--- a/build/examples/agent-control-config-nr-infra-agent.yaml
+++ b/build/examples/agent-control-config-nr-infra-agent.yaml
@@ -1,0 +1,32 @@
+# Agent Control configuration — New Relic Infrastructure agent
+# Use this as a starting point when Agent Control manages the NR Infra agent.
+
+fleet_control:
+  endpoint: https://opamp.service.newrelic.com/v1/opamp
+  auth_config:
+    token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
+    client_id: YOUR_CLIENT_ID_HERE
+    provider: local
+    private_key_path: /etc/newrelic-agent-control/auth/private_key.pem
+
+agents:
+  infrastructure: "newrelic/com.newrelic.infrastructure:0.1.0"
+
+# proxy:
+#   url: https://proxy.url:8080
+#   ignore_system_proxy: false
+
+# Optional: enable Agent Control self-instrumentation via OTLP.
+# Agent Control will send its own metrics, logs, and traces to New Relic
+# without requiring an Infra agent or Fluent Bit.
+# self_instrumentation:
+#   opentelemetry:
+#     endpoint: https://otlp.nr-data.net:4318    # US; see docs for EU/JP/staging
+#     headers:
+#       api-key: YOUR_LICENSE_KEY_HERE
+#     metrics:
+#       enabled: true
+#     logs:
+#       enabled: true
+#     traces:
+#       enabled: true

--- a/build/examples/agent-control-config-nr-otel-collector.yaml
+++ b/build/examples/agent-control-config-nr-otel-collector.yaml
@@ -1,0 +1,32 @@
+# Agent Control configuration — New Relic OTel Collector
+# Use this as a starting point when Agent Control manages the NR OpenTelemetry Collector.
+
+fleet_control:
+  endpoint: https://opamp.service.newrelic.com/v1/opamp
+  auth_config:
+    token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
+    client_id: YOUR_CLIENT_ID_HERE
+    provider: local
+    private_key_path: /etc/newrelic-agent-control/auth/private_key.pem
+
+agents:
+  nrdot: "newrelic/com.newrelic.opentelemetry.collector:0.1.0"
+
+# proxy:
+#   url: https://proxy.url:8080
+#   ignore_system_proxy: false
+
+# Optional: enable Agent Control self-instrumentation via OTLP.
+# Agent Control will send its own metrics, logs, and traces to New Relic
+# without requiring an Infra agent or Fluent Bit.
+# self_instrumentation:
+#   opentelemetry:
+#     endpoint: https://otlp.nr-data.net:4318    # US; see docs for EU/JP/staging
+#     headers:
+#       api-key: YOUR_LICENSE_KEY_HERE
+#     metrics:
+#       enabled: true
+#     logs:
+#       enabled: true
+#     traces:
+#       enabled: true

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -74,7 +74,7 @@ This configuration field enables and sets up the remote configuration features o
 fleet_control:
   endpoint: https://opamp.service.newrelic.com/v1/opamp # Fleet control endpoint.
   auth_config:
-    token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token # Endpoint to obtain access token
+    token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token # Endpoint to obtain access token
     client_id: "some-client-id" # Auth client id associated with the private key
     provider: "local" # Local auth provider which will load the provided key from 'private_key_path'
     private_key_path: "/private/key/path" # Path to the private key corresponding to the client-id.
@@ -82,7 +82,7 @@ fleet_control:
   fleet_id: "some-id" # Fleet identifier.
   signature_validation:
     enabled: true # Defaults to true, allows disabling the signature validation.
-    public_key_server_url: "https://publickeys.newrelic.com/signing/blob-management/global/agentconfiguration" # Server to obtain the public key for signature validation.
+    public_key_server_url: "https://publickeys.newrelic.com/signing/blob-management/global/agentconfiguration" # Server to obtain the public key for signature validation.
 ```
 
 ### proxy
@@ -108,30 +108,35 @@ Configuring a proxy in Agent Control does not automatically configure the same p
 
 The only exception is the infrastructure agent, which will inherit the proxy settings from Agent Control whenever the configuration is generated via the Cli.
 
-### server
-
-Agent Control status server allows consulting the status of Agent Control and any controlled agent. It can be configured as follows:
-
-```yaml
-server:
-  port: 51200 # Port for the status server. Defaults to 51200.
-  host: "127.0.0.1" # Host for the status server. Defaults to '127.0.0.1'.
-  enabled: true # The status server is enabled by default
-```
-
-### health_check
-
-Configuration fields to set-up Agent Control health-check
-
-```yaml
-health_check:
-  interval: 120s # Defaults to 30s
-  initial_delay: 120s # Defaults to 30s
-```
-
 ### self_instrumentation
 
-Agent Control can be configured to instrument itself and report logs and metrics through OpenTelemetry. If proxy is configured globally it will also apply to self-instrumentation.
+Enables Agent Control to send its own observability data (metrics, logs, traces) directly to New Relic via OTLP — no Infra agent or Fluent Bit required. If a proxy is configured globally it will also apply to self-instrumentation.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `opentelemetry.endpoint` | URL | yes | — | OTLP HTTP endpoint. US: `https://otlp.nr-data.net:4318`. EU: `https://otlp.eu01.nr-data.net:4318`. JP: `https://otlp.jp.nr-data.net:4318`. Staging: `https://staging-otlp.nr-data.net:4318` |
+| `opentelemetry.headers.api-key` | string | yes | — | New Relic license key (ingest key) |
+| `opentelemetry.metrics.enabled` | bool | no | `false` | Send Agent Control metrics to New Relic |
+| `opentelemetry.logs.enabled` | bool | no | `false` | Send Agent Control logs to New Relic |
+| `opentelemetry.traces.enabled` | bool | no | `false` | Send Agent Control traces to New Relic |
+
+Minimal working example:
+
+```yaml
+self_instrumentation:
+  opentelemetry:
+    endpoint: https://otlp.nr-data.net:4318
+    headers:
+      api-key: YOUR_LICENSE_KEY_HERE
+    metrics:
+      enabled: true
+    logs:
+      enabled: true
+    traces:
+      enabled: true
+```
+
+Additional options:
 
 ```yaml
 self_instrumentation:
@@ -142,13 +147,34 @@ self_instrumentation:
     client_timeout: 10s # Timeout for performing requests, defaults to 30s.
     custom_attributes: {} # Attributes to be decorated in all metrics and logs
     metrics:
-      enabled: true # Defaults to false.
-      interval: 120s # Interval to report metrics, it defaults to 60s.
+      enabled: true # Defaults to false.
+      interval: 120s # Interval to report metrics, it defaults to 60s.
     logs:
       enabled: true # Defaults to false.
       batch_config:
         scheduled_delay: 30s # Set the scheduled delay for batch export of logs. Defaults to 30s.
-        max_size: 512 # Se the maximum number of logs to process in a single batch. Defaults to 512.
+        max_size: 512 # Set the maximum number of logs to process in a single batch. Defaults to 512.
+```
+
+### server
+
+Agent Control status server allows consulting the status of Agent Control and any controlled agent. It can be configured as follows:
+
+```yaml
+server:
+  port: 51200 # Port for the status server. Defaults to 51200.
+  host: "127.0.0.1" # Host for the status server. Defaults to '127.0.0.1'.
+  enabled: true # The status server is enabled by default
+```
+
+### health_check
+
+Configuration fields to set-up Agent Control health-check
+
+```yaml
+health_check:
+  interval: 120s # Defaults to 30s
+  initial_delay: 120s # Defaults to 30s
 ```
 
 ### host_id
@@ -163,7 +189,7 @@ host where Agent Control is running. Order of precedence:
 This applies for on-host environments only:
 
 ```yaml
-host_id: "some-host-id" # Defaults to "" (no host set).
+host_id: "some-host-id" # Defaults to "" (no host set).
 ```
 
 ### k8s
@@ -172,7 +198,7 @@ The `k8s` configuration field applies for k8s environments only and are automati
 
 ```yaml
 k8s:
-  cluster_name: "some-cluster-name" # Required, used to identify the cluster in Fleet Control.
+  cluster_name: "some-cluster-name" # Required, used to identify the cluster in Fleet Control.
   namespace: "default" # Required, namespace where all resources managed by Agent Control will be created.
   namespace_agents: "default-agents" # Required, namespace where all sub-agents managed by Agent Control will be created.
   current_chart_version: "0.0.50-dev" # Chart version used to deploy agent-control, it will be reported to Fleet Control and used to check if a remote update should be applied.


### PR DESCRIPTION
PoC - Self Instrumentation

Productionizes the OTLP export pipeline itself: region-derived endpoint, correct HTTP client feature flags, config plumbing, and the two hardening fixes this pipeline needed. Deliberately excludes business metrics (record_* instruments) and a tracing-span expansion / id field fix for future implementations - this is the foundation those build on.

OTLP pipeline (NR-580189):
- Region-derived OTLP endpoint (US/EU/JP/staging) via OtelConfig::with_region_endpoint; port aligned to 4318 (HTTP/protobuf) end to end; no hardcoded staging endpoint
- reqwest-blocking-client (not reqwest-rustls/async): the PeriodicReader background thread uses futures_executor::block_on, which has no Tokio context - the async reqwest client would panic or deadlock from there
- Per-signal enable/disable (metrics, logs, traces) via self_instrumentation.opentelemetry config; traces default off
- Example configs and CONFIG.md updated; integration test exercises the full logs+metrics export path against a mock OTLP endpoint

Hardening (found in post-implementation review, folded in here since both depend directly on this pipeline):
- Bound OTLP force_flush() calls with a 5s timeout (instrumentation::flush) so a hung/unreachable endpoint can't stall graceful shutdown or a self-update, which previously had no bound beyond the 30s client timeout buried inside the SDK call
- Region-based endpoint derivation is now actually reachable: the ENDPOINT_SENTINEL fallback only ever triggered from test-only code because the `endpoint` config field had no serde default, so omitting it from a real config was a hard deserialization error instead of the intended region-derivation path

instrumentation::metrics is included here only as plumbing (register_provider + a bounded flush()) - the otel.rs pipeline needs it to flush metrics before self-update's exec(). The actual business `record_*` instruments land in the next PR on top of this one.
