### PR TITLE
feat: add postgresql custom queries support

### DIFF
--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml
@@ -129,6 +129,7 @@ deployment:
         NRIA_STATUS_SERVER_ENABLED: true
         NRIA_STATUS_SERVER_PORT: "${nr-var:health_port}"
         NR_HOST_ID: "${nr-ac:host_id}"
+        AC_SHARED_CFG: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-configs"
       restart_policy:
         backoff_strategy:
           type: fixed

--- a/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure.nri_postgresql-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure.nri_postgresql-0.1.0.yaml
@@ -9,6 +9,10 @@ variables:
     description: "nri-postgresql integration YAML consumed by the infra-agent"
     type: yaml
     required: true
+  custom_queries:
+    description: "custom queries to be executed by the nri-postgresql integration"
+    type: yaml
+    required: false
   version:
     description: "Agent version"
     type: string
@@ -38,6 +42,10 @@ deployment:
           kind: file
           text: |
             ${nr-var:config}
+        postgresql-custom-query.yaml:
+          kind: file
+          text: |
+            ${nr-var:custom_queries}
     infra-agent-ohi-binaries:
       kind: dir
       entries:

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml
@@ -133,6 +133,7 @@ deployment:
         NRIA_STATUS_SERVER_ENABLED: true
         NRIA_STATUS_SERVER_PORT: "${nr-var:health_port}"
         NR_HOST_ID: "${nr-ac:host_id}"
+        AC_SHARED_CFG: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-configs"
       restart_policy:
         backoff_strategy:
           type: fixed

--- a/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure.nri_postgresql-0.1.0.yaml
+++ b/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure.nri_postgresql-0.1.0.yaml
@@ -9,6 +9,10 @@ variables:
     description: "nri-postgresql integration YAML consumed by the infra-agent"
     type: yaml
     required: true
+  custom_queries:
+    description: "custom queries to be executed by the nri-postgresql integration"
+    type: yaml
+    required: false
   version:
     description: "Agent version"
     type: string
@@ -38,6 +42,10 @@ deployment:
           kind: file
           text: |
             ${nr-var:config}
+        postgresql-custom-query.yaml:
+          kind: file
+          text: |
+            ${nr-var:custom_queries}
     infra-agent-ohi-binaries:
       kind: dir
       entries:


### PR DESCRIPTION
Add postgresql custom queries support
----------------------------------------

We are setting an env var in the infra-agent  `AC_SHARED_CFG: "${nr-sub:shared_filesystem_dir}/infra-agent-ohi-configs"`.
Then, we propagate it to the integrations thanks to the fact that `{{ AC_SHARED_CFG }}` is rendered by the infra agent both in the infra config and integrations config.
We will need to set the template for postgresql with something like:
```
  config:
    integrations:
    - env:
        HOSTNAME: 127.0.0.1
        PORT: "1123"
        # Path to custom SQL queries for additional metric collection;                                                                                                                                                              
        # resolved at runtime by Agent Control from the shared config directory
        CUSTOM_METRICS_CONFIG: {{ AC_SHARED_CFG }}/postgresql-custom-query.yaml
      interval: 15s
      name: nri-postgresql
```

<!-- If you consider this checklist relevant to your PR, please uncomment and complete it.
## Checklist
- [ ] Provided a meaningful title following conventional commit style.
- [ ] Included a detailed description for the Pull Request.
- [ ] Documentation under `docs` is aligned with the change.
- [ ] Follows guidelines for Pull Requests in [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md).
- [ ] Follows [`log level guidelines`](../blob/main/docs/style/logs.md).
 -->
