### PR TITLE
feat: send supported protocol version on release

### DIFF
--- a/.github/workflows/post-release-agent-metadata.yml
+++ b/.github/workflows/post-release-agent-metadata.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
+      - name: Extract Agent Control protocol version
+        id: protocol-version
+        run: |
+          RAW_VERSION=$(awk -F'"' '/^agent_type_protocol_version/{print $2; exit}' agent-control/Cargo.toml)
+          if [[ ! "$RAW_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Could not extract a valid MAJOR.MINOR agent_type_protocol_version from agent-control/Cargo.toml (got: '$RAW_VERSION')"
+            exit 1
+          fi
+          echo "protocol_version=$RAW_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ github.token }}
@@ -46,11 +56,14 @@ jobs:
           ls -lh /tmp/artifacts/
 
       - name: Upload agent metadata to New Relic
-        uses: newrelic/agent-metadata-action@5a6654e0866cfbad9ce1de68a5e016f888771548 # v1.3.0
+        uses: newrelic/agent-metadata-action@3c2fd71b50678a84e69c766d85f23b3f1c0ca58c # v1.4.0
         with:
           agent-type: NRAgentControl
           version: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-          git-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          # git-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          git-ref: feat/send-protocol-version-to-catalog-dynamic
+          bindings-override: '[{"type":"SUPPORTS","targetType":"SPECIFICATION","target":"protocol_version","versions":["<=${{ steps.protocol-version.outputs.protocol_version }}"]}]'
+          monitoring-type: INFRA
           newrelic-client-id: ${{ secrets.AC_NEWRELIC_CLIENT_ID }}
           newrelic-private-key: ${{ secrets.AC_NEWRELIC_PRIVATE_KEY }}
           # shared newrelic key to instrument the go binary used in the action

--- a/.github/workflows/post-release-agent-metadata.yml
+++ b/.github/workflows/post-release-agent-metadata.yml
@@ -60,8 +60,7 @@ jobs:
         with:
           agent-type: NRAgentControl
           version: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-          # git-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-          git-ref: feat/send-protocol-version-to-catalog-dynamic
+          git-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
           bindings-override: '[{"type":"SUPPORTS","targetType":"SPECIFICATION","target":"protocol_version","versions":["<=${{ steps.protocol-version.outputs.protocol_version }}"]}]'
           monitoring-type: INFRA
           newrelic-client-id: ${{ secrets.AC_NEWRELIC_CLIENT_ID }}


### PR DESCRIPTION
Adding to send the binding of protocol_version supported by NRAgentControl.

That allows us to decide which agents are compatible with each agent-control