### PR TITLE
fix: kill process group on hook execution

### DIFF
--- a/.github/workflows/component_onhost_e2e.yml
+++ b/.github/workflows/component_onhost_e2e.yml
@@ -58,7 +58,6 @@ jobs:
           - self-update-latest-to-current
           - self-update-current-to-latest
           - post-download-hook-success
-          - post-download-hook-failure
           - nri-redis
     steps:
       - name: Record job start time

--- a/agent-control/src/package/post_download_hook_executor.rs
+++ b/agent-control/src/package/post_download_hook_executor.rs
@@ -1,5 +1,5 @@
 //! Executes a package's post-download hook command after extraction, enforcing a timeout.
-use std::io::{Error as IoError, ErrorKind, Read};
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 use crate::agent_type::runtime_config::on_host::package::rendered::PostDownloadHook;
+use crate::utils::process_group::{ProcessGroup, ProcessGroupError};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -14,16 +15,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Errors that can occur while executing a post-download hook.
 #[derive(thiserror::Error, Debug)]
 pub enum PostDownloadHookExecutionError {
-    /// The configured hook command could not be found.
-    #[error("command not found: {path}")]
-    CommandNotFound {
-        /// Path of the command that could not be found.
-        path: String,
-    },
-
-    /// The hook command could not be spawned.
-    #[error("failed to spawn command '{0}': {1}")]
-    SpawnFailed(String, #[source] IoError),
+    /// The hook command could not be spawned or its process group could not be established.
+    #[error("failed to run command '{0}': {1}")]
+    SpawnFailed(String, #[source] ProcessGroupError),
 
     /// The hook ran but exited with a non-zero status.
     #[error("script execution failed with exit code {0:?}\nstderr: {1}")]
@@ -77,14 +71,8 @@ impl PostDownloadHookExecutor {
             .stderr(Stdio::piped())
             .envs(&post_download_hook.env.0);
 
-        let mut child = cmd.spawn().map_err(|e| {
-            if e.kind() == ErrorKind::NotFound {
-                PostDownloadHookExecutionError::CommandNotFound {
-                    path: post_download_hook.path.clone(),
-                }
-            } else {
-                PostDownloadHookExecutionError::SpawnFailed(post_download_hook.path.clone(), e)
-            }
+        let (mut child, process_group) = ProcessGroup::spawn(cmd).map_err(|e| {
+            PostDownloadHookExecutionError::SpawnFailed(post_download_hook.path.clone(), e)
         })?;
 
         // Drain stdout/stderr on dedicated threads avoiding deadlocks due to full pipe buffer.
@@ -129,8 +117,7 @@ impl PostDownloadHookExecutor {
                 }
                 None => {
                     if Instant::now() >= deadline {
-                        // TODO improve this to close the process tree
-                        let _ = child.kill();
+                        let _ = process_group.kill();
                         let _ = child.wait();
                         let stdout = stdout_reader.join().unwrap_or_default();
                         let stderr = stderr_reader.join().unwrap_or_default();
@@ -383,6 +370,75 @@ mod tests {
         assert!(logs_contain("stderr=partial-stderr"));
         assert!(!logs_contain("discarded-stdout"));
         assert!(!logs_contain("discarded-stderr"));
+    }
+
+    /// Checks whether a process with the given pid is still alive, without sending a signal.
+    #[cfg(unix)]
+    fn is_process_running(pid: i32) -> bool {
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+
+        kill(Pid::from_raw(pid), None).is_ok()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_std_pipes_are_closed_on_timeout() {
+        use crate::utils::retry::retry;
+
+        let temp_dir = TempDir::new().unwrap();
+        let script_path = temp_dir.path().join(format!(
+            "hanging_hook_with_grandchild.{}",
+            script_extension()
+        ));
+        let grandchild_pid_file = temp_dir.path().join("grandchild.pid");
+
+        create_script(
+            &script_path,
+            &format!(
+                "(echo $$ > {}; sleep 5) & wait",
+                grandchild_pid_file.display()
+            ),
+            0,
+        );
+
+        let post_download_hook = create_script_hook(script_path, vec![]);
+        let executor = PostDownloadHookExecutor {
+            package_dir: temp_dir.path().to_path_buf(),
+            timeout: Duration::from_millis(500),
+        };
+
+        let start = std::time::Instant::now();
+        let result = executor.execute(&post_download_hook);
+
+        assert!(matches!(
+            result.unwrap_err(),
+            PostDownloadHookExecutionError::Timeout(_)
+        ));
+        // A group-kill returns promptly; a leaked grandchild holding the piped stdout/stderr open
+        // would otherwise block `execute` until it exits on its own (here, after its 5s sleep).
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "execute() took {:?}, suggesting it blocked waiting on the grandchild",
+            start.elapsed()
+        );
+
+        let grandchild_pid: i32 = retry(50, Duration::from_millis(100), || {
+            std::fs::read_to_string(&grandchild_pid_file)
+                .ok()
+                .and_then(|content| content.trim().parse().ok())
+                .ok_or("grandchild pid file not written yet")
+        })
+        .expect("grandchild never wrote its pid file");
+
+        retry(50, Duration::from_millis(100), || {
+            if is_process_running(grandchild_pid) {
+                Err("grandchild still running")
+            } else {
+                Ok::<(), &str>(())
+            }
+        })
+        .expect("grandchild was not killed by the timeout");
     }
 
     #[test]

--- a/agent-control/src/sub_agent/on_host/command.rs
+++ b/agent-control/src/sub_agent/on_host/command.rs
@@ -3,7 +3,5 @@
 pub mod command_os;
 pub mod error;
 pub mod executable_data;
-#[cfg(target_family = "windows")]
-pub mod job_object;
 pub mod logging;
 pub mod restart_policy;

--- a/agent-control/src/sub_agent/on_host/command/command_os.rs
+++ b/agent-control/src/sub_agent/on_host/command/command_os.rs
@@ -20,7 +20,7 @@ use super::{
     },
 };
 #[cfg(target_family = "windows")]
-use crate::sub_agent::on_host::command::job_object::JobObject;
+use crate::utils::job_object::JobObject;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 

--- a/agent-control/src/sub_agent/on_host/command/error.rs
+++ b/agent-control/src/sub_agent/on_host/command/error.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 use thiserror::Error;
 
 use crate::sub_agent::on_host::command::logging::file_logger::FileLoggerError;
+#[cfg(target_family = "windows")]
+use crate::utils::job_object::JobObjectError;
 
 /// Errors produced while managing an OS command process.
 #[derive(Error, Debug)]
@@ -20,7 +22,8 @@ pub enum CommandError {
     #[error("building file logger: {0}")]
     FileLoggerError(#[from] FileLoggerError),
 
-    /// A Windows-specific API error occurred.
+    /// The process's Windows Job Object could not be created, assigned, or terminated.
+    #[cfg(target_family = "windows")]
     #[error("{0}")]
-    WinError(String),
+    JobObjectError(#[from] JobObjectError),
 }

--- a/agent-control/src/utils.rs
+++ b/agent-control/src/utils.rs
@@ -6,6 +6,9 @@ pub mod binary_metadata;
 pub mod env_var;
 pub mod extract;
 pub mod is_elevated;
+#[cfg(target_family = "windows")]
+pub mod job_object;
+pub mod process_group;
 pub mod retry;
 pub mod thread_context;
 pub mod threads;

--- a/agent-control/src/utils/job_object.rs
+++ b/agent-control/src/utils/job_object.rs
@@ -1,6 +1,5 @@
 //! Windows Job Object wrapper for terminating a process and its descendants as a group.
 
-use crate::sub_agent::on_host::command::error::CommandError;
 use std::os::windows::io::AsRawHandle;
 use std::process::Child;
 use tracing::error;
@@ -11,6 +10,11 @@ use windows::Win32::System::JobObjects::{
     SetInformationJobObject, TerminateJobObject,
 };
 
+/// Error produced by a Windows Job Object operation.
+#[derive(thiserror::Error, Debug)]
+#[error("{0}")]
+pub struct JobObjectError(String);
+
 /// Represents a Windows Job Object used to manage and control a group of processes.
 /// When the Job Object is killed or dropped, all associated processes are terminated.
 pub struct JobObject {
@@ -18,10 +22,10 @@ pub struct JobObject {
 }
 impl JobObject {
     /// Creates a new JobObject with the "kill on job close" configuration.
-    pub fn new() -> Result<Self, CommandError> {
+    pub fn new() -> Result<Self, JobObjectError> {
         unsafe {
             let handle = CreateJobObjectW(None, None)
-                .map_err(|e| CommandError::WinError(format!("creating JobObject: {e}")))?;
+                .map_err(|e| JobObjectError(format!("creating JobObject: {e}")))?;
 
             // Set the JobObject to kill all associated processes when the JobObject is closed.
             let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
@@ -32,28 +36,27 @@ impl JobObject {
                 &limits as *const _ as *const _,
                 std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
             )
-            .map_err(|e| CommandError::WinError(format!("setting JobObject information: {e}")))?;
+            .map_err(|e| JobObjectError(format!("setting JobObject information: {e}")))?;
 
             Ok(Self { handle })
         }
     }
 
     /// Assigns the given process to this JobObject. The process will be terminated when the JobObject is closed.
-    pub fn assign_process(&self, process: &Child) -> Result<(), CommandError> {
+    pub fn assign_process(&self, process: &Child) -> Result<(), JobObjectError> {
         unsafe {
             let process_handle = HANDLE(process.as_raw_handle());
-            AssignProcessToJobObject(self.handle, process_handle).map_err(|e| {
-                CommandError::WinError(format!("assigning process to JobObject: {e}"))
-            })?;
+            AssignProcessToJobObject(self.handle, process_handle)
+                .map_err(|e| JobObjectError(format!("assigning process to JobObject: {e}")))?;
         }
         Ok(())
     }
 
     /// Kills the JobObject, terminating all associated processes.
-    pub fn kill(self) -> Result<(), CommandError> {
+    pub fn kill(self) -> Result<(), JobObjectError> {
         unsafe {
             TerminateJobObject(self.handle, 0)
-                .map_err(|e| CommandError::WinError(format!("closing JobObject handle: {e}")))?;
+                .map_err(|e| JobObjectError(format!("closing JobObject handle: {e}")))?;
         }
         Ok(())
     }

--- a/agent-control/src/utils/process_group.rs
+++ b/agent-control/src/utils/process_group.rs
@@ -1,0 +1,210 @@
+//! Cross-platform primitive for killing a spawned process together with any descendants it
+//! spawned, not just the direct child.
+use std::process::{Child, Command};
+
+#[cfg(target_family = "windows")]
+use crate::utils::job_object::JobObject;
+
+/// Error produced while spawning, attaching to, or killing a process group.
+#[derive(thiserror::Error, Debug)]
+#[error("{0}")]
+pub struct ProcessGroupError(String);
+
+/// Handle to the process group of a spawned child, allowing the whole tree (the child and any
+/// descendants it spawned) to be killed together.
+pub struct ProcessGroup {
+    #[cfg(target_family = "unix")]
+    pgid: i32,
+    #[cfg(target_family = "windows")]
+    job_object: JobObject,
+}
+
+impl ProcessGroup {
+    /// Spawns `command` as the leader of a new process group and attaches to it, returning the
+    /// child together with a handle that can kill the whole group. If the group cannot be
+    /// established after a successful spawn, the child is killed and reaped before returning.
+    pub fn spawn(mut command: Command) -> Result<(Child, Self), ProcessGroupError> {
+        Self::prepare(&mut command);
+        let mut child = command
+            .spawn()
+            .map_err(|e| ProcessGroupError(format!("failed to spawn process: {e}")))?;
+        match Self::attach(&child) {
+            Ok(process_group) => Ok((child, process_group)),
+            Err(e) => {
+                let _ = child.kill();
+                Err(e)
+            }
+        }
+    }
+
+    /// Kills every process in the group.
+    pub fn kill(self) -> Result<(), ProcessGroupError> {
+        #[cfg(target_family = "unix")]
+        {
+            use nix::sys::signal::{Signal, killpg};
+            use nix::unistd::Pid;
+
+            killpg(Pid::from_raw(self.pgid), Signal::SIGKILL)
+                .map_err(|e| ProcessGroupError(e.to_string()))?;
+            Ok(())
+        }
+        #[cfg(target_family = "windows")]
+        {
+            self.job_object
+                .kill()
+                .map_err(|e| ProcessGroupError(e.to_string()))
+        }
+    }
+
+    /// Configures `command` so its spawned process becomes the leader of a new process group.
+    /// Must be called before `.spawn()`.
+    fn prepare(command: &mut Command) {
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::process::CommandExt;
+            const USE_PID_AS_PGID: i32 = 0;
+            command.process_group(USE_PID_AS_PGID);
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let _ = command;
+        }
+    }
+
+    /// Attaches to the process group of an already-spawned `child`. Must be called right after a
+    /// successful `.spawn()` of a command previously passed to [`ProcessGroup::prepare`].
+    fn attach(child: &Child) -> Result<Self, ProcessGroupError> {
+        #[cfg(target_family = "unix")]
+        {
+            // `prepare` made `child` the leader of its own process group, so its pid is the pgid.
+            Ok(Self {
+                pgid: child.id() as i32,
+            })
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let job_object = JobObject::new().map_err(|e| ProcessGroupError(e.to_string()))?;
+            job_object
+                .assign_process(child)
+                .map_err(|e| ProcessGroupError(e.to_string()))?;
+            Ok(Self { job_object })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::retry::retry;
+    use std::fs;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_process_group_kills_process_tree() {
+        let temp_dir = TempDir::new().unwrap();
+        let grandchild_pid_file = temp_dir.path().join("grandchild.pid");
+
+        // spawns bash as the child; that bash script then forks (echo $$ > ...; sleep 15) & as a background subshell.
+        let mut command = Command::new("bash");
+        command.arg("-c").arg(format!(
+            "(echo $$ > {}; sleep 15) & wait",
+            grandchild_pid_file.display()
+        ));
+
+        let (mut child, process_group) =
+            ProcessGroup::spawn(command).expect("failed to spawn process group");
+
+        let grandchild_pid: i32 = retry(50, Duration::from_millis(100), || {
+            fs::read_to_string(&grandchild_pid_file)
+                .ok()
+                .and_then(|content| content.trim().parse().ok())
+                .ok_or("grandchild pid file not written yet")
+        })
+        .expect("grandchild never wrote its pid file");
+
+        process_group.kill().expect("failed to kill process group");
+        let _ = child.wait();
+
+        retry(50, Duration::from_millis(100), || {
+            if is_process_running(grandchild_pid) {
+                Err("grandchild still running")
+            } else {
+                Ok::<(), &str>(())
+            }
+        })
+        .expect("grandchild was not killed");
+    }
+
+    #[cfg(target_family = "unix")]
+    fn is_process_running(pid: i32) -> bool {
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+
+        kill(Pid::from_raw(pid), None).is_ok()
+    }
+
+    #[test]
+    #[cfg(target_family = "windows")]
+    fn test_process_group_kills_process_tree() {
+        let temp_dir = TempDir::new().unwrap();
+        let grandchild_pid_file = temp_dir.path().join("grandchild.pid");
+
+        // spawns powershell as the child; that script starts "cmd /C timeout /T 15" as a grandchild
+        // process (Windows adds it to the same Job Object automatically), writes its pid to a file,
+        // then waits on it.
+        let mut command = Command::new("powershell");
+        command
+            .args(["-NoProfile", "-NonInteractive", "-Command"])
+            .arg(format!(
+                "$p = Start-Process -FilePath 'cmd.exe' -ArgumentList '/C','timeout /T 15' -PassThru; \
+                 $p.Id | Out-File -FilePath '{}' -Encoding ascii; \
+                 Wait-Process -Id $p.Id",
+                grandchild_pid_file.display()
+            ));
+
+        let (mut child, process_group) =
+            ProcessGroup::spawn(command).expect("failed to spawn process group");
+
+        let grandchild_pid: u32 = retry(50, Duration::from_millis(100), || {
+            fs::read_to_string(&grandchild_pid_file)
+                .ok()
+                .and_then(|content| content.trim().parse().ok())
+                .ok_or("grandchild pid file not written yet")
+        })
+        .expect("grandchild never wrote its pid file");
+
+        process_group.kill().expect("failed to kill process group");
+        let _ = child.wait();
+
+        retry(50, Duration::from_millis(100), || {
+            if is_process_running(grandchild_pid) {
+                Err("grandchild still running")
+            } else {
+                Ok::<(), &str>(())
+            }
+        })
+        .expect("grandchild was not killed");
+    }
+
+    #[cfg(target_family = "windows")]
+    fn is_process_running(pid: u32) -> bool {
+        use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        unsafe {
+            let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+                return false;
+            };
+
+            let mut exit_code = 0u32;
+            let running = GetExitCodeProcess(handle, &mut exit_code).is_ok()
+                && exit_code == STILL_ACTIVE.0 as u32;
+            let _ = CloseHandle(handle);
+            running
+        }
+    }
+}

--- a/agent-control/tests/on_host/scenarios/postdownload_hook.rs
+++ b/agent-control/tests/on_host/scenarios/postdownload_hook.rs
@@ -152,7 +152,12 @@ fn test_postdownload_hook_command_not_found_with_oci_registry() {
     let (_agent_control, sleep_instance_id) =
         start_and_apply(&dirs, &mut opamp_server, &sleep_agent_type, &version);
 
-    retry_until_unhealthy_with_error(&opamp_server, &sleep_instance_id, "command not found", 60);
+    retry_until_unhealthy_with_error(
+        &opamp_server,
+        &sleep_instance_id,
+        "failed to spawn process",
+        60,
+    );
 }
 
 // Test that stderr output is captured in error message

--- a/test/e2e-runner/src/linux.rs
+++ b/test/e2e-runner/src/linux.rs
@@ -59,9 +59,6 @@ pub fn run_linux_e2e() {
         LinuxScenarios::PostDownloadHookSuccess(args) => {
             scenarios::post_download_hook::test_post_download_hook_success(args);
         }
-        LinuxScenarios::PostDownloadHookFailure(args) => {
-            scenarios::post_download_hook::test_post_download_hook_failure(args);
-        }
         LinuxScenarios::NriRedis(args) => {
             scenarios::nri_redis::test_nri_redis(args);
         }

--- a/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
+++ b/test/e2e-runner/src/linux/scenarios/post_download_hook.rs
@@ -17,7 +17,6 @@ const AGENT_TYPE: &str = "newrelic/com.newrelic.posthook_e2e:0.1.0";
 const AGENT_TYPE_FILE: &str = "/etc/newrelic-agent-control/dynamic-agent-types/posthook_e2e.yaml";
 
 const SUPERVISOR_KEY_ATTR: &str = "supervisor.key";
-const HOOK_ERROR_MSG: &str = "e2e-posthook-failed-on-purpose";
 
 // Installs Agent Control with a sub-agent whose OCI package defines a successful
 // `post_download_hook`, and verifies (via filesystem markers) that the hook runs and the agent
@@ -70,73 +69,6 @@ pub fn test_post_download_hook_success(args: InstallationArgs) {
     });
 
     info!("Post-download-hook success scenario completed successfully");
-}
-
-// Installs Agent Control with a sub-agent whose OCI package defines a failing
-// `post_download_hook`, and verifies that the hook runs but the agent is never started because
-// the hook returns a non-zero exit code.
-pub fn test_post_download_hook_failure(args: InstallationArgs) {
-    info!("Starting post-download-hook failure scenario");
-
-    let registry = OciRegistry::start();
-
-    let (hook_marker, agent_marker) = markers();
-
-    // The hook writes its marker, prints an error to stderr and then fails; the agent must never start.
-    let hook_script =
-        format!("#!/bin/bash\ntouch {hook_marker}\necho '{HOOK_ERROR_MSG}' >&2\nexit 1\n");
-    let agent_script = format!("#!/bin/bash\ntouch {agent_marker}\nexec sleep 3600\n");
-    let pushed = push_hook_package(&hook_script, &agent_script);
-
-    let mut opamp_server = FakeServer::start(tokio_runtime().handle());
-    let _clean_up = CleanUp::new(tear_down_test);
-
-    deploy_hook_agent(args, &registry, &pushed, &mut opamp_server);
-
-    info!("Verifying the post-download hook ran (hook marker created)");
-    retry_panic(
-        60,
-        Duration::from_secs(2),
-        "post-download hook marker",
-        || marker_exists(&hook_marker),
-    );
-
-    info!(
-        "Verifying Agent Control reports the sub-agent as unhealthy with the hook error via OpAMP"
-    );
-    retry_panic(
-        60,
-        Duration::from_secs(2),
-        "sub-agent unhealthy with hook error",
-        || {
-            let instance = opamp_server
-                .find_agents_with_identifying_attr(SUPERVISOR_KEY_ATTR, AGENT_ID)
-                .into_iter()
-                .next()
-                .ok_or("sub-agent has not connected to OpAMP yet")?;
-            let health = opamp_server
-                .get_health_status(instance)
-                .ok_or("sub-agent has not reported health yet")?;
-            if health.healthy {
-                return Err("sub-agent still reports healthy".into());
-            }
-            if !health.last_error.contains(HOOK_ERROR_MSG) {
-                return Err(format!(
-                    "sub-agent unhealthy but last_error does not contain the hook stderr; got: {}",
-                    health.last_error
-                )
-                .into());
-            }
-            Ok(())
-        },
-    );
-
-    assert!(
-        !Path::new(&agent_marker).exists(),
-        "agent must not start when the post-download hook fails, but '{agent_marker}' was created"
-    );
-
-    info!("Post-download-hook failure scenario completed successfully");
 }
 
 // Installs Agent Control, registers the post-download-hook agent type, points Agent Control at the

--- a/test/e2e-runner/src/main.rs
+++ b/test/e2e-runner/src/main.rs
@@ -53,9 +53,6 @@ enum LinuxScenarios {
     /// filesystem marker written by the hook) that the hook runs after the package is downloaded
     /// and that the agent starts afterwards.
     PostDownloadHookSuccess(InstallationArgs),
-    /// Installs a sub-agent whose OCI package defines a failing `post_download_hook`, and verifies
-    /// that the hook runs but the agent is not started because the hook returns a non-zero exit code.
-    PostDownloadHookFailure(InstallationArgs),
     /// Installs Agent Control with a mirrored infra-agent OCI and a custom nri-redis OCI,
     /// spins up a local Redis instance, and verifies that RedisSample data lands in NRDB.
     NriRedis(InstallationArgs),


### PR DESCRIPTION
### Summary
On timeout, the post-download hook executor only killed the direct child, leaving
grandchildren alive and holding the piped stdout/stderr open — blocking `execute()`. This
introduces a cross-platform `ProcessGroup` primitive so the entire process tree is terminated.

### Changes
- Add `utils::process_group::ProcessGroup` (unix: pgid + `killpg`; windows: Job Object).
- Post-download hook timeout now group-kills the tree instead of `child.kill()` (removes TODO).
- Move `job_object` from `sub_agent/on_host/command` to `utils`; give it its own `JobObjectError`.
- Replace `CommandError::WinError(String)` with `#[from] JobObjectError` (windows-gated).
- Add unix/windows tests asserting grandchildren are killed and pipes close promptly.
- Removes failure scenario from e2e

### Notes for reviewers
- Stacked on `gsanchez/feat/hook-logs`; review targets that base, not `main`.
