### PR TITLE
feat: enable cache for Agent Type remote registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Remember that the keywords that you can use are the following:
 - On-host: added nri-memcached Agent Type.
 - Added `agent-type validate --file <path>` subcommand to `newrelic-agent-control-cli` and `newrelic-agent-control-k8s-cli` for schema-level validation of agent type definition files.
 - Extended `agent-type validate` with semantic validation: every `${nr-var:X}` reference in `deployment` must have a matching `variables` declaration.
+- Enable cache for remote Agent Type registry
 
 
 

--- a/agent-control/src/agent_control/run.rs
+++ b/agent-control/src/agent_control/run.rs
@@ -4,13 +4,16 @@ use super::defaults::{
     AGENT_CONTROL_DATA_DIR, AGENT_CONTROL_LOCAL_DATA_DIR, AGENT_CONTROL_LOG_DIR,
     DYNAMIC_AGENT_TYPES_DIR,
 };
-use crate::agent_control::config::{AgentControlConfig, AgentControlConfigError};
+use crate::agent_control::config::{
+    AgentControlConfig, AgentControlConfigError, AgentTypeConfig, OciConfig,
+};
 use crate::agent_control::config_repository::store::AgentControlConfigStore;
 use crate::agent_control::http_server::runner::Runner;
 use crate::agent_type::oci::downloader::OCIAgentTypeArtifactDownloader;
 use crate::agent_type::registry::{Registry, RegistryConfig};
 use crate::command::RunnerContext;
 use crate::data_store::DataStore;
+use crate::environment::Environment;
 use crate::event::broadcaster::unbounded::UnboundedBroadcast;
 use crate::event::{AgentControlEvent, ApplicationEvent, SubAgentEvent, channel::EventConsumer};
 use crate::oci;
@@ -18,7 +21,7 @@ use crate::opamp::remote_config::validators::signature::validator::SignatureVali
 use crate::values::ConfigRepo;
 use oci_client::client::ClientConfig;
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::debug;
@@ -131,8 +134,13 @@ impl AgentControlRunner {
             runtime.clone(),
         )?;
 
-        let agent_type_registry =
-            Arc::new(build_agent_type_registry(&context, oci_client.clone())?);
+        let agent_type_registry = Arc::new(build_agent_type_registry(
+            &context.bootstrap_config.agent_types,
+            &context.bootstrap_config.oci,
+            context.running_mode,
+            &context.base_paths.local_dir,
+            oci_client.clone(),
+        )?);
 
         let signature_validator = context
             .bootstrap_config
@@ -163,11 +171,18 @@ impl AgentControlRunner {
     }
 }
 
