### PR TITLE
feat(cli): add agent-type validation command [NR-590798]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Remember that the keywords that you can use are the following:
 
 ## Unreleased
 
+### enhancement
+- Added `agent-type validate --file <path>` subcommand to `newrelic-agent-control-cli` and `newrelic-agent-control-k8s-cli` for schema-level validation of agent type definition files.
+
+
 ## v1.19.1 - 2026-07-23
 
 ### ⛓️ Dependencies

--- a/agent-control/src/agent_type/protocol_version.rs
+++ b/agent-control/src/agent_type/protocol_version.rs
@@ -20,6 +20,8 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 use thiserror::Error;
 
+use crate::agent_control::defaults::AGENT_CONTROL_VERSION;
+
 // Generated from `package.metadata.agent_type_protocol_version` in agent-control/Cargo.toml by
 // build.rs; defines `SUPPORTED_PROTOCOL_VERSION` (the maximum protocol version this Agent Control
 // understands).
@@ -40,7 +42,7 @@ pub enum ProtocolVersionError {
     InvalidFormat(String),
     /// The major version differs from the supported one (a breaking schema change).
     #[error(
-        "unsupported protocol_version {target}: newer than supported (this agent control supports up to {supported})"
+        "unsupported protocol_version {target}: newer than supported (Agent Control {AGENT_CONTROL_VERSION} supports up to {supported})"
     )]
     Incompatible {
         /// The version to be validated.
@@ -142,8 +144,8 @@ mod tests {
     #[case(pv(1, 0), pv(1, 6), Ok(()))]
     #[case(pv(0, 9), pv(1, 6), Ok(()))]
     // Anything newer than supported is too new, whether by minor or major.
-    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(1, 7), supported: pv(1, 6) }))]
-    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(2, 0), supported: pv(1, 6) }))]
+    #[case(pv(1, 7), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(1, 7), supported: pv(1, 6)}))]
+    #[case(pv(2, 0), pv(1, 6), Err(ProtocolVersionError::Incompatible { target: pv(2, 0), supported: pv(1, 6)}))]
     fn compatibility_matrix(
         #[case] target: ProtocolVersion,
         #[case] supported: ProtocolVersion,

--- a/agent-control/src/bin/main_agent_control_k8s_cli.rs
+++ b/agent-control/src/bin/main_agent_control_k8s_cli.rs
@@ -1,6 +1,6 @@
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand};
-use newrelic_agent_control::cli::common::{error::CliError, logs};
+use newrelic_agent_control::cli::common::{agent_type_validation, error::CliError, logs};
 use newrelic_agent_control::cli::k8s::install::agent_control::InstallAgentControl;
 use newrelic_agent_control::cli::k8s::install::flux::InstallFlux;
 use newrelic_agent_control::cli::k8s::install::{InstallData, apply_resources};
@@ -46,6 +46,17 @@ enum Operations {
 
     /// Registers the System Identity to be used in Agent Control for authentication.
     RegisterSystemIdentity(system_identity::Args),
+
+    /// Operations on agent type definitions.
+    #[command(subcommand)]
+    AgentType(AgentTypeCommand),
+}
+
+/// Commands to operate on agent type definitions.
+#[derive(Debug, Subcommand)]
+enum AgentTypeCommand {
+    /// Validates an agent type definition file (schema-level checks only).
+    Validate(agent_type_validation::Args),
 }
 
 fn main() -> ExitCode {
@@ -57,36 +68,40 @@ fn main() -> ExitCode {
         return err.into();
     }
 
-    let result = match cli.operation {
+    let result: Result<(), CliError> = match cli.operation {
         Operations::InstallAgentControl(agent_control_data) => {
             apply_resources(InstallAgentControl, &cli.namespace, &agent_control_data)
+                .map_err(CliError::from)
         }
         Operations::UninstallAgentControl(agent_control_data) => {
-            uninstall_agent_control(&cli.namespace, &agent_control_data)
+            uninstall_agent_control(&cli.namespace, &agent_control_data).map_err(CliError::from)
         }
         Operations::CreateCDResources(cd_data) => {
             // Currently this means installing Flux, but in the future it could mean other CD tool
             // or support different ones
-            apply_resources(InstallFlux, &cli.namespace, &cd_data)
+            apply_resources(InstallFlux, &cli.namespace, &cd_data).map_err(CliError::from)
         }
         Operations::RemoveCDResources(cd_data) => {
-            remove_flux_crs(&cli.namespace, &cd_data.release_name)
+            remove_flux_crs(&cli.namespace, &cd_data.release_name).map_err(CliError::from)
         }
         Operations::RegisterSystemIdentity(args) => match args.validate() {
-            Ok(spec) => register_system_identity(&cli.namespace, spec),
+            Ok(spec) => register_system_identity(&cli.namespace, spec).map_err(CliError::from),
             Err(err) => {
                 let mut cmd = Cli::command();
                 cmd.error(ErrorKind::ArgumentConflict, err.to_string())
                     .exit()
             }
         },
+        Operations::AgentType(AgentTypeCommand::Validate(args)) => {
+            agent_type_validation::validate(args)
+        }
     };
 
     match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             error!("Operation failed: {}", err);
-            CliError::from(err).into()
+            err.into()
         }
     }
 }

