### PR TITLE
feat(k8s-infra): reduce number of variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Remember that the keywords that you can use are the following:
 - On-host self-update: skip sub-agent reconciliation when a self-update is in progress. When a single remote config both bumps the Agent Control version and changes a sub-agent's `agent_type`, the changed sub-agent is no longer recreated moments before the process restarts; the new config is stored and re-applied cleanly by the restarted process, avoiding a redundant sub-agent restart and telemetry gap.
 - On-host agent-type parsing now rejects a filesystem entry marked `persistent: true` when a parent directory is not persistent. A non-persistent parent is deleted recursively on sub-agent stop and would take the persistent child with it, so the whole parent chain must be declared `persistent: true`.
 - On-host health config: replaced the flat `health.http:` / `health.file:` fields with an explicit `checks:` list. Each entry is discriminated by `kind:` (`Process`, `Http`, or `File`). The previously implicit supervised-process health check is now declared as `kind: Process`. An omitted or empty `checks:` list disables health reporting entirely.
+- K8s infra agent-type: the number of variables is reduced in a backward compatible way. This is useful to allow the customer to set a single file for the chart values.
+
 
 ## v1.18.0 - 2026-07-06
 

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.infrastructure-0.1.0.yaml
@@ -6,37 +6,10 @@ protocol_version: "1.0"
 variables:
   # HelmChart based sub agents should always have `chart_values`.
   chart_values:
-    # Chart values should always must go under a key that has the chart name.
-    # In this case there are multiple sub-charts so each key is the sub-chart name.
-    # chart_values:
-    #   <chart name>: {values of the sub chart}
-    #   global: {}
-    newrelic-infrastructure:
-      description: "newrelic-infrastructure chart values"
-      type: yaml
-      required: false
-      default: { }
-    nri-metadata-injection:
-      description: "nri-metadata-injection chart values"
-      type: yaml
-      required: false
-      default: { }
-    kube-state-metrics:
-      description: "kube-state-metrics chart values"
-      type: yaml
-      required: false
-      default: { }
-    nri-kube-events:
-      description: "nri-kube-events chart values"
-      type: yaml
-      required: false
-      default: { }
-    # Global values must have their own key, even if there is only one sub-chart.
-    global:
-      description: "Global chart values"
-      type: yaml
-      required: false
-      default: { }
+    description: "newrelic-infrastructure chart values"
+    type: yaml
+    required: false
+    default: { }
   # HelmChart based sub agents should always have `chart_version`.
   chart_version:
     description: "nri-bundle chart version"
@@ -129,16 +102,7 @@ deployment:
             verboseLog: ${nr-env:NR_VERBOSE_LOG}
         # These values are the ones that are expected to be configured by the user.
         values.yaml: |
-          newrelic-infrastructure: 
-            ${nr-var:chart_values.newrelic-infrastructure | indent 2}
-          nri-metadata-injection: 
-            ${nr-var:chart_values.nri-metadata-injection | indent 2}
-          kube-state-metrics: 
-            ${nr-var:chart_values.kube-state-metrics | indent 2}
-          nri-kube-events: 
-            ${nr-var:chart_values.nri-kube-events | indent 2}
-          global: 
-            ${nr-var:chart_values.global | indent 2}
+          ${nr-var:chart_values}
         # The rest of nri-bundle charts are explicitly disabled below.
         # Note: this needs to be in sync with nri-bundle's supported charts. If a new version of
         # nri-bundle included a new chart enabled by default, it needs to be disabled here.

--- a/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/kubernetes-com.newrelic.prometheus-0.1.0.yaml
@@ -32,7 +32,7 @@ variables:
       default: "https://newrelic.github.io/newrelic-prometheus-configurator"
       variants:
         ac_config_field: "chart_repository_urls"
-        values: ["https://newrelic.github.io/newrelic-prometheus-configurator"]
+        values: [ "https://newrelic.github.io/newrelic-prometheus-configurator" ]
     secret_reference:
       description: "HelmRepository secret reference (secretRef)"
       type: yaml
@@ -118,9 +118,11 @@ deployment:
           - kind: Secret
             name: values-${nr-sub:agent_id}
             valuesKey: default.yaml
-          - kind: Secret
-            name: values-${nr-sub:agent_id}
-            valuesKey: values.yaml
+          # Notice that the order matters, the values.yaml will
+          # override the global.yaml values if they are defined in both files.
           - kind: Secret
             name: values-${nr-sub:agent_id}
             valuesKey: global.yaml
+          - kind: Secret
+            name: values-${nr-sub:agent_id}
+            valuesKey: values.yaml

--- a/agent-control/src/opamp/remote_config.rs
+++ b/agent-control/src/opamp/remote_config.rs
@@ -1,6 +1,7 @@
 //! Remote configuration received via OpAMP: its model, configuration map, hashes, and validators.
 use crate::agent_control::agent_id::AgentID;
 use crate::opamp::remote_config::hash::ConfigState;
+use crate::opamp::remote_config::signature::ConfigID;
 use crate::opamp::remote_config::{hash::Hash, signature::SignatureData};
 use opamp_client::opamp::proto::{AgentConfigFile, AgentConfigMap, EffectiveConfig};
 use signature::Signatures;
@@ -140,7 +141,7 @@ impl OpampRemoteConfig {
 
 /// This structure represents the actual configuration values that are stored in the remote config.
 #[derive(Debug, Default, PartialEq, Clone)]
-pub struct ConfigurationMap(HashMap<String, String>);
+pub struct ConfigurationMap(HashMap<ConfigID, String>);
 
 impl ConfigurationMap {
     /// Creates a configuration map from the given key-value pairs.

--- a/agent-control/src/opamp/remote_config.rs
+++ b/agent-control/src/opamp/remote_config.rs
@@ -145,7 +145,7 @@ pub struct ConfigurationMap(HashMap<ConfigID, String>);
 
 impl ConfigurationMap {
     /// Creates a configuration map from the given key-value pairs.
-    pub fn new(config_map: HashMap<String, String>) -> Self {
+    pub fn new(config_map: HashMap<ConfigID, String>) -> Self {
         Self(config_map)
     }
 }
@@ -226,8 +226,8 @@ mod tests {
     ) {
         let opamp_config = testing_agent_config(config_map);
 
-        let result: HashMap<&String, &String> = opamp_config.agent_configs_iter().collect();
-        let expected: HashMap<String, String> = serde_json::from_value(expected).unwrap();
+        let result: HashMap<&ConfigID, &String> = opamp_config.agent_configs_iter().collect();
+        let expected: HashMap<ConfigID, String> = serde_json::from_value(expected).unwrap();
 
         assert_eq!(result.len(), expected.len());
         for (expected_key, expected_value) in &expected {


### PR DESCRIPTION
This is a draft PR to discuss a possible change on the nr-infra agentType.

I do see, if multiple configs as separate files becomes a thing, that we want to allow the user to set a single file for the whole chart_values instead of two.

The same change is not possible for the different agentTypes, this is not a big deal since we could still point to the inner variable and expose directly `chart_values.newrelic-prometheus-agent`