### PR TITLE
feat: remove persistent/ephemeral flag for filesystem [NR-579376]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Remember that the keywords that you can use are the following:
 - Add support for `copy_from_file` for on-host "in-agent" filesystem.
 - Add support for `shared_filesystem` in on-host agent types. It includes a single-owner rule: two agents claiming the same path in the shared-filesystem are invalid and reported as Failed.
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.
-- On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 - On-host health config: replaced the flat `health.http:` / `health.file:` fields with an explicit `checks:` list. Each entry is discriminated by `kind:` (`Process`, `Http`, or `File`). The previously implicit supervised-process health check is now declared as `kind: Process`. An omitted or empty `checks:` list disables health reporting entirely.
+- On-host filesystem entries (`file`/`dir`) now always survive sub-agent stop, restart, and config-apply. A stray `persistent:` key in existing agent-type YAML is ignored rather than rejected.
 
 ## v1.18.0 - 2026-07-06
 

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -72,13 +72,10 @@ deployment:
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
-    # Agent data root (NRIA_AGENT_DIR). Persistent so the agent's stored data survives restarts
+    # Agent data root (NRIA_AGENT_DIR).
     newrelic-infra:
       kind: dir
-      persistent: true
       entries:
-        # NRIA_AGENT_TEMP_DIR: fluent-bit scratch that the agent does not clean up. Declared
-        # ephemeral so AC reclaims it on every (re)start instead of letting it grow unbounded.
         tmp:
           kind: dir
   shared_filesystem:
@@ -86,11 +83,9 @@ deployment:
     # infra-agent is configured through NRIA_PLUGIN_DIR, to read configs from this folder.
     infra-agent-ohi-configs:
       kind: dir
-      persistent: true
       entries:
         docker-config.yml:
           kind: file
-          persistent: true
           text: |
             integrations:
             - name: nri-docker
@@ -103,7 +98,6 @@ deployment:
     # to read binaries from this folder.
     infra-agent-ohi-binaries:
       kind: dir
-      persistent: true
       entries:
         nri-flex:
           kind: file

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -68,36 +68,28 @@ deployment:
     logging.d:
       kind: dir_content_from_map
       source: ${nr-var:config_logging}
-    # Agent data root (NRIA_AGENT_DIR). Persistent so the agent's stored data survives restarts
+    # Agent data root (NRIA_AGENT_DIR).
     newrelic-infra:
       kind: dir
-      persistent: true
       entries:
-        # NRIA_AGENT_TEMP_DIR: fluent-bit scratch that the agent does not clean up. Declared
-        # ephemeral so AC reclaims it on every (re)start instead of letting it grow unbounded.
         tmp:
           kind: dir
-        # Logging integration directory expected by fluentBit; persistent (like its parent) so any
-        # state it holds survives restarts.
+        # Logging integration directory expected by fluentBit.
         newrelic-integrations:
           kind: dir
-          persistent: true
           entries:
             logging:
               kind: dir
-              persistent: true
   shared_filesystem:
     # OHIs config folders.
     # infra-agent is configured through NRIA_PLUGIN_DIR, to read configs from this folder.
     infra-agent-ohi-configs:
       kind: dir
-      persistent: true
     # OHIs binaries folder.
     # infra-agent is configured through NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR and NRIA_SAFE_BIN_DIR,
     # to read binaries from this folder.
     infra-agent-ohi-binaries:
       kind: dir
-      persistent: true
       entries:
         nri-flex.exe:
           kind: file

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -27,8 +27,8 @@ use super::{ResourceCleaner, ResourceCleanerError};
 /// On-host implementation of [`ResourceCleaner`] that wipes a sub-agent's fleet data by
 /// delegating to the same storers that wrote it, also recursively deletes the sub-agent's
 /// dedicated filesystem directory and its installed packages (via the [`AgentPackagesRemover`],
-/// which owns the on-disk package layout), the `persistent` flag is bypassed here because the
-/// agent has been removed from the fleet.
+/// which owns the on-disk package layout), regardless of what it contains, because the agent has
+/// been removed from the fleet.
 /// The same removal logic is reused at startup by [`Self::cleanup_stale_agents`] to reclaim the
 /// resources of agents removed from the fleet config while Agent Control was stopped.
 pub struct OnHostCleaner<S, C, D, P, R>
@@ -955,7 +955,7 @@ mod tests {
     }
 
     /// On a type bump all per-agent paths declared by the old type but absent in the new type are
-    /// deleted regardless of persistence. Files present in both types are kept.
+    /// deleted. Files present in both types are kept.
     #[test]
     fn on_type_change_reconciles_agent_filesystem() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -968,7 +968,7 @@ mod tests {
         std::fs::write(agent_dir.join("removed.yaml"), "old").unwrap();
         std::fs::create_dir_all(agent_dir.join("logging.d")).unwrap();
         std::fs::write(agent_dir.join("logging.d").join("syslog.yaml"), "log").unwrap();
-        std::fs::write(agent_dir.join("persistent.db"), "state").unwrap();
+        std::fs::write(agent_dir.join("other.db"), "state").unwrap();
 
         let old_type_id = AgentTypeID::try_from("test/oldagent:0.0.1").unwrap();
         let new_type_id = AgentTypeID::try_from("test/newagent:0.0.2").unwrap();
@@ -977,7 +977,7 @@ mod tests {
             "config.yaml":  { "kind": "file", "text": "cfg" },
             "removed.yaml": { "kind": "file", "text": "old" },
             "logging.d":    { "kind": "dir_content_from_map", "source": "${nr-var:logs}" },
-            "persistent.db": { "kind": "file", "text": "state", "persistent": true },
+            "other.db": { "kind": "file", "text": "state" },
         }));
         let new_definition = host_type_with_filesystem(serde_json::json!({
             "config.yaml": { "kind": "file", "text": "cfg" },
@@ -1002,21 +1002,21 @@ mod tests {
         );
         assert!(
             !agent_dir.join("removed.yaml").exists(),
-            "ephemeral file absent in new type must be deleted"
+            "file absent in new type must be deleted"
         );
         assert!(
             !agent_dir.join("logging.d").exists(),
             "managed dir absent in new type must be deleted"
         );
         assert!(
-            !agent_dir.join("persistent.db").exists(),
-            "persistent file absent in new type must be deleted"
+            !agent_dir.join("other.db").exists(),
+            "file absent in new type must be deleted"
         );
     }
 
-    /// On a type bump, shared paths absent from the new type are deleted regardless of their
-    /// persistence flag. Paths declared in both types are kept. Managed dirs absent in the new
-    /// type are removed. Co-owned directories are never deleted.
+    /// On a type bump, shared paths absent from the new type are deleted. Paths declared in both
+    /// types are kept. Managed dirs absent in the new type are removed. Co-owned directories are
+    /// never deleted.
     #[test]
     fn on_type_change_removes_shared_paths_absent_in_new_type() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -1025,7 +1025,7 @@ mod tests {
         std::fs::create_dir_all(shared.join("ohi-configs")).unwrap();
         std::fs::write(shared.join("ohi-configs").join("nri-redis.yaml"), "redis").unwrap();
         std::fs::write(shared.join("ohi-configs").join("nri-old.yaml"), "old").unwrap();
-        std::fs::write(shared.join("persistent.yaml"), "data").unwrap();
+        std::fs::write(shared.join("other.yaml"), "data").unwrap();
         std::fs::create_dir_all(shared.join("old-managed")).unwrap();
         std::fs::write(shared.join("old-managed").join("file.log"), "log").unwrap();
 
@@ -1040,10 +1040,10 @@ mod tests {
                     "nri-old.yaml":   { "kind": "file", "text": "old" },
                 },
             },
-            "persistent.yaml": { "kind": "file", "text": "data", "persistent": true },
+            "other.yaml": { "kind": "file", "text": "data" },
             "old-managed": { "kind": "dir_content_from_map", "source": "${nr-var:m}" },
         }));
