### PR TITLE
feat(logs): add maximum retention of 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Remember that the keywords that you can use are the following:
 - On-host: added nri-postgresql agentType.
 - On-host: added nri-mysql agentType.
 - On-host: added nri-memcached Agent Type.
+- On-host: Log files are now rotated with retention. The Maximum number of files is 30.
 - Added `agent-type validate --file <path>` subcommand to `newrelic-agent-control-cli` and `newrelic-agent-control-k8s-cli` for schema-level validation of agent type definition files.
 - Extended `agent-type validate` with semantic validation: every `${nr-var:X}` reference in `deployment` must have a matching `variables` declaration.
 - Enable cache for remote Agent Type registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,10 @@ Remember that the keywords that you can use are the following:
 - On-host: added nri-postgresql agentType.
 - On-host: added nri-mysql agentType.
 - On-host: added nri-memcached Agent Type.
-- On-host: Log files are now rotated with retention. The Maximum number of files is 30.
+- Log files rotated have now 30 days of retention.
 - Added `agent-type validate --file <path>` subcommand to `newrelic-agent-control-cli` and `newrelic-agent-control-k8s-cli` for schema-level validation of agent type definition files.
 - Extended `agent-type validate` with semantic validation: every `${nr-var:X}` reference in `deployment` must have a matching `variables` declaration.
 - Enable cache for remote Agent Type registry
-
-
 
 ## v1.19.1 - 2026-07-23
 

--- a/agent-control/src/agent_control/run/on_host.rs
+++ b/agent-control/src/agent_control/run/on_host.rs
@@ -201,7 +201,7 @@ impl AgentControlRunner {
         ));
 
         let supervisor_builder = SupervisorBuilderOnHost {
-            logging_path: self.base_paths.log_dir,
+            logging_base_path: self.base_paths.log_dir,
             package_manager: agents_package_manager,
         };
 

--- a/agent-control/src/instrumentation/config/logs/file_logging.rs
+++ b/agent-control/src/instrumentation/config/logs/file_logging.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
+const MAX_LOG_FILES_AC: usize = 30;
+
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
 pub(crate) struct FileLoggingConfig {
     pub(crate) enabled: bool,
@@ -28,6 +30,7 @@ impl FileLoggingConfig {
 
         let file_appender = RollingFileAppender::builder()
             .rotation(Rotation::DAILY)
+            .max_log_files(MAX_LOG_FILES_AC)
             .filename_suffix(log_file.file_name())
             .build(log_file.parent)
             .map_err(|e| LoggingConfigError::FileLoggingConfig(e.to_string()))?;

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -14,7 +14,7 @@ use crate::sub_agent::SubAgent;
 use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssembler};
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
-use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
+use crate::sub_agent::on_host::command::logging::file_logger::SubAgentFileLoggingConfig;
 use crate::sub_agent::on_host::supervisor::{NotStartedSupervisorOnHost, SupervisorError};
 use crate::sub_agent::remote_config_parser::RemoteConfigParser;
 use crate::sub_agent::supervisor::SupervisorBuilder;
@@ -168,7 +168,7 @@ where
             on_host.packages,
             on_host.reported_version_package,
             self.package_manager.clone(),
-            FileLoggingConfigSubAgent {
+            SubAgentFileLoggingConfig {
                 enabled: on_host.enable_file_logging,
                 base_path: self.logging_base_path.clone(),
             },

--- a/agent-control/src/sub_agent/on_host/builder.rs
+++ b/agent-control/src/sub_agent/on_host/builder.rs
@@ -14,6 +14,7 @@ use crate::sub_agent::SubAgent;
 use crate::sub_agent::effective_agents_assembler::{EffectiveAgent, EffectiveAgentsAssembler};
 use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
+use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
 use crate::sub_agent::on_host::supervisor::{NotStartedSupervisorOnHost, SupervisorError};
 use crate::sub_agent::remote_config_parser::RemoteConfigParser;
 use crate::sub_agent::supervisor::SupervisorBuilder;
@@ -122,7 +123,7 @@ where
     PM: PackageManager,
 {
     /// Directory where executable output is logged when file logging is enabled.
-    pub logging_path: PathBuf,
+    pub logging_base_path: PathBuf,
     /// Package manager used to install agent packages.
     pub package_manager: Arc<PM>,
 }
@@ -167,8 +168,10 @@ where
             on_host.packages,
             on_host.reported_version_package,
             self.package_manager.clone(),
-            on_host.enable_file_logging,
-            self.logging_path.to_path_buf(),
+            FileLoggingConfigSubAgent {
+                enabled: on_host.enable_file_logging,
+                base_path: self.logging_base_path.clone(),
+            },
             on_host.filesystem,
             on_host.shared_filesystem,
         ))