-fn build_agent_type_registry(
-    context: &RunnerContext,
+/// Builds the production agent type registry (local + remote, with caching).
+///
+/// Exposed as `pub` so integration tests can exercise the exact wiring used at startup, e.g. to
+/// verify the remote layer is actually cached, rather than reassembling an equivalent by hand.
+pub fn build_agent_type_registry(
+    agent_types: &AgentTypeConfig,
+    oci: &OciConfig,
+    running_mode: Environment,
+    local_dir: &Path,
     oci_client: oci::Client,
 ) -> Result<Registry, AgentControlConfigError> {
-    let default_remote = &context.bootstrap_config.agent_types.default_remote;
+    let default_remote = &agent_types.default_remote;
     let signature_verification_enabled = default_remote.signature_verification_enabled.into();
     let default_public_key_url = &default_remote.public_key_url;
 
@@ -181,16 +196,16 @@ fn build_agent_type_registry(
 
     let downloader = OCIAgentTypeArtifactDownloader::new(
         oci_client,
-        context.bootstrap_config.oci.registry.clone(),
+        oci.registry.clone(),
         default_remote.repository.clone(),
-        context.bootstrap_config.oci.auth.clone(),
+        oci.auth.clone(),
         public_key_url,
     );
 
     Ok(Registry::build(
-        context.running_mode,
+        running_mode,
         RegistryConfig {
-            dynamic_agent_types_path: context.base_paths.local_dir.join(DYNAMIC_AGENT_TYPES_DIR),
+            dynamic_agent_types_path: local_dir.join(DYNAMIC_AGENT_TYPES_DIR),
         },
         downloader,
     ))

--- a/agent-control/src/agent_type/registry.rs
+++ b/agent-control/src/agent_type/registry.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{debug, warn};
 
+use self::caching::CachingRegistry;
 use self::local::LocalRegistry;
 use self::remote::RemoteRegistry;
 use super::agent_type_id::AgentTypeID;
@@ -83,8 +84,9 @@ impl<R: AgentTypeRegistry> Registry<R> {
 pub enum SupportedRegistry {
     /// In-memory registry of embedded and custom agent types.
     Local(LocalRegistry),
-    /// Registry that pulls agent types from a remote OCI registry.
-    Remote(RemoteRegistry<OCIAgentTypeArtifactDownloader>),
+    /// Registry that pulls agent types from a remote OCI registry, memoizing successful lookups
+    /// since a downloaded artifact is immutable for a given [AgentTypeID].
+    Remote(CachingRegistry<RemoteRegistry<OCIAgentTypeArtifactDownloader>>),
 }
 
 impl AgentTypeRegistry for SupportedRegistry {
@@ -108,7 +110,7 @@ impl Registry<SupportedRegistry> {
         downloader: OCIAgentTypeArtifactDownloader,
     ) -> Self {
         let local = LocalRegistry::new(env, config.dynamic_agent_types_path);
-        let remote = RemoteRegistry::new(env, downloader);
+        let remote = CachingRegistry::new(RemoteRegistry::new(env, downloader));
         Self::new(vec![
             SupportedRegistry::Local(local),
             SupportedRegistry::Remote(remote),

--- a/agent-control/tests/on_host/agent_type_remote_registry.rs
+++ b/agent-control/tests/on_host/agent_type_remote_registry.rs
@@ -1,7 +1,10 @@
 use crate::common::runtime::tokio_runtime;
 use crate::on_host::tools::oci_package_manager::TestDataHelper;
 use assert_matches::assert_matches;
-use newrelic_agent_control::agent_control::config::Registry;
+use newrelic_agent_control::agent_control::config::{
+    AgentTypeConfig, DefaultAgentTypeRemote, OciConfig, Registry,
+};
+use newrelic_agent_control::agent_control::run::build_agent_type_registry;
 use newrelic_agent_control::agent_control::run::on_host::OCI_TEST_REGISTRY_URL;
 use newrelic_agent_control::agent_type::agent_type_id::AgentTypeID;
 use newrelic_agent_control::agent_type::oci::downloader::OCIAgentTypeArtifactDownloader;
@@ -14,12 +17,20 @@ use newrelic_agent_control::oci;
 use oci_client::Reference;
 use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_test_utils::{AgentTypeArtifact, OCISigner, PackagePublisher};
+use std::path::Path;
 use std::str::FromStr;
 use tempfile::tempdir;
 use url::Url;
 
-/// A minimal but valid kubernetes agent type definition.
-fn agent_type_definition_yaml(name: &str, version: &str) -> String {
+/// A well-known agent type embedded in the binary
+const EMBEDDED_AGENT_TYPE_ID: &str = "newrelic/com.newrelic.infrastructure:0.1.0";
+/// Non-existent folder for local agent-types
+const NONEXISTENT_DYNAMIC_AGENT_TYPES_DIR: &str = "/nonexistent-agent-type-registry-test-dir";
+
+/// A minimal but valid kubernetes agent type definition. `marker` is an arbitrary variable default
+/// with no effect on identity, used to distinguish two revisions pushed under the same
+/// namespace/name/version (and therefore the same tag).
+fn agent_type_definition_yaml(name: &str, version: &str, marker: &str) -> String {
     format!(
         r#"
 namespace: example
@@ -27,6 +38,12 @@ name: {name}
 version: {version}
 protocol_version: "1.0"
 platform: kubernetes
+variables:
+  marker:
+    description: "distinguishes artifact revisions in tests"
+    type: string
+    required: false
+    default: "{marker}"
 deployment:
   objects: {{}}
 "#
@@ -35,14 +52,20 @@ deployment:
 
 /// Publishes an agent type artifact (a gzipped tar with the single definition file) to the test
 /// registry under `tag`, optionally signing it, and returns the pushed reference.
-fn push_agent_type(signer: Option<&OCISigner>, name: &str, version: &str, tag: &str) -> Reference {
+fn push_agent_type(
+    signer: Option<&OCISigner>,
+    name: &str,
+    version: &str,
+    marker: &str,
+    tag: &str,
+) -> Reference {
     let source_dir = tempdir().unwrap();
     let archive_dir = tempdir().unwrap();
     let archive = archive_dir.path().join("agent-type.tar.gz");
     TestDataHelper::compress_tar_gz(
         source_dir.path(),
         &archive,
-        &agent_type_definition_yaml(name, version),
+        &agent_type_definition_yaml(name, version, marker),
         &format!("{tag}.yaml"),
     );
 
@@ -82,6 +105,40 @@ fn remote_registry(
     RemoteRegistry::new(Environment::K8s, downloader)
 }
 
+/// Builds an [`oci::Client`] pointed at the local, unencrypted test registry.
+fn test_oci_client() -> oci::Client {
+    oci::Client::try_new(
+        ClientConfig {
+            protocol: ClientProtocol::Http,
+            ..Default::default()
+        },
+        ProxyConfig::default(),
+        tokio_runtime(),
+    )
+    .unwrap()
+}
+
+/// Builds the `(AgentTypeConfig, OciConfig)` pair that [`build_agent_type_registry`] needs,
+/// pointed at the test registry/repository holding `reference` and verifying signatures against
+/// `public_key_url`.
+fn agent_type_and_oci_config(
+    reference: &Reference,
+    public_key_url: Url,
+) -> (AgentTypeConfig, OciConfig) {
+    let agent_types = AgentTypeConfig {
+        default_remote: DefaultAgentTypeRemote {
+            repository: Repository::from_str(reference.repository()).unwrap(),
+            public_key_url,
+            ..Default::default()
+        },
+    };
+    let oci = OciConfig {
+        registry: Registry::from_str(OCI_TEST_REGISTRY_URL).unwrap(),
+        auth: None,
+    };
+    (agent_types, oci)
+}
+
 #[test]
 #[ignore = "needs oci registry (use *with_oci_registry suffix)"]
 fn test_remote_registry_resolves_signed_agent_type_with_oci_registry() {
@@ -91,6 +148,7 @@ fn test_remote_registry_resolves_signed_agent_type_with_oci_registry() {
         Some(&signer),
         "some.agent.type",
         "0.0.123",
+        "n/a",
         "kubernetes-some.agent.type-0.0.123",
     );
 
@@ -114,6 +172,7 @@ fn test_remote_registry_rejects_unsigned_agent_type_when_verification_enabled_wi
         None,
         "some.agent.type",
         "0.0.124",
+        "n/a",
         "kubernetes-some.agent.type-0.0.124",
     );
 
@@ -134,6 +193,7 @@ fn test_remote_registry_errors_on_missing_agent_type_with_oci_registry() {
         Some(&signer),
         "some.agent.type",
         "0.0.125",
+        "n/a",
         "kubernetes-some.agent.type-0.0.125",
     );
 
@@ -147,4 +207,51 @@ fn test_remote_registry_errors_on_missing_agent_type_with_oci_registry() {
         registry.get(&missing),
         Err(AgentTypeRegistryError::Remote(_))
     );
+}
+
+#[test]
+#[ignore = "needs oci registry (use *with_oci_registry suffix)"]
+fn test_build_agent_type_registry_resolves_embedded_and_caches_remote_with_oci_registry() {
+    let signer = OCISigner::start(tokio_runtime().handle().clone());
+
+    let embedded_id = AgentTypeID::try_from(EMBEDDED_AGENT_TYPE_ID).unwrap();
+    let remote_id = AgentTypeID::try_from("example/some.agent.type:0.0.126").unwrap();
+    let tag = "kubernetes-some.agent.type-0.0.126";
+
+    let reference = push_agent_type(Some(&signer), "some.agent.type", "0.0.126", "first", tag);
+    let public_key_url = Url::parse(&signer.jwks_url().to_string()).unwrap();
+    let local_dir = Path::new(NONEXISTENT_DYNAMIC_AGENT_TYPES_DIR);
+
+    let (agent_types, oci) = agent_type_and_oci_config(&reference, public_key_url.clone());
+    let registry = build_agent_type_registry(
+        &agent_types,
+        &oci,
+        Environment::K8s,
+        local_dir,
+        test_oci_client(),
+    )
+    .expect("registry should build");
+
+    // Check embedded agent-type
+    let definition = registry
+        .get(&embedded_id)
+        .expect("embedded agent type should resolve without an OCI registry");
+    assert_eq!(definition.metadata.id, embedded_id);
+    assert_eq!(definition.metadata.environment, Environment::K8s);
+
+    // Not present locally, so this resolves via the remote layer and populates its cache.
+    let remote_definition = registry
+        .get(&remote_id)
+        .expect("first lookup should resolve via the remote layer");
+    assert_eq!(remote_definition.metadata.id, remote_id);
+
+    // Overwrite the same tag with a different, signed revision (same identity, different content) to prove that
+    // cache works.
+    push_agent_type(Some(&signer), "some.agent.type", "0.0.126", "second", tag);
+
+    // Check that the registry returns the cached definition
+    let cached_definition = registry
+        .get(&remote_id)
+        .expect("second lookup should be served from the cache");
+    assert_eq!(cached_definition, remote_definition);
 }


### PR DESCRIPTION
This PR wires up the cache implementation for the remote Agent Type registry. 

It also introduces an integration test to check that the registry built by the Agent Control Runner is resolving embedded, is resolving remote ant that the cache is in place. The integration test involved a small refactor of the function building the registry: it was made public (to be callable from integration tests) and the arguments were better scoped.