### PR TITLE
feat: add alert to ensure logs are produced on canaries

### DIFF
--- a/test/k8s-canaries/Makefile
+++ b/test/k8s-canaries/Makefile
@@ -119,6 +119,7 @@ endif
     --set agentControlDeployment.chartValues.config.override.self_instrumentation.opentelemetry.custom_attributes."label\.app\.kubernetes\.io/name"=agent-control \
     --set agentControlDeployment.chartValues.config.override.self_instrumentation.opentelemetry.endpoint="$(OTLP_ENDPOINT)" \
     --set agentControlDeployment.chartValues.config.override.self_instrumentation.opentelemetry.headers.api-key=$(NR_LICENSE_KEY) \
+    --set agentControlDeployment.chartValues.config.override.self_instrumentation.opentelemetry.logs.enabled=true \
     --set agentControlDeployment.chartValues.config.fleet_control.fleet_id="$(FLEET_ID)" \
     --set agentControlDeployment.chartValues.systemIdentity.create=false \
     --set agentControlDeployment.chartValues.systemIdentity.secretName="sys-identity" \

--- a/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
@@ -1,4 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE cluster_name = '${instance_id}'
-AND entity.name = 'agent-control-self-instrumentation'
+AND service.name = 'agent-control-self-instrumentation'

--- a/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
@@ -1,0 +1,3 @@
+SELECT count(*)
+FROM Log
+WHERE cluster_name = '${instance_id}'

--- a/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/production/alert_nrql_templates/log_presence.tftpl
@@ -1,3 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE cluster_name = '${instance_id}'
+AND entity.name = 'agent-control-self-instrumentation'

--- a/test/k8s-canaries/terraform/production/main.tf
+++ b/test/k8s-canaries/terraform/production/main.tf
@@ -102,5 +102,14 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
+    {
+      # Fires if no self-instrumentation logs are received in a 10-minute window.
+      name               = "Self-instrumentation logs presence"
+      threshold          = 0
+      duration           = 600
+      aggregation_window = 600
+      operator           = "below_or_equals"
+      template_name      = "./alert_nrql_templates/log_presence.tftpl"
+    },
   ]
 }

--- a/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
@@ -1,4 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE cluster_name = '${instance_id}'
-AND entity.name = 'agent-control-self-instrumentation'
+AND service.name = 'agent-control-self-instrumentation'

--- a/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
@@ -1,0 +1,3 @@
+SELECT count(*)
+FROM Log
+WHERE cluster_name = '${instance_id}'

--- a/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
+++ b/test/k8s-canaries/terraform/staging/alert_nrql_templates/log_presence.tftpl
@@ -1,3 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE cluster_name = '${instance_id}'
+AND entity.name = 'agent-control-self-instrumentation'

--- a/test/k8s-canaries/terraform/staging/main.tf
+++ b/test/k8s-canaries/terraform/staging/main.tf
@@ -103,6 +103,15 @@ module "alerts" {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
+    {
+      # Fires if no self-instrumentation logs are received in a 10-minute window.
+      name               = "Self-instrumentation logs presence"
+      threshold          = 0
+      duration           = 600
+      aggregation_window = 600
+      operator           = "below_or_equals"
+      template_name      = "./alert_nrql_templates/log_presence.tftpl"
+    },
   ]
 }
 

--- a/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
+++ b/test/onhost-canaries/ansible/install_ac_with_basic_config.yml
@@ -75,6 +75,8 @@
                 api-key: "{{ nr_license_key }}"
               logs:
                 enabled: true
+              custom_attributes:
+                host.name: "{{ inventory_hostname }}"
           agents:
             infra:
               agent_type: "newrelic/com.newrelic.infrastructure:0.1.0"

--- a/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
@@ -1,0 +1,3 @@
+SELECT count(*)
+FROM Log
+WHERE `host.name` = '${instance_id}'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
@@ -1,4 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE `host.name` = '${instance_id}'
-AND entity.name = 'agent-control-self-instrumentation'
+AND service.name = 'agent-control-self-instrumentation'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/log_presence.tftpl
@@ -1,3 +1,4 @@
 SELECT count(*)
 FROM Log
 WHERE `host.name` = '${instance_id}'
+AND entity.name = 'agent-control-self-instrumentation'

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -120,6 +120,16 @@ locals {
       operator      = "below_or_equals"
       template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
     },
+    {
+      # Fires if no self-instrumentation logs are received in a 10-minute window,
+      # which indicates AC has stopped emitting OTel logs (crash, misconfiguration, etc.).
+      name               = "Self-instrumentation logs presence"
+      threshold          = 0
+      duration           = 600
+      aggregation_window = 600
+      operator           = "below_or_equals"
+      template_name      = "./alert_nrql_templates/log_presence.tftpl"
+    },
   ]
 
   // Platform-specific memory conditions.


### PR DESCRIPTION
- Label onhost canaries logs.
- Add alert both for k8s and onhost canaries to check logs are sent.

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