-        // New type keeps only redis.yaml; drops nri-old.yaml, persistent.yaml, old-managed.
+        // New type keeps only redis.yaml; drops nri-old.yaml, other.yaml, old-managed.
         let new_definition = host_type_with_shared(serde_json::json!({
             "ohi-configs": {
                 "kind": "dir",
@@ -1076,8 +1076,8 @@ mod tests {
             "ephemeral file absent in new type must be deleted"
         );
         assert!(
-            !shared.join("persistent.yaml").exists(),
-            "persistent file absent in new type must be deleted"
+            !shared.join("other.yaml").exists(),
+            "file absent in new type must be deleted"
         );
         assert!(
             !shared.join("old-managed").exists(),

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -34,32 +34,10 @@ pub mod rendered;
 ///
 /// Every entry is tagged with a `kind:`. `dir` entries may contain further entries under
 /// `entries:`, recursively.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
 pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 
-impl<'de> Deserialize<'de> for FileSystem {
-    /// Deserializes the entry tree and then validates that persistence is declared consistently
-    /// down every branch: an entry marked `persistent: true` must not sit under a non-persistent
-    /// parent directory.
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let entries = HashMap::<SafePath, FilesystemEntry>::deserialize(deserializer)?;
-        validate_persistence_hierarchy(&entries).map_err(D::Error::custom)?;
-        Ok(FileSystem(entries))
-    }
-}
-
 /// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
-/// The `file` and `dir` variants carry a `persistent` flag (default `false`):
-///
-/// - `persistent: false` (ephemeral): the entry's on-disk tree is deleted on sub-agent stop.
-/// - `persistent: true`: the entry survives sub-agent stop and restart; it is only deleted when
-///   the agent is removed from the fleet.
-///
-/// `dir_content_from_map` has no `persistent` flag: its projected files are re-rendered on every
-/// write, so it is always ephemeral.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FilesystemEntry {
@@ -73,18 +51,12 @@ pub enum FilesystemEntry {
         /// exclusive with `text`.
         #[serde(default)]
         copy_from_file: Option<TemplateableValue<String>>,
-        /// The persistency attribute marking its lifecycle.
-        #[serde(default)]
-        persistent: bool,
     },
     /// An explicitly declared directory. Children, if any, live under `entries:`.
     Dir {
         /// The directory's child entries.
         #[serde(default)]
         entries: HashMap<SafePath, FilesystemEntry>,
-        /// The persistency attribute marking its lifecycle.
-        #[serde(default)]
-        persistent: bool,
     },
     /// A directory whose set of files is computed at deploy time from a `map[string]yaml`
     /// variable. Map keys become filenames; values become file contents.
@@ -244,7 +216,6 @@ impl Templateable for FilesystemEntry {
             FilesystemEntry::File {
                 text,
                 copy_from_file,
-                persistent,
             } => {
                 let content = match (text, copy_from_file) {
                     (Some(text), None) => {
@@ -275,23 +246,14 @@ impl Templateable for FilesystemEntry {
                         ));
                     }
                 };
-                Ok(rendered::RenderedEntry::File {
-                    content,
-                    persistent,
-                })
+                Ok(rendered::RenderedEntry::File { content })
             }
-            FilesystemEntry::Dir {
-                entries,
-                persistent,
-            } => {
+            FilesystemEntry::Dir { entries } => {
                 let children = entries
                     .into_iter()
                     .map(|(k, v)| Ok((PathBuf::from(k), v.template_with(variables)?)))
                     .collect::<Result<HashMap<_, _>, AgentTypeError>>()?;
-                Ok(rendered::RenderedEntry::Dir {
-                    children,
-                    persistent,
-                })
+                Ok(rendered::RenderedEntry::Dir { children })
             }
             FilesystemEntry::DirContentFromMap { source } => {
                 let map = source.template_with(variables)?;
@@ -424,74 +386,6 @@ fn check_basedir_escape_safety(path: &Path) -> Result<(), String> {
     })
 }
 
-/// Validates that persistence is declared consistently down every branch of the tree.
-///
-/// A non-persistent directory is deleted recursively when the sub-agent stops, taking every
-/// descendant with it. A `persistent: true` entry under a non-persistent parent would silently
-/// never survive a restart, so we require the user to declare the whole chain `persistent: true`.
-fn validate_persistence_hierarchy(
-    entries: &HashMap<SafePath, FilesystemEntry>,
-) -> Result<(), String> {
-    let mut errors = Vec::new();
-    for (key, entry) in entries {
-        check_entry_persistence(key.as_ref(), entry, false, &mut errors);
-    }
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors.join(", "))
-    }
-}
-
-/// Recursively checks a single entry (at `path`) and its subtree. `ancestor_ephemeral` is `true`
-/// when some parent directory up the chain is declared non-persistent.
-fn check_entry_persistence(
-    path: &Path,
-    entry: &FilesystemEntry,
-    ancestor_ephemeral: bool,
-    errors: &mut Vec<String>,
-) {
-    match entry {
-        FilesystemEntry::File { persistent, .. } => {
-            if ancestor_ephemeral && *persistent {
-                errors.push(persistence_error(path));
-            }
-        }
-        FilesystemEntry::Dir {
-            entries,
-            persistent,
-        } => {
-            if ancestor_ephemeral && *persistent {
-                errors.push(persistence_error(path));
-            }
-            // A child sits under a non-persistent ancestor if one already existed up the chain, or
-            // if this directory is itself declared non-persistent.
-            let child_ancestor_ephemeral = ancestor_ephemeral || !persistent;
-            for (child_key, child) in entries {
-                check_entry_persistence(
-                    &path.join(child_key),
-                    child,
-                    child_ancestor_ephemeral,
-                    errors,
-                );
-            }
-        }
-        // `dir_content_from_map` is always ephemeral and cannot declare persistent children, so it
-        // can neither be a persistent entry nor a parent of one.
-        FilesystemEntry::DirContentFromMap { .. } => {}
-    }
-}
-
-fn persistence_error(path: &Path) -> String {
-    format!(
-        "path `{}` is declared `persistent: true` but a parent directory is not persistent; a \
-         non-persistent parent is deleted when the sub-agent stops and takes its children with it, \
-         so the child's persistence has no effect. Declare every parent directory as \
-         `persistent: true`",
-        path.display()
-    )
-}
-
 fn is_within_base(path: &Path, base_dir: &Path) -> bool {
     let has_escape = path.components().any(|c| matches!(c, Component::ParentDir));
     !has_escape && path.is_absolute() && path.starts_with(base_dir)
@@ -536,7 +430,6 @@ mod tests {
             FilesystemEntry::File {
                 text: Some(TemplateableValue::from_template("hello".to_string())),
                 copy_from_file: None,
-                persistent: false,
             },
         )]));
 
@@ -546,7 +439,6 @@ mod tests {
             PathBuf::from("/base/dir/newrelic.yaml"),
             RenderedEntry::File {
                 content: rendered::FileContent::Text("hello".to_string()),
-                persistent: false,
             },
         )]));
         assert_eq!(rendered, expected);
@@ -610,7 +502,6 @@ nri-redis:
                 copy_from_file: Some(TemplateableValue::from_template(
                     source.to_string_lossy().to_string(),
                 )),
-                persistent: false,
             },
         )]));
 
@@ -620,7 +511,6 @@ nri-redis:
             agent_dir.join("nri-redis"),
             RenderedEntry::File {
                 content: rendered::FileContent::Copy(source),
-                persistent: false,
             },
         )]));
         assert_eq!(rendered, expected);
@@ -650,7 +540,6 @@ nri-redis:
                     copy_from_file: Some(TemplateableValue::from_template(
                         source.to_string_lossy().to_string(),
                     )),
-                    persistent: false,
                 },
             )]));
 
@@ -684,7 +573,6 @@ nri-redis:
             FilesystemEntry::File {
                 text,
                 copy_from_file,
-                persistent: false,
             },
         )]));
 
@@ -712,7 +600,6 @@ nri-redis:
                 copy_from_file: Some(TemplateableValue::from_template(
                     source.to_string_lossy().to_string(),
                 )),
-                persistent: false,
             },
         )]));
 
@@ -737,7 +624,6 @@ nri-redis:
             PathBuf::from("any").try_into().unwrap(),
             FilesystemEntry::Dir {
                 entries: HashMap::new(),
-                persistent: false,
             },
         )]));
 
@@ -926,214 +812,17 @@ foo:
         );
     }
 
