### PR TITLE
chore(vars): refactor injection

### DIFF
--- a/agent-control/src/agent_type/agent_attributes.rs
+++ b/agent-control/src/agent_type/agent_attributes.rs
@@ -2,6 +2,7 @@
 use super::variable::{Variable, namespace::Namespace};
 use crate::agent_control::agent_id::AgentID;
 use crate::agent_control::defaults::{AGENT_FILESYSTEM_FOLDER_NAME, SHARED_FILESYSTEM_FOLDER_NAME};
+use crate::agent_type::variable::namespace::NamespacedVariableName;
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
 use tracing::debug;
@@ -56,7 +57,7 @@ impl AgentAttributes {
     }
 
     /// returns the variables from the sub-agent attributes source 'nr-sub'.
-    pub fn sub_agent_variables(&self) -> HashMap<String, Variable> {
+    pub fn sub_agent_variables(&self) -> HashMap<NamespacedVariableName, Variable> {
         HashMap::from([
             (
                 Namespace::SubAgent.namespaced_name(Self::VARIABLE_SUB_AGENT_ID),

--- a/agent-control/src/agent_type/registry/local/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/registry/local/agent_type_validation_tests.rs
@@ -1081,7 +1081,6 @@ fn iterate_test_cases(environment: Environment) {
                 variables,
                 attributes,
                 values.additional_env.clone(),
-                HashMap::new(), // Secrets are not used in this test
             );
 
             assert!(

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -22,19 +22,22 @@ pub struct TemplateRenderer {
 
 impl TemplateRenderer {
     /// Renders an AgentType and obtain the runtime configuration needed to execute a sub agent.
+    ///
+    /// `secrets` contains every secret-namespaced value (`nr-env`, `nr-vault`,
+    /// `nr-kubesec`) referenced by either `values` or the agent type's runtime config. Values are
+    /// templated against the full map.
     pub fn render(
         &self,
         agent_type: AgentType,
         values: YAMLConfig,
         attributes: AgentAttributes,
-        env_vars: HashMap<String, Variable>,
-        secrets: HashMap<String, Variable>,
+        secrets: HashMap<NamespacedVariableName, Variable>,
     ) -> Result<Runtime, AgentTypeError> {
         // Get empty variables and runtime_config from the agent-type
         let (variables, runtime_config) = (agent_type.variables, agent_type.runtime_config);
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables and secrets are taken into consideration (no other vars for example)
+        // Values are expanded substituting all ${nr-XXX:...} secret references (env vars, vault,
+        // file, k8s) with the values loaded by the caller.
         let values_expanded = values.template_with(&secrets)?;
 
         // Fill agent variables
@@ -42,8 +45,7 @@ impl TemplateRenderer {
 
         Self::check_all_vars_are_populated(&filled_variables)?;
 
-        // Setup namespaced variables
-        let ns_variables = self.build_namespaced_variables(filled_variables, env_vars, &attributes);
+        let ns_variables = self.build_namespaced_variables(filled_variables, secrets, &attributes);
         // Render runtime config
         let rendered_runtime_config = runtime_config.template_with(&ns_variables)?;
 
@@ -84,20 +86,18 @@ impl TemplateRenderer {
     fn build_namespaced_variables(
         &self,
         variables: HashMap<String, Variable>,
-        env_vars: HashMap<String, Variable>,
+        secrets: HashMap<NamespacedVariableName, Variable>,
         attributes: &AgentAttributes,
     ) -> HashMap<NamespacedVariableName, Variable> {
         // Set the namespaced name to variables
         let vars_iter = variables
             .into_iter()
             .map(|(name, var)| (Namespace::Variable.namespaced_name(&name), var));
-        // Get the namespaced variables from sub-agent attributes
-        let sub_agent_vars_iter = attributes.sub_agent_variables().into_iter();
 
         // Join all variables together
         vars_iter
-            .chain(sub_agent_vars_iter)
-            .chain(env_vars)
+            .chain(attributes.sub_agent_variables())
+            .chain(secrets)
             .chain(self.ac_variables.clone())
             .collect::<HashMap<NamespacedVariableName, Variable>>()
     }
@@ -144,13 +144,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let mut bin_stack = vec!["/opt/first", "/opt/second"].into_iter();
@@ -181,13 +175,7 @@ pub(crate) mod tests {
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let result = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let result = renderer.render(agent_type, values, attributes, HashMap::new());
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
@@ -201,13 +189,7 @@ pub(crate) mod tests {
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let result = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let result = renderer.render(agent_type, values, attributes, HashMap::new());
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
@@ -222,13 +204,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let on_host_deployment = runtime_config.deployment.on_host();
@@ -263,13 +239,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let on_host_deployment = runtime_config.deployment.on_host();
@@ -344,13 +314,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let k8s = runtime_config.deployment.k8s();
@@ -400,8 +364,7 @@ substituted_2: my-value-2
             serde_saphyr::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(agent_type, values, attributes, env_vars);
 
         let k8s = runtime_config.unwrap().deployment.k8s();
         let cr1 = k8s.objects.get("cr1").unwrap();
@@ -454,8 +417,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             serde_saphyr::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, HashMap::new(), secrets);
+        let runtime_config = renderer.render(agent_type, values, attributes, secrets);
 
         let k8s = runtime_config.unwrap().deployment.k8s();
         let values = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
@@ -470,13 +432,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let runtime_config = renderer.render(agent_type, values, attributes, HashMap::new());
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -523,8 +479,7 @@ deployment:
         )]);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(agent_type, values, attributes, env_vars);
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -563,13 +518,7 @@ deployment:
         let renderer = TemplateRenderer::default()
             .with_agent_control_variables(agent_control_variables.into_iter());
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
         assert_eq!(
             exec_rendered::Args(vec!("fake_value".to_string())),

--- a/agent-control/src/agent_type/variable/secret_variables.rs
+++ b/agent-control/src/agent_type/variable/secret_variables.rs
@@ -1,6 +1,6 @@
 //! Extraction and loading of secret variables referenced from a sub-agent configuration.
-use std::collections::{HashMap, HashSet};
-
+use crate::agent_type::runtime_config::Runtime;
+use crate::agent_type::variable::namespace::NamespacedVariableName;
 use crate::{
     agent_type::{
         templates::template_re,
@@ -9,6 +9,7 @@ use crate::{
     secrets_provider::{Registry, SecretsProvider},
     values::yaml_config::YAMLConfig,
 };
+use std::collections::{HashMap, HashSet};
 
 /// Represents the prefix used for namespaced variables.
 /// Example: "nr-vault", "nr-var", etc.
@@ -62,14 +63,19 @@ impl From<&str> for SecretVariables {
     }
 }
 
-impl TryFrom<YAMLConfig> for SecretVariables {
-    type Error = SecretVariablesError;
-
-    fn try_from(config: YAMLConfig) -> Result<Self, Self::Error> {
-        let config: String = config
+impl SecretVariables {
+    pub fn get_from(
+        user_values: YAMLConfig,
+        runtime: Runtime,
+    ) -> Result<Self, SecretVariablesError> {
+        let user_values: String = user_values
             .try_into()
             .map_err(|_| SecretVariablesError::YamlParseError)?;
-        Ok(SecretVariables::from(config.as_str()))
+
+        // We are taking the definition of the secrets from both user_values and agent_type_runtime
+        Ok(SecretVariables::from(
+            format!("{}{:?}", user_values, runtime).as_str(),
+        ))
     }
 }
 
@@ -95,7 +101,7 @@ impl SecretVariables {
     pub fn load_secrets<S: SecretsProvider>(
         &self,
         secrets_providers_registry: &Registry<S>,
-    ) -> Result<HashMap<String, Variable>, SecretVariablesError> {
+    ) -> Result<HashMap<NamespacedVariableName, Variable>, SecretVariablesError> {
         if secrets_providers_registry.is_empty() {
             return Ok(HashMap::new());
         }
@@ -130,18 +136,6 @@ impl SecretVariables {
             .expect("Namespace format should be valid");
         self.variables.entry(prefix).or_default().insert(var_name);
     }
-}
-
-/// Loads all environment variables present in the system.
-pub fn load_env_vars() -> HashMap<String, Variable> {
-    std::env::vars_os()
-        .map(|(k, v)| {
-            (
-                Namespace::EnvironmentVariable.namespaced_name(k.to_string_lossy()),
-                Variable::new_final_string_variable(v.to_string_lossy().to_string()),
-            )
-        })
-        .collect::<HashMap<String, Variable>>()
 }
 
 #[cfg(test)]

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -9,9 +9,7 @@ use crate::agent_type::runtime_config::k8s::K8s;
 use crate::agent_type::runtime_config::on_host::rendered::OnHost;
 use crate::agent_type::runtime_config::rendered;
 use crate::agent_type::variable::constraints::VariableConstraints;
-use crate::agent_type::variable::secret_variables::{
-    SecretVariables, SecretVariablesError, load_env_vars,
-};
+use crate::agent_type::variable::secret_variables::{SecretVariables, SecretVariablesError};
 use crate::secrets_provider::SecretsProviders;
 use crate::sub_agent::identity::AgentIdentity;
 use crate::values::yaml_config::YAMLConfig;
@@ -181,15 +179,14 @@ where
                 EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string())
             })?;
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables are taken into consideration (no other vars for example)
-        let secret_variables = SecretVariables::try_from(values.clone())?;
-        let env_vars = load_env_vars();
+        let secret_variables =
+            SecretVariables::get_from(values.clone(), agent_type.runtime_config.clone())?;
+
         let secrets = secret_variables.load_secrets(&self.secrets_providers)?;
 
         let runtime_config = self
             .renderer
-            .render(agent_type, values, attributes, env_vars, secrets)?;
+            .render(agent_type, values, attributes, secrets)?;
 
         Ok(EffectiveAgent::new(agent_identity.clone(), runtime_config))
     }

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 /// The YAMLConfig represent any YAML config that the AgentControl can read and store.
 /// It enforces that the root of the tree is a hashmap and not an array or a single element.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
-pub struct YAMLConfig(HashMap<String, serde_json::Value>);
+pub struct YAMLConfig(HashMap<String, Value>);
 
 impl YAMLConfig {
     /// Returns true if the YAMLConfig is empty.


### PR DESCRIPTION
Before the refactor there was a weird mix of code.

 - Before: we were loading the environment variables defined in the values of the user via the secret provider, and all the remaining variables via a `vars_os` loading ALL environment variables, also the ones not defined.
It was not clear why there were two ways of loading variables.

This is needed to populate `${nr-env:NR_STAGING}` that is not defined in the user values

 - After the change: we are loading all environment variables via the secret provider, to do so we need to check the agentType schema. 

Now it should be cleaner to read, if the change seems dangerous we can close it, there is no feature and the code now it is working