--- a/agent-control/src/sub_agent/on_host/command/command_os.rs
+++ b/agent-control/src/sub_agent/on_host/command/command_os.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::{STDERR_LOG_FILE_NAME_SUFFIX, STDOUT_LOG_FILE_NAME_SUFFIX};
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
-use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
+use crate::sub_agent::on_host::command::logging::file_logger::SubAgentFileLoggingConfig;
 #[cfg(target_family = "windows")]
 use crate::utils::job_object::JobObject;
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -28,7 +28,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub struct CommandOSNotStarted {
     cmd: Command,
     agent_id: AgentID,
-    file_logging_config: FileLoggingConfigSubAgent,
+    file_logging_config: SubAgentFileLoggingConfig,
     shutdown_timeout: Duration,
 }
 /// A spawned OS command process with its loggers and (on Windows) job object.
@@ -50,7 +50,7 @@ impl CommandOSNotStarted {
     pub fn new(
         agent_id: AgentID,
         executable_data: &ExecutableData,
-        file_logging_config: FileLoggingConfigSubAgent,
+        file_logging_config: SubAgentFileLoggingConfig,
     ) -> Self {
         let mut cmd = Command::new(&executable_data.bin);
         cmd.args(&executable_data.args)
@@ -68,16 +68,15 @@ impl CommandOSNotStarted {
 
     /// Spawns the process, setting up file loggers and (on Windows) a job object.
     pub fn start(mut self) -> Result<CommandOSStarted, CommandError> {
-        let agent_id = self.agent_id;
         let loggers = if self.file_logging_config.enabled {
             Some(FileSystemLoggers::new(
                 file_logger(
-                    agent_id.clone(),
+                    &self.agent_id,
                     self.file_logging_config.clone(),
                     STDOUT_LOG_FILE_NAME_SUFFIX,
                 )?,
                 file_logger(
-                    agent_id.clone(),
+                    &self.agent_id,
                     self.file_logging_config.clone(),
                     STDERR_LOG_FILE_NAME_SUFFIX,
                 )?,
@@ -90,7 +89,7 @@ impl CommandOSNotStarted {
         #[cfg(target_family = "unix")]
         {
             Ok(CommandOSStarted {
-                agent_id,
+                agent_id: self.agent_id,
                 process: child,
                 loggers,
                 shutdown_timeout: self.shutdown_timeout,
@@ -103,7 +102,7 @@ impl CommandOSNotStarted {
             let job_object = JobObject::new()?;
             job_object.assign_process(&child)?;
             Ok(CommandOSStarted {
-                agent_id,
+                agent_id: self.agent_id,
                 process: child,
                 job_object: Some(job_object),
                 loggers,

--- a/agent-control/src/sub_agent/on_host/command/command_os.rs
+++ b/agent-control/src/sub_agent/on_host/command/command_os.rs
@@ -2,15 +2,6 @@
 
 use tracing::warn;
 
-use crate::agent_control::agent_id::AgentID;
-use crate::agent_control::defaults::{STDERR_LOG_FILE_NAME_SUFFIX, STDOUT_LOG_FILE_NAME_SUFFIX};
-use crate::sub_agent::on_host::command::executable_data::ExecutableData;
-use std::time::{Duration, Instant};
-use std::{
-    path::PathBuf,
-    process::{Child, Command, ExitStatus, Stdio},
-};
-
 use super::{
     error::CommandError,
     logging::{
@@ -19,8 +10,14 @@ use super::{
         logger::Logger,
     },
 };
+use crate::agent_control::agent_id::AgentID;
+use crate::agent_control::defaults::{STDERR_LOG_FILE_NAME_SUFFIX, STDOUT_LOG_FILE_NAME_SUFFIX};
+use crate::sub_agent::on_host::command::executable_data::ExecutableData;
+use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
 #[cfg(target_family = "windows")]
 use crate::utils::job_object::JobObject;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -31,8 +28,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub struct CommandOSNotStarted {
     cmd: Command,
     agent_id: AgentID,
-    logs_to_file: bool,
-    logging_path: PathBuf,
+    file_logging_config: FileLoggingConfigSubAgent,
     shutdown_timeout: Duration,
 }
 /// A spawned OS command process with its loggers and (on Windows) job object.
@@ -54,8 +50,7 @@ impl CommandOSNotStarted {
     pub fn new(
         agent_id: AgentID,
         executable_data: &ExecutableData,
-        logs_to_file: bool,
-        logging_path: PathBuf,
+        file_logging_config: FileLoggingConfigSubAgent,
     ) -> Self {
         let mut cmd = Command::new(&executable_data.bin);
         cmd.args(&executable_data.args)
@@ -66,8 +61,7 @@ impl CommandOSNotStarted {
         Self {
             agent_id,
             cmd,
-            logs_to_file,
-            logging_path,
+            file_logging_config,
             shutdown_timeout: executable_data.shutdown_timeout,
         }
     }
@@ -75,11 +69,18 @@ impl CommandOSNotStarted {
     /// Spawns the process, setting up file loggers and (on Windows) a job object.
     pub fn start(mut self) -> Result<CommandOSStarted, CommandError> {
         let agent_id = self.agent_id;
-        let loggers = if self.logs_to_file {
-            let agent_log_path = self.logging_path.join(&agent_id);
+        let loggers = if self.file_logging_config.enabled {
             Some(FileSystemLoggers::new(
-                file_logger(&agent_log_path, STDOUT_LOG_FILE_NAME_SUFFIX)?,
-                file_logger(&agent_log_path, STDERR_LOG_FILE_NAME_SUFFIX)?,
+                file_logger(
+                    agent_id.clone(),
+                    self.file_logging_config.clone(),
+                    STDOUT_LOG_FILE_NAME_SUFFIX,
+                )?,
+                file_logger(
+                    agent_id.clone(),
+                    self.file_logging_config.clone(),
+                    STDERR_LOG_FILE_NAME_SUFFIX,
+                )?,
             ))
         } else {
             None

--- a/agent-control/src/sub_agent/on_host/command/logging/file_logger.rs
+++ b/agent-control/src/sub_agent/on_host/command/logging/file_logger.rs
@@ -23,7 +23,7 @@ const MAX_LOG_FILES_SUB_AGENT: usize = 30;
 pub struct FileLoggerError(String);
 
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
-pub struct FileLoggingConfigSubAgent {
+pub struct SubAgentFileLoggingConfig {
     pub enabled: bool,
     // Default value is being set by `ConfigPatcher` right after deserialization.
     pub base_path: PathBuf,
@@ -33,11 +33,11 @@ pub struct FileLoggingConfigSubAgent {
 /// The file will be rotated daily and the file name will be in the format `<timestamp>.<suffix>`
 /// e.g. `2027-12-01.stdout.log`. Only the MAX_LOG_FILES_SUB_AGENT most recent rotated files are retained.
 pub fn file_logger(
-    agent_id: AgentID,
-    file_logging_config: FileLoggingConfigSubAgent,
+    agent_id: &AgentID,
+    file_logging_config: SubAgentFileLoggingConfig,
     file_name_suffix: &str,
 ) -> Result<FileLogger, FileLoggerError> {
-    let file_dir = file_logging_config.base_path.join(&agent_id);
+    let file_dir = file_logging_config.base_path.join(agent_id);
 
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)

--- a/agent-control/src/sub_agent/on_host/command/logging/file_logger.rs
+++ b/agent-control/src/sub_agent/on_host/command/logging/file_logger.rs
@@ -1,6 +1,9 @@
 //! File logging for executable output, using a daily-rotating appender and a thread-local subscriber.
 
-use std::{io::Write, path::Path};
+use crate::agent_control::agent_id::AgentID;
+use serde::Deserialize;
+use std::io::Write;
+use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{level_filters::LevelFilter, subscriber::DefaultGuard};
 use tracing_appender::{
@@ -12,17 +15,33 @@ use tracing_subscriber::{
     fmt::format::{DefaultFields, Format, Full},
 };
 
+const MAX_LOG_FILES_SUB_AGENT: usize = 30;
+
 /// Error produced while building a file logger.
 #[derive(Debug, Error)]
 #[error("{0}")]
 pub struct FileLoggerError(String);
 
+#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
+pub struct FileLoggingConfigSubAgent {
+    pub enabled: bool,
+    // Default value is being set by `ConfigPatcher` right after deserialization.
+    pub base_path: PathBuf,
+}
+
 /// Creates a new file logger writing to a file in the provided directory with the provided suffix.
 /// The file will be rotated daily and the file name will be in the format `<timestamp>.<suffix>`
-/// e.g. `2027-12-01.stdout.log`.
-pub fn file_logger(file_dir: &Path, file_name_suffix: &str) -> Result<FileLogger, FileLoggerError> {
+/// e.g. `2027-12-01.stdout.log`. Only the MAX_LOG_FILES_SUB_AGENT most recent rotated files are retained.
+pub fn file_logger(
+    agent_id: AgentID,
+    file_logging_config: FileLoggingConfigSubAgent,
+    file_name_suffix: &str,
+) -> Result<FileLogger, FileLoggerError> {
+    let file_dir = file_logging_config.base_path.join(&agent_id);
+
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)
+        .max_log_files(MAX_LOG_FILES_SUB_AGENT)
         .filename_suffix(file_name_suffix.to_string())
         .build(file_dir)
         .map_err(|e| FileLoggerError(format!("building file appender: {}", e)))?;

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -27,6 +27,7 @@ use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::command::command_os::{CommandOSNotStarted, CommandOSStarted};
 use crate::sub_agent::on_host::command::error::CommandError;
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
+use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
 use crate::sub_agent::on_host::command::restart_policy::RestartPolicy;
 use crate::sub_agent::supervisor::{Supervisor, SupervisorStarter};
 use crate::utils::thread_context::{
@@ -91,7 +92,7 @@ where
     /// Publisher for internal sub-agent events.
     pub internal_publisher: EventPublisher<SubAgentInternalEvent>,
     /// Directory where executable output is logged when file logging is enabled.
-    pub logging_path: PathBuf,
+    pub logging_base_path: PathBuf,
     /// The agent's filesystem.
     pub filesystem: FileSystem,
 }
@@ -103,8 +104,7 @@ where
 {
     agent_identity: AgentIdentity,
     executables: Vec<ExecutableData>,
-    file_logging_enable: bool,
-    file_logging_path: PathBuf,
+    file_logging_config: FileLoggingConfigSubAgent,
     health_config: Option<OnHostHealthConfig>,
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
@@ -159,7 +159,7 @@ where
             package_manager,
             internal_publisher,
             thread_contexts,
-            logging_path,
+            logging_base_path,
             ..
         } = self;
 
@@ -196,8 +196,10 @@ where
             onhost_config.packages,
             onhost_config.reported_version_package,
             package_manager,
-            onhost_config.enable_file_logging,
-            logging_path,
+            FileLoggingConfigSubAgent {
+                enabled: onhost_config.enable_file_logging,
+                base_path: logging_base_path,
+            },
             onhost_config.filesystem,
             onhost_config.shared_filesystem,
         );
@@ -226,16 +228,14 @@ where
         packages_config: RenderedPackages,
         reported_version_package: Option<PackageID>,
         package_manager: Arc<PM>,
-        file_logging_enable: bool,
-        file_logging_path: PathBuf,
+        file_logging_config: FileLoggingConfigSubAgent,
         filesystem: FileSystem,
         shared_filesystem: SharedFileSystem,
     ) -> Self {
         NotStartedSupervisorOnHost {
             agent_identity,
             executables,
-            file_logging_enable,
-            file_logging_path,
+            file_logging_config,
             health_config,
             package_manager,
             packages_config,
@@ -378,7 +378,7 @@ where
             package_manager: self.package_manager,
             agent_identity: self.agent_identity,
             internal_publisher: sub_agent_internal_publisher,
-            logging_path: self.file_logging_path,
+            logging_base_path: self.file_logging_config.base_path,
             filesystem: self.filesystem,
         })
     }
@@ -391,9 +391,7 @@ where
         let mut restart_policy = executable_data.restart_policy.clone();
         let exec_data = executable_data.clone();
         let agent_id = self.agent_identity.id.clone();
-        let log_to_file = self.file_logging_enable;
-        let logging_path = self.file_logging_path.clone();
-
+        let logging_config = self.file_logging_config.clone();
         let dispatch = dispatcher::get_default(|d: &Dispatch| d.clone());
         let span = tracing::Span::current();
 
@@ -419,12 +417,8 @@ where
                 let health_handler = HealthHandler::new(exec_id.clone(), health_publisher.clone());
 
                 info!(%agent_id, %exec_id, "Starting executable");
-                let command = CommandOSNotStarted::new(
-                    agent_id.clone(),
-                    &exec_data,
-                    log_to_file,
-                    logging_path.clone(),
-                );
+                let command =
+                    CommandOSNotStarted::new(agent_id.clone(), &exec_data, logging_config.clone());
 
                 let started = command.start().and_then(|cmd| cmd.stream());
 
@@ -738,8 +732,7 @@ pub mod tests {
             packages,
             Some("core".to_string()),
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -843,8 +836,7 @@ pub mod tests {
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -890,8 +882,7 @@ pub mod tests {
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -954,8 +945,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             filesystem,
             SharedFileSystem::test_empty(),
         );
@@ -1003,8 +993,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1054,8 +1043,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1105,8 +1093,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1151,8 +1138,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1216,8 +1202,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1290,9 +1275,13 @@ declared-dir:
             .with_args(vec!["/T".to_owned(), "3".to_owned(), "/NOBREAK".to_owned()]);
 
         let agent_id = AgentID::AgentControl;
-        let command = CommandOSNotStarted::new(agent_id.clone(), &exec_data, false, PathBuf::new())
-            .start()
-            .unwrap();
+        let command = CommandOSNotStarted::new(
+            agent_id.clone(),
+            &exec_data,
+            FileLoggingConfigSubAgent::default(),
+        )
+        .start()
+        .unwrap();
 
         let (health_publisher, health_consumer) = pub_sub();
         let health_handler = HealthHandler::new(exec_data.id.clone(), health_publisher);
@@ -1340,9 +1329,13 @@ declared-dir:
         ]);
 
         let agent_id = AgentID::AgentControl;
-        let command = CommandOSNotStarted::new(agent_id.clone(), &exec_data, false, PathBuf::new())
-            .start()
-            .unwrap();
+        let command = CommandOSNotStarted::new(
+            agent_id.clone(),
+            &exec_data,
+            FileLoggingConfigSubAgent::default(),
+        )
+        .start()
+        .unwrap();
 
         let (health_publisher, health_consumer) = pub_sub();
         let health_handler = HealthHandler::new(exec_data.id.clone(), health_publisher);
@@ -1398,8 +1391,7 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            true,
-            logging_path.clone(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1528,8 +1520,7 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            false,
-            logging_path.clone(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1656,8 +1647,7 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            true,
-            logging_path.clone(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1769,8 +1759,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            false,
-            PathBuf::default(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1843,8 +1832,7 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            false,
-            logging_path.clone(),
+            FileLoggingConfigSubAgent::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );

--- a/agent-control/src/sub_agent/on_host/supervisor.rs
+++ b/agent-control/src/sub_agent/on_host/supervisor.rs
@@ -27,7 +27,7 @@ use crate::sub_agent::identity::AgentIdentity;
 use crate::sub_agent::on_host::command::command_os::{CommandOSNotStarted, CommandOSStarted};
 use crate::sub_agent::on_host::command::error::CommandError;
 use crate::sub_agent::on_host::command::executable_data::ExecutableData;
-use crate::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
+use crate::sub_agent::on_host::command::logging::file_logger::SubAgentFileLoggingConfig;
 use crate::sub_agent::on_host::command::restart_policy::RestartPolicy;
 use crate::sub_agent::supervisor::{Supervisor, SupervisorStarter};
 use crate::utils::thread_context::{
@@ -104,7 +104,7 @@ where
 {
     agent_identity: AgentIdentity,
     executables: Vec<ExecutableData>,
-    file_logging_config: FileLoggingConfigSubAgent,
+    file_logging_config: SubAgentFileLoggingConfig,
     health_config: Option<OnHostHealthConfig>,
     package_manager: Arc<PM>,
     packages_config: RenderedPackages,
@@ -196,7 +196,7 @@ where
             onhost_config.packages,
             onhost_config.reported_version_package,
             package_manager,
-            FileLoggingConfigSubAgent {
+            SubAgentFileLoggingConfig {
                 enabled: onhost_config.enable_file_logging,
                 base_path: logging_base_path,
             },
@@ -228,7 +228,7 @@ where
         packages_config: RenderedPackages,
         reported_version_package: Option<PackageID>,
         package_manager: Arc<PM>,
-        file_logging_config: FileLoggingConfigSubAgent,
+        file_logging_config: SubAgentFileLoggingConfig,
         filesystem: FileSystem,
         shared_filesystem: SharedFileSystem,
     ) -> Self {
@@ -732,7 +732,7 @@ pub mod tests {
             packages,
             Some("core".to_string()),
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -836,7 +836,7 @@ pub mod tests {
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -882,7 +882,7 @@ pub mod tests {
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -945,7 +945,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             filesystem,
             SharedFileSystem::test_empty(),
         );
@@ -993,7 +993,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1043,7 +1043,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1093,7 +1093,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1138,7 +1138,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1202,7 +1202,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1278,7 +1278,7 @@ declared-dir:
         let command = CommandOSNotStarted::new(
             agent_id.clone(),
             &exec_data,
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
         )
         .start()
         .unwrap();
@@ -1332,7 +1332,7 @@ declared-dir:
         let command = CommandOSNotStarted::new(
             agent_id.clone(),
             &exec_data,
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
         )
         .start()
         .unwrap();
@@ -1391,7 +1391,10 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig {
+                enabled: true,
+                base_path: logging_path.clone(),
+            },
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1520,7 +1523,10 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig {
+                enabled: false,
+                base_path: logging_path.clone(),
+            },
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1647,7 +1653,10 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig {
+                enabled: true,
+                base_path: logging_path.clone(),
+            },
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1759,7 +1768,7 @@ declared-dir:
             get_empty_packages(),
             None,
             MockPackageManager::new_arc(),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );
@@ -1832,7 +1841,7 @@ declared-dir:
             get_empty_packages(),
             None,
             Arc::new(MockPackageManager::new()),
-            FileLoggingConfigSubAgent::default(),
+            SubAgentFileLoggingConfig::default(),
             FileSystem::test_empty(),
             SharedFileSystem::test_empty(),
         );

--- a/agent-control/tests/on_host/command/shutdown.rs
+++ b/agent-control/tests/on_host/command/shutdown.rs
@@ -1,6 +1,6 @@
 use newrelic_agent_control::sub_agent::on_host::command::command_os::CommandOSNotStarted;
 use newrelic_agent_control::sub_agent::on_host::command::executable_data::ExecutableData;
-use newrelic_agent_control::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
+use newrelic_agent_control::sub_agent::on_host::command::logging::file_logger::SubAgentFileLoggingConfig;
 use newrelic_agent_control::sub_agent::on_host::command::restart_policy::RestartPolicy;
 use std::collections::HashMap;
 use std::process::Command;
@@ -32,7 +32,7 @@ fn non_blocking_runner() {
             restart_policy: RestartPolicy::default(),
             shutdown_timeout: Default::default(),
         },
-        FileLoggingConfigSubAgent::default(),
+        SubAgentFileLoggingConfig::default(),
     );
 
     let mut started_cmd = cmd.start().unwrap();
@@ -56,7 +56,7 @@ fn command_shutdown_when_sigterm_is_ignored() {
             restart_policy: Default::default(),
             shutdown_timeout: Duration::from_millis(100),
         },
-        FileLoggingConfigSubAgent::default(),
+        SubAgentFileLoggingConfig::default(),
     )
     .start()
     .unwrap();
@@ -106,7 +106,7 @@ fn command_shutdown_kill_orphan_process() {
             restart_policy: Default::default(),
             shutdown_timeout: Duration::from_millis(100),
         },
-        FileLoggingConfigSubAgent::default(),
+        SubAgentFileLoggingConfig::default(),
     )
     .start()
     .unwrap();

--- a/agent-control/tests/on_host/command/shutdown.rs
+++ b/agent-control/tests/on_host/command/shutdown.rs
@@ -1,8 +1,8 @@
 use newrelic_agent_control::sub_agent::on_host::command::command_os::CommandOSNotStarted;
 use newrelic_agent_control::sub_agent::on_host::command::executable_data::ExecutableData;
+use newrelic_agent_control::sub_agent::on_host::command::logging::file_logger::FileLoggingConfigSubAgent;
 use newrelic_agent_control::sub_agent::on_host::command::restart_policy::RestartPolicy;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::process::Command;
 use std::{thread::sleep, time::Duration};
 
@@ -32,8 +32,7 @@ fn non_blocking_runner() {
             restart_policy: RestartPolicy::default(),
             shutdown_timeout: Default::default(),
         },
-        false,
-        PathBuf::default(),
+        FileLoggingConfigSubAgent::default(),
     );
 
     let mut started_cmd = cmd.start().unwrap();
@@ -57,8 +56,7 @@ fn command_shutdown_when_sigterm_is_ignored() {
             restart_policy: Default::default(),
             shutdown_timeout: Duration::from_millis(100),
         },
-        false,
-        Default::default(),
+        FileLoggingConfigSubAgent::default(),
     )
     .start()
     .unwrap();
@@ -108,8 +106,7 @@ fn command_shutdown_kill_orphan_process() {
             restart_policy: Default::default(),
             shutdown_timeout: Duration::from_millis(100),
         },
-        false,
-        Default::default(),
+        FileLoggingConfigSubAgent::default(),
     )
     .start()
     .unwrap();

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -66,7 +66,7 @@ log:
   show_spans: false # Show spans information as logs. It includes additional details which may be useful for debugging purposes.
 ```
 
-Notice that rotation and retention cannot be configured and is fixed to be daily with 15 days of retention.
+Notice that rotation and retention cannot be configured and is fixed to be daily with 30 days of retention.
 
 ### fleet_control
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -66,6 +66,8 @@ log:
   show_spans: false # Show spans information as logs. It includes additional details which may be useful for debugging purposes.
 ```
 
+Notice that rotation and retention cannot be configured and is fixed to be daily with 15 days of retention.
+
 ### fleet_control
 
 This configuration field enables and sets up the remote configuration features of Agent Control.


### PR DESCRIPTION
This PR is:
 - adding .max_log_files(30) when building the loggers
> When constructing a RollingFileAppender or starting a new log file, the appender will delete the oldest matching log files until at most n files remain. 
- introduced a new helper struct to clarify that `FileLoggingConfigSubAgent` is completely different from `FileLoggingConfig`. 


Note that with @gsanchezgavier we decided not to expose the max_file since we currently do not have a section in the config for the log of the subagents, moreover the "DAILY" rotation was already hardcoded