### PR TITLE
feat(k8s): make release-name optional on uninstall command [NR-572127]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Remember that the keywords that you can use are the following:
 ## Unreleased
 
 ### enhancement
+- Kubernetes: `--release-name` is now optional on `uninstall-agent-control`; omitting it skips deleting the release's own HelmRelease/HelmRepository CRs.
 - On-host: added nri-apache and nri-nginx agentTypes.
 - On-host: added nri-postgresql agentType.
 - On-host: added nri-mysql agentType.

--- a/agent-control/src/cli/k8s/uninstall/agent_control.rs
+++ b/agent-control/src/cli/k8s/uninstall/agent_control.rs
@@ -12,6 +12,7 @@ use crate::k8s::labels::Labels;
 use clap::Parser;
 use kube::api::TypeMeta;
 use std::collections::HashSet;
+use tracing::info;
 
 /// Arguments for the Agent Control uninstall command.
 #[derive(Debug, Clone, Parser)]
@@ -20,9 +21,9 @@ pub struct AgentControlUninstallData {
     #[arg(long)]
     pub namespace_agents: String,
 
-    /// Name of the Helm release.
+    /// Name of the Helm release. Omit to skip deleting the release's own HelmRelease/HelmRepository CRs.
     #[arg(long)]
-    pub release_name: String,
+    pub release_name: Option<String>,
 }
 
 /// Removes the Agent Control custom resources and all owned objects from the given namespaces.
@@ -38,7 +39,12 @@ pub fn uninstall_agent_control(
     } = uninstall_data;
 
     // we delete first the AC so that it does not interfere (by recreating resources that we have just deleted).
-    delete_agent_control_crs(&k8s_client, &kinds_available, namespace, release_name)?;
+    match release_name {
+        Some(release_name) => {
+            delete_agent_control_crs(&k8s_client, &kinds_available, namespace, release_name)?;
+        }
+        None => info!("No release name provided, skipping deletion of Agent Control own CRs"),
+    }
 
     // We filter the static list of objects we want to delete against what is actually available in the cluster.
     let valid_objects_to_delete = objects_to_delete(&kinds_available);
@@ -84,7 +90,7 @@ fn delete_owned_objects(
 /// Moreover, it adds ConfigMap to the list since it is not part of the default_group_version_kinds().
 /// it also filters away object that are not available in the cluster.
 /// On top of it, in the fluxless scenarios it loads the HelmRelease and HelmRepository CRs to be deleted,
-/// but it it a noop since they are not actually present in the cluster.
+/// but it is a noop since they are not actually present in the cluster.
 fn objects_to_delete(kinds_available: &HashSet<TypeMeta>) -> Vec<TypeMeta> {
     let mut tm_to_delete = default_group_version_kinds();
 


### PR DESCRIPTION
## Summary

This PR adds support to skipping the AC's own CRs deletion on the uninstall command for k8s.

## Context

Currently, the `agent-control-boostrap` chart [uninstallation-job](https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-bootstrap/templates/uninstallation-job.yaml) is the only one that executes the CLI's uninstall command. Therefore, Flux-less environments (where `agent-control-deployment` is installed directly) doesn't have the corresponding cleanup of resources on uninstall. At the moment, [agent-control-deployment's uninstallation-job](https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-deployment/templates/uninstallation-job.yaml) merely removes the owned ConfigMaps using a script.

The plan is to also execute the CLI's uninstall command on `agent-control-deployment` uninstall job.

* `agent-control-deployment` uninstallation-job:
  - Would wait for the  Agent Control pod to be delete through `kubectl wait --for=delete pod ...` (to avoid resources to re-created) and execute the uninstall command **without `--release-name`**.
  - Resources are removed on environments with and without `agent-control-bootstrap`.
* `agent-control-boostrap` uninstallation:
  - Would remain unchanged.
  - It will delete the Agent Control's own CRs first (triggering the agent-control-deployment's uninstall) and execute the reste of delete operations that will become no-op.

## Other options considered

- Call CLI's uninstall command as it is from deployment's uninstall: this could lead to race-conditions (causing delays) because the jobs of both uninstall jobs (bootstrap and deployment) would try to delete the Agent Control's CRs.
- Split up uninstall (Agent Control's CRs + Agent Control managed resources): this would avoid the no-op operations in the bootstrap's chart and can be addressed as follow up. However it involves a wider change in the CLI and the charts.
   