-    /// Persistent flag defaults to false; explicit `persistent: true` parses to `true`, and the
-    /// flag on `dir_content_from_map` is ignored. Independent per variant.
-    #[test]
-    fn persistent_field_parses_per_variant() {
-        let yaml = r#"
-default-file:
-  kind: file
-  text: hi
-persistent-file:
-  kind: file
-  text: hi
-  persistent: true
-persistent-dir:
-  kind: dir
-  persistent: true
-map-with-ignored-persistent:
-  kind: dir_content_from_map
-  source: ${nr-var:m}
-  persistent: true
-"#;
-        let parsed = serde_saphyr::from_str::<FileSystem>(yaml).unwrap();
-        let key = |k: &str| SafePath(PathBuf::from(k));
-
-        match parsed.0.get(&key("default-file")).unwrap() {
-            FilesystemEntry::File { persistent, .. } => {
-                assert!(!persistent);
-            }
-            other => panic!("unexpected variant: {other:?}"),
-        }
-        match parsed.0.get(&key("persistent-file")).unwrap() {
-            FilesystemEntry::File { persistent, .. } => assert!(persistent),
-            other => panic!("unexpected variant: {other:?}"),
-        }
-        match parsed.0.get(&key("persistent-dir")).unwrap() {
-            FilesystemEntry::Dir { persistent, .. } => assert!(persistent),
-            other => panic!("unexpected variant: {other:?}"),
-        }
-        match parsed.0.get(&key("map-with-ignored-persistent")).unwrap() {
-            FilesystemEntry::DirContentFromMap { .. } => {}
-            other => panic!("unexpected variant: {other:?}"),
-        }
-    }
-
-    /// A `persistent: true` entry must have every ancestor directory declared persistent too,
-    /// otherwise a non-persistent parent would wipe it on sub-agent stop. Parsing rejects the
-    /// inconsistent trees.
-    #[rstest]
-    // Top-level persistent entries have no declared parent: always fine.
-    #[case::top_level_persistent_file(
-        r#"
-a.txt:
-  kind: file
-  text: hi
-  persistent: true
-"#,
-        true
-    )]
-    #[case::top_level_persistent_dir(
-        r#"
-d:
-  kind: dir
-  persistent: true
-"#,
-        true
-    )]
-    // Persistent child under a persistent parent: fine.
-    #[case::persistent_child_under_persistent_parent(
-        r#"
-d:
-  kind: dir
-  persistent: true
-  entries:
-    a.txt:
-      kind: file
-      text: hi
-      persistent: true
-"#,
-        true
-    )]
-    // Ephemeral child under a persistent parent: fine (only the reverse is a problem).
-    #[case::ephemeral_child_under_persistent_parent(
-        r#"
-d:
-  kind: dir
-  persistent: true
-  entries:
-    a.txt:
-      kind: file
-      text: hi
-"#,
-        true
-    )]
-    // The whole chain persistent: fine.
-    #[case::deep_chain_all_persistent(
-        r#"
-a:
-  kind: dir
-  persistent: true
-  entries:
-    b:
-      kind: dir
-      persistent: true
-      entries:
-        c.txt:
-          kind: file
-          text: hi
-          persistent: true
-"#,
-        true
-    )]
-    // Persistent file under a parent that omits `persistent` (defaults to ephemeral): rejected.
-    #[case::persistent_file_under_default_parent(
-        r#"
-d:
-  kind: dir
-  entries:
-    a.txt:
-      kind: file
-      text: hi
-      persistent: true
-"#,
-        false
-    )]
-    // Persistent file under an explicitly non-persistent parent: rejected.
-    #[case::persistent_file_under_ephemeral_parent(
-        r#"
-d:
-  kind: dir
-  persistent: false
-  entries:
-    a.txt:
-      kind: file
-      text: hi
-      persistent: true
-"#,
-        false
-    )]
-    // Persistent nested dir under a non-persistent parent: rejected.
-    #[case::persistent_dir_under_ephemeral_parent(
-        r#"
-d:
-  kind: dir
-  entries:
-    inner:
-      kind: dir
-      persistent: true
-"#,
-        false
-    )]
-    // A non-persistent directory anywhere in the chain invalidates deeper persistent entries.
-    #[case::persistent_leaf_under_ephemeral_ancestor(
-        r#"
-a:
-  kind: dir
-  persistent: true
-  entries:
-    b:
-      kind: dir
-      entries:
-        c.txt:
-          kind: file
-          text: hi
-          persistent: true
-"#,
-        false
-    )]
-    fn validates_persistence_hierarchy(#[case] yaml: &str, #[case] should_parse: bool) {
-        let parsed = serde_saphyr::from_str::<FileSystem>(yaml);
-        assert_eq!(
-            parsed.is_ok(),
-            should_parse,
-            "input: {yaml}, parsed: {parsed:?}"
-        );
-    }
-
-    /// The rejection error names the offending path and explains the parent-wins behaviour.
-    #[test]
-    fn persistence_error_reports_path() {
-        let yaml = r#"
-d:
-  kind: dir
-  entries:
-    a.txt:
-      kind: file
-      text: hi
-      persistent: true
-"#;
-        let err = serde_saphyr::from_str::<FileSystem>(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("a.txt"), "error should name the path: {msg}");
-        assert!(
-            msg.contains("persistent"),
-            "error should mention persistence: {msg}"
-        );
-    }
-
     #[test]
     fn write_overwrites_declared_and_leaves_everything_else() {
         let tmp_dir = TempDir::new().unwrap();
 
-        // First write: A (top-level file), persistent-dir with declared `old.txt`, projected map.
+        // First write: A (top-level file), managed-dir with declared `old.txt`, projected map.
         let first_yaml = r#"
 A.txt:
   kind: file
   text: hello
-persistent-dir:
+managed-dir:
   kind: dir
-  persistent: true
   entries:
     old.txt:
       kind: file
@@ -1165,24 +854,23 @@ projected:
             .unwrap();
 
         assert!(tmp_dir.path().join("A.txt").exists());
-        assert!(tmp_dir.path().join("persistent-dir/old.txt").exists());
+        assert!(tmp_dir.path().join("managed-dir/old.txt").exists());
         assert!(tmp_dir.path().join("projected/a.yaml").exists());
         assert!(tmp_dir.path().join("projected/b.yaml").exists());
 
         // Sub-agent process writes runtime files that were never declared.
         let runtime_top = tmp_dir.path().join("agent-runtime.log");
-        let runtime_in_dir = tmp_dir.path().join("persistent-dir/cache.db");
+        let runtime_in_dir = tmp_dir.path().join("managed-dir/cache.db");
         let runtime_in_projected = tmp_dir.path().join("projected/agent-state.log");
         std::fs::write(&runtime_top, "top-level runtime data").unwrap();
         std::fs::write(&runtime_in_dir, "cache").unwrap();
         std::fs::write(&runtime_in_projected, "state").unwrap();
 
-        // Second write: A.txt removed; `old.txt` removed from persistent-dir's entries; `b.yaml`
+        // Second write: A.txt removed; `old.txt` removed from managed-dir's entries; `b.yaml`
         // dropped from the projected map.
         let second_yaml = r#"
-persistent-dir:
+managed-dir:
   kind: dir
-  persistent: true
 projected:
   kind: dir_content_from_map
   source: ${nr-var:proj}
@@ -1215,8 +903,8 @@ projected:
             "A.txt should survive: write never deletes previously-declared paths"
         );
         assert!(
-            tmp_dir.path().join("persistent-dir/old.txt").exists(),
-            "old.txt inside persistent-dir should survive"
+            tmp_dir.path().join("managed-dir/old.txt").exists(),
+            "old.txt inside managed-dir should survive"
         );
         assert!(
             !tmp_dir.path().join("projected/b.yaml").exists(),
@@ -1227,7 +915,7 @@ projected:
             std::fs::read_to_string(tmp_dir.path().join("projected/a.yaml")).unwrap(),
             "a-content-v2"
         );
