### PR TITLE
chore(injection): refactor envVar injection

### DIFF
--- a/agent-control/src/agent_type/agent_attributes.rs
+++ b/agent-control/src/agent_type/agent_attributes.rs
@@ -36,10 +36,10 @@ impl AgentAttributes {
 
     /// Builds [`AgentAttributes`] for a sub-agent. Returns an error if the given id is a reserved
     /// (non sub-agent) id.
-    pub fn try_new(
+    pub fn get_agent_variables(
         agent_id: AgentID,
         remote_dir: PathBuf,
-    ) -> Result<Self, AgentAttributesCreateError> {
+    ) -> Result<HashMap<VariableName, Variable>, AgentAttributesCreateError> {
         if let AgentID::SubAgent(agent_id) = agent_id {
             let agent_filesystem_dir = remote_dir
                 .join(AGENT_FILESYSTEM_FOLDER_NAME)
@@ -52,7 +52,8 @@ impl AgentAttributes {
                 agent_filesystem_dir,
                 shared_filesystem_dir,
                 remote_dir,
-            })
+            }
+            .sub_agent_variables())
         } else {
             Err(AgentAttributesCreateError("Used reserved Agent ID".into()))
         }
@@ -103,9 +104,7 @@ mod tests {
     fn filesystems_are_available() {
         let remote_dir = PathBuf::from(AGENT_CONTROL_DATA_DIR);
         let agent_id = AgentID::try_from("my-agent").unwrap();
-        let attrs = AgentAttributes::try_new(agent_id, remote_dir.clone()).unwrap();
-
-        let vars = attrs.sub_agent_variables();
+        let vars = AgentAttributes::get_agent_variables(agent_id, remote_dir.clone()).unwrap();
 
         // Build expected paths via `join` so separators match the platform (e.g. `\` on Windows).
         // Shared dir lives directly under the remote dir, with no agent-id suffix.
@@ -132,15 +131,16 @@ mod tests {
     #[test]
     fn shared_filesystem_dir_is_identical_across_agents() {
         let remote_dir = PathBuf::from(AGENT_CONTROL_DATA_DIR);
-        let a = AgentAttributes::try_new(AgentID::try_from("agent-a").unwrap(), remote_dir.clone())
-            .unwrap();
+        let a = AgentAttributes::get_agent_variables(
+            AgentID::try_from("agent-a").unwrap(),
+            remote_dir.clone(),
+        )
+        .unwrap();
         let b =
-            AgentAttributes::try_new(AgentID::try_from("agent-b").unwrap(), remote_dir).unwrap();
+            AgentAttributes::get_agent_variables(AgentID::try_from("agent-b").unwrap(), remote_dir)
+                .unwrap();
 
         let key = AgentAttributes::VARIABLE_SHARED_FILESYSTEM_DIR;
-        assert_eq!(
-            final_string(&a.sub_agent_variables(), key),
-            final_string(&b.sub_agent_variables(), key),
-        );
+        assert_eq!(final_string(&a, key), final_string(&b, key),);
     }
 }

--- a/agent-control/src/agent_type/guid_config.rs
+++ b/agent-control/src/agent_type/guid_config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the agent type GUID checker (polling interval and initial delay).
 use duration_str::deserialize_duration;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use wrapper_with_default::WrapperWithDefault;
 
@@ -12,11 +12,11 @@ pub const AGENT_CONTROL_GUID_CHECKER_INITIAL_DELAY: GuidCheckerInitialDelay =
     GuidCheckerInitialDelay(Duration::ZERO); // The Agent Control HelmRelease is supposed to exist when it starts.
 
 /// The duration to wait between GUID checks.
-#[derive(Debug, Clone, Deserialize, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Clone, Deserialize, Serialize, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_GUID_CHECKER_INTERVAL)]
 pub struct GuidCheckerInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 /// The initial delay before the first GUID check is performed.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_GUID_CHECKER_INITIAL_DELAY)]
 pub struct GuidCheckerInitialDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);

--- a/agent-control/src/agent_type/registry/local/agent_type_validation_tests.rs
+++ b/agent-control/src/agent_type/registry/local/agent_type_validation_tests.rs
@@ -1084,7 +1084,6 @@ fn iterate_test_cases(environment: Environment) {
                 variables,
                 attributes,
                 values.additional_env.clone(),
-                HashMap::new(), // Secrets are not used in this test
             );
 
             assert!(

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -1,7 +1,6 @@
 //! Renders an [`AgentType`] together with user values into a runtime configuration for a sub-agent.
 use crate::agent_type::definition::VariableTree;
 use crate::agent_type::{
-    agent_attributes::AgentAttributes,
     definition::AgentType,
     error::AgentTypeError,
     runtime_config::rendered::Runtime,
@@ -119,6 +118,7 @@ pub(crate) mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::agent_type::agent_attributes::AgentAttributes;
     use crate::agent_type::runtime_config::on_host::executable::rendered as exec_rendered;
     use crate::{
         agent_control::agent_id::AgentID,

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -1,4 +1,5 @@
 //! Renders an [`AgentType`] together with user values into a runtime configuration for a sub-agent.
+use crate::agent_type::definition::VariableTree;
 use crate::agent_type::{
     agent_attributes::AgentAttributes,
     definition::AgentType,
@@ -27,27 +28,48 @@ impl TemplateRenderer {
         agent_type: AgentType,
         values: YAMLConfig,
         attributes: AgentAttributes,
-        env_vars: HashMap<VariableName, Variable>,
         secrets: HashMap<VariableName, Variable>,
     ) -> Result<Runtime, AgentTypeError> {
         // Get empty variables and runtime_config from the agent-type
-        let (variables, runtime_config) = (agent_type.variables, agent_type.runtime_config);
+        let (variable_tree, runtime_config) = (agent_type.variables, agent_type.runtime_config);
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables and secrets are taken into consideration (no other vars for example)
-        let values_expanded = values.template_with(&secrets)?;
+        let expanded_user_variables =
+            Self::get_expanded_user_variables(variable_tree, values, &secrets)?;
 
-        // Fill agent variables
-        let filled_variables = variables.fill_with_values(values_expanded)?.flatten();
-
-        Self::check_all_vars_are_populated(&filled_variables)?;
+        // Only envVars are kept and can be used to expand the runtime template, the other secrets
+        // can be used for double expansion of the user values only
+        let env_vars = secrets
+            .into_iter()
+            .filter(|(name, _)| *name.namespace() == Namespace::EnvironmentVariable)
+            .collect();
 
         // Setup namespaced variables
-        let ns_variables = self.build_namespaced_variables(filled_variables, env_vars, &attributes);
+        let ns_variables =
+            self.chain_namespaced_variables(expanded_user_variables, env_vars, &attributes);
+
         // Render runtime config
         let rendered_runtime_config = runtime_config.template_with(&ns_variables)?;
 
         Ok(rendered_runtime_config)
+    }
+
+    fn get_expanded_user_variables(
+        variable_tree: VariableTree,
+        values: YAMLConfig,
+        secrets: &HashMap<VariableName, Variable>,
+    ) -> Result<HashMap<VariableName, Variable>, AgentTypeError> {
+        // Values are expanded substituting all ${nr-env, nr-values} performing double expansions.
+        // Notice that only data coming from secrets providers taken into consideration (no other vars for example)
+        let values_expanded = values.template_with(secrets)?;
+
+        // Fill agent data in the variables tree
+        let flat_variable_tree = variable_tree.fill_with_values(values_expanded)?.flatten();
+        Self::check_all_vars_are_populated(&flat_variable_tree)?;
+        // Set the namespaced name to variables
+        Ok(flat_variable_tree
+            .into_iter()
+            .map(|(name, var)| (VariableName::new(Namespace::Variable, &name), var))
+            .collect())
     }
 
     /// Adds variables to the renderer with the agent-control namespace.
@@ -81,23 +103,17 @@ impl TemplateRenderer {
         Ok(())
     }
 
-    fn build_namespaced_variables(
+    fn chain_namespaced_variables(
         &self,
-        variables: HashMap<String, Variable>,
-        env_vars: HashMap<VariableName, Variable>,
+        expanded_user_variables: HashMap<VariableName, Variable>,
+        environment_variables: HashMap<VariableName, Variable>,
         attributes: &AgentAttributes,
     ) -> HashMap<VariableName, Variable> {
-        // Set the namespaced name to variables
-        let vars_iter = variables
-            .into_iter()
-            .map(|(name, var)| (VariableName::new(Namespace::Variable, &name), var));
-        // Get the namespaced variables from sub-agent attributes
-        let sub_agent_vars_iter = attributes.sub_agent_variables().into_iter();
-
         // Join all variables together
-        vars_iter
-            .chain(sub_agent_vars_iter)
-            .chain(env_vars)
+        expanded_user_variables
+            .into_iter()
+            .chain(attributes.sub_agent_variables())
+            .chain(environment_variables)
             .chain(self.ac_variables.clone())
             .collect::<HashMap<VariableName, Variable>>()
     }
@@ -144,13 +160,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let mut bin_stack = vec!["/opt/first", "/opt/second"].into_iter();
@@ -181,13 +191,7 @@ pub(crate) mod tests {
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let result = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let result = renderer.render(agent_type, values, attributes, HashMap::new());
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
@@ -201,13 +205,7 @@ pub(crate) mod tests {
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let result = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let result = renderer.render(agent_type, values, attributes, HashMap::new());
         assert_matches!(result.unwrap_err(), AgentTypeError::ValuesNotPopulated(vars) => {
             assert_eq!(vars, vec!["config_path".to_string()])
         })
@@ -222,13 +220,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let on_host_deployment = runtime_config.deployment.on_host();
@@ -263,13 +255,7 @@ pub(crate) mod tests {
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let on_host_deployment = runtime_config.deployment.on_host();
@@ -344,13 +330,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
 
         let renderer = TemplateRenderer::default();
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
 
         let k8s = runtime_config.deployment.k8s();
@@ -400,8 +380,7 @@ substituted_2: my-value-2
             serde_saphyr::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(agent_type, values, attributes, env_vars);
 
         let k8s = runtime_config.unwrap().deployment.k8s();
         let cr1 = k8s.objects.get("cr1").unwrap();
@@ -454,8 +433,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
             serde_saphyr::from_str(expected_spec_yaml).unwrap();
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, HashMap::new(), secrets);
+        let runtime_config = renderer.render(agent_type, values, attributes, secrets);
 
         let k8s = runtime_config.unwrap().deployment.k8s();
         let values = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
@@ -470,13 +448,7 @@ collision_avoided: ${config.values}-${env:agent_id}-${UNTOUCHED}
         let attributes = testing_agent_attributes(&agent_id);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config = renderer.render(
-            agent_type,
-            values,
-            attributes,
-            HashMap::new(),
-            HashMap::new(),
-        );
+        let runtime_config = renderer.render(agent_type, values, attributes, HashMap::new());
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -523,8 +495,7 @@ deployment:
         )]);
 
         let renderer = TemplateRenderer::default();
-        let runtime_config =
-            renderer.render(agent_type, values, attributes, env_vars, HashMap::new());
+        let runtime_config = renderer.render(agent_type, values, attributes, env_vars);
 
         assert_matches!(
             runtime_config.unwrap_err(),
@@ -563,13 +534,7 @@ deployment:
         let renderer = TemplateRenderer::default()
             .with_agent_control_variables(agent_control_variables.into_iter());
         let runtime_config = renderer
-            .render(
-                agent_type,
-                values,
-                attributes,
-                HashMap::new(),
-                HashMap::new(),
-            )
+            .render(agent_type, values, attributes, HashMap::new())
             .unwrap();
         assert_eq!(
             exec_rendered::Args(vec!("fake_value".to_string())),
@@ -582,6 +547,117 @@ deployment:
                 .args
                 .clone()
         );
+    }
+
+    #[test]
+    fn test_render_env_in_runtime_and_all_secrets_expand_user_values() {
+        let agent_id = AgentID::try_from("some-agent-id").unwrap();
+        let attributes = testing_agent_attributes(&agent_id);
+
+        let agent_type = AgentType::build_for_testing(
+            r#"
+name: k8s_agent_type
+namespace: newrelic
+version: 0.0.1
+platform: kubernetes
+variables:
+  my_yaml:
+    description: "yaml with double-expanded secrets"
+    type: yaml
+    required: true
+deployment:
+  objects:
+    cr1:
+      apiVersion: group/version
+      kind: ObjectKind
+      metadata:
+        name: test
+        namespace: test-namespace
+      spec:
+        env_direct: ${nr-env:ENV}
+        from_sub_agent: ${nr-sub:agent_id}
+        values: ${nr-var:my_yaml}
+"#,
+        );
+
+        let values = testing_values(
+            r#"
+my_yaml:
+  vault_field: ${nr-vault:V_KEY}
+  kubesec_field: ${nr-kubesec:K_KEY}
+  env_field: ${nr-env:ENV}
+"#,
+        );
+
+        let secrets = HashMap::from([
+            (
+                VariableName::new(Namespace::EnvironmentVariable, "ENV"),
+                Variable::new_final_string_variable("env-value".to_string()),
+            ),
+            (
+                VariableName::new(Namespace::Vault, "V_KEY"),
+                Variable::new_final_string_variable("vault-value".to_string()),
+            ),
+            (
+                VariableName::new(Namespace::K8sSecret, "K_KEY"),
+                Variable::new_final_string_variable("kubesec-value".to_string()),
+            ),
+        ]);
+
+        let expected_spec_yaml = r#"
+env_direct: env-value
+from_sub_agent: some-agent-id
+values:
+  vault_field: vault-value
+  kubesec_field: kubesec-value
+  env_field: env-value
+"#;
+        let expected_spec: serde_json::Value = serde_saphyr::from_str(expected_spec_yaml).unwrap();
+
+        let renderer = TemplateRenderer::default();
+        let rendered = renderer
+            .render(agent_type, values, attributes, secrets)
+            .unwrap();
+        let k8s = rendered.deployment.k8s();
+        let spec = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
+        assert_eq!(&expected_spec, spec);
+    }
+
+    #[test]
+    fn test_render_fails_when_non_env_secret_referenced_in_runtime() {
+        let agent_id = AgentID::try_from("some-agent-id").unwrap();
+        let attributes = testing_agent_attributes(&agent_id);
+
+        let agent_type = AgentType::build_for_testing(
+            r#"
+name: k8s_agent_type
+namespace: newrelic
+version: 0.0.1
+platform: kubernetes
+variables: {}
+deployment:
+  objects:
+    cr1:
+      apiVersion: group/version
+      kind: ObjectKind
+      metadata:
+        name: test
+        namespace: test-namespace
+      spec:
+        vault: ${nr-vault:V_KEY}
+"#,
+        );
+
+        let secrets = HashMap::from([(
+            VariableName::new(Namespace::Vault, "V_KEY"),
+            Variable::new_final_string_variable("vault-value".to_string()),
+        )]);
+
+        let renderer = TemplateRenderer::default();
+        let err = renderer
+            .render(agent_type, YAMLConfig::default(), attributes, secrets)
+            .unwrap_err();
+        assert_matches!(err, AgentTypeError::MissingTemplateKey(_));
     }
 
     // Agent Type and Values definitions

--- a/agent-control/src/agent_type/render.rs
+++ b/agent-control/src/agent_type/render.rs
@@ -27,7 +27,7 @@ impl TemplateRenderer {
         &self,
         agent_type: AgentType,
         values: YAMLConfig,
-        attributes: AgentAttributes,
+        agent_variables: HashMap<VariableName, Variable>,
         secrets: HashMap<VariableName, Variable>,
     ) -> Result<Runtime, AgentTypeError> {
         // Get empty variables and runtime_config from the agent-type
@@ -36,16 +36,9 @@ impl TemplateRenderer {
         let expanded_user_variables =
             Self::get_expanded_user_variables(variable_tree, values, &secrets)?;
 
-        // Only envVars are kept and can be used to expand the runtime template, the other secrets
-        // can be used for double expansion of the user values only
-        let env_vars = secrets
-            .into_iter()
-            .filter(|(name, _)| *name.namespace() == Namespace::EnvironmentVariable)
-            .collect();
-
         // Setup namespaced variables
         let ns_variables =
-            self.chain_namespaced_variables(expanded_user_variables, env_vars, &attributes);
+            self.chain_namespaced_variables(expanded_user_variables, secrets, agent_variables);
 
         // Render runtime config
         let rendered_runtime_config = runtime_config.template_with(&ns_variables)?;
@@ -107,12 +100,12 @@ impl TemplateRenderer {
         &self,
         expanded_user_variables: HashMap<VariableName, Variable>,
         environment_variables: HashMap<VariableName, Variable>,
-        attributes: &AgentAttributes,
+        agent_variables: HashMap<VariableName, Variable>,
     ) -> HashMap<VariableName, Variable> {
         // Join all variables together
         expanded_user_variables
             .into_iter()
-            .chain(attributes.sub_agent_variables())
+            .chain(agent_variables)
             .chain(environment_variables)
             .chain(self.ac_variables.clone())
             .collect::<HashMap<VariableName, Variable>>()
@@ -142,13 +135,14 @@ pub(crate) mod tests {
         serde_saphyr::from_str(yaml_values).unwrap()
     }
 
-    pub fn testing_agent_attributes(agent_id: &AgentID) -> AgentAttributes {
+    pub fn testing_agent_attributes(agent_id: &AgentID) -> HashMap<VariableName, Variable> {
         #[cfg(windows)]
         let root = "C:\\";
         #[cfg(not(windows))]
         let root = "/";
 
-        AgentAttributes::try_new(agent_id.clone(), PathBuf::from_str(root).unwrap()).unwrap()
+        AgentAttributes::get_agent_variables(agent_id.clone(), PathBuf::from_str(root).unwrap())
+            .unwrap()
     }
 
     #[test]
@@ -574,6 +568,7 @@ deployment:
         name: test
         namespace: test-namespace
       spec:
+        vault_field: ${nr-vault:V_KEY}
         env_direct: ${nr-env:ENV}
         from_sub_agent: ${nr-sub:agent_id}
         values: ${nr-var:my_yaml}
@@ -605,6 +600,7 @@ my_yaml:
         ]);
 
         let expected_spec_yaml = r#"
+vault_field: vault-value
 env_direct: env-value
 from_sub_agent: some-agent-id
 values:
@@ -621,43 +617,6 @@ values:
         let k8s = rendered.deployment.k8s();
         let spec = k8s.objects.get("cr1").unwrap().fields.get("spec").unwrap();
         assert_eq!(&expected_spec, spec);
-    }
-
-    #[test]
-    fn test_render_fails_when_non_env_secret_referenced_in_runtime() {
-        let agent_id = AgentID::try_from("some-agent-id").unwrap();
-        let attributes = testing_agent_attributes(&agent_id);
-
-        let agent_type = AgentType::build_for_testing(
-            r#"
-name: k8s_agent_type
-namespace: newrelic
-version: 0.0.1
-platform: kubernetes
-variables: {}
-deployment:
-  objects:
-    cr1:
-      apiVersion: group/version
-      kind: ObjectKind
-      metadata:
-        name: test
-        namespace: test-namespace
-      spec:
-        vault: ${nr-vault:V_KEY}
-"#,
-        );
-
-        let secrets = HashMap::from([(
-            VariableName::new(Namespace::Vault, "V_KEY"),
-            Variable::new_final_string_variable("vault-value".to_string()),
-        )]);
-
-        let renderer = TemplateRenderer::default();
-        let err = renderer
-            .render(agent_type, YAMLConfig::default(), attributes, secrets)
-            .unwrap_err();
-        assert_matches!(err, AgentTypeError::MissingTemplateKey(_));
     }
 
     // Agent Type and Values definitions

--- a/agent-control/src/agent_type/runtime_config.rs
+++ b/agent-control/src/agent_type/runtime_config.rs
@@ -15,10 +15,11 @@ use super::error::AgentTypeError;
 use super::templates::Templateable;
 use k8s::K8s;
 use on_host::OnHost;
+use serde::Serialize;
 
 /// Strict structure that describes how to start a given agent with all needed binaries,
 /// arguments, env, etc.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Runtime {
     /// The deployment instructions for the agent.
     pub deployment: Deployment,
@@ -26,7 +27,7 @@ pub struct Runtime {
 
 /// Deployment of an agent type. Each variant carries the shape-specific config for that
 /// target.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Deployment {
     /// An on-host deployment.

--- a/agent-control/src/agent_type/runtime_config/health_config.rs
+++ b/agent-control/src/agent_type/runtime_config/health_config.rs
@@ -5,7 +5,7 @@ use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
 use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
 use duration_str::deserialize_duration;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::{collections::HashMap, time::Duration};
 use wrapper_with_default::WrapperWithDefault;
 
@@ -17,7 +17,7 @@ pub mod rendered;
 ///
 /// Defines the periodicity/timeout parameters and an explicit list of checks that the on-host
 /// supervisor should run. An empty (or omitted) `checks` list disables health reporting.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct OnHostHealthConfig {
     /// The duration to wait between health checks.
     #[serde(default)]
@@ -58,12 +58,12 @@ where
 }
 
 /// The maximum duration a health check may run before being considered failed.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_HEALTH_CHECK_TIMEOUT)]
 pub struct HealthCheckTimeout(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 /// A single on-host health check declaration.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "kind")]
 pub(crate) enum OnHostHealthCheckDefinition {
     Process,
@@ -71,7 +71,7 @@ pub(crate) enum OnHostHealthCheckDefinition {
     File(FileHealth),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct FileHealth {
     pub(crate) path: String,
 }
@@ -85,7 +85,7 @@ impl Templateable for FileHealth {
 }
 
 /// Represents an HTTP-based port.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct HttpPort(pub(super) u16);
 
 impl From<HttpPort> for u16 {
@@ -109,7 +109,7 @@ impl Default for HttpPort {
 /// Represents an HTTP-based health check.
 ///
 /// For further details, refer to [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct HttpHealth {
     #[serde(default)]
     pub(crate) host: TemplateableValue<HttpHost>,
@@ -141,7 +141,7 @@ impl Default for HttpHealth {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct HttpHost(String);
 
 impl Default for HttpHost {
@@ -162,7 +162,7 @@ impl From<String> for HttpHost {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct HttpPath(String);
 
 impl Default for HttpPath {

--- a/agent-control/src/agent_type/runtime_config/k8s.rs
+++ b/agent-control/src/agent_type/runtime_config/k8s.rs
@@ -6,13 +6,13 @@ use crate::agent_type::guid_config::{GuidCheckerInitialDelay, GuidCheckerInterva
 use crate::agent_type::templates::Templateable;
 use crate::agent_type::version_config::{VersionCheckerInitialDelay, VersionCheckerInterval};
 use crate::checkers::health::health_checker::{HealthCheckInterval, InitialDelay};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 /// The definition for an K8s supervisor.
 ///
 /// It contains the instructions of what are the agent resources to be managed by the agent-control.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct K8s {
     /// The Kubernetes objects (usually CRs) to manage, keyed by an arbitrary local name.
     pub objects: HashMap<String, K8sObject>,
@@ -27,7 +27,7 @@ pub struct K8s {
 }
 
 /// A K8s object, usually a CR, to be managed by the agent-control.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct K8sObject {
     /// The object's `apiVersion`.
     #[serde(rename = "apiVersion")]
@@ -42,7 +42,7 @@ pub struct K8sObject {
 }
 
 /// Metadata for a managed Kubernetes object.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct K8sObjectMeta {
     /// The object's labels.
     #[serde(default)]
@@ -101,7 +101,7 @@ impl Templateable for K8sObjectMeta {
 }
 
 /// The kind of Kubernetes resource to health-check.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub enum K8sHealthResourceKind {
     /// A Kubernetes Deployment.
@@ -117,7 +117,7 @@ pub enum K8sHealthResourceKind {
 }
 
 /// A single Kubernetes resource to include in health checking.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct K8sHealthCheckDefinition {
     pub(crate) name: String,
     pub(crate) namespace: String,
@@ -143,7 +143,7 @@ impl Templateable for K8sHealthCheckDefinition {
 }
 
 /// Health-check configuration for a Kubernetes deployment.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct K8sHealthConfig {
     /// The duration to wait between health checks.
     #[serde(default)]
@@ -172,7 +172,7 @@ impl Templateable for K8sHealthConfig {
 }
 
 /// Version-check configuration for a Kubernetes deployment.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct K8sVersionConfig {
     /// The duration to wait between version checks.
     #[serde(default)]
@@ -183,7 +183,7 @@ pub struct K8sVersionConfig {
 }
 
 /// GUID-check configuration for a Kubernetes deployment.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct K8sGuidCheckerConfig {
     /// The duration to wait between GUID checks.
     #[serde(default)]

--- a/agent-control/src/agent_type/runtime_config/on_host.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host.rs
@@ -8,7 +8,7 @@ use crate::agent_type::runtime_config::on_host::filesystem::{FileSystem, SharedF
 use crate::agent_type::runtime_config::on_host::package::{Package, PackageID};
 use crate::agent_type::runtime_config::on_host::rendered::RenderedPackages;
 use crate::agent_type::templates::Templateable;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{HashMap, HashSet};
 
 pub mod executable;
@@ -19,7 +19,7 @@ pub mod rendered;
 /// The definition for an on-host supervisor.
 ///
 /// It contains the instructions of what are the agent binaries, command-line arguments, the environment variables passed to it and the restart policy of the supervisor.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 pub struct OnHost {
     executables: Vec<Executable>,
     enable_file_logging: TemplateableValue<bool>,

--- a/agent-control/src/agent_type/runtime_config/on_host/executable.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/executable.rs
@@ -1,7 +1,7 @@
 //! On-host executable definition: binary path, arguments, environment and restart policy.
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::agent_type::{
     definition::Variables,
@@ -12,7 +12,7 @@ use crate::agent_type::{
 
 pub mod rendered;
 
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub(super) struct Executable {
     /// Executable identifier for the health checker.
     pub(super) id: String,
@@ -48,7 +48,7 @@ impl Templateable for Executable {
 }
 
 /// Command-line arguments, each a templateable value.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Args(
     /// The argument list.
     pub Vec<TemplateableValue<String>>,
@@ -67,7 +67,7 @@ impl Templateable for Args {
 }
 
 /// Environment variables passed to the executable, each value templateable.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Env(pub(super) HashMap<String, TemplateableValue<String>>);
 
 impl Templateable for Env {

--- a/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/filesystem.rs
@@ -27,8 +27,8 @@ use crate::agent_type::{
         namespace::{Namespace, VariableName},
     },
 };
-use serde::Deserialize;
 use serde::de::Error;
+use serde::{Deserialize, Serialize};
 
 pub mod rendered;
 
@@ -37,11 +37,11 @@ pub mod rendered;
 ///
 /// Every entry is tagged with a `kind:`. `dir` entries may contain further entries under
 /// `entries:`, recursively.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct FileSystem(HashMap<SafePath, FilesystemEntry>);
 
 /// One entry in a filesystem tree. The `kind` discriminator selects which fields are required.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FilesystemEntry {
     /// A single file whose bytes come from exactly one of `text` (literal or templated content)
@@ -71,7 +71,7 @@ pub enum FilesystemEntry {
 
 /// A path validated to be relative and not escaping its base directory (no `..`, no absolute
 /// roots, no Windows prefixes).
-#[derive(Debug, Default, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[serde(try_from = "PathBuf")]
 pub struct SafePath(PathBuf);
 
@@ -99,7 +99,7 @@ impl From<SafePath> for PathBuf {
 
 /// Helper carrying the rendered output of a `${nr-var:map[string]yaml}` source — exists
 /// to satisfy the orphan rule when implementing `Templateable` for `TemplateableValue<_>`.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Serialize, Default, PartialEq, Clone)]
 pub struct DirEntriesMap(HashMap<SafePath, String>);
 
 impl FileSystem {
@@ -145,7 +145,7 @@ impl Templateable for FileSystem {
 }
 
 /// Files and directories shared across sub-agents, rooted at `${nr-sub:shared_filesystem_dir}`.
-#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct SharedFileSystem(FileSystem);
 
 impl Templateable for SharedFileSystem {

--- a/agent-control/src/agent_type/runtime_config/on_host/package.rs
+++ b/agent-control/src/agent_type/runtime_config/on_host/package.rs
@@ -7,12 +7,12 @@ use crate::agent_type::runtime_config::on_host::executable::{Args, Env};
 use crate::agent_type::runtime_config::on_host::package::rendered::{Repository, Version};
 use crate::agent_type::runtime_config::templateable_value::TemplateableValue;
 use crate::agent_type::templates::Templateable;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 pub mod rendered;
 
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub(super) struct Package {
     /// Download defines the supported repository sources for the packages.
     pub download: Download,
@@ -25,14 +25,14 @@ pub(super) struct Package {
 pub type PackageID = String;
 
 /// Supported download sources for a package.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct Download {
     /// OCI repository definition
     pub oci: Oci,
 }
 
 /// OCI download source for a package.
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct Oci {
     /// Repository name.
     pub repository: TemplateableValue<String>,
@@ -44,7 +44,7 @@ pub struct Oci {
 }
 
 /// A hook executed after a package has been downloaded and extracted.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct PostDownloadHook {
     /// Path to the command/executable to run.
     /// Can be an absolute path (e.g., "/bin/bash") or a command name to search in PATH (e.g., "bash").

--- a/agent-control/src/agent_type/runtime_config/restart_policy.rs
+++ b/agent-control/src/agent_type/runtime_config/restart_policy.rs
@@ -2,7 +2,7 @@
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use strum::EnumString;
 use wrapper_with_default::WrapperWithDefault;
@@ -13,7 +13,7 @@ pub mod rendered;
 
 /// Defines the Restart Policy configuration.
 /// This policy outlines the procedures followed for restarting agents when their execution encounters failure.
-#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Default)]
 pub struct RestartPolicyConfig {
     /// Strategy configuration to retry in case of failure.
     #[serde(default)]
@@ -39,7 +39,7 @@ pub(super) const DEFAULT_BACKOFF_MAX_RETRIES: usize = 0;
 pub(super) const DEFAULT_BACKOFF_LAST_RETRY_INTERVAL: Duration = Duration::from_secs(600);
 
 /// The delay applied before retrying a failed execution.
-#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, Serialize, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_DELAY)]
 pub struct BackoffDelay(Duration);
 
@@ -51,7 +51,7 @@ impl BackoffDelay {
 }
 
 /// The interval after the last retry before retries reset.
-#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, Serialize, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_LAST_RETRY_INTERVAL)]
 pub struct BackoffLastRetryInterval(Duration);
 
@@ -63,12 +63,12 @@ impl BackoffLastRetryInterval {
 }
 
 /// The maximum number of retries before giving up.
-#[derive(Debug, PartialEq, Clone, WrapperWithDefault)]
+#[derive(Debug, Serialize, PartialEq, Clone, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_BACKOFF_MAX_RETRIES)]
 pub struct MaxRetries(usize);
 
 /// Backoff strategy configuration controlling how failed executions are retried.
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 #[serde(default)]
 pub struct BackoffStrategyConfig {
     /// The kind of backoff applied between retries.
@@ -102,7 +102,7 @@ impl Templateable for BackoffStrategyConfig {
 }
 
 /// The kind of backoff applied between retries.
-#[derive(Debug, Default, PartialEq, Clone, EnumString)]
+#[derive(Debug, Default, Serialize, PartialEq, Clone, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum BackoffStrategyType {
     /// A constant delay between retries.

--- a/agent-control/src/agent_type/runtime_config/templateable_value.rs
+++ b/agent-control/src/agent_type/runtime_config/templateable_value.rs
@@ -4,11 +4,11 @@ use super::restart_policy::{BackoffDelay, BackoffLastRetryInterval, MaxRetries};
 use crate::agent_type::definition::Variables;
 use crate::agent_type::error::AgentTypeError;
 use crate::agent_type::templates::Templateable;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
 
 /// Holds either a concrete value or a template string that resolves to a value of type `T`.
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, Serialize, PartialEq, Clone, Default)]
 pub struct TemplateableValue<T> {
     value: Option<T>,
     pub(super) template: String,

--- a/agent-control/src/agent_type/variable/namespace.rs
+++ b/agent-control/src/agent_type/variable/namespace.rs
@@ -18,6 +18,10 @@ impl VariableName {
             name: name.into(),
         }
     }
+
+    pub fn namespace(&self) -> &Namespace {
+        &self.namespace
+    }
 }
 
 impl Display for VariableName {

--- a/agent-control/src/agent_type/variable/secret_variables.rs
+++ b/agent-control/src/agent_type/variable/secret_variables.rs
@@ -10,7 +10,6 @@ use crate::{
         },
     },
     secrets_provider::{Registry, SecretsProvider},
-    values::yaml_config::YAMLConfig,
 };
 
 /// Represents the prefix used for namespaced variables.
@@ -65,17 +64,6 @@ impl From<&str> for SecretVariables {
     }
 }
 
-impl TryFrom<YAMLConfig> for SecretVariables {
-    type Error = SecretVariablesError;
-
-    fn try_from(config: YAMLConfig) -> Result<Self, Self::Error> {
-        let config: String = config
-            .try_into()
-            .map_err(|_| SecretVariablesError::YamlParseError)?;
-        Ok(SecretVariables::from(config.as_str()))
-    }
-}
-
 /// Errors produced while extracting or loading secret variables.
 #[derive(thiserror::Error, Debug)]
 pub enum SecretVariablesError {
@@ -89,8 +77,8 @@ pub enum SecretVariablesError {
     },
 
     /// The YAML config could not be parsed.
-    #[error("failed to parse yaml config")]
-    YamlParseError,
+    #[error("failed to parse yaml config: {0}")]
+    YamlParseError(String),
 }
 
 impl SecretVariables {

--- a/agent-control/src/agent_type/version_config.rs
+++ b/agent-control/src/agent_type/version_config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the agent type version checker (polling interval and initial delay).
 use duration_str::deserialize_duration;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use wrapper_with_default::WrapperWithDefault;
 
@@ -12,11 +12,11 @@ pub const AGENT_CONTROL_VERSION_CHECKER_INITIAL_DELAY: VersionCheckerInitialDela
     VersionCheckerInitialDelay(Duration::ZERO); // The Agent Control HelmRelease is supposed to exists when it starts.
 
 /// The duration to wait between version checks.
-#[derive(Debug, Clone, Deserialize, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Clone, Deserialize, Serialize, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_VERSION_CHECKER_INTERVAL)]
 pub struct VersionCheckerInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 /// The initial delay before the first version check is performed.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_VERSION_CHECKER_INITIAL_DELAY)]
 pub struct VersionCheckerInitialDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);

--- a/agent-control/src/checkers/health/health_checker.rs
+++ b/agent-control/src/checkers/health/health_checker.rs
@@ -8,7 +8,7 @@ use crate::k8s;
 use crate::sub_agent::identity::ID_ATTRIBUTE_NAME;
 use crate::utils::thread_context::{NotStartedThreadContext, StartedThreadContext};
 use duration_str::deserialize_duration;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, SystemTimeError};
 use tracing::{debug, info_span};
@@ -24,12 +24,12 @@ const DEFAULT_INITIAL_DELAY: Duration = Duration::ZERO;
 pub type StatusTime = SystemTime;
 
 /// Interval between consecutive health checks (defaults to 60s).
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_HEALTH_CHECK_INTERVAL)]
 pub struct HealthCheckInterval(#[serde(deserialize_with = "deserialize_duration")] Duration);
 
 /// Delay before the first health check is performed (defaults to zero).
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, WrapperWithDefault)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, WrapperWithDefault)]
 #[wrapper_default_value(DEFAULT_INITIAL_DELAY)]
 pub struct InitialDelay(#[serde(deserialize_with = "deserialize_duration")] Duration);
 

--- a/agent-control/src/sub_agent.rs
+++ b/agent-control/src/sub_agent.rs
@@ -1105,7 +1105,7 @@ deployment:
         }
     }
 
-    fn sub_agent(
+    fn test_sub_agent(
         opamp_client: Option<MockStartedOpAMPClient>,
         supervisor_builder: MockSupervisorBuilder<MockSupervisorStarter<MockSupervisor>>,
         config_repository: Arc<InMemoryConfigRepository>,
@@ -1279,7 +1279,7 @@ deployment:
             TestAgent::status_apply_failed_config_error(apply_fail_reason),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1319,7 +1319,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1369,7 +1369,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1418,7 +1418,7 @@ deployment:
             TestAgent::status_apply_failed_config_error("start failed"),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1466,7 +1466,7 @@ deployment:
             TestAgent::status_failed(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1510,7 +1510,7 @@ deployment:
                 .unwrap(),
         });
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1565,7 +1565,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1622,7 +1622,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1678,7 +1678,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1736,7 +1736,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1794,7 +1794,7 @@ deployment:
             TestAgent::status_applied(),
         ]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1848,7 +1848,7 @@ deployment:
         let supervisor_builder = expect_supervisor_do_not_build();
         opamp_client.should_set_remote_config_status_seq(vec![TestAgent::status_applied()]);
 
-        let sub_agent = sub_agent(
+        let sub_agent = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -1884,8 +1884,8 @@ deployment:
 
         let supervisor_builder = expect_supervisor_do_not_build();
 
-        let supervisor =
-            sub_agent(Some(opamp_client), supervisor_builder, config_repository).init_supervisor();
+        let supervisor = test_sub_agent(Some(opamp_client), supervisor_builder, config_repository)
+            .init_supervisor();
 
         assert!(supervisor.is_none());
     }
@@ -1902,8 +1902,8 @@ deployment:
 
         opamp_client.should_update_effective_config(1);
 
-        let supervisor =
-            sub_agent(Some(opamp_client), supervisor_builder, config_repository).init_supervisor();
+        let supervisor = test_sub_agent(Some(opamp_client), supervisor_builder, config_repository)
+            .init_supervisor();
 
         assert!(supervisor.is_some())
     }
@@ -1919,7 +1919,8 @@ deployment:
 
         let supervisor_builder = expect_supervisor_do_not_build();
 
-        let mut sub_agent = sub_agent(Some(opamp_client), supervisor_builder, config_repository);
+        let mut sub_agent =
+            test_sub_agent(Some(opamp_client), supervisor_builder, config_repository);
         // customize the effective_agent_assembler in order to use a different agent type
         sub_agent.effective_agent_assembler = Arc::new(LocalEffectiveAgentsAssembler::new(
             Arc::new(TestAgent::agent_type_definition_with_required_var().into()),
@@ -1968,7 +1969,7 @@ deployment:
 
         opamp_client.should_update_effective_config(1);
 
-        let supervisor = sub_agent(
+        let supervisor = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -2008,7 +2009,7 @@ deployment:
         opamp_client.should_update_effective_config(1);
         opamp_client.should_set_remote_config_status(TestAgent::status_applied());
 
-        let supervisor = sub_agent(
+        let supervisor = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -2046,7 +2047,7 @@ deployment:
 
         opamp_client.should_set_remote_config_status(TestAgent::status_failed());
 
-        let supervisor = sub_agent(
+        let supervisor = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),
@@ -2094,7 +2095,7 @@ deployment:
 
         opamp_client.should_update_effective_config(1);
 
-        let supervisor = sub_agent(
+        let supervisor = test_sub_agent(
             Some(opamp_client),
             supervisor_builder,
             config_repository.clone(),

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -181,14 +181,15 @@ where
         )
         .map_err(|e| EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string()))?;
 
-        let config: String = values
+        let user_values: String = values
             .clone()
             .try_into()
             .map_err(|e: YAMLConfigError| SecretVariablesError::YamlParseError(e.to_string()))?;
+        let runtime: String = serde_json::to_string(&agent_type.runtime_config)
+            .map_err(|e| SecretVariablesError::YamlParseError(e.to_string()))?;
 
-        let secret_variables_values = SecretVariables::from(config.as_str());
-        let secret_variables_runtime =
-            SecretVariables::from(format!("{:?}", agent_type.runtime_config).as_str());
+        let secret_variables_values = SecretVariables::from(user_values.as_str());
+        let secret_variables_runtime = SecretVariables::from(runtime.as_str());
 
         let mut secrets: HashMap<VariableName, Variable> = HashMap::new();
         secrets.extend(secret_variables_values.load_secrets(&self.secrets_providers)?);

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -175,14 +175,12 @@ where
             .get(&agent_identity.agent_type_id)?
             .with_constraints(&self.variable_constraints);
 
-        let attributes =
-            AgentAttributes::try_new(agent_identity.id.to_owned(), self.remote_dir.to_path_buf())
-                .map_err(|e| {
-                EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string())
-            })?;
+        let agent_variables = AgentAttributes::get_agent_variables(
+            agent_identity.id.to_owned(),
+            self.remote_dir.to_path_buf(),
+        )
+        .map_err(|e| EffectiveAgentsAssemblerError::EffectiveAgentsAssemblerError(e.to_string()))?;
 
-        // Values are expanded substituting all ${nr-env...} with environment variables.
-        // Notice that only environment variables are taken into consideration (no other vars for example)
         let config: String = values
             .clone()
             .try_into()
@@ -198,7 +196,7 @@ where
 
         let runtime_config = self
             .renderer
-            .render(agent_type, values, attributes, secrets)?;
+            .render(agent_type, values, agent_variables, secrets)?;
 
         Ok(EffectiveAgent::new(agent_identity.clone(), runtime_config))
     }

--- a/agent-control/src/sub_agent/effective_agents_assembler.rs
+++ b/agent-control/src/sub_agent/effective_agents_assembler.rs
@@ -8,14 +8,14 @@ use crate::agent_type::render::TemplateRenderer;
 use crate::agent_type::runtime_config::k8s::K8s;
 use crate::agent_type::runtime_config::on_host::rendered::OnHost;
 use crate::agent_type::runtime_config::rendered;
+use crate::agent_type::variable::Variable;
 use crate::agent_type::variable::constraints::VariableConstraints;
-use crate::agent_type::variable::secret_variables::{
-    SecretVariables, SecretVariablesError, load_env_vars,
-};
+use crate::agent_type::variable::namespace::VariableName;
+use crate::agent_type::variable::secret_variables::{SecretVariables, SecretVariablesError};
 use crate::secrets_provider::SecretsProviders;
 use crate::sub_agent::identity::AgentIdentity;
-use crate::values::yaml_config::YAMLConfig;
-
+use crate::values::yaml_config::{YAMLConfig, YAMLConfigError};
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -183,13 +183,22 @@ where
 
         // Values are expanded substituting all ${nr-env...} with environment variables.
         // Notice that only environment variables are taken into consideration (no other vars for example)
-        let secret_variables = SecretVariables::try_from(values.clone())?;
-        let env_vars = load_env_vars();
-        let secrets = secret_variables.load_secrets(&self.secrets_providers)?;
+        let config: String = values
+            .clone()
+            .try_into()
+            .map_err(|e: YAMLConfigError| SecretVariablesError::YamlParseError(e.to_string()))?;
+
+        let secret_variables_values = SecretVariables::from(config.as_str());
+        let secret_variables_runtime =
+            SecretVariables::from(format!("{:?}", agent_type.runtime_config).as_str());
+
+        let mut secrets: HashMap<VariableName, Variable> = HashMap::new();
+        secrets.extend(secret_variables_values.load_secrets(&self.secrets_providers)?);
+        secrets.extend(secret_variables_runtime.load_secrets(&self.secrets_providers)?);
 
         let runtime_config = self
             .renderer
-            .render(agent_type, values, attributes, env_vars, secrets)?;
+            .render(agent_type, values, attributes, secrets)?;
 
         Ok(EffectiveAgent::new(agent_identity.clone(), runtime_config))
     }

--- a/agent-control/src/values/yaml_config.rs
+++ b/agent-control/src/values/yaml_config.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 /// The YAMLConfig represent any YAML config that the AgentControl can read and store.
 /// It enforces that the root of the tree is a hashmap and not an array or a single element.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
-pub struct YAMLConfig(HashMap<String, serde_json::Value>);
+pub struct YAMLConfig(HashMap<String, Value>);
 
 impl YAMLConfig {
     /// Returns true if the YAMLConfig is empty.


### PR DESCRIPTION
The main objective is avoid reading from different points in code the environment variables. Now they are collected solely via secret retriever.
 -  now all values coming from the secret provider can be used at render time (not only environment variables)
 - a test were added to make sure the use-cases are clear and self-documented, since I was the first being confused by the implementation.

Review commit by commit