--- a/agent-control/src/bin/main_agent_control_k8s_cli.rs
+++ b/agent-control/src/bin/main_agent_control_k8s_cli.rs
@@ -68,7 +68,7 @@ fn main() -> ExitCode {
         return err.into();
     }
 
-    let result: Result<(), CliError> = match cli.operation {
+    let result = match cli.operation {
         Operations::InstallAgentControl(agent_control_data) => {
             apply_resources(InstallAgentControl, &cli.namespace, &agent_control_data)
                 .map_err(CliError::from)

--- a/agent-control/src/bin/main_agent_control_onhost_cli.rs
+++ b/agent-control/src/bin/main_agent_control_onhost_cli.rs
@@ -1,6 +1,7 @@
 use std::process::ExitCode;
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
+use newrelic_agent_control::cli::common::agent_type_validation;
 use newrelic_agent_control::cli::on_host::migrate_folders;
 use newrelic_agent_control::cli::{common::logs, on_host::config_gen};
 use tracing::{Level, error};
@@ -24,6 +25,16 @@ enum Commands {
     GenerateConfig(config_gen::Args),
     /// Migrates legacy on-host directories (>v1.4.0) to the new layout. Intended to be run by post-installation package scripts only.
     FilesBackwardsCompatibilityMigrationFromV120,
+    /// Operations on agent type definitions.
+    #[command(subcommand)]
+    AgentType(AgentTypeCommand),
+}
+
+/// Commands to operate on agent type definitions.
+#[derive(Debug, clap::Subcommand)]
+enum AgentTypeCommand {
+    /// Validates an agent type definition file (schema-level checks only).
+    Validate(agent_type_validation::Args),
 }
 
 fn main() -> ExitCode {
@@ -45,6 +56,9 @@ fn main() -> ExitCode {
             }
         },
         Commands::FilesBackwardsCompatibilityMigrationFromV120 => migrate_folders::migrate(),
+        Commands::AgentType(AgentTypeCommand::Validate(args)) => {
+            agent_type_validation::validate(args)
+        }
     };
 
     if let Err(err) = result {

--- a/agent-control/src/cli/common.rs
+++ b/agent-control/src/cli/common.rs
@@ -1,4 +1,5 @@
 //! Building blocks shared across the on-host and Kubernetes CLI commands.
+pub mod agent_type_validation;
 pub mod error;
 pub mod logs;
 pub mod proxy_config;

--- a/agent-control/src/cli/common/agent_type_validation.rs
+++ b/agent-control/src/cli/common/agent_type_validation.rs
@@ -1,0 +1,142 @@
+//! Implementation of the `agent-type validate` command.
+use std::{fs, path::PathBuf};
+
+use crate::agent_type::definition::AgentTypeDefinition;
+use crate::cli::common::error::CliError;
+use tracing::info;
+
+/// Validates an agent type definition file.
+#[derive(Debug, clap::Parser)]
+pub struct Args {
+    /// Path to the agent type definition file to validate.
+    #[arg(long, required = true)]
+    file: PathBuf,
+}
+
+/// Reads the agent type file and validates its schema (required fields, field types and format
+/// constraints), reporting any issue found.
+pub fn validate(args: Args) -> Result<(), CliError> {
+    let content = fs::read(&args.file).map_err(|err| {
+        CliError::FileSystemError(format!("reading '{}': {err}", args.file.display()))
+    })?;
+
+    let definition = AgentTypeDefinition::from_slice(&content).map_err(|err| {
+        CliError::Validation(format!(
+            "invalid agent type definition on '{}': {}",
+            args.file.display(),
+            err
+        ))
+    })?;
+
+    info!(
+        agent_type = %definition.agent_type_id(),
+        file = %args.file.display(),
+        "Agent type definition is valid"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use rstest::rstest;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    const VALID_HOST_YAML: &str = r#"
+namespace: newrelic
+name: test
+version: 0.0.1
+protocol_version: "1.0"
+platform: host
+operating_system: linux
+variables: {}
+deployment: {}
+"#;
+
+    const VALID_K8S_YAML: &str = r#"
+namespace: newrelic
+name: test
+version: 0.0.1
+protocol_version: "1.0"
+platform: kubernetes
+variables: {}
+deployment:
+  objects: {}
+"#;
+
+    const MISSING_REQUIRED_FIELD_YAML: &str = r#"
+namespace: newrelic
+name: test
+version: 0.0.1
+protocol_version: "1.0"
+platform: kubernetes
+"#;
+
+    const MALFORMED_YAML: &str = "name: [unclosed";
+
+    const MISSING_PROTOCOL_VERSION_YAML: &str = r#"
+namespace: newrelic
+name: test
+version: 0.0.1
+platform: kubernetes
+variables: {}
+deployment:
+  objects: {}
+"#;
+
+    // A far-future version is newer than this Agent Control understands.
+    const TOO_NEW_PROTOCOL_VERSION_YAML: &str = r#"
+namespace: newrelic
+name: test
+version: 0.0.1
+protocol_version: "9999.0"
+platform: kubernetes
+variables: {}
+deployment:
+  objects: {}
+"#;
+
+    fn write_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(content.as_bytes())
+            .expect("failed to write temp file");
+        file
+    }
+
+    #[rstest]
+    #[case::host(VALID_HOST_YAML)]
+    #[case::k8s(VALID_K8S_YAML)]
+    fn test_validate_accepts_valid_definitions(#[case] yaml: &str) {
+        let file = write_file(yaml);
+        let args = Args {
+            file: file.path().to_path_buf(),
+        };
+
+        assert_matches!(validate(args), Ok(()));
+    }
+
+    #[rstest]
+    #[case::missing_field(MISSING_REQUIRED_FIELD_YAML)]
+    #[case::malformed_yaml(MALFORMED_YAML)]
+    #[case::missing_protocol_version(MISSING_PROTOCOL_VERSION_YAML)]
+    #[case::too_new_protocol_version(TOO_NEW_PROTOCOL_VERSION_YAML)]
+    fn test_validate_rejects_invalid_definitions(#[case] yaml: &str) {
+        let file = write_file(yaml);
+        let args = Args {
+            file: file.path().to_path_buf(),
+        };
+
+        assert_matches!(validate(args), Err(CliError::Validation(_)));
+    }
+
+    #[test]
+    fn test_validate_reports_filesystem_error_for_missing_file() {
+        let args = Args {
+            file: PathBuf::from("/nonexistent/path/agent-type.yaml"),
+        };
+
+        assert_matches!(validate(args), Err(CliError::FileSystemError(_)));
+    }
+}

--- a/agent-control/src/cli/common/error.rs
+++ b/agent-control/src/cli/common/error.rs
@@ -22,6 +22,10 @@ pub enum CliError {
     /// A filesystem operation failed.
     #[error("file system error: {0}")]
     FileSystemError(String),
+
+    /// The input data provided to the command was invalid.
+    #[error("{0}")]
+    Validation(String),
 }
 
 impl From<CliError> for ExitCode {
@@ -38,6 +42,7 @@ impl From<CliError> for ExitCode {
             CliError::Tracing(_) => Self::from(70),
             CliError::Command(_) => Self::from(1),
             CliError::FileSystemError(_) => Self::from(1),
+            CliError::Validation(_) => Self::from(65),
         }
     }
 }

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -852,6 +852,14 @@ Only definitions that target the environment of the running binary are considere
 
 This precedence is what makes the custom directory useful for development: you can add a brand-new agent type, or iterate on and override an existing one, simply by dropping a file there — without rebuilding AC or editing the embedded registry — while still falling back to the built-in and remote sources for everything else. For a step-by-step walkthrough of adding a custom on-host agent type, see the [development guide in the agent type overview](./agent_type.md#development-custom-agent-types).
 
+Whichever source a definition is headed for, you can check its schema (required fields, field types, and format
+constraints) beforehand, without running AC at all, using the `agent-type validate` subcommand shipped with the CLI
+binaries:
+
+```sh
+newrelic-agent-control-cli agent-type validate --file <path-to-file>.yaml
+```
+
 ## Applying configurations
 
 The first time it runs, whether it's using static configs or when already running and receiving remote configuration values from FC, AC will create an internal entity called a *supervisor* for each of the declared sub-agents. Each of these supervisors have the following responsibilities:

--- a/docs/INTEGRATING_AGENTS.md
+++ b/docs/INTEGRATING_AGENTS.md
@@ -860,6 +860,13 @@ binaries:
 newrelic-agent-control-cli agent-type validate --file <path-to-file>.yaml
 ```
 
+Or, without installing the binary, via the published Docker image, mounting the directory that contains the file:
+
+```sh
+docker run --rm -v "$(pwd)":/data newrelic/newrelic-agent-control-cli:latest \
+  agent-type validate --file /data/<path-to-file>.yaml
+```
+
 ## Applying configurations
 
 The first time it runs, whether it's using static configs or when already running and receiving remote configuration values from FC, AC will create an internal entity called a *supervisor* for each of the declared sub-agents. Each of these supervisors have the following responsibilities:

--- a/docs/agent_type.md
+++ b/docs/agent_type.md
@@ -419,6 +419,13 @@ take precedence over any other definition with the same id (namespace + name + v
 The current layout expects **a directory** at `/etc/newrelic-agent-control/dynamic-agent-types/` containing one file per
 agent type.
 
+Before dropping a definition into that directory, you can check its schema (required fields, field types, and format
+constraints) without running Agent Control at all:
+
+```sh
+newrelic-agent-control-cli agent-type validate --file my-custom-agent-type.yaml
+```
+
 ### On-host
 
 This guideline shows how to build a custom agent type and integrate it with the agent control on-host. The [telegraf agent](https://www.influxdata.com/time-series-platform/telegraf/) is used as a reference.
@@ -540,4 +547,3 @@ Each ConfigMap key becomes a file inside the directory, so a single ConfigMap ca
    ```
 
    To pick up a fresh ConfigMap, `helm upgrade` (or restart the AC pod).
-


### PR DESCRIPTION
This PR adds an `agent-type validate --file <path>` subcommand to both the on-host and Kubernetes CLI binaries, letting users check an agent type definition's schema (required fields, types, format constraints) without running Agent Control.

The validation error message returned when the protocol version is newer than the supported by Agent Control has been updated to include the AC version (the previous message stated 'this agent control' which doesn't make sense when performing CLI validation).

```shell
cargo run --bin newrelic-agent-control-cli -- agent-type validate --file agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure.nri_redis-0.1.0.yaml

2026-07-22T11:41:33  INFO Agent type definition is valid, agent_type: newrelic/com.newrelic.infrastructure.nri_redis:0.1.0, file: agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure.nri_redis-0.1.0.yaml
```

It is included in both CLI binaries so it is distributed both in the Agent Control packages and the Agent Control container.