-        assert!(tmp_dir.path().join("persistent-dir").is_dir());
+        assert!(tmp_dir.path().join("managed-dir").is_dir());
         // Agent-process-created files survive everywhere.
         assert!(
             runtime_top.exists(),
@@ -1239,7 +927,7 @@ projected:
         );
         assert!(
             runtime_in_dir.exists(),
-            "agent-created file inside persistent dir should survive"
+            "agent-created file inside a declared dir should survive"
         );
         assert_eq!(std::fs::read_to_string(&runtime_in_dir).unwrap(), "cache");
         assert!(
@@ -1332,54 +1020,6 @@ logging.d:
         );
     }
 
-    /// `delete_ephemeral` removes ephemeral entries' on-disk paths (files and directories) but
-    /// leaves persistent ones alone.
-    #[test]
-    fn delete_ephemeral_clears_only_non_persistent() {
-        let tmp_dir = TempDir::new().unwrap();
-        let yaml = r#"
-ephemeral.txt:
-  kind: file
-  text: e
-persistent.txt:
-  kind: file
-  text: p
-  persistent: true
-ephemeral-dir:
-  kind: dir
-  entries:
-    inner.txt:
-      kind: file
-      text: e
-persistent-dir:
-  kind: dir
-  persistent: true
-"#;
-        let variables = Variables::from_iter(vec![(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
-        )]);
-        let templated = serde_saphyr::from_str::<FileSystem>(yaml)
-            .unwrap()
-            .template_with(&variables)
-            .unwrap();
-        templated.write(&LocalFile, &DirectoryManagerFs).unwrap();
-
-        assert!(tmp_dir.path().join("ephemeral.txt").exists());
-        assert!(tmp_dir.path().join("persistent.txt").exists());
-        assert!(tmp_dir.path().join("ephemeral-dir/inner.txt").exists());
-        assert!(tmp_dir.path().join("persistent-dir").is_dir());
-
-        templated
-            .delete_ephemeral(&LocalFile, &DirectoryManagerFs)
-            .unwrap();
-
-        assert!(!tmp_dir.path().join("ephemeral.txt").exists());
-        assert!(!tmp_dir.path().join("ephemeral-dir").exists());
-        assert!(tmp_dir.path().join("persistent.txt").exists());
-        assert!(tmp_dir.path().join("persistent-dir").is_dir());
-    }
-
     /// Builds the reserved variable holding the shared filesystem base dir.
     fn shared_variables(shared_dir: &Path, remote_dir: &Path) -> Variables {
         Variables::from_iter(vec![
@@ -1460,7 +1100,6 @@ infra-agent-ohi-configs:
                 copy_from_file: Some(TemplateableValue::from_template(
                     source.to_string_lossy().to_string(),
                 )),
-                persistent: false,
             },
         )])));
 

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -105,13 +105,6 @@ impl FileSystem {
     /// Deletes the on-disk path of every top-level entry that is not declared. Never descends into
     /// a declared `dir`'s own contents: those are left to the agent (or an earlier agent-type
     /// version) to own, and are only re-rendered by `write`, not pruned.
-    ///
-    /// # Known limitation: previously-declared entries inside a declared directory
-    ///
-    /// When AC configuration is changed **locally**, a file which **was** declared inside a directory
-    /// in a previous agent-type version but is no longer declared in the current one survives
-    /// since directory contents are never pruned. We would need to save a separate state of what was
-    /// written in order to handle this.
     pub fn delete_not_declared(
         &self,
         file_ops: &impl FileDeleter,

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -2,10 +2,10 @@
 use fs::file::copier::FileCopier;
 use fs::file::deleter::FileDeleter;
 use fs::{directory_manager::DirectoryManager, file::writer::FileWriter};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use tracing::{trace, warn};
+use tracing::trace;
 
 /// Rendered filesystem tree, ready to be materialized on disk.
 ///
@@ -33,15 +33,11 @@ pub enum RenderedEntry {
     File {
         /// Where the file's bytes come from.
         content: FileContent,
-        /// The persistency attribute marking its lifecycle.
-        persistent: bool,
     },
     /// A directory containing child entries keyed by their relative path.
     Dir {
         /// The dictionary containing each children path and the entry.
         children: HashMap<PathBuf, RenderedEntry>,
-        /// The persistency attribute marking its lifecycle.
-        persistent: bool,
     },
     /// A directory whose files were projected from a map (filename to content).
     DirContentFromMap {
@@ -51,15 +47,6 @@ pub enum RenderedEntry {
 }
 
 impl RenderedEntry {
-    fn persistent(&self) -> bool {
-        match self {
-            Self::File { persistent, .. } | Self::Dir { persistent, .. } => *persistent,
-            // `dir_content_from_map` has no persistent flag: Agent Control re-renders its
-            // projected files on every write, so it is always treated as ephemeral.
-            Self::DirContentFromMap { .. } => false,
-        }
-    }
-
     /// Materializes this entry (and its subtree) on disk at `path`. `file_ops` provides both the
     /// write and copy capabilities (a single type, [`LocalFile`], implements both in production).
     fn write(
@@ -96,38 +83,6 @@ impl RenderedEntry {
             }
         }
     }
-
-    /// Deletes this entry's on-disk path if it is ephemeral. A persistent directory is kept, but
-    /// the walk recurses so ephemeral descendants are still cleaned; an ephemeral ancestor is
-    /// removed recursively, taking any persistent descendants with it.
-    fn delete_ephemeral(
-        &self,
-        path: &Path,
-        file_ops: &impl FileDeleter,
-        dir_manager: &impl DirectoryManager,
-    ) -> Result<(), FileSystemEntriesError> {
-        if !self.persistent() {
-            if path.exists() {
-                let result = match self {
-                    Self::File { .. } => file_ops.delete(path),
-                    _ => dir_manager.delete(path),
-                };
-                result
-                    .map_err(|err| {
-                        FileSystemEntriesError(format!("deleting {}: {err}", path.display()))
-                    })
-                    .inspect_err(|err| warn!(?err, ?path, "delete_ephemeral failed"))?;
-            }
-            return Ok(());
-        }
-        // Persistent: keep this node, but its children may still be ephemeral.
-        if let Self::Dir { children, .. } = self {
-            for (sub, child) in children {
-                child.delete_ephemeral(&path.join(sub), file_ops, dir_manager)?;
-            }
-        }
-        Ok(())
-    }
 }
 
 impl FileSystem {
@@ -147,28 +102,16 @@ impl FileSystem {
         Ok(())
     }
 
-    /// Deletes the on-disk path of every ephemeral entry in the tree.
-    /// A persistent entry whose ancestor is ephemeral is wiped along with the ancestor
-    pub fn delete_ephemeral(
-        &self,
-        file_ops: &impl FileDeleter,
-        dir_manager: &impl DirectoryManager,
-    ) -> Result<(), FileSystemEntriesError> {
-        for (path, entry) in &self.entries {
-            entry.delete_ephemeral(path, file_ops, dir_manager)?;
-        }
-        Ok(())
-    }
-
-    /// Deletes the on-disk path of every entry in the filesystem that is not declared and is not a
-    /// child of a persistent declared directory.
+    /// Deletes the on-disk path of every top-level entry that is not declared. Never descends into
+    /// a declared `dir`'s own contents: those are left to the agent (or an earlier agent-type
+    /// version) to own, and are only re-rendered by `write`, not pruned.
     ///
-    /// # Known limitation — previously-declared entries inside persistent directories
+    /// # Known limitation: previously-declared entries inside a declared directory
     ///
-    /// Persistent directories are skipped entirely so that runtime files the agent wrote (and
-    /// never declared) are preserved. The unavoidable side-effect is that a file which *was*
-    /// declared inside a persistent directory in a previous type version but is no longer declared
-    /// in the current one also survives. We would need to save the state to handle this case
+    /// When AC configuration is changed **locally**, a file which **was** declared inside a directory
+    /// in a previous agent-type version but is no longer declared in the current one survives
+    /// since directory contents are never pruned. We would need to save a separate state of what was
+    /// written in order to handle this.
     pub fn delete_not_declared(
         &self,
         file_ops: &impl FileDeleter,
@@ -178,14 +121,26 @@ impl FileSystem {
             Some(p) => p.to_path_buf(),
             None => return Ok(()),
         };
-        // Top-level entry keys are absolute; strip to filename so the recursive helper
-        // can look items up by their single-component relative name at each level.
-        let declared: HashMap<PathBuf, &RenderedEntry> = self
+        // Top-level entry keys are absolute; strip to filename so they can be compared against
+        // the single-component names `dir_manager.list` returns.
+        let declared: HashSet<PathBuf> = self
             .entries
-            .iter()
-            .filter_map(|(abs, entry)| abs.file_name().map(|n| (PathBuf::from(n), entry)))
+            .keys()
+            .filter_map(|abs| abs.file_name().map(PathBuf::from))
             .collect();
-        prune_undeclared(&base_dir, &declared, file_ops, dir_manager)
+        // list() returns an empty vec when the directory does not exist — no extra NotFound handling needed.
+        let children = dir_manager
+            .list(&base_dir)
+            .map_err(|e| FileSystemEntriesError(format!("listing {}: {e}", base_dir.display())))?;
+        for abs in children {
+            let name = PathBuf::from(abs.file_name().unwrap_or_default());
+            if !declared.contains(&name) {
+                delete_path(&abs, file_ops, dir_manager).map_err(|e| {
+                    FileSystemEntriesError(format!("deleting {}: {e}", abs.display()))
+                })?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -211,45 +166,6 @@ impl SharedFileSystem {
         }
         Ok(())
     }
-}
-
-/// Walks `dir` on disk and deletes every item whose single-component name is absent from
-/// `declared`. Persistent `Dir` entries are skipped entirely, their contents are agent-managed.
-/// Non-persistent `Dir` entries are recursed into. `DirContentFromMap` dirs are skipped,
-/// their cleanup is owned by `write()`, which deletes and recreates the directory.
-fn prune_undeclared(
-    dir: &Path,
-    declared: &HashMap<PathBuf, &RenderedEntry>,
-    file_ops: &impl FileDeleter,
-    dir_manager: &impl DirectoryManager,
-) -> Result<(), FileSystemEntriesError> {
-    // list() returns an empty vec when the directory does not exist — no extra NotFound handling needed.
-    let children = dir_manager
-        .list(dir)
-        .map_err(|e| FileSystemEntriesError(format!("listing {}: {e}", dir.display())))?;
-    for abs in children {
-        let name = PathBuf::from(abs.file_name().unwrap_or_default());
-        match declared.get(&name) {
-            None => {
-                delete_path(&abs, file_ops, dir_manager).map_err(|e| {
-                    FileSystemEntriesError(format!("deleting {}: {e}", abs.display()))
-                })?;
-            }
-            Some(entry) => match *entry {
-                // Skip. write() owns the on-disk state for these entries.
-                RenderedEntry::File { .. } | RenderedEntry::DirContentFromMap { .. } => {}
-                RenderedEntry::Dir {
-                    persistent: true, ..
-                } => {}
-                RenderedEntry::Dir { children, .. } => {
-                    let child_refs: HashMap<PathBuf, &RenderedEntry> =
-                        children.iter().map(|(k, v)| (k.clone(), v)).collect();
-                    prune_undeclared(&abs, &child_refs, file_ops, dir_manager)?;
-                }
-            },
-        }
-    }
-    Ok(())
 }
 
 /// Creates `dir` (and any missing parents), with error context. Safe if it already exists.
@@ -339,41 +255,192 @@ mod tests {
         }
     }
 
-    fn file_entry(persistent: bool) -> RenderedEntry {
+    fn file_entry_with_text(text: &str) -> RenderedEntry {
         RenderedEntry::File {
-            content: FileContent::Text("x".into()),
-            persistent,
+            content: FileContent::Text(text.into()),
         }
     }
 
-    fn dir_entry(persistent: bool, children: HashMap<PathBuf, RenderedEntry>) -> RenderedEntry {
-        RenderedEntry::Dir {
-            children,
-            persistent,
+    fn file_entry_copy(source: PathBuf) -> RenderedEntry {
+        RenderedEntry::File {
+            content: FileContent::Copy(source),
         }
+    }
+
+    fn dir_entry(children: HashMap<PathBuf, RenderedEntry>) -> RenderedEntry {
+        RenderedEntry::Dir { children }
     }
 
     fn map_dir_entry(files: HashMap<PathBuf, String>) -> RenderedEntry {
         RenderedEntry::DirContentFromMap { files }
     }
 
-    fn fs_with(entries: HashMap<PathBuf, RenderedEntry>) -> FileSystem {
-        FileSystem::new(entries)
+    #[test]
+    fn write_creates_file_with_text_content_and_missing_parent_dir() {
+        let tmp = TempDir::new().unwrap();
+        let target_dir = tmp.path().join("does-not-exist-yet");
+        let target_path = target_dir.join("file.txt");
+
+        let fs = FileSystem::new(HashMap::from([(
+            target_path.clone(),
+            file_entry_with_text("hello"),
+        )]));
+        fs.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert!(target_dir.is_dir(), "missing parent dir must be created");
+        assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "hello");
     }
 
-    /// Undeclared top-level file is deleted; declared file is kept.
     #[test]
-    fn delete_not_declared_removes_undeclared_top_level_file() {
+    fn write_copies_file_content_from_source() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.bin");
+        let source_bytes = [0xFFu8, 0x00, b'b', b'i', b'n'];
+        std::fs::write(&source, source_bytes).unwrap();
+
+        let target_path = tmp.path().join("does-not-exist-yet").join("dest.bin");
+        let fs = FileSystem::new(HashMap::from([(
+            target_path.clone(),
+            file_entry_copy(source),
+        )]));
+        fs.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert_eq!(std::fs::read(&target_path).unwrap(), source_bytes);
+    }
+
+    #[test]
+    fn write_creates_dir_and_recurses_into_children() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        let fs = FileSystem::new(HashMap::from([(
+            base.join("parent"),
+            dir_entry(HashMap::from([
+                (PathBuf::from("child.txt"), file_entry_with_text("child")),
+                (PathBuf::from("empty-nested"), dir_entry(HashMap::new())),
+            ])),
+        )]));
+        fs.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(base.join("parent/child.txt")).unwrap(),
+            "child"
+        );
+        assert!(base.join("parent/empty-nested").is_dir());
+    }
+
+    #[test]
+    fn write_dir_content_from_map_creates_files_from_map() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        let fs = FileSystem::new(HashMap::from([(
+            base.join("logging.d"),
+            map_dir_entry(HashMap::from([
+                (PathBuf::from("a.yaml"), "a-content".to_string()),
+                (PathBuf::from("b.yaml"), "b-content".to_string()),
+            ])),
+        )]));
+        fs.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(base.join("logging.d/a.yaml")).unwrap(),
+            "a-content"
+        );
+        assert_eq!(
+            std::fs::read_to_string(base.join("logging.d/b.yaml")).unwrap(),
+            "b-content"
+        );
+    }
+
+    #[test]
+    fn write_dir_content_from_map_creates_dir_when_map_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        let fs = FileSystem::new(HashMap::from([(
+            base.join("logging.d"),
+            map_dir_entry(HashMap::new()),
+        )]));
+        fs.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert!(base.join("logging.d").is_dir());
+    }
+
+    #[test]
+    fn write_dir_content_from_map_clears_directory_before_rewrite() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        let first = FileSystem::new(HashMap::from([(
+            base.join("logging.d"),
+            map_dir_entry(HashMap::from([(
+                PathBuf::from("a.yaml"),
+                "a-content".to_string(),
+            )])),
+        )]));
+        first.write(&LocalFile, &DirectoryManagerFs).unwrap();
+        // Content that lands in the directory by other means (e.g. the agent process) is not
+        // tracked by the map, but is still cleared: the whole directory is wiped before rewrite.
+        std::fs::write(base.join("logging.d/untracked.txt"), "stray").unwrap();
+
+        let second = FileSystem::new(HashMap::from([(
+            base.join("logging.d"),
+            map_dir_entry(HashMap::from([(
+                PathBuf::from("b.yaml"),
+                "b-content".to_string(),
+            )])),
+        )]));
+        second.write(&LocalFile, &DirectoryManagerFs).unwrap();
+
+        assert!(
+            !base.join("logging.d/a.yaml").exists(),
+            "key dropped from the map must be gone"
+        );
+        assert!(
+            !base.join("logging.d/untracked.txt").exists(),
+            "untracked content must be gone: the directory is cleared before rewrite"
+        );
+        assert_eq!(
+            std::fs::read_to_string(base.join("logging.d/b.yaml")).unwrap(),
+            "b-content"
+        );
+    }
+
+    /// Writing a `File` entry at a path that already holds different content overwrites it.
+    #[test]
+    fn write_overwrites_previously_written_file_content() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("file.txt");
+
+        FileSystem::new(HashMap::from([(path.clone(), file_entry_with_text("v1"))]))
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+        FileSystem::new(HashMap::from([(path.clone(), file_entry_with_text("v2"))]))
+            .write(&LocalFile, &DirectoryManagerFs)
+            .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v2");
+    }
+
+    #[test]
+    fn delete_not_declared_removes_undeclared() {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path();
 
         std::fs::write(base.join("declared.yaml"), "d").unwrap();
         std::fs::write(base.join("undeclared.yaml"), "u").unwrap();
 
-        let fs = fs_with(HashMap::from([(
-            base.join("declared.yaml"),
-            file_entry(false),
-        )]));
+        std::fs::create_dir(base.join("declared-dir")).unwrap();
+        std::fs::write(base.join("declared-dir/inner.txt"), "inner").unwrap();
+
+        std::fs::create_dir(base.join("undeclared-dir")).unwrap();
+        std::fs::write(base.join("undeclared-dir/inner.txt"), "inner").unwrap();
+
+        let fs = FileSystem::new(HashMap::from([
+            (base.join("declared.yaml"), file_entry_with_text("x")),
+            (base.join("declared-dir"), dir_entry(HashMap::new())),
+        ]));
 
         fs.delete_not_declared(&LocalFile, &DirectoryManagerFs)
             .unwrap();
@@ -386,67 +453,17 @@ mod tests {
             !base.join("undeclared.yaml").exists(),
             "undeclared file must be deleted"
         );
-    }
-
-    /// Undeclared files inside a non-persistent declared dir are deleted; declared children kept.
-    #[test]
-    fn delete_not_declared_recurses_into_non_persistent_dir() {
-        let tmp = TempDir::new().unwrap();
-        let base = tmp.path();
-        std::fs::create_dir(base.join("config")).unwrap();
-        std::fs::write(base.join("config/declared.yaml"), "d").unwrap();
-        std::fs::write(base.join("config/runtime.log"), "r").unwrap();
-
-        let fs = fs_with(HashMap::from([(
-            base.join("config"),
-            dir_entry(
-                false,
-                HashMap::from([(PathBuf::from("declared.yaml"), file_entry(false))]),
-            ),
-        )]));
-
-        fs.delete_not_declared(&LocalFile, &DirectoryManagerFs)
-            .unwrap();
-
         assert!(
-            base.join("config/declared.yaml").exists(),
-            "declared child must be kept"
+            base.join("declared-dir/inner.txt").exists(),
+            "a file inside a declared dir must be kept, even though it isn't itself declared"
         );
         assert!(
-            !base.join("config/runtime.log").exists(),
-            "undeclared child must be deleted"
+            !base.join("undeclared-dir").exists(),
+            "an undeclared dir, and everything inside it, must be deleted"
         );
     }
 
