### PR TITLE
fix: remove nri-flex from infra agent type

### DIFF
--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -99,9 +99,6 @@ deployment:
     infra-agent-ohi-binaries:
       kind: dir
       entries:
-        nri-flex:
-          kind: file
-          copy_from_file: ${nr-sub:packages.infra-agent.dir}/integrations/nri-flex
         nri-docker:
           kind: file
           copy_from_file: ${nr-sub:packages.infra-agent.dir}/integrations/nri-docker

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -91,9 +91,6 @@ deployment:
     infra-agent-ohi-binaries:
       kind: dir
       entries:
-        nri-flex.exe:
-          kind: file
-          copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nri-flex.exe
         nri-prometheus.exe:
           kind: file
           copy_from_file: ${nr-sub:packages.infra-agent.dir}\\integrations\\nri-prometheus.exe

--- a/test/e2e-runner/src/common/ohi.rs
+++ b/test/e2e-runner/src/common/ohi.rs
@@ -5,9 +5,8 @@ use std::path::Path;
 pub const SHARED_LINUX_FILESYSTEM_DIR: &str = "/var/lib/newrelic-agent-control/shared-filesystem";
 pub const SHARED_WINDOWS_FILESYSTEM_DIR: &str =
     r"C:\ProgramData\New Relic\newrelic-agent-control\shared-filesystem";
-pub const EMBEDDED_LINUX_OHI_BINARIES: [&str; 3] = ["nri-flex", "nri-prometheus", "nri-docker"];
-pub const EMBEDDED_WINDOWS_OHI_BINARIES: [&str; 5] = [
-    "nri-flex.exe",
+pub const EMBEDDED_LINUX_OHI_BINARIES: [&str; 2] = ["nri-prometheus", "nri-docker"];
+pub const EMBEDDED_WINDOWS_OHI_BINARIES: [&str; 4] = [
     "nri-prometheus.exe",
     "nr-winpkg.exe",
     "nri-winservices.exe",


### PR DESCRIPTION
As nri-flex won't be embedded, this PR removes it from the infrastructure Agent Type