### PR TITLE
fix(k8s): avoid bootstrap/deployment uninstall collision [NR-572127]

### DIFF
--- a/agent-control/src/cli/k8s/uninstall/agent_control.rs
+++ b/agent-control/src/cli/k8s/uninstall/agent_control.rs
@@ -7,12 +7,13 @@ use crate::cli::k8s::errors::K8sCliError;
 use crate::cli::k8s::install::agent_control::REPOSITORY_NAME;
 use crate::cli::k8s::uninstall::Deleter;
 use crate::cli::k8s::utils::{retrieve_api_resources, try_new_k8s_client};
-use crate::k8s::client::SyncK8sClient;
-use crate::k8s::labels::Labels;
+use crate::k8s::annotations;
+use crate::k8s::client::K8sClient;
+use crate::k8s::labels::{self, Labels};
 use clap::Parser;
 use kube::api::TypeMeta;
-use std::collections::HashSet;
-use tracing::info;
+use std::collections::{BTreeMap, HashSet};
+use tracing::{debug, info};
 
 /// Arguments for the Agent Control uninstall command.
 #[derive(Debug, Clone, Parser)]
@@ -53,17 +54,29 @@ pub fn uninstall_agent_control(
     // created by another agent (the K8s Operator). If this agent is uninstalled before removing
     // the Instrumentation resources then these deletion attempts will fail.
     //
-    // So we split the list of objects to delete into a pair, first one with Instrumentations only,
-    // as filtered by `instrumentations_filter` (which we might extend in the future) and the
-    // second one with everything else.
+    // So we split the list of objects to delete into three groups: Instrumentations (deleted
+    // first, as above), the Flux CRs (HelmRelease/HelmRepository), and everything else.
     let instrumentations_filter = [instrumentation_v1beta3_type_meta()];
-    let (instrumentations_only, no_instrumentations): (Vec<_>, Vec<_>) = valid_objects_to_delete
+    let (instrumentations_only, remaining): (Vec<_>, Vec<_>) = valid_objects_to_delete
         .into_iter()
         .partition(|tm| instrumentations_filter.contains(tm));
+
+    // The Flux CRs are handled separately from the rest: Agent Control's own self-managed
+    // HelmRelease/HelmRepository are removed first (`delete_agent_control_crs`) and only when the
+    // release name is set. Otherwise, deletion could collide between bootstrap's uninstall
+    // and deployment's uninstall.
+    let flux_cr_filter = [helmrelease_v2_type_meta(), helmrepository_type_meta()];
+    let (flux_crs, no_instrumentations): (Vec<_>, Vec<_>) = remaining
+        .into_iter()
+        .partition(|tm| flux_cr_filter.contains(tm));
 
     // Operating over Instrumentations only.
     delete_owned_objects(&k8s_client, &instrumentations_only, namespace)?;
     delete_owned_objects(&k8s_client, &instrumentations_only, namespace_agents)?;
+
+    // Operating over Flux CRs, skipping Agent Control's own self-managed ones.
+    delete_sub_agent_owned_objects(&k8s_client, &flux_crs, namespace)?;
+    delete_sub_agent_owned_objects(&k8s_client, &flux_crs, namespace_agents)?;
 
     // Operating over everything else.
     delete_owned_objects(&k8s_client, &no_instrumentations, namespace)?;
@@ -72,8 +85,8 @@ pub fn uninstall_agent_control(
     Ok(())
 }
 
-fn delete_owned_objects(
-    k8s_client: &SyncK8sClient,
+fn delete_owned_objects<C: K8sClient>(
+    k8s_client: &C,
     objects_to_delete: &[TypeMeta],
     namespace: &str,
 ) -> Result<(), K8sCliError> {
@@ -81,6 +94,46 @@ fn delete_owned_objects(
     let deleter = Deleter::with_default_retry_setup(k8s_client);
     for tm in objects_to_delete {
         deleter.delete_collection_with_retry(tm, namespace, &ac_owned_label_selector)?;
+    }
+    Ok(())
+}
+
+/// Deletes objects of the given types that Agent Control created on behalf of a sub-agent,
+/// skipping any that are Agent Control's own.
+fn delete_sub_agent_owned_objects<C: K8sClient>(
+    k8s_client: &C,
+    objects_to_delete: &[TypeMeta],
+    namespace: &str,
+) -> Result<(), K8sCliError> {
+    let deleter = Deleter::with_default_retry_setup(k8s_client);
+    for tm in objects_to_delete {
+        let objects = k8s_client
+            .list_dynamic_objects(tm, namespace)
+            .map_err(|err| {
+                K8sCliError::GetResource(format!(
+                    "could not list resources of type '{}': {}",
+                    tm.kind, err
+                ))
+            })?;
+
+        for obj in objects {
+            let empty_map = BTreeMap::new();
+            let object_labels = obj.metadata.labels.as_ref().unwrap_or(&empty_map);
+            if !labels::is_managed_by_agent_control(object_labels) {
+                continue;
+            }
+
+            let object_annotations = obj.metadata.annotations.as_ref().unwrap_or(&empty_map);
+            let Some(name) = obj.metadata.name.as_deref() else {
+                continue;
+            };
+            if !annotations::is_owned_by_sub_agent(object_annotations) {
+                debug!(%name, type = tm.kind, "skipping resource owned by Agent Control itself");
+                continue;
+            }
+
+            deleter.delete_object_with_retry(tm, name, namespace)?;
+        }
     }
     Ok(())
 }
@@ -103,8 +156,8 @@ fn objects_to_delete(kinds_available: &HashSet<TypeMeta>) -> Vec<TypeMeta> {
     tm_to_delete
 }
 
-fn delete_agent_control_crs(
-    k8s_client: &SyncK8sClient,
+fn delete_agent_control_crs<C: K8sClient>(
+    k8s_client: &C,
     kinds_available: &HashSet<TypeMeta>,
     namespace: &str,
     release_name: &str,
@@ -122,4 +175,107 @@ fn delete_agent_control_crs(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_control::agent_id::AgentID;
+    use crate::agent_type::agent_type_id::AgentTypeID;
+    use crate::k8s::annotations::Annotations;
+    use crate::k8s::client::tests::MockK8sClient;
+    use either::Either;
+    use kube::api::{DynamicObject, ObjectMeta};
+    use kube::core::Status;
+    use std::sync::Arc;
+
+    const TEST_NAMESPACE: &str = "test-namespace";
+
+    fn dynamic_object(
+        labels: Option<BTreeMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
+    ) -> Arc<DynamicObject> {
+        Arc::new(DynamicObject {
+            types: None,
+            metadata: ObjectMeta {
+                name: Some("some-release".to_string()),
+                namespace: Some(TEST_NAMESPACE.to_string()),
+                labels,
+                annotations,
+                ..Default::default()
+            },
+            data: serde_json::Value::Null,
+        })
+    }
+
+    #[test]
+    fn skips_agent_control_owned_object() {
+        let obj = dynamic_object(
+            Some(Labels::new(&AgentID::AgentControl).get()),
+            Some(Annotations::new_agent_control_owned().get()),
+        );
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .returning(move |_, _| Ok(vec![obj.clone()]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let tm = helmrelease_v2_type_meta();
+        assert!(delete_sub_agent_owned_objects(&k8s_client, &[tm], TEST_NAMESPACE).is_ok());
+    }
+
+    #[test]
+    fn deletes_sub_agent_owned_object() {
+        let agent_id = AgentID::try_from("foo-agent").unwrap();
+        let agent_type_id = AgentTypeID::try_from("newrelic/com.example.foo:0.0.1").unwrap();
+        let obj = dynamic_object(
+            Some(Labels::new(&agent_id).get()),
+            Some(Annotations::new_sub_agent_owned_with_type(&agent_type_id).get()),
+        );
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .returning(move |_, _| Ok(vec![obj.clone()]));
+        k8s_client
+            .expect_delete_dynamic_object()
+            .once()
+            .returning(|_, _| Ok(Either::Right(Status::default())));
+
+        let tm = helmrelease_v2_type_meta();
+        assert!(delete_sub_agent_owned_objects(&k8s_client, &[tm], TEST_NAMESPACE).is_ok());
+    }
+
+    #[test]
+    fn skips_object_without_managed_by_label() {
+        let obj = dynamic_object(None, Some(Annotations::new_agent_control_owned().get()));
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .returning(move |_, _| Ok(vec![obj.clone()]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let tm = helmrelease_v2_type_meta();
+        assert!(delete_sub_agent_owned_objects(&k8s_client, &[tm], TEST_NAMESPACE).is_ok());
+    }
+
+    #[test]
+    fn skips_object_without_owned_by_annotation() {
+        let obj = dynamic_object(Some(Labels::new(&AgentID::AgentControl).get()), None);
+
+        let mut k8s_client = MockK8sClient::default();
+        k8s_client
+            .expect_list_dynamic_objects()
+            .once()
+            .returning(move |_, _| Ok(vec![obj.clone()]));
+        k8s_client.expect_delete_dynamic_object().never();
+
+        let tm = helmrelease_v2_type_meta();
+        assert!(delete_sub_agent_owned_objects(&k8s_client, &[tm], TEST_NAMESPACE).is_ok());
+    }
 }


### PR DESCRIPTION
When manually testing the changes introduced in #2742, I found out a collision between the resources removed by the `agent-control-bootstrap` and `agent-control-deployment` uninstallation jobs, making the `agent-control-deployment` uninstallation job exhaust all the available retries before (successfully timing out).

It was tested using the corresponding helm-chart's draft-pr: https://github.com/newrelic/helm-charts/pull/2362