### PR TITLE
chore(fs): improve declared-paths names

### DIFF
--- a/agent-control/src/agent_control/config_validator/on_host.rs
+++ b/agent-control/src/agent_control/config_validator/on_host.rs
@@ -34,9 +34,9 @@ impl AgentSharedPaths {
             Deployment::K8s(_) => DeclaredPaths::default(),
         };
         let claimed: Vec<PathBuf> = declared
-            .files
+            .owned_files
             .into_iter()
-            .chain(declared.managed_dirs)
+            .chain(declared.owned_dirs)
             .collect();
         Self {
             agent_id,

--- a/agent-control/src/agent_control/config_validator/on_host.rs
+++ b/agent-control/src/agent_control/config_validator/on_host.rs
@@ -33,11 +33,7 @@ impl AgentSharedPaths {
             // K8s agent-types are not expected on on-host validation
             Deployment::K8s(_) => DeclaredPaths::default(),
         };
-        let claimed: Vec<PathBuf> = declared
-            .owned_files
-            .into_iter()
-            .chain(declared.owned_dirs)
-            .collect();
+        let claimed: Vec<PathBuf> = declared.exclusive.into_iter().collect();
         Self {
             agent_id,
             agent_type,

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -205,7 +205,7 @@ where
             let paths = self.declared_shared_paths(&definition);
             all_shared_paths.owned_files.extend(paths.owned_files);
             all_shared_paths.owned_dirs.extend(paths.owned_dirs);
-            all_shared_paths.shared_dirs.extend(paths.shared_dirs);
+            all_shared_paths.dirs.extend(paths.dirs);
         }
         Ok(all_shared_paths)
     }
