### PR TITLE
fix: improve oci client error logs

### DIFF
--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -88,7 +88,7 @@ impl Client {
             self.client
                 .pull_blob(reference, layer, &mut file)
                 .await
-                .map_err(|err| OciClientError::PullBlob(err.to_string().into()))?;
+                .map_err(|err| OciClientError::PullBlob(err.into()))?;
 
             // Ensure all data is flushed to disk before returning
             file.sync_data().await.map_err(|err| {
@@ -116,7 +116,7 @@ impl Client {
                 .client
                 .pull_blob_stream(reference, layer)
                 .await
-                .map_err(|err| OciClientError::PullBlob(err.to_string().into()))?;
+                .map_err(|err| OciClientError::PullBlob(err.into()))?;
 
             // Cheap up-front rejection based on the advertised content length. This is
             // attacker-controlled (it may understate the size or be absent), so it is only an
@@ -506,7 +506,7 @@ pub mod tests {
         let fetcher = create_fetcher();
         let result = fetcher.fetch(&reference, None, pull_first_layer);
         assert_matches!(result, Err(OciClientError::AttemptsExceeded(msg)) => {
-            assert!(msg.contains("pulling image manifest"), "{msg}");
+            assert!(msg.contains("the requested version does not exist in the registry"), "{msg}");
         });
     }
 

--- a/agent-control/src/oci.rs
+++ b/agent-control/src/oci.rs
@@ -70,7 +70,7 @@ impl Client {
     ) -> Result<(OciImageManifest, String), OciClientError> {
         self.runtime
             .block_on(self.client.pull_image_manifest(reference, auth))
-            .map_err(|err| OciClientError::PullManifest(err.into()))
+            .map_err(|err| OciClientError::PullArtifactManifest(err.into()))
     }
 
     /// Pulls  the specified blob through [oci_client::Client::pull_blob] and stores it in the specified file path.
@@ -347,7 +347,7 @@ pub mod tests {
         let result =
             client.verify_signature(&image_ref, &jwks_server.url, &RegistryAuth::Anonymous);
 
-        assert_matches!(result, Err(OciClientError::Verify(_)));
+        assert_matches!(result, Err(OciClientError::PullSignatureManifest(_)));
     }
 
     #[test]
@@ -483,7 +483,8 @@ pub mod tests {
             )
             .unwrap_err();
         assert!(
-            err.to_string().contains("signature verification failed"),
+            err.to_string()
+                .contains("failure pulling signature manifest"),
             "{err}"
         );
     }

--- a/agent-control/src/oci/error.rs
+++ b/agent-control/src/oci/error.rs
@@ -6,28 +6,20 @@ use thiserror::Error;
 /// Errors produced by the OCI client when pulling and verifying artifacts.
 #[derive(Debug, Error)]
 pub enum OciClientError {
-    /// The OCI client could not be constructed (e.g. invalid configuration).
     #[error("could not build the OCI client: {0}")]
     Build(String),
-    /// Pulling the image manifest from the registry failed.
-    #[error("failure pulling image manifest: {0}")]
+    #[error("failure pulling artifact manifest: {0}")]
     PullManifest(OciErrorMessage),
-    /// Pulling a blob from the registry failed.
-    #[error("failure pulling blob: {0}")]
+    #[error("failure pulling artifact blob: {0}")]
     PullBlob(OciErrorMessage),
-    /// The generated image reference was not a valid OCI reference.
     #[error("invalid reference format generated: {0}")]
     InvalidReference(String),
-    /// Signature verification of the artifact failed.
     #[error("signature verification failed: {0}")]
     Verify(String),
-    /// Fetching the public key used for verification failed.
     #[error("failed to fetch public key: {0}")]
     KeyFetch(String),
-    /// Fetching the artifact failed.
     #[error("failed to fetch artifact: {0}")]
     FetchArtifact(String),
-    /// All download attempts (including retries) were exhausted.
     #[error("download attempts exceeded, last error: {0}")]
     AttemptsExceeded(String),
 }

--- a/agent-control/src/oci/error.rs
+++ b/agent-control/src/oci/error.rs
@@ -9,7 +9,9 @@ pub enum OciClientError {
     #[error("could not build the OCI client: {0}")]
     Build(String),
     #[error("failure pulling artifact manifest: {0}")]
-    PullManifest(OciErrorMessage),
+    PullArtifactManifest(OciErrorMessage),
+    #[error("failure pulling signature manifest: {0}")]
+    PullSignatureManifest(OciErrorMessage),
     #[error("failure pulling artifact blob: {0}")]
     PullBlob(OciErrorMessage),
     #[error("invalid reference format generated: {0}")]

--- a/agent-control/src/oci/signature_verification.rs
+++ b/agent-control/src/oci/signature_verification.rs
@@ -93,9 +93,7 @@ impl Client {
                     .client
                     .fetch_manifest_digest(reference, auth)
                     .await
-                    .map_err(|err| {
-                        OciClientError::Verify(format!("could not fetch manifest: {err}"))
-                    })?;
+                    .map_err(|err| OciClientError::PullManifest(err.into()))?;
                 debug!(%digest, "Manifest digest resolved");
                 digest
             }

--- a/agent-control/src/oci/signature_verification.rs
+++ b/agent-control/src/oci/signature_verification.rs
@@ -93,7 +93,7 @@ impl Client {
                     .client
                     .fetch_manifest_digest(reference, auth)
                     .await
-                    .map_err(|err| OciClientError::PullManifest(err.into()))?;
+                    .map_err(|err| OciClientError::PullArtifactManifest(err.into()))?;
                 debug!(%digest, "Manifest digest resolved");
                 digest
             }
@@ -108,9 +108,7 @@ impl Client {
             .client
             .pull_image_manifest(&signature_ref, auth)
             .await
-            .map_err(|err| {
-                OciClientError::Verify(format!("could not fetch signature manifest: {err}"))
-            })?;
+            .map_err(|err| OciClientError::PullSignatureManifest(err.into()))?;
 
         // Try to validate signature for each valid signature in the manifest's layers
         for layer in signature_manifest.layers {
@@ -479,7 +477,7 @@ mod tests {
                 &RegistryAuth::Anonymous,
             ));
 
-        assert_matches!(result, Err(OciClientError::Verify(_)));
+        assert_matches!(result, Err(OciClientError::PullSignatureManifest(_)));
     }
 
     #[test]

--- a/agent-control/tests/on_host/scenarios/ac_self_update.rs
+++ b/agent-control/tests/on_host/scenarios/ac_self_update.rs
@@ -237,7 +237,7 @@ agents: {{}}
             if status.status != RemoteConfigStatuses::Failed as i32 {
                 return Err(format!("expected Failed status, got: {}", status.status).into());
             }
-            if !status.error_message.contains("signature verification") {
+            if !status.error_message.contains("failure pulling signature") {
                 return Err(format!(
                     "expected error message to contain 'signature verification', got: {}",
                     status.error_message

--- a/agent-control/tests/on_host/scenarios/install_remote_package.rs
+++ b/agent-control/tests/on_host/scenarios/install_remote_package.rs
@@ -206,7 +206,7 @@ fn test_unsigned_artifact_makes_remote_config_fail_with_oci_registry() {
             if config_status.status == RemoteConfigStatuses::Failed as i32
                 && config_status
                     .error_message
-                    .contains("signature verification failed")
+                    .contains("failure pulling signature")
             {
                 Ok(())
             } else {


### PR DESCRIPTION
Make use of the existent `OciErrorMessage` conversion improving the logging in situations where the target tag is missing in the registry for packages and agent types. 
Fixes a regression introduced with the retries #2610 related to log improvements.