### PR TITLE
fix: number of messages fro alerts in slack

### DIFF
--- a/.github/workflows/component_send_warning_via_slack.yml
+++ b/.github/workflows/component_send_warning_via_slack.yml
@@ -19,6 +19,7 @@ jobs:
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook-type: webhook-trigger
+          retries: '0'
           payload: |
             {
               "text": ":warning: [${{ inputs.message }}] @hero check <${{ env.GITHUB_JOB_URL }}>"


### PR DESCRIPTION
Fixes duplicate Slack failure notifications (up to 6 identical messages per alert) by disabling the Slack GitHub Action's built-in retry behavior.

bug from: https://github.com/slackapi/slack-github-action/issues/654