-    /// Nothing inside a persistent declared dir is touched, even if undeclared.
-    #[test]
-    fn delete_not_declared_skips_persistent_dir_contents() {
-        let tmp = TempDir::new().unwrap();
-        let base = tmp.path();
-        std::fs::create_dir(base.join("data")).unwrap();
-        std::fs::write(base.join("data/agent-state.db"), "state").unwrap();
-        std::fs::write(base.join("data/undeclared-but-inside-persistent.txt"), "x").unwrap();
-
-        let fs = fs_with(HashMap::from([(
-            base.join("data"),
-            dir_entry(true, HashMap::new()),
-        )]));
-
-        fs.delete_not_declared(&LocalFile, &DirectoryManagerFs)
-            .unwrap();
-
-        assert!(
-            base.join("data/agent-state.db").exists(),
-            "contents of persistent dir must be kept"
-        );
-        assert!(
-            base.join("data/undeclared-but-inside-persistent.txt")
-                .exists(),
-            "undeclared files inside persistent dir must be kept"
-        );
-    }
-
-    /// DirContentFromMap dirs are skipped by delete_not_declared, write() owns their cleanup.
+    /// DirContentFromMap dirs contents are skipped by delete_not_declared, write() owns their cleanup.
     #[test]
     fn delete_not_declared_skips_map_dir_contents() {
         let tmp = TempDir::new().unwrap();
@@ -455,7 +472,7 @@ mod tests {
         std::fs::write(base.join("logging.d/syslog.yaml"), "sys").unwrap();
         std::fs::write(base.join("logging.d/stale.yaml"), "stale").unwrap();
 
-        let fs = fs_with(HashMap::from([(
+        let fs = FileSystem::new(HashMap::from([(
             base.join("logging.d"),
             map_dir_entry(HashMap::from([(
                 PathBuf::from("syslog.yaml"),

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -202,22 +202,13 @@ where
             onhost_config.shared_filesystem,
         );
 
-        // No explicit file deletion is needed on apply: spin_up re-renders the filesystem. Its
-        // `delete_ephemeral` freshens ephemeral state before `write` materializes the declared tree.
         let new_started_supervisor = starter.spin_up(internal_publisher)?;
 
         Ok(new_started_supervisor)
     }
 
     fn stop(self) -> Result<(), ThreadContextStopperError> {
-        let stop_result = stop_supervisor_threads(self.thread_contexts);
-        if let Err(err) = self
-            .filesystem
-            .delete_ephemeral(&LocalFile, &DirectoryManagerFs)
-        {
-            warn!(?err, "filesystem ephemeral cleanup failed on stop");
-        }
-        stop_result
+        stop_supervisor_threads(self.thread_contexts)
     }
 }
 
@@ -347,15 +338,7 @@ where
     ) -> Result<StartedSupervisorOnHost<PM>, SupervisorError> {
         let (health_publisher, health_consumer) = pub_sub();
 
-        // Ensure all ephemeral entries are removed before start in case it didn't work on stop.
-        if let Err(err) = self
-            .filesystem
-            .delete_ephemeral(&LocalFile, &DirectoryManagerFs)
-        {
-            warn!(?err, "filesystem: ephemeral cleanup failed on start");
-        }
-
-        // Ensure all non-declared files and dirs not on a declared persistent dir are deleted.
+        // Ensure all top-level non-declared files and dirs are deleted.
         if let Err(err) = self
             .filesystem
             .delete_not_declared(&LocalFile, &DirectoryManagerFs)
@@ -928,81 +911,14 @@ pub mod tests {
     }
 
     #[test]
-    fn test_stop_runs_filesystem_delete_ephemeral() {
+    fn test_start_deletes_undeclared_entries() {
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let yaml = r#"
-ephemeral.txt:
+declared.txt:
   kind: file
-  text: e
-persistent.txt:
-  kind: file
-  text: p
-  persistent: true
-"#;
-        let variables = Variables::from_iter(vec![(
-            Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
-            Variable::new_final_string_variable(tmp_dir.path().to_string_lossy()),
-        )]);
-        let filesystem = serde_saphyr::from_str::<ParsedFileSystem>(yaml)
-            .unwrap()
-            .template_with(&variables)
-            .unwrap();
-
-        let agent_identity = AgentIdentity::from((
-            "stop-test-agent".to_owned().try_into().unwrap(),
-            AgentTypeID::try_from("ns/test:0.1.2").unwrap(),
-        ));
-
-        let supervisor = NotStartedSupervisorOnHost::new(
-            agent_identity,
-            vec![],
-            None,
-            get_empty_packages(),
-            None,
-            MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
-            filesystem,
-            SharedFileSystem::test_empty(),
-        );
-
-        let (publisher, _consumer) = pub_sub();
-        let started = supervisor.start(publisher).expect("start");
-
-        let ephemeral_path = tmp_dir.path().join("ephemeral.txt");
-        let persistent_path = tmp_dir.path().join("persistent.txt");
-        assert!(
-            ephemeral_path.exists(),
-            "spin_up should have written ephemeral.txt"
-        );
-        assert!(
-            persistent_path.exists(),
-            "spin_up should have written persistent.txt"
-        );
-
-        let stop_result = started.stop();
-        assert!(stop_result.is_ok(), "stop should succeed: {stop_result:?}");
-
-        assert!(
-            !ephemeral_path.exists(),
-            "stop should have removed the ephemeral file"
-        );
-        assert!(
-            persistent_path.exists(),
-            "stop should have left the persistent file alone"
-        );
-    }
-
-    #[test]
-    fn test_start_resets_ephemeral_entries_before_write() {
-        let tmp_dir = tempfile::TempDir::new().unwrap();
-        let yaml = r#"
-ephemeral-dir:
+  text: d
+declared-dir:
   kind: dir
-persistent.txt:
-  kind: file
-  text: p
-  persistent: true
 "#;
         let variables = Variables::from_iter(vec![(
             Namespace::SubAgent.namespaced_name(AgentAttributes::VARIABLE_FILESYSTEM_AGENT_DIR),
@@ -1013,12 +929,19 @@ persistent.txt:
             .template_with(&variables)
             .unwrap();
 
-        // Simulate leftover state from an ungraceful previous run (stop-time cleanup skipped):
-        // an agent-created file inside the ephemeral dir.
-        let stale_file = tmp_dir.path().join("ephemeral-dir").join("stale.txt");
-        fs::create_dir_all(stale_file.parent().unwrap()).unwrap();
-        fs::write(&stale_file, "stale").unwrap();
-        assert!(stale_file.exists());
+        // Simulate a leftover file from a previous agent-type version that no longer declares it.
+        let undeclared_path = tmp_dir.path().join("undeclared.txt");
+        fs::write(&undeclared_path, "stale").unwrap();
+
+        // Content nested inside a declared dir is never pruned, no matter how deep, since
+        // delete_not_declared only reclaims top-level undeclared paths.
+        let nested_path = tmp_dir
+            .path()
+            .join("declared-dir")
+            .join("some-sub-dir")
+            .join("some-file.txt");
+        fs::create_dir_all(nested_path.parent().unwrap()).unwrap();
+        fs::write(&nested_path, "nested").unwrap();
 
         let agent_identity = AgentIdentity::from((
             "start-test-agent".to_owned().try_into().unwrap(),
@@ -1040,14 +963,18 @@ persistent.txt:
         let (publisher, _consumer) = pub_sub();
         let started = supervisor.start(publisher).expect("start");
 
-        // The ephemeral dir is wiped before the write, so leftover content is gone; the dir itself
-        // is re-created by the write, and the persistent entry is present.
         assert!(
-            !stale_file.exists(),
-            "startup should have removed stale content from the ephemeral dir"
+            !undeclared_path.exists(),
+            "start should have removed the undeclared top-level file"
         );
-        assert!(tmp_dir.path().join("ephemeral-dir").is_dir());
-        assert!(tmp_dir.path().join("persistent.txt").exists());
+        assert!(
+            tmp_dir.path().join("declared.txt").exists(),
+            "start should have written the declared file"
+        );
+        assert!(
+            nested_path.exists(),
+            "content nested inside a declared dir must survive, declared or not"
+        );
 
         let _ = started.stop();
     }

--- a/agent-control/tests/on_host/scenarios/filesystem_ops.rs
+++ b/agent-control/tests/on_host/scenarios/filesystem_ops.rs
@@ -316,35 +316,26 @@ deployment:
   filesystem:
     config:
       kind: dir
-      persistent: true
       entries:
         newrelic-infra.yaml:
           kind: file
-          persistent: true
           text: |-
             ${{nr-var:config_agent}}
     logging.d:
       kind: dir
-      persistent: true
       entries:
         logging.yaml:
           kind: file
-          persistent: true
           text: |-
             ${{nr-var:config_logging}}
-    # This directory needs to persist across restarts for the infra agent. Every level down to
-    # the leaf must be persistent: an ephemeral ancestor is wiped (with its whole subtree) on stop.
     newrelic-infra:
       kind: dir
-      persistent: true
       entries:
         newrelic-integrations:
           kind: dir
-          persistent: true
           entries:
             logging:
               kind: dir
-              persistent: true
 "#,
         ),
         dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
@@ -480,84 +471,4 @@ fn read_file_and_expect_content(
             e
         )),
     }
-}
-
-#[test]
-fn ephemeral_entries_wiped_on_stop() {
-    let opamp_server = FakeServer::start(tokio_runtime().handle());
-
-    let dirs = TempBasePaths::default();
-
-    let agent_id = "ephemeral-agent";
-
-    create_file(
-        format!(
-            r#"
-namespace: test
-name: ephemeral
-version: 0.0.0
-platform: host
-operating_system: {AGENT_CONTROL_MODE_ON_HOST}
-protocol_version: "1.0"
-variables: {{}}
-deployment:
-  filesystem:
-    ephemeral.txt:
-      kind: file
-      text: "ephemeral content"
-    persistent.txt:
-      kind: file
-      persistent: true
-      text: "persistent content"
-"#,
-        ),
-        dirs.local_dir().join(DYNAMIC_AGENT_TYPE_FILENAME),
-    );
-
-    OnHostAgentControlConfigBuilder::new(opamp_server.endpoint(), opamp_server.jwks_endpoint())
-        .with_agents(format!(
-            "\n  {agent_id}:\n    agent_type: \"test/ephemeral:0.0.0\"\n"
-        ))
-        .write(dirs.local_dir());
-    create_local_config(
-        agent_id.to_string(),
-        NO_CONFIG.to_string(),
-        dirs.local_dir(),
-    );
-
-    let base_paths = dirs.base_paths();
-
-    let ephemeral_path = base_paths
-        .remote_dir
-        .join(AGENT_FILESYSTEM_FOLDER_NAME)
-        .join(agent_id)
-        .join("ephemeral.txt");
-    let persistent_path = base_paths
-        .remote_dir
-        .join(AGENT_FILESYSTEM_FOLDER_NAME)
-        .join(agent_id)
-        .join("persistent.txt");
-
-    {
-        let _agent_control =
-            start_agent_control_with_custom_config(base_paths.clone(), AGENT_CONTROL_MODE_ON_HOST);
-
-        retry(30, Duration::from_secs(1), || {
-            read_file_and_expect_content(&ephemeral_path, "ephemeral content")?;
-            read_file_and_expect_content(&persistent_path, "persistent content")?;
-            Ok(())
-        });
-    }
-    // After AC drops the supervisor calls delete_ephemeral.
-    retry(30, Duration::from_secs(1), || {
-        if ephemeral_path.exists() {
-            return Err(format!("ephemeral file still on disk: {ephemeral_path:?}").into());
-        }
-        if !persistent_path.exists() {
-            return Err(
-                format!("persistent file should still be present: {persistent_path:?}").into(),
-            );
-        }
-        Ok(())
-    });
 }

--- a/docs/AC_repositories_and_files.md
+++ b/docs/AC_repositories_and_files.md
@@ -24,9 +24,8 @@ The remote configurations and in general any files expected to dynamically chang
 - The remote configurations, the hash and its state of AC and each sub-agent are stored in their respective subfolder inside `fleet-data`, in a file named `remote_config.yaml`.
 - On the other hand, host identifiers and the agent ULID are store in `instance_id.yaml`.
  - Moreover, `filesystem` is the directory where Agent Control renders each sub-agent's declared files. An agent may also write
-its own files here; these survive restarts **unless they live inside a directory AC declared as ephemeral** (the default), which AC
-wipes on stop and before each re-render. To keep agent-created data across restarts, place it under a `persistent` directory or a path
-AC doesn't manage. See [Persistence in Filesystem](./INTEGRATING_AGENTS.md#persistence-in-filesystem).
+its own files here; these always survive restarts, except inside a `dir_content_from_map` directory, which is fully deleted and
+re-rendered on every write. See [Filesystem entry lifecycle](./INTEGRATING_AGENTS.md#filesystem-entry-lifecycle).
 - `shared-filesystem` is a directory shared across all sub-agents (not suffixed per agent) where an agent type's `shared_filesystem`
 entries are written, so other sub-agents (e.g. the infrastructure agent) can read them. See [`shared_filesystem`](./INTEGRATING_AGENTS.md#shared_filesystem).
 

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -418,13 +418,11 @@ And this `filesystem` block:
 filesystem:
   newrelic-infra.yaml:
     kind: file
-    persistent: true
     text: |
       ${nr-var:config_agent}
 
   config:
     kind: dir
-    persistent: true
 
   logging.d:
     kind: dir_content_from_map
@@ -435,7 +433,6 @@ filesystem:
     entries:
       data:
         kind: dir
-        persistent: true
       newrelic-infra.yaml:
         kind: file
         text: |
@@ -461,19 +458,19 @@ config_logging:
 
 The runtime produces the following on disk under `${nr-sub:filesystem_agent_dir}`. Each kind is shown in isolation.
 
-**`kind: file`**: single file rendered from the templated `text:` field. `persistent: true` keeps it across agent-control stop and restarts.
+**`kind: file`**: single file rendered from the templated `text:` field. It survives agent-control stop and restart.
 
 ```
 newrelic-infra.yaml      ← contents from ${nr-var:config_agent}
 ```
 
-**`kind: dir`**: an explicitly declared directory. With no `entries:` it's just an (optionally persistent) empty directory; with `entries:` it builds a tree, where each child is itself any of the three kinds, including another `dir`, so recursion is uniform.
+**`kind: dir`**: an explicitly declared directory. With no `entries:` it's just an empty directory; with `entries:` it builds a tree, where each child is itself any of the three kinds, including another `dir`, so recursion is uniform.
 
 ```
-config/                  ← empty, persistent
+config/                  ← empty
 
 agent/
-├── data/                ← empty, persistent
+├── data/                ← empty
 └── newrelic-infra.yaml  ← contents from ${nr-var:config_agent}
 ```
 
@@ -493,7 +490,6 @@ logging.d/
 | `kind`           | yes      | —       | Must be `file`.                                                                                                  |
 | `text`           | *        | —       | Inline file body. May reference `${nr-var:…}` / `${nr-sub:…}`. Mutually exclusive with `copy_from_file`.         |
 | `copy_from_file` | *        | —       | Path of a source file whose bytes are copied into this entry (e.g. a binary from a package dir). Mutually exclusive with `text`. |
-| `persistent`     | no       | `false` | If `true`, survives sub-agent stop/restart.                                                                     |
 
 *Exactly one of `text` or `copy_from_file` is required. `copy_from_file` copies the source byte-for-byte, preserving its permissions (e.g. the executable bit on Unix), and its source must resolve to a path within `${nr-sub:remote_dir}`.
 
@@ -503,7 +499,6 @@ logging.d/
 |--------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `kind`       | yes      | —       | Must be `dir`.                                                                                                                                             |
 | `entries`    | no       | `{}`    | Map of child entries (any kind). Recursive. Each key must be a single path segment, not a sub-path.                                                        |
-| `persistent` | no       | `false` | If `true`, this directory survives stop/restart. Not inherited, each child is judged by its own `persistent` flag (see [Persistence](#persistence-in-filesystem)). |
 
 **`dir_content_from_map`** — a directory whose set of files is computed at deploy time from a `map[string]yaml` variable. The map's keys become filenames; the values become file contents.
 
@@ -512,31 +507,15 @@ logging.d/
 | `kind`       | yes      | —       | Must be `dir_content_from_map`.                                                                                        |
 | `source`     | yes      | —       | Reference to a `map[string]yaml` variable (`${nr-var:…}`).                                                             |
 
-##### Persistence in Filesystem
+##### Filesystem entry lifecycle
 
-Every `file` and `dir` entry accepts a boolean `persistent:` (default `false`). The `persistent` flag controls whether the entry's on-disk path is wiped when the tree is cleaned: on sub-agent stop, and just before every (re)write of the tree (start, restart, and config apply). Ephemeral entries are wiped at those points; persistent entries are kept. Wiping before each write means leftover ephemeral content never carries across — even after an ungraceful shutdown (crash/SIGKILL) that skipped the stop-time cleanup.
+Every `file` and `dir` entry survives sub-agent stop, restart, and config-apply: nothing is wiped at those points. `write` only ever overwrites the paths it declares; it never touches anything else on disk, so agent-process-created files (declared or not) are left alone.
 
-**`persistent` applies per entry and does not cascade to children.** When cleaning (on stop, and before each (re)write), cleanup walks the declared tree: a persistent entry is kept and the walk descends into its children, while an ephemeral entry is deleted together with its entire on-disk subtree (a recursive `remove_dir_all`, which stops the walk there). So a nested path survives cleanup only if **every declared node on the path is `persistent: true`**.
+**`dir_content_from_map` is the one exception**: instead of reconciling individual files like a `dir`, its whole directory is treated as a single unit, fully derived from its `map[string]yaml` variable. Every write deletes the directory and recreates it from the current map, rather than merging changes into what's already there. Like a `file: text` entry, its on-disk content is entirely determined by the current variable value, so unchanged variables produce the exact same files across a stop, restart, or config-apply, and a key removed from the map is gone after the next write. Unlike `file`/`dir`, though, this reconciliation is unconditional: any content that lands in the directory by other means (for example, the agent process writing into it) is wiped on every write too, not only when the map itself changes.
 
-**An entry removed from the agent type while the sub-agent is stopped is not reclaimed.** Cleanup only ever walks the *currently declared* tree, so a path that is no longer declared is kept on disk if its parent is persistent, even if it used to be ephemeral.
+**On start, Agent Control reclaims top-level paths that are no longer declared at all** under the sub-agent's filesystem directory. Declared `dir`'s contents are kept.
 
-**`dir_content_from_map` has no `persistent` flag.** Agent Control re-renders the projected files on every write, so it is always ephemeral. A `persistent:` key left in the YAML is silently ignored, so older configs still parse.
-
-###### Lifecycle
-
-- **Ephemeral (`persistent: false`, default).** Wiped on sub-agent stop, and again just before every (re)write of the tree (start, restart, config apply); the declared entry itself is then re-created by the write. Leftover content (including files the agent created inside an ephemeral directory) never carries across a restart, even an ungraceful one.
-- **Persistent (`persistent: true`).** Kept on stop and across (re)writes; only `write` re-renders its declared content.
-- **Removed from fleet.** When an agent is removed from the fleet config (via remote config or by being absent at AC startup after a previous deploy), its entire filesystem directory is deleted by `ResourceCleaner`. The `persistent` flag is bypassed.
-
-| Event              | Ephemeral (`persistent: false`)                 | Persistent (`persistent: true`)           |
-|--------------------|-------------------------------------------------|-------------------------------------------|
-| Agent start        | Wiped, then write                               | Kept; write                               |
-| Agent stop         | Path deleted                                    | Path kept                                 |
-| Agent restart      | Wiped, then write                               | Kept; write                               |
-| Config update      | Wiped, then write                               | Kept; write                               |
-| Removed from fleet | Filesystem dir deleted by ResourceCleaner       | Filesystem dir deleted by ResourceCleaner |
-
-Agent-process-created files are never declared, so `write` leaves them untouched **except** files inside an *ephemeral* directory, which are wiped along with it on stop and before each (re)write. To keep agent-created content across restarts, place it under a `persistent` directory.
+**Removed from fleet.** When an agent is removed from the fleet config (via remote config or by being absent at AC startup after a previous deploy), its entire filesystem directory is deleted by `ResourceCleaner`, regardless of what it contains.
 
 ##### `shared_filesystem`
 


### PR DESCRIPTION
## Summary

This PR removes the `persistent:` field from on-host `file`/`dir` filesystem entries. Declared filesystem entries now always survive sub-agent stop, restart, and config-apply, instead of requiring every entry down a branch to opt in with `persistent: true`. There was no known use case for the `persistent: false` and removing the field prevents some potential footguns (the expected behavior when persistent/non-persistent elements were nested was hard to understand.

## Changes

- Drop support for `persistent: field` and remove the corresponding validators.
- Simplify `delete_not_declared` to apply only on top-level elements (everything else persist over restarts)
- Update the corresponding Agent Types to remove the `persistent` field.
- Improve unit test coverage for filesystem related operations.
