### PR TITLE
chore: introduce strum for enum iteration and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "serial_test",
+ "strum 0.28.0",
  "tar",
  "tempfile",
  "thiserror",
@@ -3258,8 +3259,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror",
 ]
 
@@ -4692,10 +4693,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ oci-client = { version = "0.17.0", default-features = false }
 tokio = "1.53.1"
 base64 = "0.23.0"
 actix-web = "4.14.0"
+strum = { version = "0.28.0", features = ["derive"] }
 
 [profile.release-debug]
 inherits = "release"

--- a/agent-control/Cargo.toml
+++ b/agent-control/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
 base64 = { workspace = true }
+strum = { workspace = true }
 
 # New Relic dependencies (external repos)
 opamp-client = { workspace = true }

--- a/agent-control/src/agent_type/error.rs
+++ b/agent-control/src/agent_type/error.rs
@@ -31,9 +31,6 @@ pub enum AgentTypeError {
     /// A `kind: file` entry is invalid
     #[error("invalid filesystem file entry: {0}")]
     InvalidFileEntry(String),
-    /// The configured backoff strategy type is not recognized.
-    #[error("unknown backoff strategy type: {0}")]
-    UnknownBackoffStrategyType(String),
     /// The provided value is not one of the allowed variants.
     #[error("invalid value provided. Variants allowed: {0}")]
     InvalidVariant(String),

--- a/agent-control/src/agent_type/oci.rs
+++ b/agent-control/src/agent_type/oci.rs
@@ -52,6 +52,7 @@ fn environment_prefix(environment: Environment) -> &'static str {
 mod tests {
     use super::*;
     use crate::agent_type::agent_type_id::{NAME_NAMESPACE_MAX_LENGTH, VERSION_MAX_LENGTH};
+    use strum::IntoEnumIterator;
 
     /// Maximum length of an OCI image tag (see the OCI distribution spec).
     const MAX_TAG_LENGTH: usize = 128;
@@ -77,7 +78,7 @@ mod tests {
     /// compile when a variant is added, forcing a re-check here.
     #[test]
     fn longest_tag_never_overflows() {
-        for environment in Environment::all() {
+        for environment in Environment::iter() {
             let longest_tag_length = environment_prefix(environment).len()
                 + SEPARATORS_COUNT
                 + NAME_NAMESPACE_MAX_LENGTH

--- a/agent-control/src/agent_type/runtime_config/restart_policy.rs
+++ b/agent-control/src/agent_type/runtime_config/restart_policy.rs
@@ -2,9 +2,9 @@
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
-use duration_str::deserialize_duration;
 use serde::Deserialize;
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
+use strum::EnumString;
 use wrapper_with_default::WrapperWithDefault;
 
 use super::templateable_value::TemplateableValue;
@@ -39,9 +39,9 @@ pub(super) const DEFAULT_BACKOFF_MAX_RETRIES: usize = 0;
 pub(super) const DEFAULT_BACKOFF_LAST_RETRY_INTERVAL: Duration = Duration::from_secs(600);
 
 /// The delay applied before retrying a failed execution.
-#[derive(Debug, Deserialize, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_DELAY)]
-pub struct BackoffDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
+pub struct BackoffDelay(Duration);
 
 impl BackoffDelay {
     /// Builds a delay of the given number of seconds.
@@ -51,9 +51,9 @@ impl BackoffDelay {
 }
 
 /// The interval after the last retry before retries reset.
-#[derive(Debug, Deserialize, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_LAST_RETRY_INTERVAL)]
-pub struct BackoffLastRetryInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
+pub struct BackoffLastRetryInterval(Duration);
 
 impl BackoffLastRetryInterval {
     /// Builds an interval of the given number of seconds.
@@ -63,7 +63,7 @@ impl BackoffLastRetryInterval {
 }
 
 /// The maximum number of retries before giving up.
-#[derive(Debug, Deserialize, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_MAX_RETRIES)]
 pub struct MaxRetries(usize);
 
@@ -102,8 +102,8 @@ impl Templateable for BackoffStrategyConfig {
 }
 
 /// The kind of backoff applied between retries.
-#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
-#[serde(rename_all = "lowercase", tag = "type")]
+#[derive(Debug, Default, PartialEq, Clone, EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum BackoffStrategyType {
     /// A constant delay between retries.
     #[default]
@@ -114,19 +114,6 @@ pub enum BackoffStrategyType {
     Exponential,
 }
 
-impl FromStr for BackoffStrategyType {
-    type Err = AgentTypeError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "fixed" => Ok(Self::Fixed),
-            "linear" => Ok(Self::Linear),
-            "exponential" => Ok(Self::Exponential),
-            _ => Err(AgentTypeError::UnknownBackoffStrategyType(s.to_string())),
-        }
-    }
-}
-
 impl Default for BackoffStrategyConfig {
     fn default() -> Self {
         Self {
@@ -135,5 +122,52 @@ impl Default for BackoffStrategyConfig {
             max_retries: TemplateableValue::new(DEFAULT_BACKOFF_MAX_RETRIES.into()),
             last_retry_interval: TemplateableValue::new(DEFAULT_BACKOFF_LAST_RETRY_INTERVAL.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_and_resolves_all_backoff_strategy_fields() {
+        let yaml = r#"
+backoff_strategy:
+  type: exponential
+  backoff_delay: 99s
+  max_retries: 999
+  last_retry_interval: 100m
+"#;
+        let config: RestartPolicyConfig = serde_saphyr::from_str(yaml).unwrap();
+
+        assert_eq!(
+            config.backoff_strategy.backoff_type,
+            TemplateableValue::from_template("exponential".to_string())
+        );
+        assert_eq!(
+            config.backoff_strategy.backoff_delay,
+            TemplateableValue::from_template("99s".to_string())
+        );
+        assert_eq!(
+            config.backoff_strategy.max_retries,
+            TemplateableValue::from_template("999".to_string())
+        );
+        assert_eq!(
+            config.backoff_strategy.last_retry_interval,
+            TemplateableValue::from_template("100m".to_string())
+        );
+
+        let rendered = config
+            .backoff_strategy
+            .template_with(&Variables::new())
+            .unwrap();
+
+        assert_eq!(rendered.backoff_type, BackoffStrategyType::Exponential);
+        assert_eq!(rendered.backoff_delay, BackoffDelay::from_secs(99));
+        assert_eq!(rendered.max_retries, MaxRetries::from(999));
+        assert_eq!(
+            rendered.last_retry_interval,
+            BackoffLastRetryInterval::from_secs(6000)
+        );
     }
 }

--- a/agent-control/src/agent_type/validation.rs
+++ b/agent-control/src/agent_type/validation.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::agent_type::definition::{AgentTypeDefinition, AgentTypeDefinitionParseError};
 use crate::agent_type::templates::template_re;
 use crate::agent_type::variable::namespace::Namespace;
+use strum::IntoEnumIterator;
 
 #[derive(Error, Debug)]
 pub enum ValidationError {
@@ -19,7 +20,7 @@ pub enum ValidationError {
     )]
     UndeclaredVariables(BTreeSet<String>),
     #[error(
-        "unknown namespace(s) referenced in deployment: {}",
+        "unknown variable namespace(s) referenced in deployment: {}",
         .0.iter().map(String::as_str).collect::<Vec<_>>().join(", ")
     )]
     UnknownNamespaces(BTreeSet<String>),
@@ -37,7 +38,7 @@ struct VariableReference<'a> {
 /// - **Undeclared variable**: every `${nr-var:X}` reference found anywhere in
 ///   `deployment` must have a matching declaration in `variables`.
 /// - **Unknown namespace**: every `${nr-xxx:...}` reference found anywhere in `deployment`
-///   must use one of the namespaces in [`Namespace::ALL`].
+///   must use one of the [`Namespace`] variants.
 pub fn validate(raw_agent_type_content: &[u8]) -> Result<(), ValidationError> {
     let document: serde_json::Value = serde_saphyr::from_slice(raw_agent_type_content)?;
     let definition = AgentTypeDefinition::from_value(document.clone())?;
@@ -77,10 +78,9 @@ fn referenced_variables(deployment_text: &str) -> Vec<VariableReference<'_>> {
 }
 
 /// Returns the set of namespace prefixes (e.g. `nr-bogus`) among `references` that don't match
-/// any [`Namespace::ALL`] variant.
+/// any [`Namespace`] variant.
 fn unknown_namespaces(references: &[VariableReference]) -> BTreeSet<String> {
-    let known_namespaces: BTreeSet<String> =
-        Namespace::ALL.iter().map(ToString::to_string).collect();
+    let known_namespaces: BTreeSet<String> = Namespace::iter().map(|ns| ns.to_string()).collect();
 
     references
         .iter()

--- a/agent-control/src/agent_type/variable/namespace.rs
+++ b/agent-control/src/agent_type/variable/namespace.rs
@@ -1,12 +1,13 @@
 //! Namespaces used to prefix agent type variable names (e.g. `nr-var`, `nr-env`, `nr-vault`).
 use std::fmt::Display;
+use strum::{EnumIter, IntoEnumIterator};
 
 /// Holds the variable name prefixed with the namespace.
 /// Example: "nr-env:MY_ENV_VAR" for the environment variable "MY_ENV_VAR".
 pub type NamespacedVariableName = String;
 
 /// Namespace defines the supported namespace names for variables definition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
 pub enum Namespace {
     /// Variables defined in the agent type.
     Variable,
@@ -28,17 +29,6 @@ pub enum Namespace {
 }
 
 impl Namespace {
-    /// All supported namespace variants.
-    pub const ALL: [Namespace; 7] = [
-        Namespace::Variable,
-        Namespace::SubAgent,
-        Namespace::AgentControl,
-        Namespace::EnvironmentVariable,
-        Namespace::Vault,
-        Namespace::File,
-        Namespace::K8sSecret,
-    ];
-
     const PREFIX: &'static str = "nr-";
     /// Separator between a namespace prefix and the variable name.
     pub const PREFIX_NS_SEPARATOR: &'static str = ":";
@@ -65,14 +55,20 @@ impl Namespace {
 
     /// Returns whether the given namespaced name belongs to a secret namespace.
     pub fn is_secret_variable(s: &str) -> bool {
-        [
-            Namespace::Vault,
-            Namespace::K8sSecret,
-            Namespace::File,
-            Namespace::EnvironmentVariable,
-        ]
-        .iter()
-        .any(|ns| s.starts_with(ns.to_string().as_str()))
+        Self::iter()
+            .filter(Namespace::is_secret)
+            .any(|ns| s.starts_with(ns.to_string().as_str()))
+    }
+
+    /// Whether this namespace holds "secret" variables (loaded on every remote config fetch).
+    fn is_secret(&self) -> bool {
+        match self {
+            Namespace::Variable | Namespace::SubAgent | Namespace::AgentControl => false,
+            Namespace::EnvironmentVariable
+            | Namespace::Vault
+            | Namespace::File
+            | Namespace::K8sSecret => true,
+        }
     }
 }
 

--- a/agent-control/src/environment.rs
+++ b/agent-control/src/environment.rs
@@ -1,9 +1,10 @@
 //! The runtime environment Agent Control is executing in.
 
 use std::fmt::{self, Display, Formatter};
+use strum::EnumIter;
 
 /// The kind of host environment Agent Control is running in.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, EnumIter)]
 pub enum Environment {
     /// A Linux host (on-host mode).
     Linux,
@@ -19,27 +20,6 @@ impl Display for Environment {
             Environment::Linux => write!(f, "linux"),
             Environment::Windows => write!(f, "windows"),
             Environment::K8s => write!(f, "kubernetes"),
-        }
-    }
-}
-
-#[cfg(test)]
-#[allow(missing_docs)]
-pub mod tests {
-    use super::*;
-
-    impl Environment {
-        /// Iterates over every [Environment] variant.
-        pub fn all() -> impl Iterator<Item = Environment> {
-            std::iter::successors(Some(Environment::Linux), Environment::succeeding)
-        }
-
-        fn succeeding(current: &Environment) -> Option<Environment> {
-            match current {
-                Environment::Linux => Some(Environment::Windows),
-                Environment::Windows => Some(Environment::K8s),
-                Environment::K8s => None,
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces hand-written enum helpers (`FromStr`, `Namespace::ALL`, `Environment::all()`) with `strum` derives. Reduces boilerplate and makes variant sets compiler-enforced.

While refactoring i noticed that there were dead `Deserialize`/`deserialize_with` attributes from the backoff types (parsing actually flows through `TemplateableValue`), so they are removed too.

## Changes

- Add workspace `strum` 0.28.0 dependency
- `BackoffStrategyType`: derive `EnumString` instead of a manual `FromStr` + drop `Deserialize`
- `Namespace`/`Environment`: derive `EnumIter`, remove `Namespace::ALL` and the test-only `Environment::all()`
- Rework `Namespace::is_secret_variable` around an exhaustive `is_secret` match (identical secret set)
- Add a deserialize-and-resolve test for the backoff strategy config

## Notes for reviewers

- `AgentTypeError::UnknownBackoffStrategyType` was already unreachable (errors funnel to `ValueNotParseableFromString` via `TemplateableValue`); its removal is safe.
- `strum` 0.27.2 remains in the tree transitively, so the lockfile now carries two `strum` majors.

Follow up from #2727