### PR TITLE
chore: add docker image make targets [NR-566516]

### DIFF
--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -82,41 +82,13 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
 
-      - name: Build and push images
-        if: ${{ inputs.push }}
+      - name: Build images (push=${{ inputs.push }})
         run: |
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME_AGENT_CONTROL:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control_cli \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
-
-      - name: Build images
-        if: ${{ ! inputs.push }}
-        run: |
-          docker buildx build \
-            --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME_AGENT_CONTROL:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
-          
-          docker buildx build \
-            --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control_cli \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
+          make image/agent-control image/agent-control-cli \
+            DOCKER_PLATFORMS=$DOCKER_PLATFORMS \
+            IMAGE_TAG=${{ inputs.image-tag }} \
+            PUSH=${{ inputs.push }} \
+            LOAD=false \
+            ATTEST=true \
+            DOCKER_IMAGE_NAME_AGENT_CONTROL=$DOCKER_IMAGE_NAME_AGENT_CONTROL \
+            DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI=$DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI

--- a/.github/workflows/on_demand_dhat_heap_image.yml
+++ b/.github/workflows/on_demand_dhat_heap_image.yml
@@ -77,11 +77,9 @@ jobs:
 
       - name: Build and push dhat-heap images
         run: |
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev:dhat-heap-${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
+          make image/agent-control \
+            DOCKER_PLATFORMS=$DOCKER_PLATFORMS \
+            IMAGE_TAG=dhat-heap-${{ inputs.image-tag }} \
+            PUSH=true \
+            ATTEST=true \
+            DOCKER_IMAGE_NAME_AGENT_CONTROL=ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev

--- a/.github/workflows/on_demand_push_internal_image.yml
+++ b/.github/workflows/on_demand_push_internal_image.yml
@@ -81,20 +81,11 @@ jobs:
 
       - name: Build and push images
         run: |
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
-          docker buildx build \
-            --push \
-            --platform=$DOCKER_PLATFORMS \
-            -t ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-cli-dev:${{ inputs.image-tag }} \
-            --file Dockerfiles/Dockerfile_agent_control_cli \
-            --attest type=provenance,mode=max \
-            --attest type=sbom \
-            .
+          make image/agent-control image/agent-control-cli \
+            DOCKER_PLATFORMS=$DOCKER_PLATFORMS \
+            IMAGE_TAG=${{ inputs.image-tag }} \
+            PUSH=true \
+            ATTEST=true \
+            DOCKER_IMAGE_NAME_AGENT_CONTROL=ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-dev \
+            DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI=ghcr.io/${{ github.repository_owner }}/newrelic-agent-control-cli-dev
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,59 @@ build-%:
 tilt-up:
 	tilt up ; tilt down
 
+##########################################
+# 		     Image targets 			 #
+##########################################
+DOCKER_IMAGE_NAME_AGENT_CONTROL ?= newrelic/newrelic-agent-control
+DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI ?= newrelic/newrelic-agent-control-cli
+DOCKER_PLATFORMS ?= linux/$(ARCH)
+IMAGE_TAG ?= local
+# PUSH pushes to the registry; LOAD loads into the local docker daemon instead
+# (single platform only). ATTEST attaches provenance/SBOM attestations, which
+# requires PUSH.
+PUSH ?= false
+LOAD ?= true
+ATTEST ?= false
+
+DOCKERFILE_AGENT_CONTROL := Dockerfiles/Dockerfile_agent_control
+DOCKERFILE_AGENT_CONTROL_CLI := Dockerfiles/Dockerfile_agent_control_cli
+
+ATTEST_FLAGS := --attest type=provenance,mode=max --attest type=sbom
+
+DOCKER_BUILD_OUTPUT_FLAG = $(if $(filter true,$(PUSH)),--push,$(if $(filter true,$(LOAD)),--load))
+DOCKER_BUILD_ATTEST_FLAGS = $(if $(filter true,$(ATTEST)),$(ATTEST_FLAGS))
+
+# Assumes the binaries for $(DOCKER_PLATFORMS) already exist under ./bin (e.g.
+# `make build-agent-control-k8s`). No build prerequisite on purpose, so CI can
+# call these directly without triggering a second, differently-configured
+# build. Use `make image` for a one-command local build.
+.PHONY: image/agent-control
+image/agent-control:
+	docker buildx build \
+		--platform=$(DOCKER_PLATFORMS) \
+		-t $(DOCKER_IMAGE_NAME_AGENT_CONTROL):$(IMAGE_TAG) \
+		--file $(DOCKERFILE_AGENT_CONTROL) \
+		$(DOCKER_BUILD_OUTPUT_FLAG) \
+		$(DOCKER_BUILD_ATTEST_FLAGS) \
+		.
+
+.PHONY: image/agent-control-cli
+image/agent-control-cli:
+	docker buildx build \
+		--platform=$(DOCKER_PLATFORMS) \
+		-t $(DOCKER_IMAGE_NAME_AGENT_CONTROL_CLI):$(IMAGE_TAG) \
+		--file $(DOCKERFILE_AGENT_CONTROL_CLI) \
+		$(DOCKER_BUILD_OUTPUT_FLAG) \
+		$(DOCKER_BUILD_ATTEST_FLAGS) \
+		.
+
+.PHONY: image
+image:
+	$(MAKE) build-agent-control-k8s
+	$(MAKE) build-agent-control-k8s-cli
+	$(MAKE) image/agent-control
+	$(MAKE) image/agent-control-cli
+
 COVERAGE_OUT_FORMAT ?= lcov
 COVERAGE_OUT_FILEPATH ?= coverage/lcov.info
 coverage: llvm-cov

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,6 +139,30 @@ To address it, increase the number of file descriptors for the current shell ses
 ulimit -n 4096
 ```
 
+### Building a container image
+
+To build the Agent Control container image locally (the same image used for the Kubernetes deployment), without
+needing `minikube`/`tilt`:
+
+```sh
+make image
+```
+
+This compiles the `newrelic-agent-control-k8s` and `newrelic-agent-control-k8s-cli` binaries and builds both images,
+loading them into your local docker daemon as `newrelic/newrelic-agent-control:local` and
+`newrelic/newrelic-agent-control-cli:local`. `ARCH` defaults to `arm64`; on an `amd64` host, pass it explicitly, e.g.
+`make image ARCH=amd64`.
+
+Useful variables to override (see the `Makefile` for the full list): `ARCH`, `IMAGE_TAG`,
+`DOCKER_IMAGE_NAME_AGENT_CONTROL[_CLI]`, `PUSH`. For example, to build only the main image with a custom tag:
+
+```sh
+make image/agent-control IMAGE_TAG=my-test
+```
+
+This same `make image/agent-control[-cli]` target is used by the CI workflows that build and publish the image, so a
+local build failure here is a good early signal that the image build is broken.
+
 ## Troubleshooting
 
 See [diagnose issues with agent control logging](https://docs.newrelic.com/docs/new-relic-control/agent-control/troubleshooting/).


### PR DESCRIPTION
## Summary

* Adds Makefile targets (`image/agent-control`, `image/agent-control-cli`, `image`) that wrap the `docker buildx build` calls for the Agent Control container images, so they can be easily built locally (without `minikube`/`tilt`) and reused as-is by CI. The corresponding workflows now call `make image/...` instead of duplicating the `docker buildx build` invocation inline.

* `make image` usage is documented in `docs/DEVELOPMENT.md`.

```shell
❯ make image
# ...
❯ docker images
IMAGE                                                                                                 ID             DISK USAGE   CONTENT SIZE   EXTRA
newrelic/newrelic-agent-control-cli:local                                                             6e827bba7b96        356MB         89.3MB    U   
newrelic/newrelic-agent-control:local                                                                 c4a6356f266f        215MB         57.8MB        
```