@@ -255,14 +255,14 @@ where
     fn reconcile_shared_filesystem(&self, configured: &SubAgentsMap) {
         let mut expected_files = HashSet::new();
         let mut owned_dirs = HashSet::new();
-        let mut shared_dirs = HashSet::new();
+        let mut dirs = HashSet::new();
         for agent_config in configured.values() {
             match self.get_definition(&agent_config.agent_type) {
                 Ok(definition) => {
                     let declared = self.declared_shared_paths(&definition);
                     expected_files.extend(declared.owned_files);
                     owned_dirs.extend(declared.owned_dirs);
-                    shared_dirs.extend(declared.shared_dirs);
+                    dirs.extend(declared.dirs);
                 }
                 Err(err) => {
                     warn!(
@@ -278,7 +278,7 @@ where
             &self.shared_filesystem_base,
             &expected_files,
             &owned_dirs,
-            &shared_dirs,
+            &dirs,
         ) {
             warn!(?err, base = ?self.shared_filesystem_base, "shared filesystem reconcile failed");
         }
@@ -295,7 +295,7 @@ fn delete_stale_paths(
         .owned_files
         .difference(&new.owned_files)
         .chain(old.owned_dirs.difference(&new.owned_dirs))
-        .chain(old.shared_dirs.difference(&new.shared_dirs))
+        .chain(old.dirs.difference(&new.dirs))
     {
         remove_path(path).map_err(|e| (path.clone(), e))?;
     }

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -194,7 +194,9 @@ where
         }
     }
 
-    /// Union of shared-filesystem paths declared by every agent in `agents`.
+    /// Union of shared-filesystem paths declared by every agent in `agents`. Once combined, no two
+    /// agents may claim the same `exclusive` path, and a `dirs` node is safe to remove only once
+    /// none of them still declares it.
     fn declared_shared_paths_from_all_agents(
         &self,
         agents: &SubAgentsMap,
@@ -203,8 +205,7 @@ where
         for config in agents.values() {
             let definition = self.get_definition(&config.agent_type)?;
             let paths = self.declared_shared_paths(&definition);
-            all_shared_paths.owned_files.extend(paths.owned_files);
-            all_shared_paths.owned_dirs.extend(paths.owned_dirs);
+            all_shared_paths.exclusive.extend(paths.exclusive);
             all_shared_paths.dirs.extend(paths.dirs);
         }
         Ok(all_shared_paths)
@@ -250,18 +251,16 @@ where
             .map_err(|(path, source)| OnHostCleanerError::SharedFilesystem { path, source })
     }
 
-    /// Deletes shared files no configured agent owns, and directories (managed or co-owned) no
-    /// configured agent declares.
+    /// Deletes shared paths no configured agent declares: exclusive paths no longer claimed by
+    /// anyone, and `dirs` nodes no configured agent references anymore.
     fn reconcile_shared_filesystem(&self, configured: &SubAgentsMap) {
-        let mut expected_files = HashSet::new();
-        let mut owned_dirs = HashSet::new();
+        let mut exclusive = HashSet::new();
         let mut dirs = HashSet::new();
         for agent_config in configured.values() {
             match self.get_definition(&agent_config.agent_type) {
                 Ok(definition) => {
                     let declared = self.declared_shared_paths(&definition);
-                    expected_files.extend(declared.owned_files);
-                    owned_dirs.extend(declared.owned_dirs);
+                    exclusive.extend(declared.exclusive);
                     dirs.extend(declared.dirs);
                 }
                 Err(err) => {
@@ -274,12 +273,7 @@ where
             }
         }
 
-        if let Err(err) = reconcile_shared_dir(
-            &self.shared_filesystem_base,
-            &expected_files,
-            &owned_dirs,
-            &dirs,
-        ) {
+        if let Err(err) = reconcile_shared_dir(&self.shared_filesystem_base, &exclusive, &dirs) {
             warn!(?err, base = ?self.shared_filesystem_base, "shared filesystem reconcile failed");
         }
     }
@@ -292,9 +286,8 @@ fn delete_stale_paths(
     new: &DeclaredPaths,
 ) -> Result<(), (PathBuf, io::Error)> {
     for path in old
-        .owned_files
-        .difference(&new.owned_files)
-        .chain(old.owned_dirs.difference(&new.owned_dirs))
+        .exclusive
+        .difference(&new.exclusive)
         .chain(old.dirs.difference(&new.dirs))
     {
         remove_path(path).map_err(|e| (path.clone(), e))?;
@@ -314,17 +307,18 @@ fn remove_path(path: &Path) -> io::Result<()> {
     }
 }
 
-/// Recursively deletes files under `dir` not in `expected_files`. For a subdirectory found along
-/// the way:
-/// - in `owned_dirs`: kept whole, not descended into.
-/// - in `shared_dirs` (but not `owned_dirs`): kept, and recursed into to prune stray
-///   contents.
+/// Recursively deletes paths under `dir` not declared by any configured agent. For a subdirectory
+/// found along the way:
+/// - in `exclusive`: kept whole, not descended into (an individually-owned file or a whole managed
+///   subtree can't have stray contents pruned from it).
+/// - in `dirs` (but not `exclusive`): kept, and recursed into to prune stray contents.
 /// - in neither (no configured agent declares it): removed wholesale, not descended into.
+///
+/// A non-directory entry not in `exclusive` is removed.
 fn reconcile_shared_dir(
     dir: &Path,
-    expected_files: &HashSet<PathBuf>,
-    owned_dirs: &HashSet<PathBuf>,
-    shared_dirs: &HashSet<PathBuf>,
+    exclusive: &HashSet<PathBuf>,
+    dirs: &HashSet<PathBuf>,
 ) -> io::Result<()> {
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -335,15 +329,15 @@ fn reconcile_shared_dir(
     for entry in entries {
         let path = entry?.path();
         if path.is_dir() {
-            if owned_dirs.contains(&path) {
+            if exclusive.contains(&path) {
                 continue;
             }
-            if shared_dirs.contains(&path) {
-                reconcile_shared_dir(&path, expected_files, owned_dirs, shared_dirs)?;
+            if dirs.contains(&path) {
+                reconcile_shared_dir(&path, exclusive, dirs)?;
             } else {
                 remove_path(&path)?;
             }
-        } else if !expected_files.contains(&path) {
+        } else if !exclusive.contains(&path) {
             remove_path(&path)?;
         }
     }
@@ -1045,6 +1039,36 @@ mod tests {
         assert!(
             !shared.join("stale-configs").exists(),
             "a directory no configured agent declares must be removed wholesale"
+        );
+    }
+
+    /// An `exclusive` path is kept whole even if it unexpectedly exists on disk as a directory.
+    #[test]
+    fn reconcile_keeps_exclusive_path_even_if_unexpectedly_a_directory() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let shared = tmp.path().to_path_buf();
+        // `declared-file` is declared as `kind: file`, but on disk it is (unexpectedly) a
+        // directory with stray contents.
+        std::fs::create_dir_all(shared.join("declared-file")).unwrap();
+        std::fs::write(shared.join("declared-file").join("stray.txt"), "stray").unwrap();
+
+        let definition = host_type_with_shared(serde_json::json!({
+            "declared-file": { "kind": "file", "text": "hi" },
+        }));
+        let type_id = AgentTypeID::try_from("test/ohi:0.0.1").unwrap();
+        let mut registry = MockAgentTypeRegistry::new();
+        registry.should_get(type_id, &definition);
+
+        shared_cleaner(registry, shared.clone())
+            .reconcile_shared_filesystem(&configured(&[("ohi-agent", "test/ohi:0.0.1")]));
+
+        assert!(
+            shared.join("declared-file").is_dir(),
+            "an exclusive path is kept whole even if its on-disk shape doesn't match what was declared"
+        );
+        assert!(
+            shared.join("declared-file").join("stray.txt").exists(),
+            "contents under an exclusive path are not pruned, since it's treated as an opaque unit"
         );
     }
 

--- a/agent-control/src/agent_control/resource_cleaner/on_host.rs
+++ b/agent-control/src/agent_control/resource_cleaner/on_host.rs
@@ -203,9 +203,9 @@ where
         for config in agents.values() {
             let definition = self.get_definition(&config.agent_type)?;
             let paths = self.declared_shared_paths(&definition);
-            all_shared_paths.files.extend(paths.files);
-            all_shared_paths.managed_dirs.extend(paths.managed_dirs);
-            all_shared_paths.declared_dirs.extend(paths.declared_dirs);
+            all_shared_paths.owned_files.extend(paths.owned_files);
+            all_shared_paths.owned_dirs.extend(paths.owned_dirs);
+            all_shared_paths.shared_dirs.extend(paths.shared_dirs);
         }
         Ok(all_shared_paths)
     }
@@ -254,15 +254,15 @@ where
     /// configured agent declares.
     fn reconcile_shared_filesystem(&self, configured: &SubAgentsMap) {
         let mut expected_files = HashSet::new();
-        let mut managed_dirs = HashSet::new();
-        let mut declared_dirs = HashSet::new();
+        let mut owned_dirs = HashSet::new();
+        let mut shared_dirs = HashSet::new();
         for agent_config in configured.values() {
             match self.get_definition(&agent_config.agent_type) {
                 Ok(definition) => {
                     let declared = self.declared_shared_paths(&definition);
-                    expected_files.extend(declared.files);
-                    managed_dirs.extend(declared.managed_dirs);
-                    declared_dirs.extend(declared.declared_dirs);
+                    expected_files.extend(declared.owned_files);
+                    owned_dirs.extend(declared.owned_dirs);
+                    shared_dirs.extend(declared.shared_dirs);
                 }
                 Err(err) => {
                     warn!(
@@ -277,8 +277,8 @@ where
         if let Err(err) = reconcile_shared_dir(
             &self.shared_filesystem_base,
             &expected_files,
-            &managed_dirs,
-            &declared_dirs,
+            &owned_dirs,
+            &shared_dirs,
         ) {
             warn!(?err, base = ?self.shared_filesystem_base, "shared filesystem reconcile failed");
         }
@@ -292,10 +292,10 @@ fn delete_stale_paths(
     new: &DeclaredPaths,
 ) -> Result<(), (PathBuf, io::Error)> {
     for path in old
-        .files
-        .difference(&new.files)
-        .chain(old.managed_dirs.difference(&new.managed_dirs))
-        .chain(old.declared_dirs.difference(&new.declared_dirs))
+        .owned_files
+        .difference(&new.owned_files)
+        .chain(old.owned_dirs.difference(&new.owned_dirs))
+        .chain(old.shared_dirs.difference(&new.shared_dirs))
     {
         remove_path(path).map_err(|e| (path.clone(), e))?;
     }
@@ -316,15 +316,15 @@ fn remove_path(path: &Path) -> io::Result<()> {
 
 /// Recursively deletes files under `dir` not in `expected_files`. For a subdirectory found along
 /// the way:
-/// - in `managed_dirs`: kept whole, not descended into.
-/// - in `declared_dirs` (but not `managed_dirs`): kept, and recursed into to prune stray
+/// - in `owned_dirs`: kept whole, not descended into.
+/// - in `shared_dirs` (but not `owned_dirs`): kept, and recursed into to prune stray
 ///   contents.
 /// - in neither (no configured agent declares it): removed wholesale, not descended into.
 fn reconcile_shared_dir(
     dir: &Path,
     expected_files: &HashSet<PathBuf>,
-    managed_dirs: &HashSet<PathBuf>,
-    declared_dirs: &HashSet<PathBuf>,
+    owned_dirs: &HashSet<PathBuf>,
+    shared_dirs: &HashSet<PathBuf>,
 ) -> io::Result<()> {
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -335,11 +335,11 @@ fn reconcile_shared_dir(
     for entry in entries {
         let path = entry?.path();
         if path.is_dir() {
-            if managed_dirs.contains(&path) {
+            if owned_dirs.contains(&path) {
                 continue;
             }
-            if declared_dirs.contains(&path) {
-                reconcile_shared_dir(&path, expected_files, managed_dirs, declared_dirs)?;
+            if shared_dirs.contains(&path) {
+                reconcile_shared_dir(&path, expected_files, owned_dirs, shared_dirs)?;
             } else {
                 remove_path(&path)?;
             }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -165,14 +165,14 @@ impl Templateable for SharedFileSystem {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DeclaredPaths {
     /// Files owned individually. Several agents may drop sibling files into the same
-    /// co-owned directory, but no two may own the exact same file path.
-    pub files: HashSet<PathBuf>,
+    /// shared directory, but no two may own the exact same file path.
+    pub owned_files: HashSet<PathBuf>,
     /// Directories owned as a whole: the entire subtree is managed as a unit, and no
     /// other agent may own anything at or under the path.
-    pub managed_dirs: HashSet<PathBuf>,
-    /// Co-owned `kind: dir` nodes. Several agents may declare the same one; a directory is only
+    pub owned_dirs: HashSet<PathBuf>,
+    /// Shared `kind: dir` nodes. Several agents may declare the same one; a directory is only
     /// safe to remove once no agent declares it here anymore.
-    pub declared_dirs: HashSet<PathBuf>,
+    pub shared_dirs: HashSet<PathBuf>,
 }
 
 impl SharedFileSystem {
@@ -189,21 +189,21 @@ impl SharedFileSystem {
 
 /// Recursively gathers the paths declared by `entry` (rooted at `path`) into `declared`.
 ///
-/// `Dir` entries are co-owned drop zones: the directory path is tracked separately in
-/// `declared_dirs` (not `files`/`managed_dirs`), since several agents may declare the same one.
+/// `Dir` entries are shared drop zones: the directory path is tracked separately in
+/// `shared_dirs` (not `owned_files`/`owned_dirs`), since several agents may declare the same one.
 fn collect_declared_paths(path: &Path, entry: &FilesystemEntry, declared: &mut DeclaredPaths) {
     match entry {
         FilesystemEntry::File { .. } => {
-            declared.files.insert(path.to_path_buf());
+            declared.owned_files.insert(path.to_path_buf());
         }
         FilesystemEntry::Dir { entries, .. } => {
-            declared.declared_dirs.insert(path.to_path_buf());
+            declared.shared_dirs.insert(path.to_path_buf());
             for (key, child) in entries {
                 collect_declared_paths(&path.join(key), child, declared);
             }
         }
         FilesystemEntry::DirContentFromMap { .. } => {
-            declared.managed_dirs.insert(path.to_path_buf());
+            declared.owned_dirs.insert(path.to_path_buf());
         }
     }
 }
@@ -1162,7 +1162,7 @@ projected:
         let declared = shared.declared_paths(base);
 
         assert_eq!(
-            declared.files,
+            declared.owned_files,
             HashSet::from([
                 base.join("top-file"),
                 base.join("co-owned").join("nri-redis.yaml"),
@@ -1171,12 +1171,12 @@ projected:
             "every `kind: file` must be reported, and the co-owned dir path must not be"
         );
         assert_eq!(
-            declared.managed_dirs,
+            declared.owned_dirs,
             HashSet::from([base.join("projected")]),
             "`dir_content_from_map` must be reported as a whole-directory owner"
         );
         assert_eq!(
-            declared.declared_dirs,
+            declared.shared_dirs,
             HashSet::from([base.join("co-owned"), base.join("co-owned").join("nested"),]),
             "every `kind: dir` node, including nested ones, must be reported as co-owned"
         );
@@ -1187,8 +1187,8 @@ projected:
     fn declared_paths_of_empty_is_empty() {
         let tmp_dir = TempDir::new().unwrap();
         let declared = SharedFileSystem::default().declared_paths(tmp_dir.path());
-        assert!(declared.files.is_empty());
-        assert!(declared.managed_dirs.is_empty());
-        assert!(declared.declared_dirs.is_empty());
+        assert!(declared.owned_files.is_empty());
+        assert!(declared.owned_dirs.is_empty());
+        assert!(declared.shared_dirs.is_empty());
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -160,8 +160,8 @@ impl Templateable for SharedFileSystem {
     }
 }
 
-/// The shared-filesystem paths an Agent Type declares ownership of, rooted under a base directory
-/// and split by ownership granularity.
+/// The filesystem paths an Agent Type declares ownership of, rooted under a base directory and split by ownership
+/// granularity.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DeclaredPaths {
     /// Files owned individually. Several agents may drop sibling files into the same
@@ -172,7 +172,7 @@ pub struct DeclaredPaths {
     pub owned_dirs: HashSet<PathBuf>,
     /// Shared `kind: dir` nodes. Several agents may declare the same one; a directory is only
     /// safe to remove once no agent declares it here anymore.
-    pub shared_dirs: HashSet<PathBuf>,
+    pub dirs: HashSet<PathBuf>,
 }
 
 impl SharedFileSystem {
@@ -197,7 +197,7 @@ fn collect_declared_paths(path: &Path, entry: &FilesystemEntry, declared: &mut D
             declared.owned_files.insert(path.to_path_buf());
         }
         FilesystemEntry::Dir { entries, .. } => {
-            declared.shared_dirs.insert(path.to_path_buf());
+            declared.dirs.insert(path.to_path_buf());
             for (key, child) in entries {
                 collect_declared_paths(&path.join(key), child, declared);
             }
@@ -1176,7 +1176,7 @@ projected:
             "`dir_content_from_map` must be reported as a whole-directory owner"
         );
         assert_eq!(
-            declared.shared_dirs,
+            declared.dirs,
             HashSet::from([base.join("co-owned"), base.join("co-owned").join("nested"),]),
             "every `kind: dir` node, including nested ones, must be reported as co-owned"
         );
@@ -1189,6 +1189,6 @@ projected:
         let declared = SharedFileSystem::default().declared_paths(tmp_dir.path());
         assert!(declared.owned_files.is_empty());
         assert!(declared.owned_dirs.is_empty());
-        assert!(declared.shared_dirs.is_empty());
+        assert!(declared.dirs.is_empty());
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -160,18 +160,15 @@ impl Templateable for SharedFileSystem {
     }
 }
 
-/// The filesystem paths an Agent Type declares ownership of, rooted under a base directory and split by ownership
-/// granularity.
+/// The filesystem paths a single Agent Type declares, rooted under a base directory and split by
+/// removal semantics.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DeclaredPaths {
-    /// Files owned individually. Several agents may drop sibling files into the same
-    /// shared directory, but no two may own the exact same file path.
-    pub owned_files: HashSet<PathBuf>,
-    /// Directories owned as a whole: the entire subtree is managed as a unit, and no
-    /// other agent may own anything at or under the path.
-    pub owned_dirs: HashSet<PathBuf>,
-    /// Shared `kind: dir` nodes. Several agents may declare the same one; a directory is only
-    /// safe to remove once no agent declares it here anymore.
+    /// Paths claimed exclusively, as an atomic unit: individual files (`kind: file`) and whole
+    /// managed subtrees (`kind: dir_content_from_map`).
+    pub exclusive: HashSet<PathBuf>,
+    /// `kind: dir` nodes: not claimed exclusively, so untracked content may coexist alongside
+    /// their declared children.
     pub dirs: HashSet<PathBuf>,
 }
 
@@ -189,12 +186,12 @@ impl SharedFileSystem {
 
 /// Recursively gathers the paths declared by `entry` (rooted at `path`) into `declared`.
 ///
-/// `Dir` entries are shared drop zones: the directory path is tracked separately in
-/// `shared_dirs` (not `owned_files`/`owned_dirs`), since several agents may declare the same one.
+/// `Dir` entries are tracked separately in `dirs` (not `exclusive`): the directory itself isn't
+/// claimed as an atomic unit, only its declared children are.
 fn collect_declared_paths(path: &Path, entry: &FilesystemEntry, declared: &mut DeclaredPaths) {
     match entry {
         FilesystemEntry::File { .. } => {
-            declared.owned_files.insert(path.to_path_buf());
+            declared.exclusive.insert(path.to_path_buf());
         }
         FilesystemEntry::Dir { entries, .. } => {
             declared.dirs.insert(path.to_path_buf());
@@ -203,7 +200,7 @@ fn collect_declared_paths(path: &Path, entry: &FilesystemEntry, declared: &mut D
             }
         }
         FilesystemEntry::DirContentFromMap { .. } => {
-            declared.owned_dirs.insert(path.to_path_buf());
+            declared.exclusive.insert(path.to_path_buf());
         }
     }
 }
@@ -1128,11 +1125,10 @@ infra-agent-ohi-configs:
             .unwrap();
     }
 
-    /// `declared_paths` reports every `kind: file` (including files nested in co-owned directories)
-    /// as an individually-owned file, every `kind: dir_content_from_map` as a whole-directory
-    /// owner, and every `kind: dir` node (including nested ones) as a co-owned directory.
+    /// `declared_paths` reports files and `dir_content_from_map` as `exclusive`, and `dir` nodes
+    /// (including nested ones) separately in `dirs`.
     #[test]
-    fn declared_paths_splits_files_and_managed_dirs() {
+    fn declared_paths_splits_exclusive_paths_and_dir_nodes() {
         let yaml = r#"
 top-file:
   kind: file
@@ -1162,33 +1158,28 @@ projected:
         let declared = shared.declared_paths(base);
 
         assert_eq!(
-            declared.owned_files,
+            declared.exclusive,
             HashSet::from([
                 base.join("top-file"),
                 base.join("co-owned").join("nri-redis.yaml"),
                 base.join("co-owned").join("nested").join("deep.yaml"),
+                base.join("projected"),
             ]),
-            "every `kind: file` must be reported, and the co-owned dir path must not be"
-        );
-        assert_eq!(
-            declared.owned_dirs,
-            HashSet::from([base.join("projected")]),
-            "`dir_content_from_map` must be reported as a whole-directory owner"
+            "every `kind: file` and `dir_content_from_map` must be claimed exclusively"
         );
         assert_eq!(
             declared.dirs,
             HashSet::from([base.join("co-owned"), base.join("co-owned").join("nested"),]),
-            "every `kind: dir` node, including nested ones, must be reported as co-owned"
+            "every `kind: dir` node, including nested ones, must be reported separately"
         );
     }
 
-    /// A shared filesystem with no entries declares no owned paths.
+    /// A shared filesystem with no entries declares no paths.
     #[test]
     fn declared_paths_of_empty_is_empty() {
         let tmp_dir = TempDir::new().unwrap();
         let declared = SharedFileSystem::default().declared_paths(tmp_dir.path());
-        assert!(declared.owned_files.is_empty());
-        assert!(declared.owned_dirs.is_empty());
+        assert!(declared.exclusive.is_empty());
         assert!(declared.dirs.is_empty());
     }
 }

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -47,12 +47,15 @@ pub enum RenderedEntry {
 }
 
 impl RenderedEntry {
-    /// Materializes this entry (and its subtree) on disk at `path`. `file_ops` provides both the
-    /// write and copy capabilities (a single type, [`LocalFile`], implements both in production).
+    /// Materializes this entry (and its subtree) on disk at `path`. `file_ops` provides the write,
+    /// copy and delete capabilities (a single type, [`LocalFile`], implements all three in
+    /// production). Delete is needed to clear a stale entry whose on-disk shape doesn't match what
+    /// is declared here anymore, e.g. after an Agent Type update changes a path's `kind` between
+    /// `file` and `dir`/`dir_content_from_map`.
     fn write(
         &self,
         path: &Path,
-        file_ops: &(impl FileWriter + FileCopier),
+        file_ops: &(impl FileWriter + FileCopier + FileDeleter),
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         match self {
@@ -61,7 +64,7 @@ impl RenderedEntry {
                 FileContent::Copy(source) => copy_file(file_ops, dir_manager, path, source),
             },
             Self::Dir { children, .. } => {
-                ensure_dir(dir_manager, path)?;
+                ensure_dir(file_ops, dir_manager, path)?;
                 for (sub_path, child) in children {
                     let child_path = path.join(sub_path);
                     trace!("Recursing into child entry {}", child_path.display());
@@ -70,12 +73,11 @@ impl RenderedEntry {
                 Ok(())
             }
             Self::DirContentFromMap { files, .. } => {
-                // Without this delete, a remote cfg that removes a file from the map would leave
+                // Without this clear, a remote cfg that removes a file from the map would leave
                 // the old file on disk until the agent control is stopped.
-                dir_manager
-                    .delete(path)
+                delete_path(path, file_ops, dir_manager)
                     .map_err(|err| FileSystemEntriesError(format!("clearing {path:?}: {err}")))?;
-                ensure_dir(dir_manager, path)?;
+                ensure_dir(file_ops, dir_manager, path)?;
                 for (file_name, content) in files {
                     write_file(file_ops, dir_manager, &path.join(file_name), content)?;
                 }
@@ -93,7 +95,7 @@ impl FileSystem {
     /// Writes the declared tree under `base_dir`, overwriting any declared paths already on disk.
     pub fn write(
         &self,
-        file_ops: &(impl FileWriter + FileCopier),
+        file_ops: &(impl FileWriter + FileCopier + FileDeleter),
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         for (path, entry) in &self.entries {
@@ -151,7 +153,7 @@ impl SharedFileSystem {
     /// Materializes the declared tree on disk. Existing files are overwritten; nothing is pruned.
     pub fn write(
         &self,
-        file_ops: &(impl FileWriter + FileCopier),
+        file_ops: &(impl FileWriter + FileCopier + FileDeleter),
         dir_manager: &impl DirectoryManager,
     ) -> Result<(), FileSystemEntriesError> {
         for (path, entry) in &self.entries {
@@ -161,11 +163,15 @@ impl SharedFileSystem {
     }
 }
 
-/// Creates `dir` (and any missing parents), with error context. Safe if it already exists.
+/// Creates `dir` (and any missing parents), with error context. Safe if it already exists. Clears
+/// a stale file left at `dir` first (e.g. by a previous Agent Type declaring it as `kind: file`).
 fn ensure_dir(
+    file_ops: &impl FileDeleter,
     dir_manager: &impl DirectoryManager,
     dir: &Path,
 ) -> Result<(), FileSystemEntriesError> {
+    clear_if_wrong_shape(dir, true, file_ops, dir_manager)
+        .map_err(|err| FileSystemEntriesError(format!("clearing {dir:?}: {err}")))?;
     trace!("Creating directory {}", dir.display());
     dir_manager
         .create(dir)
@@ -173,8 +179,10 @@ fn ensure_dir(
 }
 
 /// Writes `content` to `path`, creating its parent directory first. Overwrites an existing file.
+/// Clears a stale directory left at `path` first (e.g. by a previous Agent Type declaring it as
+/// `kind: dir` or `dir_content_from_map`).
 fn write_file(
-    file_writer: &impl FileWriter,
+    file_ops: &(impl FileWriter + FileDeleter),
     dir_manager: &impl DirectoryManager,
     path: &Path,
     content: &str,
@@ -184,15 +192,18 @@ fn write_file(
     let parent = path
         .parent()
         .ok_or_else(|| FileSystemEntriesError(format!("{} has no parent dir", path.display())))?;
-    ensure_dir(dir_manager, parent)?;
-    file_writer
+    ensure_dir(file_ops, dir_manager, parent)?;
+    clear_if_wrong_shape(path, false, file_ops, dir_manager)
+        .map_err(|err| FileSystemEntriesError(format!("clearing {path:?}: {err}")))?;
+    file_ops
         .write(path, content.to_owned())
         .map_err(|err| FileSystemEntriesError(format!("creating file {path:?}: {err}")))
 }
 
 /// Copies `source` to `path`, creating its parent directory first. Overwrites an existing file.
+/// Clears a stale directory left at `path` first, for the same reason as [`write_file`].
 fn copy_file(
-    file_copier: &impl FileCopier,
+    file_ops: &(impl FileCopier + FileDeleter),
     dir_manager: &impl DirectoryManager,
     path: &Path,
     source: &Path,
@@ -205,17 +216,37 @@ fn copy_file(
     let parent = path
         .parent()
         .ok_or_else(|| FileSystemEntriesError(format!("{} has no parent dir", path.display())))?;
-    ensure_dir(dir_manager, parent)?;
-    file_copier
+    ensure_dir(file_ops, dir_manager, parent)?;
+    clear_if_wrong_shape(path, false, file_ops, dir_manager)
+        .map_err(|err| FileSystemEntriesError(format!("clearing {path:?}: {err}")))?;
+    file_ops
         .copy(source, path)
         .map_err(|err| FileSystemEntriesError(format!("copying {source:?} to {path:?}: {err}")))
 }
-/// Deletes the file or directory at `path`.
+
+/// Removes whatever currently occupies `path` if it exists and its on-disk shape (directory vs.
+/// file) doesn't match `expect_dir`. A missing path is not an error.
+fn clear_if_wrong_shape(
+    path: &Path,
+    expect_dir: bool,
+    file_ops: &impl FileDeleter,
+    dir_manager: &impl DirectoryManager,
+) -> std::io::Result<()> {
+    if path.exists() && path.is_dir() != expect_dir {
+        delete_path(path, file_ops, dir_manager)?;
+    }
+    Ok(())
+}
+
+/// Deletes the file or directory at `path`. A missing path is not an error.
 fn delete_path(
     path: &Path,
     file_ops: &impl FileDeleter,
     dir_manager: &impl DirectoryManager,
 ) -> std::io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
     trace!("Deleting path {}", path.display());
     if path.is_dir() {
         dir_manager.delete(path)
@@ -414,6 +445,101 @@ mod tests {
             .unwrap();
 
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "v2");
+    }
+
+    /// Writing a `kind: file` entry clears a stale directory left there by a previous Agent Type.
+    #[test]
+    fn write_replaces_stale_directory_with_declared_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("entry");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("leftover.txt"), "old").unwrap();
+
+        FileSystem::new(HashMap::from([(
+            path.clone(),
+            file_entry_with_text("hello"),
+        )]))
+        .write(&LocalFile, &DirectoryManagerFs)
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello");
+    }
+
+    /// Writing a `kind: dir` entry clears a stale file left there by a previous Agent Type.
+    #[test]
+    fn write_replaces_stale_file_with_declared_dir() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("entry");
+        std::fs::write(&path, "old").unwrap();
+
+        FileSystem::new(HashMap::from([(
+            path.clone(),
+            dir_entry(HashMap::from([(
+                PathBuf::from("child.txt"),
+                file_entry_with_text("child"),
+            )])),
+        )]))
+        .write(&LocalFile, &DirectoryManagerFs)
+        .unwrap();
+
+        assert!(path.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(path.join("child.txt")).unwrap(),
+            "child"
+        );
+    }
+
+    /// Writing a `dir_content_from_map` entry clears a stale file left there by a previous Agent Type.
+    #[test]
+    fn write_dir_content_from_map_replaces_stale_file_with_declared_dir() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("entry");
+        std::fs::write(&path, "old").unwrap();
+
+        FileSystem::new(HashMap::from([(
+            path.clone(),
+            map_dir_entry(HashMap::from([(
+                PathBuf::from("a.yaml"),
+                "a-content".to_string(),
+            )])),
+        )]))
+        .write(&LocalFile, &DirectoryManagerFs)
+        .unwrap();
+
+        assert!(path.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(path.join("a.yaml")).unwrap(),
+            "a-content"
+        );
+    }
+
+    /// Writing a `Dir` entry that already exists correctly must not touch its existing contents.
+    #[test]
+    fn write_dir_does_not_delete_existing_directory_contents_when_shape_already_matches() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("managed-dir");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("untracked.txt"), "untracked").unwrap();
+
+        FileSystem::new(HashMap::from([(
+            path.clone(),
+            dir_entry(HashMap::from([(
+                PathBuf::from("declared.txt"),
+                file_entry_with_text("declared"),
+            )])),
+        )]))
+        .write(&LocalFile, &DirectoryManagerFs)
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(path.join("untracked.txt")).unwrap(),
+            "untracked",
+            "untracked content in an already-correct directory must survive"
+        );
+        assert_eq!(
+            std::fs::read_to_string(path.join("declared.txt")).unwrap(),
+            "declared"
+        );
     }
 
     #[test]

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem/rendered.rs
@@ -163,8 +163,11 @@ impl SharedFileSystem {
     }
 }
 
-/// Creates `dir` (and any missing parents), with error context. Safe if it already exists. Clears
-/// a stale file left at `dir` first (e.g. by a previous Agent Type declaring it as `kind: file`).
+/// Creates `dir` (and any missing parents), with error context. Clears a stale file left at
+/// `dir` first (e.g. by a previous Agent Type declaring it as `kind: file`). Does nothing if
+/// `dir` already exists as a directory: on Windows, `dir_manager.create` also resets on-disk
+/// permissions to Administrators-only, which would strip access from whatever already owns a
+/// pre-existing directory.
 fn ensure_dir(
     file_ops: &impl FileDeleter,
     dir_manager: &impl DirectoryManager,
@@ -172,6 +175,9 @@ fn ensure_dir(
 ) -> Result<(), FileSystemEntriesError> {
     clear_if_wrong_shape(dir, true, file_ops, dir_manager)
         .map_err(|err| FileSystemEntriesError(format!("clearing {dir:?}: {err}")))?;
+    if dir.is_dir() {
+        return Ok(());
+    }
     trace!("Creating directory {}", dir.display());
     dir_manager
         .create(dir)


### PR DESCRIPTION
This PR is a follow-up of #2703. It addresses the following comments regarding names

- https://github.com/newrelic/newrelic-agent-control/pull/2703#discussion_r3614677619
- https://github.com/newrelic/newrelic-agent-control/pull/2703#discussion_r3615606783