### PR TITLE
feat: add new check for binary size in prs

### DIFF
--- a/.github/workflows/component_packages.yml
+++ b/.github/workflows/component_packages.yml
@@ -22,6 +22,18 @@ on:
       pfx_passphrase:
         description: 'Passphrase of the PFX certificate'
         required: false
+      nr_account_id:
+        description: 'New Relic account ID for binary size reporting (optional)'
+        required: false
+      nr_license_key:
+        description: 'New Relic license key, Events API ingest key (optional)'
+        required: false
+      nr_user_api_key:
+        description: 'New Relic User API key for the growth check via NerdGraph (optional)'
+        required: false
+      slack_webhook_url:
+        description: 'Slack webhook for binary size growth warnings (optional)'
+        required: false
     inputs:
       pre-release:
         description: 'set to true if running a real pre-release'
@@ -41,6 +53,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build and upload
+    outputs:
+      binary-size-warnings: ${{ steps.binary-size.outputs.warnings }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -117,6 +131,29 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ inputs.tag_name }}
           SKIP_WINDOWS_SIGN: ${{ env.SKIP_WINDOWS_SIGN }}
 
+      - name: Report binary sizes to New Relic
+        id: binary-size
+        env:
+          BINARY_VERSION: ${{ inputs.tag_name }}
+          NR_ACCOUNT_ID: ${{ secrets.nr_account_id }}
+          NR_LICENSE_KEY: ${{ secrets.nr_license_key }}
+          NR_USER_API_KEY: ${{ secrets.nr_user_api_key }}
+          WARNINGS_FILE: binary-size-warnings.txt
+        run: |
+          : > "$WARNINGS_FILE"
+          for path in dist/*/newrelic-agent-control dist/*/newrelic-agent-control-cli dist/*/newrelic-agent-control.exe dist/*/newrelic-agent-control-cli.exe; do
+            [ -f "$path" ] || continue
+            export BINARY_PATH="$path"
+            bash .github/workflows/scripts/report_binary_size.sh
+          done
+          if [ -s "$WARNINGS_FILE" ]; then
+            {
+              echo "warnings<<EOF"
+              cat "$WARNINGS_FILE"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload assets to pipeline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -125,6 +162,22 @@ jobs:
           path: |
             ./bin/*
             ./dist/*
+
+  notify-binary-size-growth:
+    name: Warn on binary size growth
+    needs: build
+    # Keep this event allow-list in sync with TRACKED_TRIGGER_EVENTS in report_binary_size.sh:
+    # only nightly (schedule/workflow_dispatch) and real pre-releases (release) build comparable
+    # binaries. Explicit here too so a PR run can never trigger this, even if warnings weren't empty.
+    if: |
+      needs.build.outputs.binary-size-warnings != '' &&
+      contains(fromJSON('["schedule", "workflow_dispatch", "release"]'), github.event_name)
+    continue-on-error: true
+    uses: ./.github/workflows/component_send_warning_via_slack.yml
+    with:
+      message: ${{ needs.build.outputs.binary-size-warnings }}
+    secrets:
+      slack_webhook_url: ${{ secrets.slack_webhook_url }}
 
   verify-windows-signatures:
     runs-on: windows-latest

--- a/.github/workflows/component_send_warning_via_slack.yml
+++ b/.github/workflows/component_send_warning_via_slack.yml
@@ -7,6 +7,10 @@ on:
         description: 'The message to include in the Slack notification'
         required: true
         type: string
+    secrets:
+      slack_webhook_url:
+        description: 'Slack webhook URL (optional; falls back to AC_SLACK_WEBHOOK via secrets: inherit)'
+        required: false
 
 permissions:
   contents: read
@@ -24,5 +28,5 @@ jobs:
               "text": ":warning: [${{ inputs.message }}] @hero check <${{ env.GITHUB_JOB_URL }}>"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.AC_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url || secrets.AC_SLACK_WEBHOOK }}
           GITHUB_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,10 @@ jobs:
       gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
       pfx_certificate_base64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
       pfx_passphrase: ${{ secrets.OHAI_PFX_PASSPHRASE }}
+      nr_account_id: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      nr_license_key: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
+      nr_user_api_key: ${{ secrets.AC_NR_USER_API_KEY }}
+      slack_webhook_url: ${{ secrets.AC_SLACK_WEBHOOK }}
 
   build-image:
     name: Build and Push nightly image

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,6 +33,10 @@ jobs:
       gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
       pfx_certificate_base64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
       pfx_passphrase: ${{ secrets.OHAI_PFX_PASSPHRASE }}
+      nr_account_id: ${{ secrets.AC_PROD_E2E_ACCOUNT_ID }}
+      nr_license_key: ${{ secrets.AC_PROD_E2E_LICENSE_KEY }}
+      nr_user_api_key: ${{ secrets.AC_NR_USER_API_KEY }}
+      slack_webhook_url: ${{ secrets.AC_SLACK_WEBHOOK }}
 
   build-image:
     name: Build and Push container image

--- a/.github/workflows/push_pr_checks_tests.yml
+++ b/.github/workflows/push_pr_checks_tests.yml
@@ -149,6 +149,11 @@ jobs:
   generate-release-build:
     name: "Build release binaries"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      binary-size-report: ${{ steps.sizes.outputs.report }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -182,6 +187,94 @@ jobs:
         run: cargo zigbuild --release --package newrelic_agent_control --bin newrelic-agent-control-k8s --target x86_64-unknown-linux-musl
       - name: Build onhost in release mode
         run: cargo zigbuild --release --package newrelic_agent_control --bin newrelic-agent-control --target x86_64-unknown-linux-musl
+      - name: Build onhost CLI in release mode
+        run: cargo zigbuild --release --package newrelic_agent_control --bin newrelic-agent-control-cli --target x86_64-unknown-linux-musl
+
+      - name: Find latest baseline run on main
+        id: baseline-run
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list --workflow=push_pr_checks_tests.yml --branch=main \
+            --status=success --limit=1 --json databaseId --jq '.[0].databaseId // empty')
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download baseline artifact
+        if: steps.baseline-run.outputs.run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-size-baseline
+          path: binary-size/baseline
+          run-id: ${{ steps.baseline-run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Measure binary sizes
+        id: sizes
+        run: |
+          dir="target/x86_64-unknown-linux-musl/release"
+          mkdir -p binary-size
+          : > binary-size/current.txt
+          for name in newrelic-agent-control newrelic-agent-control-cli; do
+            stat -c%s "$dir/$name" | xargs -I{} echo "$name {}" >> binary-size/current.txt
+          done
+
+          baseline_file="binary-size/baseline/current.txt"
+          {
+            echo "report<<EOF"
+            echo "## 📦 Binary size"
+            if [ -f "$baseline_file" ]; then
+              echo "| Binary | main | PR | Δ |"
+              echo "|---|---|---|---|"
+            else
+              echo "| Binary | Size |"
+              echo "|---|---|"
+            fi
+            while read -r name bytes; do
+              human=$(awk -v b="$bytes" 'BEGIN { printf "%.2f MB", b / 1000000 }')
+              if [ -f "$baseline_file" ]; then
+                base_bytes=$(awk -v n="$name" '$1==n {print $2}' "$baseline_file")
+                if [ -n "$base_bytes" ]; then
+                  base_human=$(awk -v b="$base_bytes" 'BEGIN { printf "%.2f MB", b / 1000000 }')
+                  delta=$((bytes - base_bytes))
+                  delta_mb=$(awk -v d="$delta" 'BEGIN { printf (d>=0?"+%.2f":"%.2f"), d/1000000 }')
+                  pct=$(awk -v d="$delta" -v b="$base_bytes" 'BEGIN { printf "%.2f", (b==0)?0:(d*100.0/b) }')
+                  icon="➡️"; [ "$delta" -gt 0 ] && icon="⬆️"; [ "$delta" -lt 0 ] && icon="⬇️"
+                  echo "| $name | $base_human | $human | $icon ${delta_mb} MB (${pct}%) |"
+                else
+                  echo "| $name | _no baseline_ | $human | — |"
+                fi
+              else
+                echo "| $name | $human |"
+              fi
+            done < binary-size/current.txt
+            if [ ! -f "$baseline_file" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo ""
+              echo "_No baseline found for \`main\` (first run after enabling this check, or the artifact expired)._"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload size baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-size-baseline
+          path: binary-size/current.txt
+
+  binary-size-comment:
+    name: Comment binary size on PR
+    needs: generate-release-build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: binary-size
+          message: ${{ needs.generate-release-build.outputs.binary-size-report }}
 
   unit-docs-onhost-integration-tests:
     name: Unit, docs and onhost integration tests

--- a/.github/workflows/scripts/report_binary_size.sh
+++ b/.github/workflows/scripts/report_binary_size.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Reports one AgentControlStats event to New Relic; appends a warning to WARNINGS_FILE
+# if the binary grew >10%. Sending that warning to Slack is the caller's job, not this script's.
+#
+# BINARY_NAME and BINARY_TARGET are derived from BINARY_PATH, assuming the goreleaser
+# layout dist/<build-id>_<target>/<binary>.
+#
+# Required env: BINARY_PATH, BINARY_VERSION, NR_ACCOUNT_ID, NR_LICENSE_KEY
+# Optional env: NR_USER_API_KEY (NerdGraph, skips growth check if unset), WARNINGS_FILE (default: binary-size-warnings.txt)
+
+set -euo pipefail
+
+GROWTH_THRESHOLD_PCT=10
+
+if [[ -z "${BINARY_PATH:-}" ]]; then
+  echo "BINARY_PATH is required" >&2
+  exit 1
+fi
+
+# Only nightly (schedule/workflow_dispatch) and real pre-releases (release) build the binary
+# the same way, so only they are size-comparable. Gate on this explicitly instead of relying
+# on which callers happen to be wired with NR secrets.
+TRACKED_TRIGGER_EVENTS=("schedule" "workflow_dispatch" "release")
+if ! printf '%s\n' "${TRACKED_TRIGGER_EVENTS[@]}" | grep -qx "${GITHUB_EVENT_NAME:-}"; then
+  echo "GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME:-<unset>} is not a tracked release pipeline, skipping binary size report for ${BINARY_PATH}"
+  exit 0
+fi
+
+if [[ -z "${NR_ACCOUNT_ID:-}" || -z "${NR_LICENSE_KEY:-}" ]]; then
+  echo "NR_ACCOUNT_ID/NR_LICENSE_KEY not set, skipping binary size report for ${BINARY_PATH}"
+  exit 0
+fi
+
+BINARY_NAME=$(basename "$BINARY_PATH" .exe)
+BINARY_TARGET_DIR=$(basename "$(dirname "$BINARY_PATH")")
+BINARY_TARGET="${BINARY_TARGET_DIR#*_}"
+
+SIZE_BYTES=$(stat -c%s "$BINARY_PATH")
+
+# GITHUB_HEAD_REF is set for PRs; GITHUB_REF_NAME covers push/schedule/dispatch.
+BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+
+# Fetch the previous size before reporting the current one, so we don't race our own insert.
+PREVIOUS_SIZE_BYTES=""
+if [[ -n "${NR_USER_API_KEY:-}" ]]; then
+  nrql_query="SELECT sizeBytes FROM AgentControlStats WHERE binaryName = '${BINARY_NAME}' AND target = '${BINARY_TARGET}' SINCE 90 days ago ORDER BY timestamp DESC LIMIT 1"
+  graphql_query="{ actor { account(id: ${NR_ACCOUNT_ID}) { nrql(query: \"${nrql_query}\") { results } } } }"
+  request_body=$(jq -n --arg query "$graphql_query" '{query: $query}')
+
+  nerdgraph_response=$(curl -s -X POST "https://api.newrelic.com/graphql" \
+    -H "Content-Type: application/json" \
+    -H "API-Key: ${NR_USER_API_KEY}" \
+    -d "$request_body")
+
+  PREVIOUS_SIZE_BYTES=$(echo "$nerdgraph_response" | jq -r '.data.actor.account.nrql.results[0].sizeBytes // empty')
+fi
+
+event=$(jq -n \
+  --arg binaryName   "$BINARY_NAME" \
+  --arg target       "$BINARY_TARGET" \
+  --arg version      "$BINARY_VERSION" \
+  --arg commit       "$GITHUB_SHA" \
+  --arg branch       "$BRANCH" \
+  --arg runId        "$GITHUB_RUN_ID" \
+  --arg triggerEvent "$GITHUB_EVENT_NAME" \
+  --argjson sizeBytes "$SIZE_BYTES" \
+  '[{
+    eventType:    "AgentControlStats",
+    binaryName:   $binaryName,
+    target:       $target,
+    version:      $version,
+    commit:       $commit,
+    branch:       $branch,
+    runId:        $runId,
+    triggerEvent: $triggerEvent,
+    sizeBytes:    $sizeBytes
+  }]')
+
+curl -s -X POST \
+  "https://insights-collector.newrelic.com/v1/accounts/${NR_ACCOUNT_ID}/events" \
+  -H "Content-Type: application/json" \
+  -H "Api-Key: ${NR_LICENSE_KEY}" \
+  -d "$event"
+
+if [[ -z "$PREVIOUS_SIZE_BYTES" ]]; then
+  echo "No previous build found for ${BINARY_NAME} (${BINARY_TARGET}), skipping growth check"
+elif [[ "$PREVIOUS_SIZE_BYTES" == "0" ]]; then
+  echo "Previous build for ${BINARY_NAME} (${BINARY_TARGET}) reported size 0 bytes, skipping growth check"
+else
+  growth_pct=$(awk -v cur="$SIZE_BYTES" -v prev="$PREVIOUS_SIZE_BYTES" \
+    'BEGIN { printf "%.2f", (cur - prev) * 100.0 / prev }')
+
+  if awk -v p="$growth_pct" -v t="$GROWTH_THRESHOLD_PCT" 'BEGIN { exit !(p > t) }'; then
+    prev_mb=$(awk -v b="$PREVIOUS_SIZE_BYTES" 'BEGIN { printf "%.2f", b / 1000000 }')
+    cur_mb=$(awk -v b="$SIZE_BYTES" 'BEGIN { printf "%.2f", b / 1000000 }')
+    warning="Agent Control binary \`${BINARY_NAME}\` (${BINARY_TARGET}) grew ${growth_pct}% versus its previous build: ${prev_mb} MB -> ${cur_mb} MB (version ${BINARY_VERSION})"
+    echo "Binary size regression: $warning"
+    echo "$warning" >> "${WARNINGS_FILE:-binary-size-warnings.txt}"
+  fi
+fi


### PR DESCRIPTION
## Summary

Adds a binary size check for Agent Control: a PR comment that tracks size against `main`, plus reporting and alerting for nightly/release builds.

- **PR check**: measures `newrelic-agent-control` / `newrelic-agent-control-cli` on every PR build and posts a sticky comment with size and Δ vs the last successful build on `main` (bytes/% delta). Purely informational, doesn't block merge. Falls back gracefully to "no baseline found" when there's nothing to compare against yet (first run after enabling this, or the baseline artifact expired).
- **Nightly/release reporting**: every built binary (control + CLI, all platforms) is reported as an `AgentControlStats` custom event to New Relic on `nightly.yml` and `prerelease.yml` runs, queryable via NRQL.
- **Growth alert**: before reporting, looks up the previous build's size for that same binary+target via NerdGraph. If it grew more than 10%, warns on Slack by reusing the existing `component_send_warning_via_slack.yml`.

## Changes

- `.github/workflows/push_pr_checks_tests.yml` binary size measurement, baseline artifact (published on push to `main`, downloaded on PRs), sticky PR comment.
- `.github/workflows/scripts/report_binary_size.sh` new script: reports size to the Events API, checks growth via NerdGraph, writes a warning file if >10%.
- `.github/workflows/component_packages.yml` new step calling the script per binary; new `notify-binary-size-growth` job that warns on Slack when triggered.
- `.github/workflows/component_send_warning_via_slack.yml` accepts an explicit `slack_webhook_url` secret.

