### PR TITLE
feat: refactor onhost canarie alerts

### DIFF
--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_count.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_count.tftpl
@@ -1,5 +1,5 @@
 SELECT count(${metric})
-FROM ${sample}
+FROM ProcessSample
 WHERE (
   hostname = '${instance_id}'
   AND processDisplayName LIKE 'newrelic-agent-control%'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_count.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_count.tftpl
@@ -1,4 +1,4 @@
-SELECT max(${metric}) OR 0
+SELECT count(${metric})
 FROM ${sample}
 WHERE (
   hostname = '${instance_id}'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_derivative.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_derivative.tftpl
@@ -1,4 +1,4 @@
-SELECT max(${metric}) OR 0
+SELECT ${metric}
 FROM ${sample}
 WHERE (
   hostname = '${instance_id}'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_derivative.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_derivative.tftpl
@@ -1,5 +1,5 @@
 SELECT ${metric}
-FROM ${sample}
+FROM ProcessSample
 WHERE (
   hostname = '${instance_id}'
   AND processDisplayName LIKE 'newrelic-agent-control%'

--- a/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_threshold.tftpl
+++ b/test/onhost-canaries/terraform/alert_nrql_templates/generic_metric_threshold.tftpl
@@ -1,5 +1,5 @@
 SELECT max(${metric}) OR 0
-FROM ${sample}
+FROM ProcessSample
 WHERE (
   hostname = '${instance_id}'
   AND processDisplayName LIKE 'newrelic-agent-control%'

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -86,7 +86,7 @@ locals {
   common_alert_conditions = [
     {
       name          = "CPU usage (percentage)"
-      metric        = "max(cpuPercent) OR 0"
+      metric        = "cpuPercent"
       sample        = "ProcessSample"
       threshold     = 0.06
       duration      = 3600
@@ -95,7 +95,7 @@ locals {
     },
     {
       name          = "Read bytes rate"
-      metric        = "max(ioReadBytesPerSecond) OR 0"
+      metric        = "ioReadBytesPerSecond"
       sample        = "ProcessSample"
       threshold     = 500000
       duration      = 300
@@ -104,7 +104,7 @@ locals {
     },
     {
       name          = "Written bytes rate"
-      metric        = "max(ioWriteBytesPerSecond) OR 0"
+      metric        = "ioWriteBytesPerSecond"
       sample        = "ProcessSample"
       threshold     = 20000
       duration      = 300
@@ -113,12 +113,12 @@ locals {
     },
     {
       name          = "Agent Control metrics presence"
-      metric        = "count(*)"
+      metric        = "*"
       sample        = "ProcessSample"
       threshold     = 0
       duration      = 3600
       operator      = "below_or_equals"
-      template_name = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+      template_name = "./alert_nrql_templates/generic_metric_count.tftpl"
     },
     {
       # Fires if no self-instrumentation logs are received in a 10-minute window,
@@ -148,7 +148,7 @@ locals {
     linux = [
       {
         name          = "Memory usage (bytes)"
-        metric        = "max(memoryResidentSizeBytes) OR 0"
+        metric        = "memoryResidentSizeBytes"
         sample        = "ProcessSample"
         threshold     = 42000000
         duration      = 600
@@ -176,7 +176,7 @@ locals {
         threshold          = 210000
         duration           = 21600
         operator           = "above"
-        template_name      = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+        template_name      = "./alert_nrql_templates/generic_metric_derivative.tftpl"
       }
     ],
     windows = [
@@ -184,7 +184,7 @@ locals {
         name = "Memory usage (bytes)"
         # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
         # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
-        metric        = "max(memoryVirtualSizeBytes) OR 0"
+        metric        = "memoryVirtualSizeBytes"
         sample        = "ProcessSample"
         threshold     = 35000000
         duration      = 600
@@ -214,7 +214,7 @@ locals {
         threshold          = 210000
         duration           = 21600
         operator           = "above"
-        template_name      = "./alert_nrql_templates/generic_metric_threshold.tftpl"
+        template_name      = "./alert_nrql_templates/generic_metric_derivative.tftpl"
       }
     ]
   }
@@ -237,18 +237,6 @@ locals {
       )
     }
   }
-
-  // Flatten the structure for creating individual alert conditions
-  alert_conditions_flat = flatten([
-    for instance_id, instance_data in local.instance_alerts : [
-      for idx, condition in instance_data.conditions : {
-        instance_id = instance_id
-        condition   = condition
-        policy_id   = newrelic_alert_policy.alert_policy[instance_id].id
-        unique_key  = "${instance_id}-${idx}"
-      }
-    ]
-  ])
 }
 
 # Create EC2 instances
@@ -371,44 +359,19 @@ output "ansible_inventory_content" {
   sensitive   = true
 }
 
+# Create alert policy, workflow, notification channels and NRQL conditions for each instance via the shared module
+module "alerts" {
+  source = "../../terraform/modules/nr_alerts"
 
-# Create alert policy for each instance
-resource "newrelic_alert_policy" "alert_policy" {
   for_each = local.instance_alerts
 
-  name = format("%s: %s", var.nr_region, each.key)
-}
+  api_key           = var.api_key
+  account_id        = var.account_id
+  slack_webhook_url = var.slack_webhook_url
+  emails            = var.emails
 
-# Create a single notification destination for all instances
-resource "newrelic_notification_destination" "slack_webhook" {
-  name = "SlackWebhook"
-  type = "WEBHOOK"
-
-  property {
-    key   = "url"
-    value = var.slack_webhook_url
-  }
-}
-
-resource "newrelic_notification_destination" "email" {
-  name = "Email"
-  type = "EMAIL"
-
-  property {
-    key   = "email"
-    value = var.emails
-  }
-}
-
-# Create notification channel for each instance
-resource "newrelic_notification_channel" "slack_channel" {
-  for_each = local.instance_alerts
-
-  name           = "${each.key}-slack"
-  type           = "WEBHOOK"
-  destination_id = newrelic_notification_destination.slack_webhook.id
-  product        = "IINT"
-
+  region      = var.nr_region
+  instance_id = each.key
   property {
     key   = "payload"
     value = templatefile("${path.module}/../../terraform/modules/nr_alerts/alert_slack_payload.tftpl", {
@@ -468,48 +431,5 @@ resource "newrelic_nrql_alert_condition" "condition" {
   name                         = each.value.condition.name
   violation_time_limit_seconds = 3600
 
-  # Defaults values from https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition#example-usage
-  aggregation_window = try(each.value.condition.aggregation_window, 60)
-  slide_by           = try(each.value.condition.slide_by, 30)
-
-  nrql {
-    query = templatefile(
-      each.value.condition.template_name,
-      merge(
-        {
-          "instance_id" : each.value.instance_id,
-          "function" : null,
-          "wheres" : {},
-        },
-        each.value.condition
-      )
-    )
-  }
-
-  critical {
-    operator              = each.value.condition.operator
-    threshold             = each.value.condition.threshold
-    threshold_duration    = each.value.condition.duration
-    threshold_occurrences = "ALL"
-  }
-}
-
-output "alert_policies" {
-  description = "Created alert policies"
-  value = {
-    for k, v in newrelic_alert_policy.alert_policy : k => {
-      id   = v.id
-      name = v.name
-    }
-  }
-}
-
-output "alert_conditions" {
-  description = "Created alert conditions"
-  value = {
-    for k, v in newrelic_nrql_alert_condition.condition : k => {
-      name  = v.name
-      query = v.nrql[0].query
-    }
-  }
+  conditions = each.value.conditions
 }

--- a/test/onhost-canaries/terraform/main.tf
+++ b/test/onhost-canaries/terraform/main.tf
@@ -87,7 +87,6 @@ locals {
     {
       name          = "CPU usage (percentage)"
       metric        = "cpuPercent"
-      sample        = "ProcessSample"
       threshold     = 0.06
       duration      = 3600
       operator      = "above"
@@ -96,7 +95,6 @@ locals {
     {
       name          = "Read bytes rate"
       metric        = "ioReadBytesPerSecond"
-      sample        = "ProcessSample"
       threshold     = 500000
       duration      = 300
       operator      = "above"
@@ -105,7 +103,6 @@ locals {
     {
       name          = "Written bytes rate"
       metric        = "ioWriteBytesPerSecond"
-      sample        = "ProcessSample"
       threshold     = 20000
       duration      = 300
       operator      = "above"
@@ -114,7 +111,6 @@ locals {
     {
       name          = "Agent Control metrics presence"
       metric        = "*"
-      sample        = "ProcessSample"
       threshold     = 0
       duration      = 3600
       operator      = "below_or_equals"
@@ -149,7 +145,6 @@ locals {
       {
         name          = "Memory usage (bytes)"
         metric        = "memoryResidentSizeBytes"
-        sample        = "ProcessSample"
         threshold     = 42000000
         duration      = 600
         operator      = "above"
@@ -170,7 +165,6 @@ locals {
         # In our case, we want 2 data points to be above the threshold, so the duration is 3 hours * 2 = 6 hours.
         name               = "Memory growth (bytes/hour)"
         metric             = "derivative(memoryResidentSizeBytes, 1 hour)"
-        sample             = "ProcessSample"
         aggregation_window = 10800
         slide_by           = 3600
         threshold          = 210000
@@ -185,7 +179,6 @@ locals {
         # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
         # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
         metric        = "memoryVirtualSizeBytes"
-        sample        = "ProcessSample"
         threshold     = 35000000
         duration      = 600
         operator      = "above"
@@ -208,7 +201,6 @@ locals {
         # For the purpose of leak detection using memoryVirtualSizeBytes reflects better the AC memory intent of usage,
         # as memoryResidentSizeBytes gets heavily affected by the way windows manages memory.
         metric             = "derivative(memoryVirtualSizeBytes, 1 hour)"
-        sample             = "ProcessSample"
         aggregation_window = 10800
         slide_by           = 3600
         threshold          = 210000
@@ -372,64 +364,6 @@ module "alerts" {
 
   region      = var.nr_region
   instance_id = each.key
-  property {
-    key   = "payload"
-    value = templatefile("${path.module}/../../terraform/modules/nr_alerts/alert_slack_payload.tftpl", {
-      instance_id    = each.key
-      environment    = var.nr_region
-      alert_subtitle = "Agent Control — On-host canary"
-    })
-  }
-}
-
-resource "newrelic_notification_channel" "email_channel" {
-  for_each = local.instance_alerts
-
-  name           = "${each.key}-email"
-  type           = "EMAIL"
-  destination_id = newrelic_notification_destination.email.id
-  product        = "IINT"
-
-  property {
-    key   = "subject"
-    value = "Alert: ${each.key}"
-  }
-}
-
-# Create workflow for each instance
-resource "newrelic_workflow" "workflow" {
-  for_each = local.instance_alerts
-
-  name                  = each.key
-  muting_rules_handling = "NOTIFY_ALL_ISSUES"
-
-  issues_filter {
-    name = "Issue Filter"
-    type = "FILTER"
-    predicate {
-      attribute = "labels.policyIds"
-      operator  = "EXACTLY_MATCHES"
-      values    = [newrelic_alert_policy.alert_policy[each.key].id]
-    }
-  }
-
-  destination {
-    channel_id = newrelic_notification_channel.slack_channel[each.key].id
-  }
-
-  destination {
-    channel_id = newrelic_notification_channel.email_channel[each.key].id
-  }
-}
-
-# Create NRQL alert conditions
-resource "newrelic_nrql_alert_condition" "condition" {
-  for_each = { for item in local.alert_conditions_flat : item.unique_key => item }
-
-  account_id                   = var.account_id
-  policy_id                    = each.value.policy_id
-  name                         = each.value.condition.name
-  violation_time_limit_seconds = 3600
 
   conditions = each.value.conditions
 }


### PR DESCRIPTION
Refactors the onhost canary alerting in `test/onhost-canaries/terraform/main.tf` to reuse the shared `../../terraform/modules/nr_alerts` module instead of duplicating the policy/notification/workflow/condition resources inline for each canary instance.